### PR TITLE
[fix] 音声ファイル分割後、後ろの開始位置が変わらない問題を修正

### DIFF
--- a/src/libraries/BEditor.Primitive/Objects/AudioFile.cs
+++ b/src/libraries/BEditor.Primitive/Objects/AudioFile.cs
@@ -248,12 +248,10 @@ namespace BEditor.Primitive.Objects
 
         private void Clip_Splitted(object? sender, ClipSplittedEventArgs e)
         {
-            if (e.After.Effect[0] is VideoFile after)
+            if (e.After.Effect[0] is AudioFile after)
             {
                 var sub = (float)e.Before.Length.ToMilliseconds(this.GetRequiredParent<Project>().Framerate);
-                var astart = after.Start.Pairs[0];
-
-                after.Start.Pairs[0] = astart.WithValue(astart.Value + sub);
+                after.Start.Value += sub;
             }
         }
     }


### PR DESCRIPTION
音声ファイル分割処理でもVideoFileで分岐されていたため、後ろの開始位置が続きからにする処理が実行されなかった問題を修正した。

Windows 11 Home (64bit)でVisual Studio 2022 Previewでビルドをして動作確認済み