### PR TITLE
[fix] DirectoryTreeViewですでに存在してもファイルコピーする問題を修正

### DIFF
--- a/src/executable/BEditor.Avalonia/Controls/DirectoryTreeViewItem.cs
+++ b/src/executable/BEditor.Avalonia/Controls/DirectoryTreeViewItem.cs
@@ -505,7 +505,10 @@ namespace BEditor.Controls
                 foreach (var src in e.Data.GetFileNames() ?? Enumerable.Empty<string>())
                 {
                     var dst = Path.Combine(baseDir, Path.GetFileName(src));
-                    File.Copy(src, dst);
+                    if (!File.Exists(dst))
+                    {
+                        File.Copy(src, dst);
+                    }
                 }
             }
         }


### PR DESCRIPTION
プロジェクトrootフォルダー内のファイルを再生しようとしたときにすでにファイルが有るのにコピーしようとした問題を修正。

ファイルが存在するかチェックしてからコピーするようにした

Windows 11 Home (64bit)でVisual Studio 2022 Previewでビルドをして動作確認済み