### PR TITLE
fix: handle null sound source by clearing audio context

### DIFF
--- a/src/Beutl.Engine/Audio/Sound.cs
+++ b/src/Beutl.Engine/Audio/Sound.cs
@@ -74,7 +74,11 @@ public abstract class Sound : Renderable
     public virtual void Compose(AudioContext context)
     {
         var soundSource = GetSoundSource();
-        if (soundSource == null) throw new Exception("Sound source is not available");
+        if (soundSource == null)
+        {
+            context.Clear();
+            return;
+        }
 
         // Create source node
         var sourceNode = context.CreateSourceNode(soundSource);


### PR DESCRIPTION
SoundSourceが設定されていない状態で再生すると例外が発生するのを修正

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle null sound source in `Sound.Compose` by clearing the `AudioContext` and returning instead of throwing an exception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18fa5ddd7ba0fc2734f0cffc38e9fcd35084045f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->