### PR TITLE
feat: update OpenTelemetry dependencies and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,5 @@ packages/ubuntu22.04_amd64/usr/bin/
 
 coverage_report/
 .nuke/temp
+
+telemetry-data.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.6" />
     <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageVersion Include="Avalonia.Xaml.Interactivity" Version="11.3.0.6" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Dotnet.Bundle" Version="0.9.13" />

--- a/docker/otel-collector/compose.yml
+++ b/docker/otel-collector/compose.yml
@@ -1,0 +1,33 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: beutl-otel-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./telemetry-data:/telemetry-data
+    ports:
+      - "4317:4317"   # OTLP gRPC receiver
+      - "4318:4318"   # OTLP HTTP receiver
+      - "8888:8888"   # Prometheus metrics exposed by the collector
+      - "8889:8889"   # Prometheus exporter metrics
+      - "13133:13133" # health_check extension
+    restart: unless-stopped
+    networks:
+      - beutl-telemetry
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: beutl-jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "14250:14250" # gRPC
+    restart: unless-stopped
+    networks:
+      - beutl-telemetry
+
+networks:
+  beutl-telemetry:
+    driver: bridge

--- a/docker/otel-collector/otel-collector-config.yaml
+++ b/docker/otel-collector/otel-collector-config.yaml
@@ -1,0 +1,55 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+
+  # 追加の属性を付与する場合
+  attributes:
+    actions:
+      - key: deployment.environment
+        value: "development"
+        action: insert
+
+exporters:
+  # デバッグ用 - コンソールに出力
+  debug:
+    verbosity: detailed
+
+  # ファイルに出力する場合
+  file:
+    path: /telemetry-data/telemetry-data.json
+
+  # Jaegerに送信
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, attributes]
+      exporters: [debug, file, otlp/jaeger]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch, attributes]
+      exporters: [debug, file]
+
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, file]
+
+  telemetry:
+    logs:
+      level: info

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -19,7 +19,8 @@
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="FluentIcons.FluentAvalonia" />
     <PackageReference Include="AsyncImageLoader.Avalonia" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" />
     <PackageReference Include="Avalonia.Xaml.Interactivity" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="Dotnet.Bundle" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />


### PR DESCRIPTION
## Description
The telemetry sending backend was migrated from Azure Monitor to Grafana.

## Breaking changes

## Fixed issues
