### PR TITLE
Add metadata saving and registration for release assets

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -92,3 +92,9 @@ jobs:
         with:
           name: ubuntu22.04_amd64
           path: ./packages/beutl_${{ inputs.simpleVer }}-${{ inputs.revision }}ubuntu22.04_amd64.deb
+
+      - name: Save Metadata
+        uses: actions/upload-artifact@v5
+        with:
+          name: metadata-ubuntu22.04_amd64
+          path: ./packages/ubuntu22.04_amd64/usr/lib/beutl/asset_metadata.json

--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -97,3 +97,9 @@ jobs:
         with:
           name: beutl-${{ matrix.rid }}${{ matrix.standalone == true && '-standalone' || '' }}-${{ inputs.semVer }}
           path: ./artifacts/*.zip
+
+      - name: Save Metadata
+        uses: actions/upload-artifact@v5
+        with:
+          name: metadata-beutl-${{ matrix.rid }}${{ matrix.standalone == true && '-standalone' || '' }}
+          path: ./output/Beutl/asset_metadata.json

--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -145,3 +145,9 @@ jobs:
         with:
           name: Beutl_${{ matrix.rid }}
           path: artifacts/Beutl.${{ matrix.rid }}.app.zip
+
+      - name: Save Metadata
+        uses: actions/upload-artifact@v5
+        with:
+          name: metadata-Beutl_${{ matrix.rid }}
+          path: ./output/AppBundle/Beutl.app/Contents/MacOS/asset_metadata.json

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -67,3 +67,9 @@ jobs:
         with:
           name: beutl${{ matrix.standalone == true && '-standalone' || '' }}-setup
           path: ./artifacts/beutl${{ matrix.standalone == true && '-standalone' || '' }}-setup.exe
+
+      - name: Save Metadata
+        uses: actions/upload-artifact@v5
+        with:
+          name: metadata-beutl${{ matrix.standalone == true && '-standalone' || '' }}-setup
+          path: ./output/Beutl/asset_metadata.json

--- a/.github/workflows/register-release.yml
+++ b/.github/workflows/register-release.yml
@@ -1,0 +1,132 @@
+name: Register Release Assets
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  API_URL: https://release.api.beutl.beditor.net
+
+jobs:
+  register-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get OIDC Token
+        id: oidc
+        run: |
+          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/b-editor/beutl" \
+            | jq -r '.value')
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+
+      - name: Download metadata from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # assets_metadata.jsonをリリースアセットからダウンロード
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "assets_metadata.json" \
+            --output assets_metadata.json
+
+          echo "Downloaded metadata:"
+          cat assets_metadata.json | jq .
+
+      - name: Get release assets URLs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # リリースアセットのURL情報を取得
+          gh api "repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets" > release_assets.json
+
+          echo "Release assets:"
+          cat release_assets.json | jq -r '.[].name'
+
+      - name: Build request payload
+        run: |
+          # assets_metadata.jsonの各エントリにURLを追加
+          # ファイル名のパターンマッチングでURLを特定
+
+          jq -c '.[]' assets_metadata.json | while read -r metadata; do
+            ID=$(echo "$metadata" | jq -r '.id')
+            OS=$(echo "$metadata" | jq -r '.os')
+            ARCH=$(echo "$metadata" | jq -r '.arch')
+            TYPE=$(echo "$metadata" | jq -r '.type')
+            VERSION=$(echo "$metadata" | jq -r '.version')
+            STANDALONE=$(echo "$metadata" | jq -r '.standalone')
+
+            # ファイル名パターンを生成してURLを検索
+            URL=""
+            case "$TYPE" in
+              zip)
+                if [ "$STANDALONE" = "true" ]; then
+                  PATTERN="Beutl-${OS}-${ARCH}-standalone-${VERSION}.zip"
+                else
+                  PATTERN="Beutl-${OS}-${ARCH}-${VERSION}.zip"
+                fi
+                URL=$(jq -r --arg pattern "$PATTERN" '.[] | select(.name == $pattern) | .browser_download_url' release_assets.json)
+                ;;
+              installer)
+                if [ "$STANDALONE" = "true" ]; then
+                  PATTERN="beutl-standalone-setup.exe"
+                else
+                  PATTERN="beutl-setup.exe"
+                fi
+                URL=$(jq -r --arg pattern "$PATTERN" '.[] | select(.name == $pattern) | .browser_download_url' release_assets.json)
+                ;;
+              app)
+                PATTERN="Beutl.${OS}_${ARCH}.app.zip"
+                URL=$(jq -r --arg pattern "$PATTERN" '.[] | select(.name == $pattern) | .browser_download_url' release_assets.json)
+                ;;
+              debian)
+                # debパッケージはバージョン形式が異なる
+                URL=$(jq -r '.[] | select(.name | endswith(".deb")) | .browser_download_url' release_assets.json)
+                ;;
+            esac
+
+            if [ -n "$URL" ] && [ "$URL" != "null" ]; then
+              echo "$metadata" | jq --arg url "$URL" '. + {url: $url}'
+            else
+              echo "Warning: Could not find URL for $TYPE ($OS-$ARCH, standalone=$STANDALONE)" >&2
+            fi
+          done | jq -s '.' > assets_with_urls.json
+
+          echo ""
+          echo "Assets with URLs:"
+          cat assets_with_urls.json | jq .
+
+          # リクエストペイロードを作成
+          jq '{assets: .}' assets_with_urls.json > request_payload.json
+
+          echo ""
+          echo "Request payload:"
+          cat request_payload.json | jq .
+
+      - name: Register release assets
+        env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+        run: |
+          # APIを呼び出し
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer $OIDC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d @request_payload.json \
+            "$API_URL/releases/bulk")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          echo ""
+          echo "Response code: $HTTP_CODE"
+          echo "Response body: $BODY"
+
+          if [ "$HTTP_CODE" -ne 201 ]; then
+            echo "::error::API call failed with status $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "::notice::Successfully registered release assets"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,35 @@ jobs:
       - name: Print
         run: ls artifacts
 
+      - name: Download metadata artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: metadata-*
+          path: metadata
+          merge-multiple: false
+
+      - name: Merge metadata
+        run: |
+          echo "Metadata files:"
+          find metadata -name "asset_metadata.json" -type f
+
+          # 全てのasset_metadata.jsonを結合
+          echo '[]' > assets_metadata.json
+          for file in $(find metadata -name "asset_metadata.json" -type f); do
+            echo "Processing: $file"
+            cat "$file"
+            # 各ファイルの内容を配列に追加
+            jq -s '.[0] + [.[1]]' assets_metadata.json "$file" > tmp.json && mv tmp.json assets_metadata.json
+          done
+
+          echo ""
+          echo "Combined metadata:"
+          cat assets_metadata.json | jq .
+
       - uses: ncipollo/release-action@v1
         id: create_release
         with:
-          artifacts: "artifacts/**/*.zip,artifacts/**/*.deb,artifacts/beutl-setup/beutl-setup.exe,artifacts/beutl-standalone-setup/beutl-standalone-setup.exe"
+          artifacts: "artifacts/**/*.zip,artifacts/**/*.deb,artifacts/beutl-setup/beutl-setup.exe,artifacts/beutl-standalone-setup/beutl-standalone-setup.exe,assets_metadata.json"
           draft: true
           makeLatest: true
           generateReleaseNotes: true


### PR DESCRIPTION
## Description
Implement functionality to save and register metadata for release assets during the release process. This includes downloading metadata, merging it, and sending it to the API for registration.

## Breaking changes
None.

## Fixed issues
None.

