### PR TITLE
Add Display attribute to IProperty properties

### DIFF
--- a/src/Beutl.Engine/Audio/Sound.cs
+++ b/src/Beutl.Engine/Audio/Sound.cs
@@ -3,6 +3,7 @@ using Beutl.Audio.Effects;
 using Beutl.Audio.Graph;
 using Beutl.Engine;
 using Beutl.Media;
+using Beutl.Language;
 using Beutl.Media.Source;
 
 namespace Beutl.Audio;
@@ -15,14 +16,18 @@ public abstract class Sound : EngineObject
         ScanProperties<Sound>();
     }
 
+    [Display(Name = nameof(Strings.OffsetPosition), ResourceType = typeof(Strings))]
     public IProperty<TimeSpan> OffsetPosition { get; } = Property.Create<TimeSpan>();
 
     [Range(0, float.MaxValue)]
+    [Display(Name = nameof(Strings.Gain), ResourceType = typeof(Strings))]
     public IProperty<float> Gain { get; } = Property.CreateAnimatable(100f);
 
     [Range(0, float.MaxValue)]
+    [Display(Name = nameof(Strings.Speed), ResourceType = typeof(Strings))]
     public IProperty<float> Speed { get; } = Property.CreateAnimatable(100f);
 
+    [Display(Name = nameof(Strings.Effect), ResourceType = typeof(Strings))]
     public IProperty<AudioEffect?> Effect { get; } = Property.Create<AudioEffect?>();
 
     protected abstract SoundSource? GetSoundSource();

--- a/src/Beutl.Engine/Audio/SourceSound.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.cs
@@ -13,6 +13,7 @@ public sealed class SourceSound : Sound
         ScanProperties<SourceSound>();
     }
 
+    [Display(Name = nameof(Strings.Source), ResourceType = typeof(Strings))]
     public IProperty<SoundSource?> Source { get; } = Property.Create<SoundSource?>();
 
     protected override SoundSource? GetSoundSource()

--- a/src/Beutl.Engine/Graphics/DrawablePresenter.cs
+++ b/src/Beutl.Engine/Graphics/DrawablePresenter.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;
+using Beutl.Language;
 
 namespace Beutl.Graphics;
 
+[Display(Name = nameof(Strings.Presenter), ResourceType = typeof(Strings))]
 public sealed partial class DrawablePresenter : Drawable, IPresenter<Drawable>
 {
     public DrawablePresenter()
@@ -10,6 +13,7 @@ public sealed partial class DrawablePresenter : Drawable, IPresenter<Drawable>
         ScanProperties<DrawablePresenter>();
     }
 
+    [Display(Name = nameof(Strings.Target), ResourceType = typeof(Strings))]
     public IProperty<Drawable?> Target { get; } = Property.Create<Drawable?>();
 
     public override void Render(GraphicsContext2D context, Drawable.Resource resource)

--- a/src/Beutl.Engine/Graphics/FilterEffects/ColorShift.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/ColorShift.cs
@@ -56,12 +56,16 @@ public partial class ColorShift : FilterEffect
         ScanProperties<ColorShift>();
     }
 
+    [Display(Name = nameof(Strings.RedOffset), ResourceType = typeof(Strings))]
     public IProperty<PixelPoint> RedOffset { get; } = Property.CreateAnimatable<PixelPoint>();
 
+    [Display(Name = nameof(Strings.GreenOffset), ResourceType = typeof(Strings))]
     public IProperty<PixelPoint> GreenOffset { get; } = Property.CreateAnimatable<PixelPoint>();
 
+    [Display(Name = nameof(Strings.BlueOffset), ResourceType = typeof(Strings))]
     public IProperty<PixelPoint> BlueOffset { get; } = Property.CreateAnimatable<PixelPoint>();
 
+    [Display(Name = nameof(Strings.AlphaOffset), ResourceType = typeof(Strings))]
     public IProperty<PixelPoint> AlphaOffset { get; } = Property.CreateAnimatable<PixelPoint>();
 
     public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)

--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
@@ -54,8 +54,10 @@ public partial class DisplacementMapTranslateTransform : DisplacementMapTransfor
         ScanProperties<DisplacementMapTranslateTransform>();
     }
 
+    [Display(Name = nameof(Strings.X), ResourceType = typeof(Strings))]
     public IProperty<float> X { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.Y), ResourceType = typeof(Strings))]
     public IProperty<float> Y { get; } = Property.CreateAnimatable<float>();
 
     internal override void ApplyTo(
@@ -147,14 +149,19 @@ public partial class DisplacementMapScaleTransform : DisplacementMapTransform
         ScanProperties<DisplacementMapScaleTransform>();
     }
 
+    [Display(Name = nameof(Strings.Scale), ResourceType = typeof(Strings))]
     public IProperty<float> Scale { get; } = Property.CreateAnimatable<float>(100);
 
+    [Display(Name = nameof(Strings.ScaleX), ResourceType = typeof(Strings))]
     public IProperty<float> ScaleX { get; } = Property.CreateAnimatable<float>(100);
 
+    [Display(Name = nameof(Strings.ScaleY), ResourceType = typeof(Strings))]
     public IProperty<float> ScaleY { get; } = Property.CreateAnimatable<float>(100);
 
+    [Display(Name = nameof(Strings.CenterX), ResourceType = typeof(Strings))]
     public IProperty<float> CenterX { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.CenterY), ResourceType = typeof(Strings))]
     public IProperty<float> CenterY { get; } = Property.CreateAnimatable<float>();
 
     internal override void ApplyTo(
@@ -252,10 +259,13 @@ public partial class DisplacementMapRotationTransform : DisplacementMapTransform
         ScanProperties<DisplacementMapRotationTransform>();
     }
 
+    [Display(Name = nameof(Strings.Rotation), ResourceType = typeof(Strings))]
     public IProperty<float> Rotation { get; } = Property.CreateAnimatable<float>(0);
 
+    [Display(Name = nameof(Strings.CenterX), ResourceType = typeof(Strings))]
     public IProperty<float> CenterX { get; } = Property.CreateAnimatable<float>(0);
 
+    [Display(Name = nameof(Strings.CenterY), ResourceType = typeof(Strings))]
     public IProperty<float> CenterY { get; } = Property.CreateAnimatable<float>(0);
 
     internal override void ApplyTo(

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectPresenter.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectPresenter.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;
+using Beutl.Language;
 
 namespace Beutl.Graphics.Effects;
 
+[Display(Name = nameof(Strings.Presenter), ResourceType = typeof(Strings))]
 public sealed partial class FilterEffectPresenter : FilterEffect, IPresenter<FilterEffect>
 {
     public FilterEffectPresenter()
@@ -10,6 +13,7 @@ public sealed partial class FilterEffectPresenter : FilterEffect, IPresenter<Fil
         ScanProperties<FilterEffectPresenter>();
     }
 
+    [Display(Name = nameof(Strings.Target), ResourceType = typeof(Strings))]
     public IProperty<FilterEffect?> Target { get; } = Property.Create<FilterEffect?>();
 
     public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)

--- a/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/LutEffect.cs
@@ -127,6 +127,7 @@ public sealed partial class LutEffect : FilterEffect
         Source.ValueChanged += (_, args) => UpdateCube(args.NewValue);
     }
 
+    [Display(Name = nameof(Strings.Source), ResourceType = typeof(Strings))]
     public IProperty<FileInfo?> Source { get; } = Property.Create<FileInfo?>();
 
     [Display(Name = nameof(Strings.Strength), ResourceType = typeof(Strings))]

--- a/src/Beutl.Engine/Graphics/FilterEffects/Negaposi.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/Negaposi.cs
@@ -13,13 +13,17 @@ public partial class Negaposi : FilterEffect
         ScanProperties<Negaposi>();
     }
 
+    [Display(Name = nameof(Strings.Red), ResourceType = typeof(Strings))]
     public IProperty<byte> Red { get; } = Property.CreateAnimatable<byte>();
 
+    [Display(Name = nameof(Strings.Green), ResourceType = typeof(Strings))]
     public IProperty<byte> Green { get; } = Property.CreateAnimatable<byte>();
 
+    [Display(Name = nameof(Strings.Blue), ResourceType = typeof(Strings))]
     public IProperty<byte> Blue { get; } = Property.CreateAnimatable<byte>();
 
     [Range(0, 100)]
+    [Display(Name = nameof(Strings.Strength), ResourceType = typeof(Strings))]
     public IProperty<float> Strength { get; } = Property.CreateAnimatable(100f);
 
     public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)

--- a/src/Beutl.Engine/Graphics/Shapes/GeometryShape.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/GeometryShape.cs
@@ -13,6 +13,7 @@ public sealed partial class GeometryShape : Shape
         ScanProperties<GeometryShape>();
     }
 
+    [Display(Name = nameof(Strings.Data), ResourceType = typeof(Strings))]
     public IProperty<Geometry?> Data { get; } = Property.Create<Geometry?>();
 
     public partial class Resource

--- a/src/Beutl.Engine/Graphics/SourceImage.cs
+++ b/src/Beutl.Engine/Graphics/SourceImage.cs
@@ -15,6 +15,7 @@ public partial class SourceImage : Drawable
         ScanProperties<SourceImage>();
     }
 
+    [Display(Name = nameof(Strings.Source), ResourceType = typeof(Strings))]
     public IProperty<ImageSource?> Source { get; } = Property.Create<ImageSource?>();
 
     protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)

--- a/src/Beutl.Engine/Graphics/Transformation/MatrixTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/MatrixTransform.cs
@@ -1,8 +1,11 @@
-﻿using Beutl.Engine;
+﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
 using Beutl.Graphics.Rendering;
+using Beutl.Language;
 
 namespace Beutl.Graphics.Transformation;
 
+[Display(Name = nameof(Strings.MatrixTransform), ResourceType = typeof(Strings))]
 public sealed class MatrixTransform : Transform
 {
     public MatrixTransform()
@@ -15,6 +18,7 @@ public sealed class MatrixTransform : Transform
         Matrix.CurrentValue = matrix;
     }
 
+    [Display(Name = nameof(Strings.Matrix), ResourceType = typeof(Strings))]
     public IProperty<Matrix> Matrix { get; } = Property.CreateAnimatable(Graphics.Matrix.Identity);
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/Rotation3DTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/Rotation3DTransform.cs
@@ -31,18 +31,25 @@ public sealed class Rotation3DTransform : Transform
         CenterZ.CurrentValue = centerZ;
     }
 
+    [Display(Name = nameof(Strings.RotationX), ResourceType = typeof(Strings))]
     public IProperty<float> RotationX { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.RotationY), ResourceType = typeof(Strings))]
     public IProperty<float> RotationY { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.RotationZ), ResourceType = typeof(Strings))]
     public IProperty<float> RotationZ { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.CenterX), ResourceType = typeof(Strings))]
     public IProperty<float> CenterX { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.CenterY), ResourceType = typeof(Strings))]
     public IProperty<float> CenterY { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.CenterZ), ResourceType = typeof(Strings))]
     public IProperty<float> CenterZ { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.Depth), ResourceType = typeof(Strings))]
     public IProperty<float> Depth { get; } = Property.CreateAnimatable(500f);
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/RotationTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/RotationTransform.cs
@@ -19,6 +19,7 @@ public sealed class RotationTransform : Transform
         Rotation.CurrentValue = rotation;
     }
 
+    [Display(Name = nameof(Strings.Rotation), ResourceType = typeof(Strings))]
     public IProperty<float> Rotation { get; } = Property.CreateAnimatable<float>();
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/ScaleTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/ScaleTransform.cs
@@ -27,10 +27,13 @@ public sealed class ScaleTransform : Transform
         ScaleY.CurrentValue = y;
     }
 
+    [Display(Name = nameof(Strings.Scale), ResourceType = typeof(Strings))]
     public IProperty<float> Scale { get; } = Property.CreateAnimatable(100f);
 
+    [Display(Name = nameof(Strings.ScaleX), ResourceType = typeof(Strings))]
     public IProperty<float> ScaleX { get; } = Property.CreateAnimatable(100f);
 
+    [Display(Name = nameof(Strings.ScaleY), ResourceType = typeof(Strings))]
     public IProperty<float> ScaleY { get; } = Property.CreateAnimatable(100f);
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/SkewTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/SkewTransform.cs
@@ -20,8 +20,10 @@ public sealed class SkewTransform : Transform
         ScanProperties<SkewTransform>();
     }
 
+    [Display(Name = nameof(Strings.SkewX), ResourceType = typeof(Strings))]
     public IProperty<float> SkewX { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.SkewY), ResourceType = typeof(Strings))]
     public IProperty<float> SkewY { get; } = Property.CreateAnimatable<float>();
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/TransformPresenter.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/TransformPresenter.cs
@@ -1,9 +1,12 @@
+using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;
+using Beutl.Language;
 
 namespace Beutl.Graphics.Transformation;
 
 [SuppressResourceClassGeneration]
+[Display(Name = nameof(Strings.Presenter), ResourceType = typeof(Strings))]
 public sealed class TransformPresenter : Transform, IPresenter<Transform>
 {
     public TransformPresenter()
@@ -11,6 +14,7 @@ public sealed class TransformPresenter : Transform, IPresenter<Transform>
         ScanProperties<TransformPresenter>();
     }
 
+    [Display(Name = nameof(Strings.Target), ResourceType = typeof(Strings))]
     public IProperty<Transform?> Target { get; } = Property.Create<Transform?>();
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Graphics/Transformation/TranslateTransform.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/TranslateTransform.cs
@@ -31,8 +31,10 @@ public sealed class TranslateTransform : Transform
         Y.CurrentValue = point.Y;
     }
 
+    [Display(Name = nameof(Strings.X), ResourceType = typeof(Strings))]
     public IProperty<float> X { get; } = Property.CreateAnimatable(0f);
 
+    [Display(Name = nameof(Strings.Y), ResourceType = typeof(Strings))]
     public IProperty<float> Y { get; } = Property.CreateAnimatable(0f);
 
     public override Matrix CreateMatrix(RenderContext context)

--- a/src/Beutl.Engine/Media/Brushes/BrushPresenter.cs
+++ b/src/Beutl.Engine/Media/Brushes/BrushPresenter.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;
+using Beutl.Language;
 
 namespace Beutl.Media;
 
+[Display(Name = nameof(Strings.Presenter), ResourceType = typeof(Strings))]
 public sealed partial class BrushPresenter : Brush, IPresenter<Brush>
 {
     public BrushPresenter()
@@ -10,5 +13,6 @@ public sealed partial class BrushPresenter : Brush, IPresenter<Brush>
         ScanProperties<BrushPresenter>();
     }
 
+    [Display(Name = nameof(Strings.Target), ResourceType = typeof(Strings))]
     public IProperty<Brush?> Target { get; } = Property.Create<Brush?>();
 }

--- a/src/Beutl.Engine/Media/Brushes/GradientStop.cs
+++ b/src/Beutl.Engine/Media/Brushes/GradientStop.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Engine;
+﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
 
 namespace Beutl.Media;
 
@@ -26,7 +28,9 @@ public sealed partial class GradientStop : EngineObject
         Offset.CurrentValue = offset;
     }
 
+    [Display(Name = nameof(Strings.Offset), ResourceType = typeof(Strings))]
     public IProperty<float> Offset { get; } = Property.Create<float>();
 
+    [Display(Name = nameof(Strings.Color), ResourceType = typeof(Strings))]
     public IProperty<Color> Color { get; } = Property.Create<Color>();
 }

--- a/src/Beutl.Engine/Media/Brushes/ImageBrush.cs
+++ b/src/Beutl.Engine/Media/Brushes/ImageBrush.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Engine;
+﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
 using Beutl.Media.Source;
 
 namespace Beutl.Media;
@@ -28,5 +30,6 @@ public partial class ImageBrush : TileBrush
     /// <summary>
     /// Gets or sets the image to draw.
     /// </summary>
+    [Display(Name = nameof(Strings.Source), ResourceType = typeof(Strings))]
     public IProperty<ImageSource?> Source { get; } = Property.Create<ImageSource?>();
 }

--- a/src/Beutl.Engine/Media/Brushes/PerlinNoiseBrush.cs
+++ b/src/Beutl.Engine/Media/Brushes/PerlinNoiseBrush.cs
@@ -13,14 +13,19 @@ public sealed partial class PerlinNoiseBrush : Brush
     }
 
     [Range(0, 100)]
+    [Display(Name = nameof(Strings.BaseFrequencyX), ResourceType = typeof(Strings))]
     public IProperty<float> BaseFrequencyX { get; } = Property.CreateAnimatable(0f);
 
     [Range(0, 100)]
+    [Display(Name = nameof(Strings.BaseFrequencyY), ResourceType = typeof(Strings))]
     public IProperty<float> BaseFrequencyY { get; } = Property.CreateAnimatable(0f);
 
+    [Display(Name = nameof(Strings.Octaves), ResourceType = typeof(Strings))]
     public IProperty<int> Octaves { get; } = Property.CreateAnimatable(1);
 
+    [Display(Name = nameof(Strings.Seed), ResourceType = typeof(Strings))]
     public IProperty<float> Seed { get; } = Property.CreateAnimatable(0f);
 
+    [Display(Name = nameof(Strings.PerlinNoiseType), ResourceType = typeof(Strings))]
     public IProperty<PerlinNoiseType> PerlinNoiseType { get; } = Property.CreateAnimatable(Media.PerlinNoiseType.Turbulence);
 }

--- a/src/Beutl.Engine/Media/Geometry/EllipseGeometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/EllipseGeometry.cs
@@ -13,8 +13,10 @@ public sealed partial class EllipseGeometry : Geometry
         ScanProperties<EllipseGeometry>();
     }
 
+    [Display(Name = nameof(Strings.Width), ResourceType = typeof(Strings))]
     public IProperty<float> Width { get; } = Property.CreateAnimatable<float>();
 
+    [Display(Name = nameof(Strings.Height), ResourceType = typeof(Strings))]
     public IProperty<float> Height { get; } = Property.CreateAnimatable<float>();
 
     public override void ApplyTo(IGeometryContext context, Geometry.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Geometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/Geometry.cs
@@ -1,7 +1,9 @@
-﻿using Beutl.Engine;
+﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Transformation;
+using Beutl.Language;
 using SkiaSharp;
 
 namespace Beutl.Media;
@@ -12,8 +14,10 @@ public abstract partial class Geometry : EngineObject
     {
     }
 
+    [Display(Name = nameof(Strings.FillType), ResourceType = typeof(Strings))]
     public IProperty<PathFillType> FillType { get; } = Property.Create<PathFillType>();
 
+    [Display(Name = nameof(Strings.Transform), ResourceType = typeof(Strings))]
     public IProperty<Transform?> Transform { get; } = Property.Create<Transform?>(null);
 
     public virtual void ApplyTo(IGeometryContext context, Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Operations/ArcSegment.cs
+++ b/src/Beutl.Engine/Media/Geometry/Operations/ArcSegment.cs
@@ -13,14 +13,19 @@ public sealed partial class ArcSegment : PathSegment
         ScanProperties<ArcSegment>();
     }
 
+    [Display(Name = nameof(Strings.Radius), ResourceType = typeof(Strings))]
     public IProperty<Size> Radius { get; } = Property.CreateAnimatable<Size>();
 
+    [Display(Name = nameof(Strings.RotationAngle), ResourceType = typeof(Strings))]
     public IProperty<float> RotationAngle { get; } = Property.CreateAnimatable<float>(0);
 
+    [Display(Name = nameof(Strings.IsLargeArc), ResourceType = typeof(Strings))]
     public IProperty<bool> IsLargeArc { get; } = Property.CreateAnimatable<bool>(false);
 
+    [Display(Name = nameof(Strings.SweepClockwise), ResourceType = typeof(Strings))]
     public IProperty<bool> SweepClockwise { get; } = Property.CreateAnimatable<bool>(true);
 
+    [Display(Name = nameof(Strings.Point), ResourceType = typeof(Strings))]
     public IProperty<Point> Point { get; } = Property.CreateAnimatable<Point>();
 
     public override void ApplyTo(IGeometryContext context, PathSegment.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Operations/ConicSegment.cs
+++ b/src/Beutl.Engine/Media/Geometry/Operations/ConicSegment.cs
@@ -20,10 +20,13 @@ public sealed partial class ConicSegment : PathSegment
         Weight.CurrentValue = weight;
     }
 
+    [Display(Name = nameof(Strings.ControlPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> ControlPoint { get; } = Property.CreateAnimatable<Point>();
 
+    [Display(Name = nameof(Strings.EndPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> EndPoint { get; } = Property.CreateAnimatable<Point>();
 
+    [Display(Name = nameof(Strings.Weight), ResourceType = typeof(Strings))]
     public IProperty<float> Weight { get; } = Property.CreateAnimatable<float>(1);
 
     public override void ApplyTo(IGeometryContext context, PathSegment.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Operations/CubicBezierSegment.cs
+++ b/src/Beutl.Engine/Media/Geometry/Operations/CubicBezierSegment.cs
@@ -20,10 +20,13 @@ public sealed partial class CubicBezierSegment : PathSegment
         EndPoint.CurrentValue = endPoint;
     }
 
+    [Display(Name = nameof(Strings.ControlPoint1), ResourceType = typeof(Strings))]
     public IProperty<Point> ControlPoint1 { get; } = Property.CreateAnimatable<Point>();
 
+    [Display(Name = nameof(Strings.ControlPoint2), ResourceType = typeof(Strings))]
     public IProperty<Point> ControlPoint2 { get; } = Property.CreateAnimatable<Point>();
 
+    [Display(Name = nameof(Strings.EndPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> EndPoint { get; } = Property.CreateAnimatable<Point>();
 
     public override void ApplyTo(IGeometryContext context, PathSegment.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Operations/LineSegment.cs
+++ b/src/Beutl.Engine/Media/Geometry/Operations/LineSegment.cs
@@ -23,6 +23,7 @@ public sealed partial class LineSegment : PathSegment
     {
     }
 
+    [Display(Name = nameof(Strings.Point), ResourceType = typeof(Strings))]
     public IProperty<Point> Point { get; } = Property.CreateAnimatable<Point>();
 
     public override void ApplyTo(IGeometryContext context, PathSegment.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/Operations/QuadraticBezierSegment.cs
+++ b/src/Beutl.Engine/Media/Geometry/Operations/QuadraticBezierSegment.cs
@@ -19,8 +19,10 @@ public sealed partial class QuadraticBezierSegment : PathSegment
         EndPoint.CurrentValue = endPoint;
     }
 
+    [Display(Name = nameof(Strings.ControlPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> ControlPoint { get; } = Property.CreateAnimatable<Point>();
 
+    [Display(Name = nameof(Strings.EndPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> EndPoint { get; } = Property.CreateAnimatable<Point>();
 
     public override void ApplyTo(IGeometryContext context, PathSegment.Resource resource)

--- a/src/Beutl.Engine/Media/Geometry/PathFigure.cs
+++ b/src/Beutl.Engine/Media/Geometry/PathFigure.cs
@@ -15,8 +15,10 @@ public sealed partial class PathFigure : EngineObject
         ScanProperties<PathFigure>();
     }
 
+    [Display(Name = nameof(Strings.IsClosed), ResourceType = typeof(Strings))]
     public IProperty<bool> IsClosed { get; } = Property.CreateAnimatable<bool>();
 
+    [Display(Name = nameof(Strings.StartPoint), ResourceType = typeof(Strings))]
     public IProperty<Point> StartPoint { get; } = Property.CreateAnimatable(new Point(float.NaN, float.NaN));
 
     public IListProperty<PathSegment> Segments { get; } = Property.CreateList<PathSegment>();

--- a/src/Beutl.Language/Strings.Designer.cs
+++ b/src/Beutl.Language/Strings.Designer.cs
@@ -3260,5 +3260,233 @@ namespace Beutl.Language {
                 return ResourceManager.GetString("CSharpScriptEffect", resourceCulture);
             }
         }
+        
+        public static string Target {
+            get {
+                return ResourceManager.GetString("Target", resourceCulture);
+            }
+        }
+        
+        public static string ScaleX {
+            get {
+                return ResourceManager.GetString("ScaleX", resourceCulture);
+            }
+        }
+        
+        public static string ScaleY {
+            get {
+                return ResourceManager.GetString("ScaleY", resourceCulture);
+            }
+        }
+        
+        public static string SkewX {
+            get {
+                return ResourceManager.GetString("SkewX", resourceCulture);
+            }
+        }
+        
+        public static string SkewY {
+            get {
+                return ResourceManager.GetString("SkewY", resourceCulture);
+            }
+        }
+        
+        public static string X {
+            get {
+                return ResourceManager.GetString("X", resourceCulture);
+            }
+        }
+        
+        public static string Y {
+            get {
+                return ResourceManager.GetString("Y", resourceCulture);
+            }
+        }
+        
+        public static string RotationX {
+            get {
+                return ResourceManager.GetString("RotationX", resourceCulture);
+            }
+        }
+        
+        public static string RotationY {
+            get {
+                return ResourceManager.GetString("RotationY", resourceCulture);
+            }
+        }
+        
+        public static string RotationZ {
+            get {
+                return ResourceManager.GetString("RotationZ", resourceCulture);
+            }
+        }
+        
+        public static string CenterX {
+            get {
+                return ResourceManager.GetString("CenterX", resourceCulture);
+            }
+        }
+        
+        public static string CenterY {
+            get {
+                return ResourceManager.GetString("CenterY", resourceCulture);
+            }
+        }
+        
+        public static string CenterZ {
+            get {
+                return ResourceManager.GetString("CenterZ", resourceCulture);
+            }
+        }
+        
+        public static string Depth {
+            get {
+                return ResourceManager.GetString("Depth", resourceCulture);
+            }
+        }
+        
+        public static string Matrix {
+            get {
+                return ResourceManager.GetString("Matrix", resourceCulture);
+            }
+        }
+        
+        public static string MatrixTransform {
+            get {
+                return ResourceManager.GetString("MatrixTransform", resourceCulture);
+            }
+        }
+        
+        public static string OffsetPosition {
+            get {
+                return ResourceManager.GetString("OffsetPosition", resourceCulture);
+            }
+        }
+        
+        public static string Effect {
+            get {
+                return ResourceManager.GetString("Effect", resourceCulture);
+            }
+        }
+        
+        public static string RedOffset {
+            get {
+                return ResourceManager.GetString("RedOffset", resourceCulture);
+            }
+        }
+        
+        public static string GreenOffset {
+            get {
+                return ResourceManager.GetString("GreenOffset", resourceCulture);
+            }
+        }
+        
+        public static string BlueOffset {
+            get {
+                return ResourceManager.GetString("BlueOffset", resourceCulture);
+            }
+        }
+        
+        public static string AlphaOffset {
+            get {
+                return ResourceManager.GetString("AlphaOffset", resourceCulture);
+            }
+        }
+        
+        public static string BaseFrequencyX {
+            get {
+                return ResourceManager.GetString("BaseFrequencyX", resourceCulture);
+            }
+        }
+        
+        public static string BaseFrequencyY {
+            get {
+                return ResourceManager.GetString("BaseFrequencyY", resourceCulture);
+            }
+        }
+        
+        public static string Octaves {
+            get {
+                return ResourceManager.GetString("Octaves", resourceCulture);
+            }
+        }
+        
+        public static string Seed {
+            get {
+                return ResourceManager.GetString("Seed", resourceCulture);
+            }
+        }
+        
+        public static string PerlinNoiseType {
+            get {
+                return ResourceManager.GetString("PerlinNoiseType", resourceCulture);
+            }
+        }
+        
+        public static string FillType {
+            get {
+                return ResourceManager.GetString("FillType", resourceCulture);
+            }
+        }
+        
+        public static string IsClosed {
+            get {
+                return ResourceManager.GetString("IsClosed", resourceCulture);
+            }
+        }
+        
+        public static string Point {
+            get {
+                return ResourceManager.GetString("Point", resourceCulture);
+            }
+        }
+        
+        public static string ControlPoint {
+            get {
+                return ResourceManager.GetString("ControlPoint", resourceCulture);
+            }
+        }
+        
+        public static string ControlPoint1 {
+            get {
+                return ResourceManager.GetString("ControlPoint1", resourceCulture);
+            }
+        }
+        
+        public static string ControlPoint2 {
+            get {
+                return ResourceManager.GetString("ControlPoint2", resourceCulture);
+            }
+        }
+        
+        public static string Weight {
+            get {
+                return ResourceManager.GetString("Weight", resourceCulture);
+            }
+        }
+        
+        public static string Data {
+            get {
+                return ResourceManager.GetString("Data", resourceCulture);
+            }
+        }
+        
+        public static string RotationAngle {
+            get {
+                return ResourceManager.GetString("RotationAngle", resourceCulture);
+            }
+        }
+        
+        public static string IsLargeArc {
+            get {
+                return ResourceManager.GetString("IsLargeArc", resourceCulture);
+            }
+        }
+        
+        public static string SweepClockwise {
+            get {
+                return ResourceManager.GetString("SweepClockwise", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1740,4 +1740,118 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="CSharpScriptEffect" xml:space="preserve">
     <value>C#スクリプト</value>
   </data>
+  <data name="Target" xml:space="preserve">
+    <value>ターゲット</value>
+  </data>
+  <data name="ScaleX" xml:space="preserve">
+    <value>X拡大率</value>
+  </data>
+  <data name="ScaleY" xml:space="preserve">
+    <value>Y拡大率</value>
+  </data>
+  <data name="SkewX" xml:space="preserve">
+    <value>X傾き</value>
+  </data>
+  <data name="SkewY" xml:space="preserve">
+    <value>Y傾き</value>
+  </data>
+  <data name="X" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="Y" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="RotationX" xml:space="preserve">
+    <value>X回転</value>
+  </data>
+  <data name="RotationY" xml:space="preserve">
+    <value>Y回転</value>
+  </data>
+  <data name="RotationZ" xml:space="preserve">
+    <value>Z回転</value>
+  </data>
+  <data name="CenterX" xml:space="preserve">
+    <value>中心X</value>
+  </data>
+  <data name="CenterY" xml:space="preserve">
+    <value>中心Y</value>
+  </data>
+  <data name="CenterZ" xml:space="preserve">
+    <value>中心Z</value>
+  </data>
+  <data name="Depth" xml:space="preserve">
+    <value>深度</value>
+  </data>
+  <data name="Matrix" xml:space="preserve">
+    <value>行列</value>
+  </data>
+  <data name="MatrixTransform" xml:space="preserve">
+    <value>行列変形</value>
+  </data>
+  <data name="OffsetPosition" xml:space="preserve">
+    <value>オフセット位置</value>
+  </data>
+  <data name="Effect" xml:space="preserve">
+    <value>エフェクト</value>
+  </data>
+  <data name="RedOffset" xml:space="preserve">
+    <value>赤オフセット</value>
+  </data>
+  <data name="GreenOffset" xml:space="preserve">
+    <value>緑オフセット</value>
+  </data>
+  <data name="BlueOffset" xml:space="preserve">
+    <value>青オフセット</value>
+  </data>
+  <data name="AlphaOffset" xml:space="preserve">
+    <value>透明度オフセット</value>
+  </data>
+  <data name="BaseFrequencyX" xml:space="preserve">
+    <value>基本周波数X</value>
+  </data>
+  <data name="BaseFrequencyY" xml:space="preserve">
+    <value>基本周波数Y</value>
+  </data>
+  <data name="Octaves" xml:space="preserve">
+    <value>オクターブ</value>
+  </data>
+  <data name="Seed" xml:space="preserve">
+    <value>シード</value>
+  </data>
+  <data name="PerlinNoiseType" xml:space="preserve">
+    <value>ノイズタイプ</value>
+  </data>
+  <data name="FillType" xml:space="preserve">
+    <value>塗りつぶしタイプ</value>
+  </data>
+  <data name="IsClosed" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="Point" xml:space="preserve">
+    <value>点</value>
+  </data>
+  <data name="ControlPoint" xml:space="preserve">
+    <value>制御点</value>
+  </data>
+  <data name="ControlPoint1" xml:space="preserve">
+    <value>制御点1</value>
+  </data>
+  <data name="ControlPoint2" xml:space="preserve">
+    <value>制御点2</value>
+  </data>
+  <data name="Weight" xml:space="preserve">
+    <value>重み</value>
+  </data>
+  <data name="Data" xml:space="preserve">
+    <value>データ</value>
+  </data>
+  <data name="RotationAngle" xml:space="preserve">
+    <value>回転角度</value>
+  </data>
+  <data name="IsLargeArc" xml:space="preserve">
+    <value>大弧</value>
+  </data>
+  <data name="SweepClockwise" xml:space="preserve">
+    <value>時計回り</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1735,4 +1735,118 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="CSharpScriptEffect" xml:space="preserve">
     <value>C# Script</value>
   </data>
+  <data name="Target" xml:space="preserve">
+    <value>Target</value>
+  </data>
+  <data name="ScaleX" xml:space="preserve">
+    <value>Scale X</value>
+  </data>
+  <data name="ScaleY" xml:space="preserve">
+    <value>Scale Y</value>
+  </data>
+  <data name="SkewX" xml:space="preserve">
+    <value>Skew X</value>
+  </data>
+  <data name="SkewY" xml:space="preserve">
+    <value>Skew Y</value>
+  </data>
+  <data name="X" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="Y" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="RotationX" xml:space="preserve">
+    <value>Rotation X</value>
+  </data>
+  <data name="RotationY" xml:space="preserve">
+    <value>Rotation Y</value>
+  </data>
+  <data name="RotationZ" xml:space="preserve">
+    <value>Rotation Z</value>
+  </data>
+  <data name="CenterX" xml:space="preserve">
+    <value>Center X</value>
+  </data>
+  <data name="CenterY" xml:space="preserve">
+    <value>Center Y</value>
+  </data>
+  <data name="CenterZ" xml:space="preserve">
+    <value>Center Z</value>
+  </data>
+  <data name="Depth" xml:space="preserve">
+    <value>Depth</value>
+  </data>
+  <data name="Matrix" xml:space="preserve">
+    <value>Matrix</value>
+  </data>
+  <data name="MatrixTransform" xml:space="preserve">
+    <value>Matrix Transform</value>
+  </data>
+  <data name="OffsetPosition" xml:space="preserve">
+    <value>Offset Position</value>
+  </data>
+  <data name="Effect" xml:space="preserve">
+    <value>Effect</value>
+  </data>
+  <data name="RedOffset" xml:space="preserve">
+    <value>Red Offset</value>
+  </data>
+  <data name="GreenOffset" xml:space="preserve">
+    <value>Green Offset</value>
+  </data>
+  <data name="BlueOffset" xml:space="preserve">
+    <value>Blue Offset</value>
+  </data>
+  <data name="AlphaOffset" xml:space="preserve">
+    <value>Alpha Offset</value>
+  </data>
+  <data name="BaseFrequencyX" xml:space="preserve">
+    <value>Base Frequency X</value>
+  </data>
+  <data name="BaseFrequencyY" xml:space="preserve">
+    <value>Base Frequency Y</value>
+  </data>
+  <data name="Octaves" xml:space="preserve">
+    <value>Octaves</value>
+  </data>
+  <data name="Seed" xml:space="preserve">
+    <value>Seed</value>
+  </data>
+  <data name="PerlinNoiseType" xml:space="preserve">
+    <value>Noise Type</value>
+  </data>
+  <data name="FillType" xml:space="preserve">
+    <value>Fill Type</value>
+  </data>
+  <data name="IsClosed" xml:space="preserve">
+    <value>Is Closed</value>
+  </data>
+  <data name="Point" xml:space="preserve">
+    <value>Point</value>
+  </data>
+  <data name="ControlPoint" xml:space="preserve">
+    <value>Control Point</value>
+  </data>
+  <data name="ControlPoint1" xml:space="preserve">
+    <value>Control Point 1</value>
+  </data>
+  <data name="ControlPoint2" xml:space="preserve">
+    <value>Control Point 2</value>
+  </data>
+  <data name="Weight" xml:space="preserve">
+    <value>Weight</value>
+  </data>
+  <data name="Data" xml:space="preserve">
+    <value>Data</value>
+  </data>
+  <data name="RotationAngle" xml:space="preserve">
+    <value>Rotation Angle</value>
+  </data>
+  <data name="IsLargeArc" xml:space="preserve">
+    <value>Is Large Arc</value>
+  </data>
+  <data name="SweepClockwise" xml:space="preserve">
+    <value>Sweep Clockwise</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description

This PR adds System.ComponentModel.DataAnnotations Display attributes to IProperty properties across multiple classes for proper UI localization support. This enables displaying localized property names in the UI via the Strings resource file.

## Breaking changes

None.

## Fixed issues

None.