### PR TITLE
feat: add dry-run mode to release workflow via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       infoVer: ${{ needs.determine-version.outputs.infoVer }}
 
   create-release:
-    if: ${{ !inputs.dry-run }}
+    if: ${{ github.event_name == 'push' || github.event.inputs['dry-run'] != 'true' }}
     needs: [ build-executable, build-windows-installer, build-debian-package, build-nuget, build-app-bundle ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (build and upload artifacts only, skip GitHub Release creation)"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -63,6 +70,7 @@ jobs:
       infoVer: ${{ needs.determine-version.outputs.infoVer }}
 
   create-release:
+    if: ${{ !inputs.dry-run }}
     needs: [ build-executable, build-windows-installer, build-debian-package, build-nuget, build-app-bundle ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

- Add `workflow_dispatch` trigger with a `dry-run` boolean input to the release workflow
- When `dry-run` is enabled (default: `true`), all build jobs run and upload artifacts, but the GitHub Release creation step is skipped
- Tag-push triggered runs are unaffected and continue to create releases as before

## Breaking changes

None

## Fixed issues

None