### PR TITLE
feat: add feedback feature with session tracking

### DIFF
--- a/src/Beutl.ExceptionHandler/App.axaml.cs
+++ b/src/Beutl.ExceptionHandler/App.axaml.cs
@@ -15,7 +15,15 @@ public class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow();
+            string? sessionId = null;
+            string[] args = desktop.Args ?? [];
+            int idx = Array.IndexOf(args, "--session-id");
+            if (idx >= 0 && idx + 1 < args.Length)
+            {
+                sessionId = args[idx + 1];
+            }
+
+            desktop.MainWindow = new MainWindow(sessionId);
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/src/Beutl.ExceptionHandler/MainWindow.axaml
+++ b/src/Beutl.ExceptionHandler/MainWindow.axaml
@@ -71,6 +71,10 @@
                                 Command="{Binding ShowLog}"
                                 Content="{x:Static lang:Resources.ShowLog}"
                                 Theme="{StaticResource TaskDialogMoreDetailsButton}" />
+                        <Button Classes="TaskDialog_MoreDetails"
+                                Command="{Binding SendFeedback}"
+                                Content="{x:Static lang:Resources.SendFeedback}"
+                                Theme="{StaticResource TaskDialogMoreDetailsButton}" />
                     </StackPanel>
                     <SelectableTextBlock Name="FooterHost"
                                          HorizontalAlignment="Stretch"

--- a/src/Beutl.ExceptionHandler/MainWindow.axaml.cs
+++ b/src/Beutl.ExceptionHandler/MainWindow.axaml.cs
@@ -7,10 +7,14 @@ public partial class MainWindow : Window
 {
     private readonly MainWindowViewModel _viewModel;
 
-    public MainWindow()
+    public MainWindow() : this(null)
+    {
+    }
+
+    public MainWindow(string? sessionId)
     {
         InitializeComponent();
-        _viewModel = new MainWindowViewModel();
+        _viewModel = new MainWindowViewModel(sessionId);
         DataContext = _viewModel;
     }
 

--- a/src/Beutl.ExceptionHandler/MainWindowViewModel.cs
+++ b/src/Beutl.ExceptionHandler/MainWindowViewModel.cs
@@ -9,9 +9,11 @@ namespace Beutl.ExceptionHandler;
 public class MainWindowViewModel
 {
     private readonly string? _logFile;
+    private readonly string? _sessionId;
 
-    public MainWindowViewModel()
+    public MainWindowViewModel(string? sessionId = null)
     {
+        _sessionId = sessionId;
         Header = Resources.ErrorOccurred;
         Content.Value = Resources.Content;
 
@@ -47,6 +49,22 @@ public class MainWindowViewModel
             {
             }
         });
+
+        SendFeedback.Subscribe(() =>
+        {
+            try
+            {
+                string url = "https://beutl.beditor.net/feedback";
+                if (!string.IsNullOrEmpty(_sessionId))
+                {
+                    url = $"{url}?traceId={_sessionId}";
+                }
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            catch
+            {
+            }
+        });
     }
 
     public string Header { get; }
@@ -56,6 +74,8 @@ public class MainWindowViewModel
     public string Footer { get; }
 
     public ReactiveCommand ShowLog { get; } = new();
+
+    public ReactiveCommand SendFeedback { get; } = new();
 
     public ReactiveCommand Cancel { get; } = new();
 }

--- a/src/Beutl.ExceptionHandler/Properties/Resources.ja.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.ja.resx
@@ -138,4 +138,7 @@ Beutlで正常に処理されないエラーが発生しました。
   <data name="ShowLog" xml:space="preserve">
     <value>ログを表示</value>
   </data>
+  <data name="SendFeedback" xml:space="preserve">
+    <value>フィードバックを送信</value>
+  </data>
 </root>

--- a/src/Beutl.ExceptionHandler/Properties/Resources.resx
+++ b/src/Beutl.ExceptionHandler/Properties/Resources.resx
@@ -138,4 +138,7 @@ If telemetry collection is enabled, logs are collected automatically.</value>
   <data name="ShowLog" xml:space="preserve">
     <value>Show Log</value>
   </data>
+  <data name="SendFeedback" xml:space="preserve">
+    <value>Send Feedback</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -375,6 +375,9 @@
   <data name="Favorites" xml:space="preserve">
     <value>お気に入り</value>
   </data>
+  <data name="Feedback" xml:space="preserve">
+    <value>フィードバック</value>
+  </data>
   <data name="AddToFavorites" xml:space="preserve">
     <value>お気に入りに追加</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -380,6 +380,9 @@
   <data name="Favorites" xml:space="preserve">
     <value>Favorites</value>
   </data>
+  <data name="Feedback" xml:space="preserve">
+    <value>Feedback</value>
+  </data>
   <data name="AddToFavorites" xml:space="preserve">
     <value>Add to Favorites</value>
   </data>

--- a/src/Beutl/Services/UnhandledExceptionHandler.cs
+++ b/src/Beutl/Services/UnhandledExceptionHandler.cs
@@ -51,6 +51,8 @@ public static class UnhandledExceptionHandler
                 UseShellExecute = true
             };
             DotNetProcess.Configure(startInfo, exePath);
+            startInfo.ArgumentList.Add("--session-id");
+            startInfo.ArgumentList.Add(Telemetry.Instance._sessionId);
             Process.Start(startInfo);
         }
         catch

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -236,6 +236,14 @@
                                   IsVisible="{Binding IsRunningStartupTasks.Value}" />
                 </Border>
 
+                <Button x:Name="OpenFeedbackButton"
+                        wnd:AppWindow.AllowInteractionInTitleBar="True"
+                        Click="OpenFeedbackClick"
+                        ToolTip.Tip="{x:Static lang:Strings.Feedback}"
+                        Theme="{StaticResource TitleBarButtonStyle}">
+                    <icons:SymbolIcon Symbol="Chat" Margin="0,0,0,2" />
+                </Button>
+
                 <Button x:Name="OpenNotificationsButton"
                         HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -372,6 +372,12 @@ public sealed partial class MainView : UserControl
         }
     }
 
+    private void OpenFeedbackClick(object? sender, RoutedEventArgs e)
+    {//FluentIcons.Common.Symbol.Chat
+        string url = $"https://beutl.beditor.net/feedback?traceId={Telemetry.Instance._sessionId}";
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+
     private void OpenNotificationsClick(object? sender, RoutedEventArgs e)
     {
         if (HiddenNotificationPanel.Children.Count > 0


### PR DESCRIPTION
## Description

- Add a feedback button to the main view title bar and the exception handler dialog, allowing users to submit feedback via the web
- Pass the telemetry session ID as a `traceId` query parameter so feedback can be correlated with application logs
- Add localized strings for "Feedback" and "Send Feedback" in both English and Japanese

## Breaking changes

None

## Fixed issues

None