### PR TITLE
feat: Add copy-paste support for core objects in property editors

### DIFF
--- a/src/Beutl.Core/Services/LibraryService.cs
+++ b/src/Beutl.Core/Services/LibraryService.cs
@@ -181,6 +181,7 @@ public static class KnownLibraryItemFormats
     public const string Brush = "Beutl.Media.Brush";
     public const string Easing = "Beutl.Animation.Easings.Easing";
     public const string Geometry = "Beutl.Media.Geometry";
+    public const string Pen = "Beutl.Media.Pen";
 }
 
 public sealed class LibraryService

--- a/src/Beutl.Editor.Components/BeutlDataFormats.cs
+++ b/src/Beutl.Editor.Components/BeutlDataFormats.cs
@@ -22,4 +22,5 @@ public static class BeutlDataFormats
     public static readonly DataFormat<string> Brush = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Brush);
     public static readonly DataFormat<string> Easing = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Easing);
     public static readonly DataFormat<string> Geometry = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Geometry);
+    public static readonly DataFormat<string> Pen = DataFormat.CreateStringApplicationFormat("Beutl.Media.Pen");
 }

--- a/src/Beutl.Editor.Components/BeutlDataFormats.cs
+++ b/src/Beutl.Editor.Components/BeutlDataFormats.cs
@@ -22,5 +22,5 @@ public static class BeutlDataFormats
     public static readonly DataFormat<string> Brush = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Brush);
     public static readonly DataFormat<string> Easing = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Easing);
     public static readonly DataFormat<string> Geometry = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Geometry);
-    public static readonly DataFormat<string> Pen = DataFormat.CreateStringApplicationFormat("Beutl.Media.Pen");
+    public static readonly DataFormat<string> Pen = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Pen);
 }

--- a/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
+++ b/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Beutl.Editor.Services;
+using Beutl.Serialization;
+
+namespace Beutl.Editor.Components.Helpers;
+
+public static class CoreObjectClipboard
+{
+    // クリップボードにICoreSerializableオブジェクトをJSON化して保存する
+    public static async ValueTask<bool> CopyAsync(ICoreSerializable obj, DataFormat<string> format)
+    {
+        IClipboard? clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+
+        string json = CoreSerializer.SerializeToJsonString(obj);
+        var data = new DataTransfer();
+        data.Add(DataTransferItem.CreateText(json));
+        data.Add(DataTransferItem.Create(format, json));
+        await clipboard.SetDataAsync(data);
+        return true;
+    }
+
+    // クリップボードから指定フォーマットのJSON文字列を取得
+    public static async ValueTask<string?> TryGetJsonAsync(IClipboard clipboard, DataFormat<string> format)
+    {
+        if (await clipboard.TryGetValueAsync(format) is not { } data) return null;
+        return IsJsonData(data) ? data : null;
+    }
+
+    // JSON文字列から指定型のオブジェクトに復元し、Idを新規生成して返す
+    public static bool TryDeserializeJson<T>(string? json, [NotNullWhen(true)] out T? result)
+        where T : class, ICoreObject
+    {
+        result = null;
+        if (string.IsNullOrEmpty(json)) return false;
+        try
+        {
+            if (JsonNode.Parse(json) is not JsonObject jsonObj) return false;
+
+            Type baseType = typeof(T);
+            Type? actualType = baseType.IsSealed ? baseType : jsonObj.GetDiscriminator(baseType);
+            if (actualType == null || !actualType.IsAssignableTo(baseType)) return false;
+
+            if (Activator.CreateInstance(actualType) is not T instance) return false;
+
+            CoreSerializer.PopulateFromJsonObject(instance, actualType, jsonObj);
+            ObjectRegenerator.Regenerate(instance, out string newJson);
+            var newJsonNode = JsonNode.Parse(newJson) as JsonObject;
+            if (newJsonNode == null) return false;
+
+            var newInstance = (T)Activator.CreateInstance(actualType)!;
+            CoreSerializer.PopulateFromJsonObject(newInstance, actualType, newJsonNode);
+
+            result = newInstance;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // 文字列がJSON形式かどうかを判定する
+    public static bool IsJsonData(string? data)
+    {
+        if (string.IsNullOrWhiteSpace(data)) return false;
+        ReadOnlySpan<char> span = data.AsSpan().TrimStart();
+        return span.Length > 0 && span[0] == '{';
+    }
+}

--- a/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
+++ b/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
@@ -3,12 +3,16 @@ using System.Text.Json.Nodes;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Beutl.Editor.Services;
+using Beutl.Logging;
 using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Editor.Components.Helpers;
 
 public static class CoreObjectClipboard
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(CoreObjectClipboard));
+
     // クリップボードにICoreSerializableオブジェクトをJSON化して保存する
     public static async ValueTask<bool> CopyAsync(ICoreSerializable obj, DataFormat<string> format)
     {
@@ -44,21 +48,16 @@ public static class CoreObjectClipboard
             Type? actualType = baseType.IsSealed ? baseType : jsonObj.GetDiscriminator(baseType);
             if (actualType == null || !actualType.IsAssignableTo(baseType)) return false;
 
-            if (Activator.CreateInstance(actualType) is not T instance) return false;
+            if (Activator.CreateInstance(actualType) is not ICoreSerializable tmp) return false;
+            CoreSerializer.PopulateFromJsonObject(tmp, actualType, jsonObj);
 
-            CoreSerializer.PopulateFromJsonObject(instance, actualType, jsonObj);
-            ObjectRegenerator.Regenerate(instance, out string newJson);
-            var newJsonNode = JsonNode.Parse(newJson) as JsonObject;
-            if (newJsonNode == null) return false;
-
-            var newInstance = (T)Activator.CreateInstance(actualType)!;
-            CoreSerializer.PopulateFromJsonObject(newInstance, actualType, newJsonNode);
-
-            result = newInstance;
+            ObjectRegenerator.Regenerate(tmp, actualType, out ICoreSerializable newInstance);
+            result = (T)newInstance;
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            s_logger.LogWarning(ex, "Failed to deserialize clipboard JSON as {Type}", typeof(T).Name);
             return false;
         }
     }

--- a/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
+++ b/src/Beutl.Editor.Components/Helpers/CoreObjectClipboard.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using Avalonia.Input;
 using Avalonia.Input.Platform;

--- a/src/Beutl.Editor/Services/ObjectRegenerator.cs
+++ b/src/Beutl.Editor/Services/ObjectRegenerator.cs
@@ -84,6 +84,19 @@ public static class ObjectRegenerator
         json = Encoding.UTF8.GetString(buffer);
     }
 
+    public static void Regenerate(ICoreSerializable obj, Type actualType, out ICoreSerializable newInstance)
+    {
+        using var output = new PooledArrayBufferWriter<byte>(BufferSizeDefault);
+        RegenerateCore(obj, output);
+
+        Span<byte> buffer = PooledArrayBufferWriter<byte>.GetArray(output).AsSpan().Slice(0, output.WrittenCount);
+        JsonObject jsonObj = JsonNode.Parse(buffer)!.AsObject();
+
+        var instance = (ICoreSerializable)Activator.CreateInstance(actualType)!;
+        CoreSerializer.PopulateFromJsonObject(instance, actualType, jsonObj);
+        newInstance = instance;
+    }
+
     public static void Regenerate<T>(T[] obj, out T[] newInstance)
         where T : class, ICoreObject, new()
     {

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -353,4 +353,7 @@
   <data name="KeyframeExistsAtPastePosition" xml:space="preserve">
     <value>貼り付け位置にキーフレームが既に存在します。イージングと値が更新されました。</value>
   </data>
+  <data name="CannotPasteFromClipboard" xml:space="preserve">
+    <value>貼り付けできません: クリップボードに互換性のあるオブジェクトがありません。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -358,4 +358,7 @@ Do you want to restart the application?</value>
   <data name="KeyframeExistsAtPastePosition" xml:space="preserve">
     <value>A keyframe already exists at the paste position. The easing and value have been updated.</value>
   </data>
+  <data name="CannotPasteFromClipboard" xml:space="preserve">
+    <value>Cannot paste: clipboard does not contain a compatible object.</value>
+  </data>
 </root>

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 
+using Avalonia.Input;
 using Beutl.Audio.Effects;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
@@ -15,6 +16,10 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
     public AudioEffectEditorViewModel(IPropertyAdapter<AudioEffect?> property)
         : base(property)
     {
+        CanCopy = Value.Select(v => v is AudioEffect and not FallbackAudioEffect)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         IsFallback = Value.Select(v => v is IFallback)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
@@ -84,6 +89,10 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
             .DisposeWith(Disposables);
 
     }
+
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.AudioEffect;
 
     public ReadOnlyReactivePropertySlim<string?> FilterName { get; }
 
@@ -167,25 +176,10 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         }
     }
 
-    public override bool CanCopy => Value.Value is AudioEffect and not FallbackAudioEffect;
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is AudioEffect ae and not FallbackAudioEffect ? ae : null;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not AudioEffect ae || ae is FallbackAudioEffect) return false;
-        return await CoreObjectClipboard.CopyAsync(ae, BeutlDataFormats.AudioEffect);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.AudioEffect);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<AudioEffect>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -167,6 +167,45 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         }
     }
 
+    public override bool CanCopy => Value.Value is AudioEffect and not FallbackAudioEffect;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not AudioEffect ae || ae is FallbackAudioEffect) return false;
+        return await CoreObjectClipboard.CopyAsync(ae, BeutlDataFormats.AudioEffect);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.AudioEffect);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<AudioEffect>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (Value.Value is AudioEffectGroup group)
+        {
+            group.Children.Add(pasted);
+        }
+        else if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void AddItem(Type type)
     {
         if (Value.Value is AudioEffectGroup group

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -192,10 +192,15 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         {
             kf.Value = pasted;
         }
+        else if (PropertyAdapter is ListItemAccessorImpl<AudioEffect> listItemAccessor)
+        {
+            listItemAccessor.List.Insert(listItemAccessor.Index, pasted);
+        }
         else
         {
             PropertyAdapter.SetValue(pasted);
         }
+
         Commit(CommandNames.PasteObject);
         return true;
     }

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -326,6 +326,15 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         return null;
     }
 
+    // 任意のICoreSerializableオブジェクトのクリップボードコピー&ペースト対応
+    public virtual bool CanCopy => false;
+
+    public virtual bool CanPaste => false;
+
+    public virtual ValueTask<bool> CopyAsync() => ValueTask.FromResult(false);
+
+    public virtual ValueTask<bool> PasteAsync() => ValueTask.FromResult(false);
+
     public virtual object? GetService(Type serviceType)
     {
         if (serviceType.IsAssignableTo(typeof(IPropertyAdapter)))

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -289,6 +289,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     protected virtual void Dispose(bool disposing)
     {
         Disposables.Dispose();
+        _canPaste.Dispose();
         _currentFrameRevoker?.Dispose();
         _currentFrameRevoker = null;
         _editViewModel = null!;

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Beutl.Animation;
 using Beutl.Animation.Easings;
@@ -14,6 +15,7 @@ using Beutl.Engine.Expressions;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.ProjectSystem;
+using Beutl.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
@@ -327,13 +329,60 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     }
 
     // 任意のICoreSerializableオブジェクトのクリップボードコピー&ペースト対応
-    public virtual bool CanCopy => false;
+    private static readonly IReadOnlyReactiveProperty<bool> s_alwaysFalse
+        = new ReactivePropertySlim<bool>(false);
 
-    public virtual bool CanPaste => false;
+    private readonly ReactivePropertySlim<bool> _canPaste = new(false);
 
-    public virtual ValueTask<bool> CopyAsync() => ValueTask.FromResult(false);
+    public virtual IReadOnlyReactiveProperty<bool> CanCopy => s_alwaysFalse;
 
-    public virtual ValueTask<bool> PasteAsync() => ValueTask.FromResult(false);
+    public IReadOnlyReactiveProperty<bool> CanPaste => _canPaste;
+
+    protected virtual DataFormat<string>? PasteFormat => null;
+
+    protected virtual ICoreSerializable? GetCopyTarget() => null;
+
+    public virtual bool TryPasteJson(string json) => false;
+
+    public virtual async ValueTask<bool> CopyAsync()
+    {
+        if (PasteFormat is not { } format) return false;
+        if (GetCopyTarget() is not { } obj) return false;
+        return await CoreObjectClipboard.CopyAsync(obj, format);
+    }
+
+    public virtual async ValueTask<bool> PasteAsync()
+    {
+        if (PasteFormat is not { } format) return false;
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, format);
+        return json != null && TryPasteJson(json);
+    }
+
+    public async ValueTask RefreshCanPasteAsync()
+    {
+        if (PasteFormat is not { } format)
+        {
+            _canPaste.Value = false;
+            return;
+        }
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null)
+        {
+            _canPaste.Value = false;
+            return;
+        }
+        try
+        {
+            string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, format);
+            _canPaste.Value = json != null;
+        }
+        catch
+        {
+            _canPaste.Value = false;
+        }
+    }
 
     public virtual object? GetService(Type serviceType)
     {

--- a/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Composition;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
@@ -34,6 +35,10 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
         ChildContext = Value.Select(v => v as ICoreObject)
             .Select(x => x != null ? new PropertiesEditorViewModel(x) : null)
             .Do(AcceptChildren)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
+        CanCopy = Value.Select(v => v is Brush and not FallbackBrush)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
 
@@ -114,6 +119,10 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
 
     public ReadOnlyReactivePropertySlim<PropertiesEditorViewModel?> ChildContext { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Brush;
+
     public ReadOnlyReactivePropertySlim<bool> IsSolid { get; }
 
     public ReadOnlyReactivePropertySlim<bool> IsLinearGradient { get; }
@@ -193,25 +202,10 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
         }
     }
 
-    public override bool CanCopy => Value.Value is Brush and not FallbackBrush;
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is Brush brush and not FallbackBrush ? brush : null;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not Brush brush || brush is FallbackBrush) return false;
-        return await CoreObjectClipboard.CopyAsync(brush, BeutlDataFormats.Brush);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Brush);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<Brush>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
@@ -193,6 +193,34 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
         }
     }
 
+    public override bool CanCopy => Value.Value is Brush and not FallbackBrush;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not Brush brush || brush is FallbackBrush) return false;
+        return await CoreObjectClipboard.CopyAsync(brush, BeutlDataFormats.Brush);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Brush);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<Brush>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(pasted);
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void SetColor(Color oldValue, Color newValue)
     {
         if (Value.Value is SolidColorBrush solid)

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Composition;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
@@ -31,6 +32,10 @@ public interface ICoreObjectEditorViewModel : IServiceProvider
     ReadOnlyReactivePropertySlim<bool> IsPresenter { get; }
 
     ReadOnlyReactivePropertySlim<string?> CurrentTargetName { get; }
+
+    IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    IReadOnlyReactiveProperty<bool> CanPaste { get; }
 
     IPropertyAdapter PropertyAdapter { get; }
 
@@ -101,6 +106,10 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
 
+        CanCopy = Value.Select(v => v is T and not IFallback)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         ActualTypeName = Value.Select(FallbackHelper.GetTypeName)
             .ToReadOnlyReactivePropertySlim(Strings.Unknown)
             .DisposeWith(Disposables);
@@ -111,6 +120,10 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
     }
 
     public ReadOnlyReactivePropertySlim<T?> Value { get; }
+
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.EngineObject;
 
     public ReadOnlyReactivePropertySlim<PropertiesEditorViewModel?> Properties { get; }
 
@@ -180,25 +193,10 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
         }
     }
 
-    public override bool CanCopy => Value.Value is T and not IFallback;
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is T obj and not IFallback ? obj : null;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not T obj || obj is IFallback) return false;
-        return await CoreObjectClipboard.CopyAsync(obj, BeutlDataFormats.EngineObject);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.EngineObject);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<T>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -180,6 +180,41 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
         }
     }
 
+    public override bool CanCopy => Value.Value is T and not IFallback;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not T obj || obj is IFallback) return false;
+        return await CoreObjectClipboard.CopyAsync(obj, BeutlDataFormats.EngineObject);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.EngineObject);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<T>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void SetTarget(CoreObject? target)
     {
         if (Value.Value is not IPresenter<T> presenter)

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -205,10 +205,15 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
         {
             kf.Value = pasted;
         }
+        else if (PropertyAdapter is ListItemAccessorImpl<T> listItemAccessor)
+        {
+            listItemAccessor.List.Insert(listItemAccessor.Index, pasted);
+        }
         else
         {
             PropertyAdapter.SetValue(pasted);
         }
+
         Commit(CommandNames.PasteObject);
         return true;
     }

--- a/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Graphics.Effects;
+using Beutl.Serialization;
 using Reactive.Bindings;
 
 namespace Beutl.ViewModels.Editors;
@@ -51,6 +53,10 @@ public sealed class DisplacementMapTransformEditorViewModel : ValueEditorViewMod
     public DisplacementMapTransformEditorViewModel(IPropertyAdapter<DisplacementMapTransform?> property)
         : base(property)
     {
+        CanCopy = Value.Select(v => v is DisplacementMapTransform)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         TransformType = Value.Select(GetTransformType)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
@@ -94,6 +100,10 @@ public sealed class DisplacementMapTransformEditorViewModel : ValueEditorViewMod
             .DisposeWith(Disposables);
 
     }
+
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.EngineObject;
 
     public ReadOnlyReactivePropertySlim<string?> TransformName { get; }
 
@@ -140,25 +150,9 @@ public sealed class DisplacementMapTransformEditorViewModel : ValueEditorViewMod
         SetValue(Value.Value, null);
     }
 
-    public override bool CanCopy => Value.Value is DisplacementMapTransform;
+    protected override ICoreSerializable? GetCopyTarget() => Value.Value;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not DisplacementMapTransform obj) return false;
-        return await CoreObjectClipboard.CopyAsync(obj, BeutlDataFormats.EngineObject);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.EngineObject);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<DisplacementMapTransform>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Graphics.Effects;
 using Reactive.Bindings;
 
@@ -137,6 +138,41 @@ public sealed class DisplacementMapTransformEditorViewModel : ValueEditorViewMod
     public void SetNull()
     {
         SetValue(Value.Value, null);
+    }
+
+    public override bool CanCopy => Value.Value is DisplacementMapTransform;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not DisplacementMapTransform obj) return false;
+        return await CoreObjectClipboard.CopyAsync(obj, BeutlDataFormats.EngineObject);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.EngineObject);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<DisplacementMapTransform>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
     }
 
     public override void ReadFromJson(JsonObject json)

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -169,6 +169,46 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
         }
     }
 
+    public override bool CanCopy => Value.Value is FilterEffect and not FallbackFilterEffect;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not FilterEffect fe || fe is FallbackFilterEffect) return false;
+        return await CoreObjectClipboard.CopyAsync(fe, BeutlDataFormats.FilterEffect);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.FilterEffect);
+        return json != null && TryPasteJson(json);
+    }
+
+    // Drop時にも利用できる、JSON文字列からの貼り付け処理
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<FilterEffect>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (Value.Value is FilterEffectGroup group)
+        {
+            group.Children.Add(pasted);
+        }
+        else if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void AddItem(Type type)
     {
         if (Value.Value is FilterEffectGroup group

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Composition;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
@@ -16,6 +17,10 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
     public FilterEffectEditorViewModel(IPropertyAdapter<FilterEffect?> property)
         : base(property)
     {
+        CanCopy = Value.Select(v => v is FilterEffect and not FallbackFilterEffect)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         IsFallback = Value.Select(v => v is IFallback)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
@@ -116,6 +121,10 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
             .DisposeWith(Disposables);
     }
 
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.FilterEffect;
+
     public ReadOnlyReactivePropertySlim<string?> FilterName { get; }
 
     public ReadOnlyReactivePropertySlim<bool> IsGroup { get; }
@@ -169,26 +178,11 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
         }
     }
 
-    public override bool CanCopy => Value.Value is FilterEffect and not FallbackFilterEffect;
-
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not FilterEffect fe || fe is FallbackFilterEffect) return false;
-        return await CoreObjectClipboard.CopyAsync(fe, BeutlDataFormats.FilterEffect);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.FilterEffect);
-        return json != null && TryPasteJson(json);
-    }
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is FilterEffect fe and not FallbackFilterEffect ? fe : null;
 
     // Drop時にも利用できる、JSON文字列からの貼り付け処理
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<FilterEffect>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -195,10 +195,15 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
         {
             kf.Value = pasted;
         }
+        else if (PropertyAdapter is ListItemAccessorImpl<FilterEffect> listItemAccessor)
+        {
+            listItemAccessor.List.Insert(listItemAccessor.Index, pasted);
+        }
         else
         {
             PropertyAdapter.SetValue(pasted);
         }
+
         Commit(CommandNames.PasteObject);
         return true;
     }

--- a/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
@@ -145,6 +145,41 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
         }
     }
 
+    public override bool CanCopy => Value.Value is Geometry and not FallbackGeometry;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not Geometry geom || geom is FallbackGeometry) return false;
+        return await CoreObjectClipboard.CopyAsync(geom, BeutlDataFormats.Geometry);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Geometry);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<Geometry>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void AddItem()
     {
         if (Value.Value is PathGeometry group)

--- a/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
@@ -166,10 +166,15 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
         {
             kf.Value = pasted;
         }
+        else if (PropertyAdapter is ListItemAccessorImpl<Geometry> listItemAccessor)
+        {
+            listItemAccessor.List.Insert(listItemAccessor.Index, pasted);
+        }
         else
         {
             PropertyAdapter.SetValue(pasted);
         }
+
         Commit(CommandNames.PasteObject);
         return true;
     }

--- a/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 
+using Avalonia.Input;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PropertyEditors.Services;
 using Beutl.Media;
@@ -15,6 +16,10 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
     public GeometryEditorViewModel(IPropertyAdapter<Geometry?> property)
         : base(property)
     {
+        CanCopy = Value.Select(v => v is Geometry and not FallbackGeometry)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         IsFallback = Value.Select(v => v is IFallback)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
@@ -73,6 +78,10 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
     public ReadOnlyReactivePropertySlim<bool> IsGroupOrNull { get; }
 
     public ReactivePropertySlim<bool> IsExpanded { get; } = new();
+
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Geometry;
 
     public ReactivePropertySlim<PropertiesEditorViewModel?> Properties { get; } = new();
 
@@ -145,25 +154,10 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
         }
     }
 
-    public override bool CanCopy => Value.Value is Geometry and not FallbackGeometry;
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is Geometry geom and not FallbackGeometry ? geom : null;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not Geometry geom || geom is FallbackGeometry) return false;
-        return await CoreObjectClipboard.CopyAsync(geom, BeutlDataFormats.Geometry);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Geometry);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<Geometry>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
@@ -10,14 +10,15 @@ namespace Beutl.ViewModels.Editors;
 public sealed class ListItemAccessorImpl<T> : IPropertyAdapter<T>
 {
     private readonly ReactivePropertySlim<T?> _inner = new();
-    private readonly IList<T?> _list;
 
     public ListItemAccessorImpl(int index, T? item, IList<T?> list)
     {
         Index = index;
         _inner.Value = item;
-        _list = list;
+        List = list;
     }
+
+    public IList<T?> List { get; }
 
     public Type ImplementedType => throw new InvalidOperationException();
 
@@ -48,7 +49,7 @@ public sealed class ListItemAccessorImpl<T> : IPropertyAdapter<T>
 
     public void SetValue(T? value)
     {
-        _list[Index] = value;
+        List[Index] = value;
     }
 
     public void OnItemChanged(T? value)

--- a/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Collections.Pooled;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
 using Beutl.Media;
 using Beutl.PropertyAdapters;
+using Beutl.Serialization;
 using Beutl.Services;
 
 using DynamicData;
@@ -18,6 +20,10 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
     {
         Value = property.GetObservable()
             .ToReadOnlyReactiveProperty()
+            .DisposeWith(Disposables);
+
+        CanCopy = Value.Select(v => v is Pen)
+            .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
 
         Value.Subscribe(Update)
@@ -96,6 +102,10 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
 
     public ReadOnlyReactiveProperty<Pen?> Value { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Pen;
+
     public CoreList<IPropertyEditorContext> MajorProperties { get; } = [];
 
     public CoreList<IPropertyEditorContext> MinorProperties { get; } = [];
@@ -117,25 +127,9 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
         }
     }
 
-    public override bool CanCopy => Value.Value is Pen;
+    protected override ICoreSerializable? GetCopyTarget() => Value.Value;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not Pen pen) return false;
-        return await CoreObjectClipboard.CopyAsync(pen, BeutlDataFormats.Pen);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Pen);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<Pen>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 using Beutl.Collections.Pooled;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
 using Beutl.Media;
 using Beutl.PropertyAdapters;
@@ -114,6 +115,34 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
             PropertyAdapter.SetValue(newValue);
             Commit();
         }
+    }
+
+    public override bool CanCopy => Value.Value is Pen;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not Pen pen) return false;
+        return await CoreObjectClipboard.CopyAsync(pen, BeutlDataFormats.Pen);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Pen);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<Pen>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(pasted);
+        Commit(CommandNames.PasteObject);
+        return true;
     }
 
     public override void Accept(IPropertyEditorContextVisitor visitor)

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Avalonia.Input;
 using Beutl.Composition;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Engine;
@@ -74,6 +75,10 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
     public TransformEditorViewModel(IPropertyAdapter<Transform?> property)
         : base(property)
     {
+        CanCopy = Value.Select(v => v is Transform and not FallbackTransform)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(Disposables);
+
         IsFallback = Value.Select(v => v is IFallback)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
@@ -170,6 +175,10 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
     }
 
     public ReadOnlyReactivePropertySlim<string?> TransformName { get; }
+
+    public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
+
+    protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Transform;
 
     public ReadOnlyReactivePropertySlim<KnownTransformType> TransformType { get; }
 
@@ -278,25 +287,10 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
         }
     }
 
-    public override bool CanCopy => Value.Value is Transform and not FallbackTransform;
+    protected override ICoreSerializable? GetCopyTarget()
+        => Value.Value is { } tf and not FallbackTransform ? tf : null;
 
-    public override bool CanPaste => true;
-
-    public override async ValueTask<bool> CopyAsync()
-    {
-        if (Value.Value is not Transform tf || tf is FallbackTransform) return false;
-        return await CoreObjectClipboard.CopyAsync(tf, BeutlDataFormats.Transform);
-    }
-
-    public override async ValueTask<bool> PasteAsync()
-    {
-        var clipboard = ClipboardHelper.GetClipboard();
-        if (clipboard == null) return false;
-        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Transform);
-        return json != null && TryPasteJson(json);
-    }
-
-    public bool TryPasteJson(string? json)
+    public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<Transform>(json, out var pasted)) return false;
 

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -303,10 +303,15 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
         {
             kf.Value = pasted;
         }
+        else if (PropertyAdapter is ListItemAccessorImpl<Transform> listItemAccessor)
+        {
+            listItemAccessor.List.Insert(listItemAccessor.Index, pasted);
+        }
         else
         {
             PropertyAdapter.SetValue(pasted);
         }
+
         Commit(CommandNames.PasteObject);
         return true;
     }

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -278,6 +278,45 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
         }
     }
 
+    public override bool CanCopy => Value.Value is Transform and not FallbackTransform;
+
+    public override bool CanPaste => true;
+
+    public override async ValueTask<bool> CopyAsync()
+    {
+        if (Value.Value is not Transform tf || tf is FallbackTransform) return false;
+        return await CoreObjectClipboard.CopyAsync(tf, BeutlDataFormats.Transform);
+    }
+
+    public override async ValueTask<bool> PasteAsync()
+    {
+        var clipboard = ClipboardHelper.GetClipboard();
+        if (clipboard == null) return false;
+        string? json = await CoreObjectClipboard.TryGetJsonAsync(clipboard, BeutlDataFormats.Transform);
+        return json != null && TryPasteJson(json);
+    }
+
+    public bool TryPasteJson(string? json)
+    {
+        if (!CoreObjectClipboard.TryDeserializeJson<Transform>(json, out var pasted)) return false;
+
+        IsExpanded.Value = true;
+        if (Value.Value is TransformGroup group)
+        {
+            group.Children.Add(pasted);
+        }
+        else if (EditingKeyFrame.Value is { } kf)
+        {
+            kf.Value = pasted;
+        }
+        else
+        {
+            PropertyAdapter.SetValue(pasted);
+        }
+        Commit(CommandNames.PasteObject);
+        return true;
+    }
+
     public void SetNull()
     {
         SetValue(Value.Value, null);

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -18,26 +18,14 @@
         <ToggleButton x:Name="expandToggle"
                       Margin="8,4"
                       IsChecked="{Binding IsExpanded.Value}"
-                      ToolTip.Tip="{Binding Description.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:MenuFlyoutItem Click="ChangeEffectTypeClick"
-                                       FontWeight="Normal"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick"
-                                       FontWeight="Normal"
-                                       Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
+                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -68,7 +56,7 @@
                 </StackPanel>
             </ToggleButton.Tag>
             <WrapPanel Orientation="Horizontal">
-                <TextBlock FontWeight="DemiBold" Text="{Binding Header, FallbackValue=Filter}" />
+                <TextBlock Text="{Binding Header, FallbackValue=Filter}" />
                 <TextBlock Margin="8,0,0,0"
                            IsVisible="{Binding !IsGroupOrNull.Value}"
                            Text="{Binding FilterName.Value}" />

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -29,6 +29,13 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -21,7 +21,7 @@
                       ToolTip.Tip="{Binding Description.Value}"
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:MenuFlyoutItem Click="ChangeEffectTypeClick"
                                        FontWeight="Normal"
                                        IconSource="New"
@@ -29,12 +29,14 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Language;
 using Beutl.Models;
@@ -60,9 +61,17 @@ public partial class AudioEffectEditor : UserControl
 
     private void Drop(object? sender, DragEventArgs e)
     {
-        if (e.DataTransfer.TryGetValue(BeutlDataFormats.AudioEffect) is { } typeName
-            && TypeFormat.ToType(typeName) is { } type
-            && DataContext is AudioEffectEditorViewModel { IsDisposed: false } viewModel)
+        if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (e.DataTransfer.TryGetValue(BeutlDataFormats.AudioEffect) is not { } data) return;
+
+        if (CoreObjectClipboard.IsJsonData(data))
+        {
+            if (viewModel.TryPasteJson(data))
+            {
+                e.Handled = true;
+            }
+        }
+        else if (TypeFormat.ToType(data) is { } type)
         {
             if (viewModel.IsGroup.Value)
             {
@@ -172,6 +181,32 @@ public partial class AudioEffectEditor : UserControl
         if (DataContext is AudioEffectEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.SetNull();
+        }
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
         }
     }
 }

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -186,10 +186,10 @@ public partial class AudioEffectEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -199,14 +199,25 @@ public partial class AudioEffectEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 }

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -6,11 +6,10 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
-using Beutl.Language;
-using Beutl.Models;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -57,6 +56,8 @@ public partial class AudioEffectEditor : UserControl
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)
@@ -184,40 +185,4 @@ public partial class AudioEffectEditor : UserControl
         }
     }
 
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
-    }
 }

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -184,5 +184,4 @@ public partial class AudioEffectEditor : UserControl
             viewModel.SetNull();
         }
     }
-
 }

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"
              d:DesignHeight="450"
              d:DesignWidth="400"
@@ -16,7 +18,20 @@
                           ToolTip.Tip="{Binding Description.Value}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}" />
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
+                <ToggleButton.ContextFlyout>
+                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:MenuFlyoutItem Click="CopyClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanCopy.Value}"
+                                           Text="{x:Static lang:Strings.Copy}" />
+                        <ui:MenuFlyoutItem Click="PasteClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanPaste.Value}"
+                                           Text="{x:Static lang:Strings.Paste}" />
+                    </ui:FAMenuFlyout>
+                </ToggleButton.ContextFlyout>
+            </ToggleButton>
 
             <ToggleButton Grid.Column="1"
                           Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
@@ -15,23 +15,10 @@
         <Grid Margin="8,0,0,0" ColumnDefinitions="*,Auto,Auto">
             <ToggleButton x:Name="reorderHandle"
                           Content="{Binding FilterName.Value}"
-                          ToolTip.Tip="{Binding Description.Value}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
-                <ToggleButton.ContextFlyout>
-                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
-                        <ui:MenuFlyoutItem Click="CopyClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanCopy.Value}"
-                                           Text="{x:Static lang:Strings.Copy}" />
-                        <ui:MenuFlyoutItem Click="PasteClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanPaste.Value}"
-                                           Text="{x:Static lang:Strings.Paste}" />
-                    </ui:FAMenuFlyout>
-                </ToggleButton.ContextFlyout>
-            </ToggleButton>
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}"
+                          ToolTip.Tip="{Binding Description.Value}" />
 
             <ToggleButton Grid.Column="1"
                           Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Beutl.Editor.Components.Views;
+using Beutl.Services;
 using Beutl.ViewModels.Editors;
 
 namespace Beutl.Views.Editors;
@@ -54,5 +55,42 @@ public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
     private void DeleteClick(object? sender, RoutedEventArgs e)
     {
         DeleteRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            await vm.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
+        }
     }
 }

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
@@ -4,8 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Beutl.Editor.Components.Views;
-using Beutl.Services;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -46,6 +46,9 @@ public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
                 _fallbackObjectView = new FallbackObjectView();
                 content.Children.Add(_fallbackObjectView);
             });
+
+        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle => reorderHandle;
@@ -55,42 +58,5 @@ public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
     private void DeleteClick(object? sender, RoutedEventArgs e)
     {
         DeleteRequested?.Invoke(this, EventArgs.Empty);
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 }

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -23,12 +23,11 @@
         <ToggleButton x:Name="expandToggle"
                       Margin="8,4"
                       Classes="center-fill"
-                      ToolTip.Tip="{Binding Description.Value}"
                       Content="{Binding Header, FallbackValue=Brush}"
-                      FontWeight="DemiBold"
                       IsChecked="{Binding IsExpanded.Value}"
                       IsVisible="{Binding !IsPresenter.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.Tag>
                 <Grid ColumnDefinitions="*,4,Auto">
                     <Button Width="80"
@@ -45,7 +44,8 @@
                         </Panel>
                     </Button>
 
-                    <Button Grid.Column="2"
+                    <Button x:Name="ExpandMenuButton"
+                            Grid.Column="2"
                             Padding="0"
                             HorizontalContentAlignment="Center"
                             VerticalContentAlignment="Center"
@@ -53,7 +53,7 @@
                             Click="Menu_Click"
                             Theme="{StaticResource TransparentButton}">
                         <Button.ContextFlyout>
-                            <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                            <ui:FAMenuFlyout>
                                 <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                         Tag="Solid"
@@ -86,15 +86,6 @@
                                                         IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                         Tag="Null"
                                                         Text="{x:Static lang:Strings.Null}" />
-                                <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                                <ui:MenuFlyoutItem Click="CopyClick"
-                                                   FontWeight="Normal"
-                                                   IsVisible="{Binding CanCopy.Value}"
-                                                   Text="{x:Static lang:Strings.Copy}" />
-                                <ui:MenuFlyoutItem Click="PasteClick"
-                                                   FontWeight="Normal"
-                                                   IsVisible="{Binding CanPaste.Value}"
-                                                   Text="{x:Static lang:Strings.Paste}" />
                             </ui:FAMenuFlyout>
                         </Button.ContextFlyout>
                         <icons:SymbolIcon Symbol="Compose" />
@@ -104,17 +95,18 @@
         </ToggleButton>
 
         <pe:ReferenceEditor Header="{Binding Header, FallbackValue=Brush}"
-                            ToolTip.Tip="{Binding Description.Value}"
                             IsVisible="{Binding IsPresenter.Value}"
                             SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
                             TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
-                <Button Margin="0,0,4,0"
+                <Button x:Name="ReferenceMenuButton"
+                        Margin="0,0,4,0"
                         Padding="0"
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:FAMenuFlyout>
                             <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                     Tag="Solid"
@@ -147,15 +139,6 @@
                                                     IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                     Tag="Null"
                                                     Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                            <ui:MenuFlyoutItem Click="CopyClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanCopy.Value}"
-                                               Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanPaste.Value}"
-                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -86,6 +86,13 @@
                                                         IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                         Tag="Null"
                                                         Text="{x:Static lang:Strings.Null}" />
+                                <ui:MenuFlyoutSeparator />
+                                <ui:MenuFlyoutItem Click="CopyClick"
+                                                   FontWeight="Normal"
+                                                   Text="{x:Static lang:Strings.Copy}" />
+                                <ui:MenuFlyoutItem Click="PasteClick"
+                                                   FontWeight="Normal"
+                                                   Text="{x:Static lang:Strings.Paste}" />
                             </ui:FAMenuFlyout>
                         </Button.ContextFlyout>
                         <icons:SymbolIcon Symbol="Compose" />
@@ -138,6 +145,13 @@
                                                     IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                     Tag="Null"
                                                     Text="{x:Static lang:Strings.Null}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Click="CopyClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -53,7 +53,7 @@
                             Click="Menu_Click"
                             Theme="{StaticResource TransparentButton}">
                         <Button.ContextFlyout>
-                            <ui:FAMenuFlyout>
+                            <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                                 <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                         Tag="Solid"
@@ -86,12 +86,14 @@
                                                         IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                         Tag="Null"
                                                         Text="{x:Static lang:Strings.Null}" />
-                                <ui:MenuFlyoutSeparator />
+                                <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                                 <ui:MenuFlyoutItem Click="CopyClick"
                                                    FontWeight="Normal"
+                                                   IsVisible="{Binding CanCopy.Value}"
                                                    Text="{x:Static lang:Strings.Copy}" />
                                 <ui:MenuFlyoutItem Click="PasteClick"
                                                    FontWeight="Normal"
+                                                   IsVisible="{Binding CanPaste.Value}"
                                                    Text="{x:Static lang:Strings.Paste}" />
                             </ui:FAMenuFlyout>
                         </Button.ContextFlyout>
@@ -112,7 +114,7 @@
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                             <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                     Tag="Solid"
@@ -145,12 +147,14 @@
                                                     IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                     Tag="Null"
                                                     Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                             <ui:MenuFlyoutItem Click="CopyClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanCopy.Value}"
                                                Text="{x:Static lang:Strings.Copy}" />
                             <ui:MenuFlyoutItem Click="PasteClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanPaste.Value}"
                                                Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Beutl.Controls;
 using Beutl.Controls.PropertyEditors;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
 using Beutl.Editor.Components.Views;
 using Beutl.Engine;
@@ -366,6 +367,32 @@ public sealed partial class BrushEditor : UserControl
         if (sender is Button button)
         {
             button.ContextFlyout?.ShowAt(button);
+        }
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
         }
     }
 

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -6,7 +6,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Beutl.Controls;
 using Beutl.Controls.PropertyEditors;
-using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
 using Beutl.Editor.Components.Views;
 using Beutl.Engine;
@@ -69,6 +68,9 @@ public sealed partial class BrushEditor : UserControl
                 _fallbackObjectView = new FallbackObjectView();
                 (content.Child as Panel)?.Children.Add(_fallbackObjectView);
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     public Avalonia.Media.Brush? Brush
@@ -367,43 +369,6 @@ public sealed partial class BrushEditor : UserControl
         if (sender is Button button)
         {
             button.ContextFlyout?.ShowAt(button);
-        }
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -372,10 +372,10 @@ public sealed partial class BrushEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -385,14 +385,25 @@ public sealed partial class BrushEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
+++ b/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
@@ -62,7 +62,11 @@ public static class CopyPasteMenuHelper
             var separator = new MenuFlyoutSeparator();
             separator.Bind(
                 Visual.IsVisibleProperty,
-                dataContext.Select(d => d?.CanCopy ?? Observable.ReturnThenNever(false)).Switch());
+                dataContext
+                    .Select(d => d != null
+                        ? d.CanCopy.CombineLatest(d.CanPaste, (canCopy, canPaste) => canCopy || canPaste)
+                        : Observable.ReturnThenNever(false))
+                    .Switch());
             menuFlyout.Items.Add(separator);
         }
 

--- a/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
+++ b/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
@@ -1,0 +1,72 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Beutl.Services;
+using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.Views.Editors;
+
+public class CopyPasteMenuHelper
+{
+    public static void AddMenus(FAMenuFlyout menuFlyout, Control control)
+    {
+        var dataContext = control.GetObservable(StyledElement.DataContextProperty)
+            .Select(obj => obj as BaseEditorViewModel);
+        var copyMenu = new MenuFlyoutItem { Text = Strings.Copy };
+        copyMenu.Bind(
+            InputElement.IsEnabledProperty,
+            dataContext.Select(d => d?.CanCopy ?? Observable.ReturnThenNever(false)).Switch());
+        copyMenu.Click += async (_, _) =>
+        {
+            if (control.DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+            try
+            {
+                await vm.CopyAsync();
+            }
+            catch (Exception ex)
+            {
+                NotificationService.ShowError(Strings.Error, ex.Message);
+            }
+        };
+        var pasteMenu = new MenuFlyoutItem { Text = Strings.Paste };
+        pasteMenu.Bind(
+            InputElement.IsEnabledProperty,
+            dataContext.Select(d => d?.CanPaste ?? Observable.ReturnThenNever(false)).Switch());
+        pasteMenu.Click += async (_, _) =>
+        {
+            if (control.DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+            try
+            {
+                if (!await vm.PasteAsync())
+                {
+                    NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+                }
+            }
+            catch (Exception ex)
+            {
+                NotificationService.ShowError(Strings.Error, ex.Message);
+            }
+        };
+
+        menuFlyout.Opening += async (sender, args) =>
+        {
+            if (control.DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+            {
+                await vm.RefreshCanPasteAsync();
+            }
+        };
+
+        if (menuFlyout.Items.Count > 0)
+        {
+            var separator = new MenuFlyoutSeparator();
+            separator.Bind(
+                Visual.IsVisibleProperty,
+                dataContext.Select(d => d?.CanCopy ?? Observable.ReturnThenNever(false)).Switch());
+            menuFlyout.Items.Add(separator);
+        }
+
+        menuFlyout.Items.Add(copyMenu);
+        menuFlyout.Items.Add(pasteMenu);
+    }
+}

--- a/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
+++ b/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
-public class CopyPasteMenuHelper
+public static class CopyPasteMenuHelper
 {
     public static void AddMenus(FAMenuFlyout menuFlyout, Control control)
     {

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -33,6 +33,13 @@
                     <ui:MenuFlyoutItem Click="Navigate_Click"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.OpenInTab}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -67,6 +74,13 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Click="CopyClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -17,31 +17,17 @@
     <Grid RowDefinitions="Auto,Auto">
         <ToggleButton x:Name="expandToggle"
                       Margin="8,4"
-                      ToolTip.Tip="{Binding Description.Value}"
                       IsChecked="{Binding IsExpanded.Value}"
                       IsVisible="{Binding !IsPresenter.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:MenuFlyoutItem Click="NewClick"
-                                       FontWeight="Normal"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick"
-                                       FontWeight="Normal"
-                                       Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutItem Click="Navigate_Click"
-                                       FontWeight="Normal"
-                                       Text="{x:Static lang:Strings.OpenInTab}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
+                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                    <ui:MenuFlyoutItem Click="Navigate_Click" Text="{x:Static lang:Strings.OpenInTab}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -54,37 +40,26 @@
                     <icons:SymbolIcon Symbol="New" />
                 </Button>
             </ToggleButton.Tag>
-            <TextBlock FontWeight="DemiBold" Text="{Binding Header}" />
+            <TextBlock Text="{Binding Header}" />
         </ToggleButton>
 
         <pe:ReferenceEditor Header="{Binding Header}"
-                            ToolTip.Tip="{Binding Description.Value}"
                             IsVisible="{Binding IsPresenter.Value}"
                             SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
                             TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
-                <Button Margin="0,0,4,0"
+                <Button x:Name="ReferenceMenuButton"
+                        Margin="0,0,4,0"
                         Padding="0"
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:FAMenuFlyout>
                             <ui:MenuFlyoutItem Click="NewClick"
-                                               FontWeight="Normal"
                                                IconSource="New"
                                                Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick"
-                                               FontWeight="Normal"
-                                               Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                            <ui:MenuFlyoutItem Click="CopyClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanCopy.Value}"
-                                               Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanPaste.Value}"
-                                               Text="{x:Static lang:Strings.Paste}" />
+                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -22,7 +22,7 @@
                       IsVisible="{Binding !IsPresenter.Value}"
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:MenuFlyoutItem Click="NewClick"
                                        FontWeight="Normal"
                                        IconSource="New"
@@ -33,12 +33,14 @@
                     <ui:MenuFlyoutItem Click="Navigate_Click"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.OpenInTab}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
@@ -66,7 +68,7 @@
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                             <ui:MenuFlyoutItem Click="NewClick"
                                                FontWeight="Normal"
                                                IconSource="New"
@@ -74,12 +76,14 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                             <ui:MenuFlyoutItem Click="CopyClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanCopy.Value}"
                                                Text="{x:Static lang:Strings.Copy}" />
                             <ui:MenuFlyoutItem Click="PasteClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanPaste.Value}"
                                                Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -10,6 +10,7 @@ using Beutl.Services;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.Views.Editors;
@@ -52,6 +53,9 @@ public partial class CoreObjectEditor : UserControl
                 _fallbackObjectView = new FallbackObjectView();
                 content.Children.Add(_fallbackObjectView);
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Navigate_Click(object? sender, RoutedEventArgs e)
@@ -66,14 +70,6 @@ public partial class CoreObjectEditor : UserControl
 
         objViewModel.NavigateCore(viewModel.Value.Value, false, viewModel);
         editViewModel.OpenToolTab(objViewModel);
-    }
-
-    private void Menu_Click(object? sender, RoutedEventArgs e)
-    {
-        if (sender is Button button)
-        {
-            button.ContextMenu?.Open();
-        }
     }
 
     private async void NewClick(object? sender, RoutedEventArgs e)
@@ -106,43 +102,6 @@ public partial class CoreObjectEditor : UserControl
         if (DataContext is not ICoreObjectEditorViewModel { IsDisposed: false } viewModel) return;
 
         viewModel.SetNull();
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 
     private void SelectTarget_Requested(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -108,6 +108,32 @@ public partial class CoreObjectEditor : UserControl
         viewModel.SetNull();
     }
 
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel vm || vm.IsDisposed) return;
+        try
+        {
+            await vm.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel vm || vm.IsDisposed) return;
+        try
+        {
+            await vm.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
     private void SelectTarget_Requested(object? sender, RoutedEventArgs e)
     {
         OnSelectTargetRequested();

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -110,7 +110,7 @@ public partial class CoreObjectEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not BaseEditorViewModel vm || vm.IsDisposed) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
             await vm.CopyAsync();
@@ -123,14 +123,25 @@ public partial class CoreObjectEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not BaseEditorViewModel vm || vm.IsDisposed) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await vm.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
@@ -15,27 +15,14 @@
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,Auto">
         <Grid Margin="8,0,0,0"
-              ToolTip.Tip="{Binding Description.Value}"
               ColumnDefinitions="*,Auto,Auto"
-              IsVisible="{Binding !IsPresenter.Value}">
+              IsVisible="{Binding !IsPresenter.Value}"
+              ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton x:Name="reorderHandle"
                           Content="{x:Static lang:Strings.Item}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
-                <ToggleButton.ContextFlyout>
-                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
-                        <ui:MenuFlyoutItem Click="CopyClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanCopy.Value}"
-                                           Text="{x:Static lang:Strings.Copy}" />
-                        <ui:MenuFlyoutItem Click="PasteClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanPaste.Value}"
-                                           Text="{x:Static lang:Strings.Paste}" />
-                    </ui:FAMenuFlyout>
-                </ToggleButton.ContextFlyout>
-            </ToggleButton>
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}" />
 
             <Button Grid.Column="1"
                     Margin="4,0,0,0"
@@ -63,8 +50,8 @@
                             EditorStyle="ListItem"
                             IsVisible="{Binding IsPresenter.Value}"
                             SelectTargetRequested="SelectTarget_Requested"
-                            TargetName="{Binding CurrentTargetName.Value}"
-                            ToolTip.Tip="{Binding Description.Value}">
+                            ToolTip.Tip="{Binding Description.Value}"
+                            TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
                 <StackPanel Orientation="Horizontal">
                     <ToggleButton Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
@@ -7,6 +7,7 @@
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:vm="using:Beutl.ViewModels.Editors"
              d:DesignHeight="450"
              d:DesignWidth="400"
@@ -21,7 +22,20 @@
                           Content="{x:Static lang:Strings.Item}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}" />
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
+                <ToggleButton.ContextFlyout>
+                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:MenuFlyoutItem Click="CopyClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanCopy.Value}"
+                                           Text="{x:Static lang:Strings.Copy}" />
+                        <ui:MenuFlyoutItem Click="PasteClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanPaste.Value}"
+                                           Text="{x:Static lang:Strings.Paste}" />
+                    </ui:FAMenuFlyout>
+                </ToggleButton.ContextFlyout>
+            </ToggleButton>
 
             <Button Grid.Column="1"
                     Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -8,6 +8,7 @@ using Beutl.Engine;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -49,6 +50,9 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
                 _fallbackObjectView = new FallbackObjectView();
                 content.Children.Add(_fallbackObjectView);
             });
+
+        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle => reorderHandle;
@@ -58,43 +62,6 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
     private void DeleteClick(object? sender, RoutedEventArgs e)
     {
         DeleteRequested?.Invoke(this, EventArgs.Empty);
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 
     private async void NewClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -60,6 +60,43 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
         DeleteRequested?.Invoke(this, EventArgs.Empty);
     }
 
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            await vm.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
+        }
+    }
+
     private async void NewClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not ICoreObjectEditorViewModel { IsDisposed: false } viewModel) return;

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -21,7 +21,7 @@
                       IsChecked="{Binding IsExpanded.Value}"
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding IsTranslate.Value, Mode=OneWay}"
                                             Tag="Translate"
@@ -50,12 +50,14 @@
                                             IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                             Tag="Null"
                                             Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -16,12 +16,12 @@
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,Auto">
         <ToggleButton x:Name="expandToggle"
-                      ToolTip.Tip="{Binding Description.Value}"
                       Margin="8,4"
                       IsChecked="{Binding IsExpanded.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding IsTranslate.Value, Mode=OneWay}"
                                             Tag="Translate"
@@ -50,15 +50,6 @@
                                             IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                             Tag="Null"
                                             Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -71,7 +62,7 @@
                     <icons:SymbolIcon Symbol="Compose" />
                 </Button>
             </ToggleButton.Tag>
-            <TextBlock FontWeight="DemiBold" Text="{Binding Header, FallbackValue=Transform}" />
+            <TextBlock Text="{Binding Header, FallbackValue=Transform}" />
         </ToggleButton>
 
         <Panel x:Name="content"

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -50,6 +50,13 @@
                                             IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                             Tag="Null"
                                             Text="{x:Static lang:Strings.Null}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -3,7 +3,6 @@ using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
-using Beutl.Services;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
 
@@ -33,6 +32,8 @@ public partial class DisplacementMapTransformEditor : UserControl
                     await s_transition.Start(content, null, localToken);
                 }
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)
@@ -54,50 +55,5 @@ public partial class DisplacementMapTransformEditor : UserControl
             "Scale" => DispMapTransformType.Scale,
             _ => DispMapTransformType.Null
         });
-    }
-
-    private void SetNullClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel)
-        {
-            viewModel.SetNull();
-        }
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 }

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -66,10 +66,10 @@ public partial class DisplacementMapTransformEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -79,14 +79,25 @@ public partial class DisplacementMapTransformEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 }

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Beutl.Services;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
 
@@ -60,6 +61,32 @@ public partial class DisplacementMapTransformEditor : UserControl
         if (DataContext is DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.SetNull();
+        }
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
         }
     }
 }

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -19,28 +19,16 @@
     <Grid RowDefinitions="Auto,Auto">
         <ToggleButton x:Name="expandToggle"
                       Margin="8,4"
-                      ToolTip.Tip="{Binding Description.Value}"
                       IsChecked="{Binding IsExpanded.Value}"
                       IsVisible="{Binding !IsPresenter.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
-                                       FontWeight="Normal"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick"
-                                       FontWeight="Normal"
-                                       Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
+                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -71,7 +59,7 @@
                 </StackPanel>
             </ToggleButton.Tag>
             <WrapPanel Orientation="Horizontal">
-                <TextBlock FontWeight="DemiBold" Text="{Binding Header, FallbackValue=Filter}" />
+                <TextBlock Text="{Binding Header, FallbackValue=Filter}" />
                 <TextBlock Margin="8,0,0,0"
                            IsVisible="{Binding !IsGroupOrNull.Value}"
                            Text="{Binding FilterName.Value}" />
@@ -79,33 +67,22 @@
         </ToggleButton>
 
         <pe:ReferenceEditor Header="{Binding Header, FallbackValue=Filter}"
-                            ToolTip.Tip="{Binding Description.Value}"
                             IsVisible="{Binding IsPresenter.Value}"
                             SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
                             TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
-                <Button Margin="0,0,4,0"
+                <Button x:Name="ReferenceMenuButton"
+                        Margin="0,0,4,0"
                         Padding="0"
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:FAMenuFlyout>
                             <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
-                                               FontWeight="Normal"
                                                IconSource="New"
                                                Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick"
-                                               FontWeight="Normal"
-                                               Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                            <ui:MenuFlyoutItem Click="CopyClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanCopy.Value}"
-                                               Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanPaste.Value}"
-                                               Text="{x:Static lang:Strings.Paste}" />
+                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -24,7 +24,7 @@
                       IsVisible="{Binding !IsPresenter.Value}"
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
                                        FontWeight="Normal"
                                        IconSource="New"
@@ -32,12 +32,14 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
@@ -87,7 +89,7 @@
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                             <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
                                                FontWeight="Normal"
                                                IconSource="New"
@@ -95,12 +97,14 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                             <ui:MenuFlyoutItem Click="CopyClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanCopy.Value}"
                                                Text="{x:Static lang:Strings.Copy}" />
                             <ui:MenuFlyoutItem Click="PasteClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanPaste.Value}"
                                                Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -32,6 +32,13 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -88,6 +95,13 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Click="CopyClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Engine;
 using Beutl.Graphics.Effects;
@@ -61,9 +62,17 @@ public partial class FilterEffectEditor : UserControl
 
     private void Drop(object? sender, DragEventArgs e)
     {
-        if (e.DataTransfer.TryGetValue(BeutlDataFormats.FilterEffect) is { } typeName
-            && TypeFormat.ToType(typeName) is { } type
-            && DataContext is FilterEffectEditorViewModel { IsDisposed: false } viewModel)
+        if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (e.DataTransfer.TryGetValue(BeutlDataFormats.FilterEffect) is not { } data) return;
+
+        if (CoreObjectClipboard.IsJsonData(data))
+        {
+            if (viewModel.TryPasteJson(data))
+            {
+                e.Handled = true;
+            }
+        }
+        else if (TypeFormat.ToType(data) is { } type)
         {
             if (viewModel.IsGroup.Value)
             {
@@ -204,6 +213,32 @@ public partial class FilterEffectEditor : UserControl
         if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
 
         viewModel.SetNull();
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
     }
 
     private async void SelectTarget_Requested(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -12,6 +12,7 @@ using Beutl.Models;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -58,6 +59,9 @@ public partial class FilterEffectEditor : UserControl
                 _fallbackObjectView = new FallbackObjectView();
                 content.Children.Add(_fallbackObjectView);
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)
@@ -213,43 +217,6 @@ public partial class FilterEffectEditor : UserControl
         if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
 
         viewModel.SetNull();
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 
     private async void SelectTarget_Requested(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -217,10 +217,10 @@ public partial class FilterEffectEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -230,14 +230,25 @@ public partial class FilterEffectEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"
              d:DesignHeight="450"
              d:DesignWidth="400"
@@ -19,7 +21,20 @@
                           Content="{Binding FilterName.Value}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}" />
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
+                <ToggleButton.ContextFlyout>
+                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:MenuFlyoutItem Click="CopyClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanCopy.Value}"
+                                           Text="{x:Static lang:Strings.Copy}" />
+                        <ui:MenuFlyoutItem Click="PasteClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanPaste.Value}"
+                                           Text="{x:Static lang:Strings.Paste}" />
+                    </ui:FAMenuFlyout>
+                </ToggleButton.ContextFlyout>
+            </ToggleButton>
 
             <ToggleButton Grid.Column="1"
                           Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
@@ -5,8 +5,8 @@
              xmlns:icons="using:FluentIcons.FluentAvalonia"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
-             xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"
              d:DesignHeight="450"
@@ -14,27 +14,14 @@
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,Auto">
         <Grid Margin="8,0,0,0"
-              ToolTip.Tip="{Binding Description.Value}"
               ColumnDefinitions="*,Auto,Auto"
-              IsVisible="{Binding !IsPresenter.Value}">
+              IsVisible="{Binding !IsPresenter.Value}"
+              ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton x:Name="reorderHandle"
                           Content="{Binding FilterName.Value}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
-                <ToggleButton.ContextFlyout>
-                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
-                        <ui:MenuFlyoutItem Click="CopyClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanCopy.Value}"
-                                           Text="{x:Static lang:Strings.Copy}" />
-                        <ui:MenuFlyoutItem Click="PasteClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanPaste.Value}"
-                                           Text="{x:Static lang:Strings.Paste}" />
-                    </ui:FAMenuFlyout>
-                </ToggleButton.ContextFlyout>
-            </ToggleButton>
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}" />
 
             <ToggleButton Grid.Column="1"
                           Margin="4,0,0,0"
@@ -54,12 +41,12 @@
         </Grid>
 
         <pe:ReferenceEditor x:Name="presenterEditor"
-                             ToolTip.Tip="{Binding Description.Value}"
-                             Margin="8,0,0,0"
-                             EditorStyle="ListItem"
-                             IsVisible="{Binding IsPresenter.Value}"
-                             TargetName="{Binding CurrentTargetName.Value}"
-                             SelectTargetRequested="SelectTarget_Requested">
+                            Margin="8,0,0,0"
+                            EditorStyle="ListItem"
+                            IsVisible="{Binding IsPresenter.Value}"
+                            SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
+                            TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
                 <StackPanel Orientation="Horizontal">
                     <ToggleButton Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Interactivity;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Effects;
+using Beutl.Services;
 using Beutl.ViewModels.Editors;
 
 namespace Beutl.Views.Editors;
@@ -90,5 +91,42 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             vm,
             vm => vm.GetAvailableTargets(),
             (vm, target) => vm.SetTarget(target));
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            await vm.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
+        }
     }
 }

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
@@ -8,6 +8,7 @@ using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Effects;
 using Beutl.Services;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -60,6 +61,9 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             .Switch()
             .CombineLatest(presenterEditor.GetObservable(PropertyEditor.ReorderHandleProperty))
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
+
+        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle
@@ -91,42 +95,5 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             vm,
             vm => vm.GetAvailableTargets(),
             (vm, target) => vm.SetTarget(target));
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 }

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -22,7 +22,7 @@
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
@@ -32,12 +32,14 @@
                     <ui:MenuFlyoutItem Click="ImportFromSvgPathClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.ImportSvgPath}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -22,25 +22,13 @@
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:MenuFlyoutItem Click="SetNullClick"
-                                       FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
                     <ui:MenuFlyoutItem Click="InitializeClick"
-                                       FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Initialize}" />
                     <ui:MenuFlyoutItem Click="ImportFromSvgPathClick"
-                                       FontWeight="Normal"
                                        Text="{x:Static lang:Strings.ImportSvgPath}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -63,7 +51,7 @@
                 </Button>
             </ToggleButton.Tag>
             <WrapPanel Orientation="Horizontal">
-                <TextBlock FontWeight="DemiBold" Text="{Binding Header, FallbackValue=Filter}" />
+                <TextBlock Text="{Binding Header, FallbackValue=Filter}" />
                 <!--<TextBlock Margin="8,0,0,0"
                 IsVisible="{Binding !IsGroupOrNull.Value}"
                 Text="{Binding FilterName.Value}" />-->
@@ -76,7 +64,7 @@
                 <local:PropertiesEditor Padding="0"
                                         DataContext="{Binding Properties.Value}"
                                         IsVisible="{ReflectionBinding #root.DataContext.Properties.Value,
-                                        Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                                                      Converter={x:Static ObjectConverters.IsNotNull}}" />
 
                 <ItemsControl Margin="-16,0,0,0"
                               DataContext="{Binding Group.Value}"

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -32,6 +32,13 @@
                     <ui:MenuFlyoutItem Click="ImportFromSvgPathClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.ImportSvgPath}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -146,10 +146,10 @@ public partial class GeometryEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -160,15 +160,26 @@ public partial class GeometryEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception occurred while pasting the geometry.");
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 }

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -53,6 +53,8 @@ public partial class GeometryEditor : UserControl
                 _fallbackObjectView = new FallbackObjectView();
                 content.Children.Add(_fallbackObjectView);
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)
@@ -142,44 +144,5 @@ public partial class GeometryEditor : UserControl
 
         _logger.LogInformation("Initializing geometry type.");
         viewModel.ChangeGeometryType(typeof(PathGeometry));
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "An exception occurred while copying the geometry.");
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "An exception occurred while pasting the geometry.");
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 }

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -143,4 +143,32 @@ public partial class GeometryEditor : UserControl
         _logger.LogInformation("Initializing geometry type.");
         viewModel.ChangeGeometryType(typeof(PathGeometry));
     }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred while copying the geometry.");
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred while pasting the geometry.");
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
 }

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -35,6 +35,9 @@
                         <ui:FAMenuFlyout>
                             <ui:MenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
                             <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Click="CopyClick" Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick" Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
                     <icons:SymbolIcon Symbol="Compose" />

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -32,12 +32,16 @@
                         Click="Menu_Click"
                         Theme="{StaticResource TransparentButton}">
                     <Button.ContextFlyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                             <ui:MenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
                             <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
-                            <ui:MenuFlyoutSeparator />
-                            <ui:MenuFlyoutItem Click="CopyClick" Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick" Text="{x:Static lang:Strings.Paste}" />
+                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
+                            <ui:MenuFlyoutItem Click="CopyClick"
+                                               IsVisible="{Binding CanCopy.Value}"
+                                               Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick"
+                                               IsVisible="{Binding CanPaste.Value}"
+                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
                     <icons:SymbolIcon Symbol="Compose" />

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -19,12 +19,13 @@
     <Grid RowDefinitions="Auto,Auto">
         <ToggleButton x:Name="expandToggle"
                       Margin="8,4"
-                      ToolTip.Tip="{Binding Description.Value}"
                       Content="{Binding Header, FallbackValue=Pen}"
                       IsChecked="{Binding IsExpanded.Value}"
-                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}">
+                      Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
+                      ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.Tag>
-                <Button Width="24"
+                <Button x:Name="ExpandMenuButton"
+                        Width="24"
                         Height="24"
                         Padding="0"
                         HorizontalContentAlignment="Center"
@@ -32,16 +33,9 @@
                         Click="Menu_Click"
                         Theme="{StaticResource TransparentButton}">
                     <Button.ContextFlyout>
-                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:FAMenuFlyout>
                             <ui:MenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
                             <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
-                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                            <ui:MenuFlyoutItem Click="CopyClick"
-                                               IsVisible="{Binding CanCopy.Value}"
-                                               Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick"
-                                               IsVisible="{Binding CanPaste.Value}"
-                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
                     <icons:SymbolIcon Symbol="Compose" />

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -7,7 +7,7 @@ using Avalonia.Interactivity;
 using Beutl.Media;
 using Beutl.Services;
 using Beutl.ViewModels.Editors;
-
+using FluentAvalonia.UI.Controls;
 using static Beutl.Views.Editors.PropertiesEditor;
 
 namespace Beutl.Views.Editors;
@@ -56,6 +56,8 @@ public sealed partial class PenEditor : UserControl
                     await s_transition.Start(minorProps, null, localToken);
                 }
             });
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
     }
 
     private void InitializeClick(object? sender, RoutedEventArgs e)
@@ -80,43 +82,6 @@ public sealed partial class PenEditor : UserControl
         if (sender is Button button)
         {
             button.ContextFlyout?.ShowAt(button);
-        }
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
         }
     }
 }

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -85,10 +85,10 @@ public sealed partial class PenEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not PenEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -98,14 +98,25 @@ public sealed partial class PenEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not PenEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 }

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 
 using Beutl.Media;
+using Beutl.Services;
 using Beutl.ViewModels.Editors;
 
 using static Beutl.Views.Editors.PropertiesEditor;
@@ -79,6 +80,32 @@ public sealed partial class PenEditor : UserControl
         if (sender is Button button)
         {
             button.ContextFlyout?.ShowAt(button);
+        }
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not PenEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not PenEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
         }
     }
 }

--- a/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
@@ -21,9 +21,7 @@
                Grid.Row="1"
                Margin="8,4"
                IsVisible="False">
-            <TextBlock VerticalAlignment="Center"
-                       FontWeight="Bold"
-                       Text="{Binding GroupName}" />
+            <TextBlock VerticalAlignment="Center" Text="{Binding GroupName}" />
 
             <Button Padding="0"
                     HorizontalAlignment="Right"

--- a/src/Beutl/Views/Editors/SceneEditor.axaml
+++ b/src/Beutl/Views/Editors/SceneEditor.axaml
@@ -19,9 +19,7 @@
                     Theme="{StaticResource TransparentButton}">
                 <Button.Flyout>
                     <ui:FAMenuFlyout>
-                        <ui:MenuFlyoutItem Click="SetNullClick"
-                                           FontWeight="Normal"
-                                           Text="{x:Static lang:Strings.Null}" />
+                        <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                     </ui:FAMenuFlyout>
                 </Button.Flyout>
                 <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -23,23 +23,11 @@
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                <ui:FAMenuFlyout>
                     <ui:MenuFlyoutSubItem x:Name="ChangeTypeMenu"
-                                          FontWeight="Normal"
                                           IconSource="New"
                                           Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick"
-                                       FontWeight="Normal"
-                                       Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                    <ui:MenuFlyoutItem Click="CopyClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanCopy.Value}"
-                                       Text="{x:Static lang:Strings.Copy}" />
-                    <ui:MenuFlyoutItem Click="PasteClick"
-                                       FontWeight="Normal"
-                                       IsVisible="{Binding CanPaste.Value}"
-                                       Text="{x:Static lang:Strings.Paste}" />
+                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -69,37 +57,26 @@
                     </Button>
                 </StackPanel>
             </ToggleButton.Tag>
-            <TextBlock FontWeight="DemiBold" Text="{Binding Header, FallbackValue=Transform}" />
+            <TextBlock Text="{Binding Header, FallbackValue=Transform}" />
         </ToggleButton>
 
         <pe:ReferenceEditor Header="{Binding Header, FallbackValue=Transform}"
-                            ToolTip.Tip="{Binding Description.Value}"
                             IsVisible="{Binding IsPresenter.Value}"
                             SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
                             TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
-                <Button Margin="0,0,4,0"
+                <Button x:Name="ReferenceMenuButton"
+                        Margin="0,0,4,0"
                         Padding="0"
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:FAMenuFlyout>
                             <ui:MenuFlyoutSubItem x:Name="PresenterChangeTypeMenu"
-                                                  FontWeight="Normal"
                                                   IconSource="New"
                                                   Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick"
-                                               FontWeight="Normal"
-                                               Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
-                            <ui:MenuFlyoutItem Click="CopyClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanCopy.Value}"
-                                               Text="{x:Static lang:Strings.Copy}" />
-                            <ui:MenuFlyoutItem Click="PasteClick"
-                                               FontWeight="Normal"
-                                               IsVisible="{Binding CanPaste.Value}"
-                                               Text="{x:Static lang:Strings.Paste}" />
+                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />
@@ -119,7 +96,7 @@
                 <local:PropertiesEditor Padding="0"
                                         DataContext="{Binding Properties.Value}"
                                         IsVisible="{ReflectionBinding #root.DataContext.Properties.Value,
-                                        Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                                                      Converter={x:Static ObjectConverters.IsNotNull}}" />
             </controls:TreeLineDecorator>
 
             <ItemsControl DataContext="{Binding Group.Value}" ItemsSource="{Binding Items}">

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -23,7 +23,7 @@
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                     <ui:MenuFlyoutSubItem x:Name="ChangeTypeMenu"
                                           FontWeight="Normal"
                                           IconSource="New"
@@ -31,12 +31,14 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                     <ui:MenuFlyoutItem Click="CopyClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanCopy.Value}"
                                        Text="{x:Static lang:Strings.Copy}" />
                     <ui:MenuFlyoutItem Click="PasteClick"
                                        FontWeight="Normal"
+                                       IsVisible="{Binding CanPaste.Value}"
                                        Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
@@ -81,7 +83,7 @@
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
                             <ui:MenuFlyoutSubItem x:Name="PresenterChangeTypeMenu"
                                                   FontWeight="Normal"
                                                   IconSource="New"
@@ -89,12 +91,14 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
-                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutSeparator IsVisible="{Binding CanCopy.Value}" />
                             <ui:MenuFlyoutItem Click="CopyClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanCopy.Value}"
                                                Text="{x:Static lang:Strings.Copy}" />
                             <ui:MenuFlyoutItem Click="PasteClick"
                                                FontWeight="Normal"
+                                               IsVisible="{Binding CanPaste.Value}"
                                                Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -31,6 +31,13 @@
                     <ui:MenuFlyoutItem Click="SetNullClick"
                                        FontWeight="Normal"
                                        Text="{x:Static lang:Strings.Null}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:MenuFlyoutItem Click="CopyClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Copy}" />
+                    <ui:MenuFlyoutItem Click="PasteClick"
+                                       FontWeight="Normal"
+                                       Text="{x:Static lang:Strings.Paste}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -82,6 +89,13 @@
                             <ui:MenuFlyoutItem Click="SetNullClick"
                                                FontWeight="Normal"
                                                Text="{x:Static lang:Strings.Null}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Click="CopyClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Copy}" />
+                            <ui:MenuFlyoutItem Click="PasteClick"
+                                               FontWeight="Normal"
+                                               Text="{x:Static lang:Strings.Paste}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:SymbolIcon Symbol="MoreVertical" />

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -61,6 +61,9 @@ public partial class TransformEditor : UserControl
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
+
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)
@@ -216,43 +219,6 @@ public partial class TransformEditor : UserControl
         if (DataContext is TransformEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.SetNull();
-        }
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -221,10 +221,10 @@ public partial class TransformEditor : UserControl
 
     private async void CopyClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.CopyAsync();
+            await vm.CopyAsync();
         }
         catch (Exception ex)
         {
@@ -234,14 +234,25 @@ public partial class TransformEditor : UserControl
 
     private async void PasteClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
         try
         {
-            await viewModel.PasteAsync();
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
         }
         catch (Exception ex)
         {
             NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
         }
     }
 

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
 using Beutl.Models;
@@ -82,9 +83,19 @@ public partial class TransformEditor : UserControl
                 return KnownTransformType.Unknown;
         }
 
-        if (e.DataTransfer.TryGetValue(BeutlDataFormats.Transform) is { } typeName
-            && TypeFormat.ToType(typeName) is { } type
-            && DataContext is TransformEditorViewModel { IsDisposed: false } viewModel)
+        if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+        if (e.DataTransfer.TryGetValue(BeutlDataFormats.Transform) is not { } data) return;
+
+        if (CoreObjectClipboard.IsJsonData(data))
+        {
+            if (viewModel.TryPasteJson(data))
+            {
+                e.Handled = true;
+            }
+            return;
+        }
+
+        if (TypeFormat.ToType(data) is { } type)
         {
             KnownTransformType knownType = ToKnownType(type);
             if (knownType == KnownTransformType.Unknown)
@@ -205,6 +216,32 @@ public partial class TransformEditor : UserControl
         if (DataContext is TransformEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.SetNull();
+        }
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+        try
+        {
+            await viewModel.PasteAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
         }
     }
 

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml
@@ -4,6 +4,7 @@
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -25,6 +26,18 @@
                 <ToggleButton.Tag>
                     <ui:FAPathIcon Data="{Binding TransformType.Value, Converter={StaticResource TransformTypeToIconConverter}}" RenderTransform="scale(0.7)" />
                 </ToggleButton.Tag>
+                <ToggleButton.ContextFlyout>
+                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
+                        <ui:MenuFlyoutItem Click="CopyClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanCopy.Value}"
+                                           Text="{x:Static lang:Strings.Copy}" />
+                        <ui:MenuFlyoutItem Click="PasteClick"
+                                           FontWeight="Normal"
+                                           IsVisible="{Binding CanPaste.Value}"
+                                           Text="{x:Static lang:Strings.Paste}" />
+                    </ui:FAMenuFlyout>
+                </ToggleButton.ContextFlyout>
             </ToggleButton>
 
             <ToggleButton Grid.Column="1"

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml
@@ -6,8 +6,8 @@
              xmlns:icons="using:FluentIcons.FluentAvalonia"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
-             xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"
              d:DesignHeight="450"
@@ -18,26 +18,14 @@
               ColumnDefinitions="*,Auto,Auto"
               IsVisible="{Binding !IsPresenter.Value}">
             <ToggleButton x:Name="reorderHandle"
-                          ToolTip.Tip="{Binding Description.Value}"
                           Content="{Binding TransformName.Value}"
                           Cursor="SizeNorthSouth"
                           IsChecked="{Binding IsExpanded.Value}"
-                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
+                          Theme="{StaticResource ListEditorMiniExpanderToggleButton}"
+                          ToolTip.Tip="{Binding Description.Value}">
                 <ToggleButton.Tag>
                     <ui:FAPathIcon Data="{Binding TransformType.Value, Converter={StaticResource TransformTypeToIconConverter}}" RenderTransform="scale(0.7)" />
                 </ToggleButton.Tag>
-                <ToggleButton.ContextFlyout>
-                    <ui:FAMenuFlyout Opening="CopyPasteFlyout_Opening">
-                        <ui:MenuFlyoutItem Click="CopyClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanCopy.Value}"
-                                           Text="{x:Static lang:Strings.Copy}" />
-                        <ui:MenuFlyoutItem Click="PasteClick"
-                                           FontWeight="Normal"
-                                           IsVisible="{Binding CanPaste.Value}"
-                                           Text="{x:Static lang:Strings.Paste}" />
-                    </ui:FAMenuFlyout>
-                </ToggleButton.ContextFlyout>
             </ToggleButton>
 
             <ToggleButton Grid.Column="1"
@@ -58,12 +46,12 @@
         </Grid>
 
         <pe:ReferenceEditor x:Name="presenterEditor"
-                             ToolTip.Tip="{Binding Description.Value}"
-                             Margin="8,0,0,0"
-                             EditorStyle="ListItem"
-                             IsVisible="{Binding IsPresenter.Value}"
-                             TargetName="{Binding CurrentTargetName.Value}"
-                             SelectTargetRequested="SelectTarget_Requested">
+                            Margin="8,0,0,0"
+                            EditorStyle="ListItem"
+                            IsVisible="{Binding IsPresenter.Value}"
+                            SelectTargetRequested="SelectTarget_Requested"
+                            ToolTip.Tip="{Binding Description.Value}"
+                            TargetName="{Binding CurrentTargetName.Value}">
             <pe:ReferenceEditor.MenuContent>
                 <StackPanel Orientation="Horizontal">
                     <ToggleButton Margin="4,0,0,0"

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
@@ -9,6 +9,7 @@ using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
 using Beutl.Services;
 using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
@@ -62,6 +63,9 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             .Switch()
             .CombineLatest(presenterEditor.GetObservable(PropertyEditor.ReorderHandleProperty))
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
+
+        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle
@@ -93,43 +97,6 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             vm,
             vm => vm.GetAvailableTargets(),
             (vm, target) => vm.SetTarget(target));
-    }
-
-    private async void CopyClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            await vm.CopyAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void PasteClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-        try
-        {
-            if (!await vm.PasteAsync())
-            {
-                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
-            }
-        }
-        catch (Exception ex)
-        {
-            NotificationService.ShowError(Strings.Error, ex.Message);
-        }
-    }
-
-    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
-    {
-        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
-        {
-            await vm.RefreshCanPasteAsync();
-        }
     }
 
     private sealed class TransformTypeToIconConverter : IValueConverter

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Interactivity;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
+using Beutl.Services;
 using Beutl.ViewModels.Editors;
 
 namespace Beutl.Views.Editors;
@@ -92,6 +93,43 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             vm,
             vm => vm.GetAvailableTargets(),
             (vm, target) => vm.SetTarget(target));
+    }
+
+    private async void CopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            await vm.CopyAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void PasteClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+        try
+        {
+            if (!await vm.PasteAsync())
+            {
+                NotificationService.ShowInformation(Strings.Paste, MessageStrings.CannotPasteFromClipboard);
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.ShowError(Strings.Error, ex.Message);
+        }
+    }
+
+    private async void CopyPasteFlyout_Opening(object? sender, EventArgs e)
+    {
+        if (DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+        {
+            await vm.RefreshCanPasteAsync();
+        }
     }
 
     private sealed class TransformTypeToIconConverter : IValueConverter


### PR DESCRIPTION
## Description

- Add clipboard copy-paste functionality for core objects (FilterEffect, AudioEffect, Transform, Brush, Pen, Geometry, CoreObject) in property editors via context menu
- Introduce `CoreObjectClipboard` helper that handles JSON serialization/deserialization with proper ID regeneration
- Consolidate copy-paste logic into `BaseEditorViewModel` with reactive `CanCopy`/`CanPaste` properties, allowing each editor to opt in by overriding `PasteFormat`, `GetCopyTarget()`, and `TryPasteJson()`

## Breaking changes

None

## Fixed issues

None