### PR TITLE
feat: optimize color scopes rendering and add color space selection

### DIFF
--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
@@ -55,6 +55,9 @@ public sealed class ColorScopesTabViewModel : IToolContext
 
     public ReactivePropertySlim<float> HistogramHdrRange { get; } = new(1.0f);
 
+    // Shared settings
+    public ReactivePropertySlim<ScopeColorSpace> ColorSpace { get; } = new(ScopeColorSpace.Gamma);
+
     public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
 
     public void Dispose()
@@ -110,6 +113,15 @@ public sealed class ColorScopesTabViewModel : IToolContext
                 HistogramHdrRange.Value = histogramHdr;
             }
         }
+
+        // Shared settings
+        if (json.TryGetPropertyValue("colorSpace", out var colorSpaceNode) && colorSpaceNode is JsonValue colorSpaceValue)
+        {
+            if (colorSpaceValue.TryGetValue(out int colorSpace) && Enum.IsDefined(typeof(ScopeColorSpace), colorSpace))
+            {
+                ColorSpace.Value = (ScopeColorSpace)colorSpace;
+            }
+        }
     }
 
     public void WriteToJson(JsonObject json)
@@ -123,5 +135,8 @@ public sealed class ColorScopesTabViewModel : IToolContext
         // Histogram settings
         json["histogramMode"] = (int)HistogramMode.Value;
         json["histogramHdrRange"] = HistogramHdrRange.Value;
+
+        // Shared settings
+        json["colorSpace"] = (int)ColorSpace.Value;
     }
 }

--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ScopeColorSpace.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ScopeColorSpace.cs
@@ -1,0 +1,7 @@
+namespace Beutl.Editor.Components.ColorScopesTab.ViewModels;
+
+public enum ScopeColorSpace
+{
+    Gamma = 0,
+    Linear = 1
+}

--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ScopeColorSpace.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ScopeColorSpace.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Editor.Components.ColorScopesTab.ViewModels;
+﻿namespace Beutl.Editor.Components.ColorScopesTab.ViewModels;
 
 public enum ScopeColorSpace
 {

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
@@ -12,7 +12,7 @@
              x:DataType="viewModels:ColorScopesTabViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <Grid Height="32" ColumnDefinitions="Auto,Auto">
+        <Grid Height="32" ColumnDefinitions="Auto,Auto,Auto">
             <ComboBox Grid.Column="0"
                       Margin="8,0,0,0"
                       HorizontalAlignment="Stretch"
@@ -48,12 +48,23 @@
                     <ComboBoxItem Content="{x:Static lang:Strings.RgbParade}" />
                 </ComboBox>
             </Grid>
+
+            <ComboBox Grid.Column="2"
+                      Margin="8,0,0,0"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Center"
+                      SelectedIndex="{Binding ColorSpace.Value, Converter={x:Static scopes:ScopeColorSpaceConverter.Instance}}"
+                      Theme="{StaticResource LiteComboBoxStyle}">
+                <ComboBoxItem Content="{x:Static lang:Strings.Gamma}" />
+                <ComboBoxItem Content="{x:Static lang:Strings.Linear}" />
+            </ComboBox>
         </Grid>
 
         <Panel Grid.Row="1">
             <scopes:WaveformControl x:Name="WaveformControl"
                                     AxisBrush="{StaticResource ColorScopeAxisBrush}"
                                     BackgroundBrush="{StaticResource ColorScopeBackgroundBrush}"
+                                    ColorSpace="{Binding ColorSpace.Value}"
                                     HdrRange="{Binding WaveformHdrRange.Value, Mode=TwoWay}"
                                     IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Waveform}"
                                     LabelBrush="{StaticResource ColorScopeLabelBrush}"
@@ -63,6 +74,7 @@
             <scopes:HistogramControl x:Name="HistogramControl"
                                      AxisBrush="{StaticResource ColorScopeAxisBrush}"
                                      BackgroundBrush="{StaticResource ColorScopeBackgroundBrush}"
+                                     ColorSpace="{Binding ColorSpace.Value}"
                                      HdrRange="{Binding HistogramHdrRange.Value, Mode=TwoWay}"
                                      IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Histogram}"
                                      LabelBrush="{StaticResource ColorScopeLabelBrush}"
@@ -72,6 +84,7 @@
             <scopes:VectorscopeControl x:Name="VectorscopeControl"
                                        AxisBrush="{StaticResource ColorScopeAxisBrush}"
                                        BackgroundBrush="{StaticResource ColorScopeBackgroundBrush}"
+                                       ColorSpace="{Binding ColorSpace.Value}"
                                        IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Vectorscope}"
                                        LabelBrush="{StaticResource ColorScopeLabelBrush}"
                                        SourceBitmap="{Binding SourceBitmap.Value}" />

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HistogramControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HistogramControl.cs
@@ -21,6 +21,13 @@ public class HistogramControl : HdrScopeControlBase
 
     private HistogramMode _mode = HistogramMode.Overlay;
 
+    // Cached histogram bin arrays (reused across frames to avoid per-frame allocation)
+    // Thread safety: _renderLock in ScopeControlBase serializes RenderScope calls
+    private readonly int[] _rHist = new int[256];
+    private readonly int[] _gHist = new int[256];
+    private readonly int[] _bHist = new int[256];
+    private readonly object _histLock = new();
+
     private static readonly string[] s_horizontalLabelsSdr = ["0", "0.3", "0.5", "0.8", "1.0"];
     private static readonly (float R, float G, float B) s_colorRed = (1.00f, 0.25f, 0.25f);
     private static readonly (float R, float G, float B) s_colorGreen = (0.25f, 1.00f, 0.35f);
@@ -53,11 +60,13 @@ public class HistogramControl : HdrScopeControlBase
         int targetHeight,
         WriteableBitmap? existingBitmap)
     {
-        // Calculate histograms using RgbaF16 for HDR support
         const int binCount = 256;
-        var rHist = new int[binCount];
-        var gHist = new int[binCount];
-        var bHist = new int[binCount];
+        int[] rHist = _rHist;
+        int[] gHist = _gHist;
+        int[] bHist = _bHist;
+        Array.Clear(rHist);
+        Array.Clear(gHist);
+        Array.Clear(bHist);
 
         int sourceWidth = sourceBitmap.Width;
         int sourceHeight = sourceBitmap.Height;
@@ -81,30 +90,53 @@ public class HistogramControl : HdrScopeControlBase
         try
         {
             bool premul = rgbaF16.AlphaType == BitmapAlphaType.Premul;
-            for (int y = 0; y < sourceHeight; y += yStep)
-            {
-                var row = rgbaF16.GetRow<RgbaF16>(y);
-                for (int x = 0; x < sourceWidth; x += xStep)
+            int yCount = (sourceHeight + yStep - 1) / yStep;
+
+            // Parallelize binning with per-task local histograms, merged at the end
+            var rgbaF16Local = rgbaF16; // capture for closure
+            Parallel.For(0, yCount,
+                () => (new int[binCount], new int[binCount], new int[binCount]),
+                (yi, _, local) =>
                 {
-                    RgbaF16 pixel = row[x];
-                    float r = (float)pixel.R;
-                    float g = (float)pixel.G;
-                    float b = (float)pixel.B;
-                    float a = (float)pixel.A;
-
-                    if (premul && a > 0f && a < 1f)
+                    int y = yi * yStep;
+                    var (lR, lG, lB) = local;
+                    // ReSharper disable once AccessToDisposedClosure
+                    var row = rgbaF16Local.GetRow<RgbaF16>(y);
+                    for (int x = 0; x < sourceWidth; x += xStep)
                     {
-                        float invA = 1f / a;
-                        r *= invA;
-                        g *= invA;
-                        b *= invA;
-                    }
+                        RgbaF16 pixel = row[x];
+                        float r = (float)pixel.R;
+                        float g = (float)pixel.G;
+                        float b = (float)pixel.B;
+                        float a = (float)pixel.A;
 
-                    rHist[Math.Clamp((int)(r * binScale + 0.5f), 0, binCount - 1)]++;
-                    gHist[Math.Clamp((int)(g * binScale + 0.5f), 0, binCount - 1)]++;
-                    bHist[Math.Clamp((int)(b * binScale + 0.5f), 0, binCount - 1)]++;
-                }
-            }
+                        if (premul && a > 0f && a < 1f)
+                        {
+                            float invA = 1f / a;
+                            r *= invA;
+                            g *= invA;
+                            b *= invA;
+                        }
+
+                        lR[Math.Clamp((int)(r * binScale + 0.5f), 0, binCount - 1)]++;
+                        lG[Math.Clamp((int)(g * binScale + 0.5f), 0, binCount - 1)]++;
+                        lB[Math.Clamp((int)(b * binScale + 0.5f), 0, binCount - 1)]++;
+                    }
+                    return local;
+                },
+                local =>
+                {
+                    var (lR, lG, lB) = local;
+                    lock (_histLock)
+                    {
+                        for (int i = 0; i < binCount; i++)
+                        {
+                            rHist[i] += lR[i];
+                            gHist[i] += lG[i];
+                            bHist[i] += lB[i];
+                        }
+                    }
+                });
         }
         finally
         {
@@ -139,13 +171,22 @@ public class HistogramControl : HdrScopeControlBase
         return bitmap;
     }
 
+    private static (int rMax, int gMax, int bMax) ComputeMax(int[] rHist, int[] gHist, int[] bHist)
+    {
+        int rMax = 0, gMax = 0, bMax = 0;
+        for (int i = 0; i < 256; i++)
+        {
+            if (rHist[i] > rMax) rMax = rHist[i];
+            if (gHist[i] > gMax) gMax = gHist[i];
+            if (bHist[i] > bMax) bMax = bHist[i];
+        }
+        return (rMax, gMax, bMax);
+    }
+
     private void RenderOverlayMode(int[] rHist, int[] gHist, int[] bHist, Span<uint> dest, int stridePixels, int targetWidth, int targetHeight)
     {
-        int rMax = rHist.Max();
-        int gMax = gHist.Max();
-        int bMax = bHist.Max();
-        int max = Math.Max(rMax, Math.Max(gMax, bMax));
-        max = Math.Max(max, 1);
+        var (rMax, gMax, bMax) = ComputeMax(rHist, gHist, bHist);
+        int max = Math.Max(1, Math.Max(rMax, Math.Max(gMax, bMax)));
 
         // Pre-compute colors (DaVinci Resolve style)
         uint redColor = PackColor(
@@ -164,40 +205,44 @@ public class HistogramControl : HdrScopeControlBase
             (byte)(s_colorBlue.B * 200),
             180);
 
-        // Render histogram bars
+        // Render histogram bars with per-bin pre-computed zone colors (no per-pixel branching/blending)
         for (int i = 0; i < 256; i++)
         {
             int x = i * targetWidth / 256;
             int nextX = (i + 1) * targetWidth / 256;
             int barWidth = Math.Max(1, nextX - x);
+            int barEnd = Math.Min(x + barWidth, stridePixels);
 
-            int rHeight = rHist[i] * targetHeight / max;
-            int gHeight = gHist[i] * targetHeight / max;
-            int bHeight = bHist[i] * targetHeight / max;
+            // Sort (height, color) triples ascending by height
+            (int H, uint C) a = (rHist[i] * targetHeight / max, redColor);
+            (int H, uint C) b = (gHist[i] * targetHeight / max, greenColor);
+            (int H, uint C) c = (bHist[i] * targetHeight / max, blueColor);
+            if (a.H > b.H) (a, b) = (b, a);
+            if (b.H > c.H) (b, c) = (c, b);
+            if (a.H > b.H) (a, b) = (b, a);
+            // Now a.H <= b.H <= c.H
 
-            int maxHeight = Math.Max(rHeight, Math.Max(gHeight, bHeight));
+            // Zones: [0, a.H) = a+b+c, [a.H, b.H) = b+c, [b.H, c.H) = c
+            uint zone0 = BlendAdd(BlendAdd(BlendAdd(0u, a.C), b.C), c.C);
+            uint zone1 = BlendAdd(BlendAdd(0u, b.C), c.C);
+            uint zone2 = BlendAdd(0u, c.C);
 
-            for (int bx = x; bx < x + barWidth && bx < stridePixels; bx++)
+            // Clamp to target bounds
+            int h0 = Math.Min(a.H, targetHeight);
+            int h1 = Math.Min(b.H, targetHeight);
+            int h2 = Math.Min(c.H, targetHeight);
+
+            for (int bx = x; bx < barEnd; bx++)
             {
-                for (int y = 0; y < maxHeight && y < targetHeight; y++)
-                {
-                    int destY = targetHeight - 1 - y;
-                    if (destY < 0) continue;
-
-                    int destIndex = destY * stridePixels + bx;
-                    if (destIndex >= dest.Length) continue;
-
-                    uint color = dest[destIndex];
-
-                    if (y < rHeight)
-                        color = BlendAdd(color, redColor);
-                    if (y < gHeight)
-                        color = BlendAdd(color, greenColor);
-                    if (y < bHeight)
-                        color = BlendAdd(color, blueColor);
-
-                    dest[destIndex] = color;
-                }
+                // Zone 0 (all 3 channels): rows [targetHeight - h0, targetHeight)
+                for (int y = 0; y < h0; y++)
+                    dest[(targetHeight - 1 - y) * stridePixels + bx] = zone0;
+                // Zone 1 (2 channels): rows [targetHeight - h1, targetHeight - h0)
+                for (int y = h0; y < h1; y++)
+                    dest[(targetHeight - 1 - y) * stridePixels + bx] = zone1;
+                // Zone 2 (1 channel): rows [targetHeight - h2, targetHeight - h1)
+                for (int y = h1; y < h2; y++)
+                    dest[(targetHeight - 1 - y) * stridePixels + bx] = zone2;
             }
         }
     }
@@ -210,9 +255,10 @@ public class HistogramControl : HdrScopeControlBase
         int gSectionStart = sectionHeight;
         int bSectionStart = sectionHeight * 2;
 
-        int rMax = Math.Max(1, rHist.Max());
-        int gMax = Math.Max(1, gHist.Max());
-        int bMax = Math.Max(1, bHist.Max());
+        var (rMaxR, gMaxR, bMaxR) = ComputeMax(rHist, gHist, bHist);
+        int rMax = Math.Max(1, rMaxR);
+        int gMax = Math.Max(1, gMaxR);
+        int bMax = Math.Max(1, bMaxR);
 
         // Pre-compute colors (DaVinci Resolve style)
         uint redColor = PackColor(
@@ -231,53 +277,45 @@ public class HistogramControl : HdrScopeControlBase
             (byte)(s_colorBlue.B * 220),
             200);
 
+        // Pre-blend once (each bar writes to a unique pixel within its section)
+        uint redBlended = BlendAdd(0u, redColor);
+        uint greenBlended = BlendAdd(0u, greenColor);
+        uint blueBlended = BlendAdd(0u, blueColor);
+
         // Render each channel in its section
         for (int i = 0; i < 256; i++)
         {
             int x = i * targetWidth / 256;
             int nextX = (i + 1) * targetWidth / 256;
             int barWidth = Math.Max(1, nextX - x);
+            int barEnd = Math.Min(x + barWidth, stridePixels);
 
-            int rHeight = rHist[i] * sectionHeight / rMax;
-            int gHeight = gHist[i] * sectionHeight / gMax;
-            int bHeight = bHist[i] * sectionHeight / bMax;
+            int rHeight = Math.Min(rHist[i] * sectionHeight / rMax, sectionHeight);
+            int gHeight = Math.Min(gHist[i] * sectionHeight / gMax, sectionHeight);
+            int bHeight = Math.Min(bHist[i] * sectionHeight / bMax, sectionHeight);
 
-            for (int bx = x; bx < x + barWidth && bx < stridePixels; bx++)
+            for (int bx = x; bx < barEnd; bx++)
             {
-                // Red section (top) - draws from bottom of section upward
-                for (int y = 0; y < rHeight && y < sectionHeight; y++)
+                // Red section (top) - fill from bottom of section upward
+                for (int y = 0; y < rHeight; y++)
                 {
                     int destY = rSectionStart + sectionHeight - 1 - y;
-                    if (destY < 0 || destY >= targetHeight) continue;
-
-                    int destIndex = destY * stridePixels + bx;
-                    if (destIndex >= dest.Length) continue;
-
-                    dest[destIndex] = BlendAdd(dest[destIndex], redColor);
+                    if ((uint)destY < (uint)targetHeight)
+                        dest[destY * stridePixels + bx] = redBlended;
                 }
-
-                // Green section (middle) - draws from bottom of section upward
-                for (int y = 0; y < gHeight && y < sectionHeight; y++)
+                // Green section (middle)
+                for (int y = 0; y < gHeight; y++)
                 {
                     int destY = gSectionStart + sectionHeight - 1 - y;
-                    if (destY < 0 || destY >= targetHeight) continue;
-
-                    int destIndex = destY * stridePixels + bx;
-                    if (destIndex >= dest.Length) continue;
-
-                    dest[destIndex] = BlendAdd(dest[destIndex], greenColor);
+                    if ((uint)destY < (uint)targetHeight)
+                        dest[destY * stridePixels + bx] = greenBlended;
                 }
-
-                // Blue section (bottom) - draws from bottom of section upward
-                for (int y = 0; y < bHeight && y < sectionHeight; y++)
+                // Blue section (bottom)
+                for (int y = 0; y < bHeight; y++)
                 {
                     int destY = bSectionStart + sectionHeight - 1 - y;
-                    if (destY < 0 || destY >= targetHeight) continue;
-
-                    int destIndex = destY * stridePixels + bx;
-                    if (destIndex >= dest.Length) continue;
-
-                    dest[destIndex] = BlendAdd(dest[destIndex], blueColor);
+                    if ((uint)destY < (uint)targetHeight)
+                        dest[destY * stridePixels + bx] = blueBlended;
                 }
             }
         }

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HistogramControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HistogramControl.cs
@@ -75,15 +75,18 @@ public class HistogramControl : HdrScopeControlBase
         float hdrRange = HdrRange;
         float binScale = (binCount - 1) / hdrRange;
 
+        BitmapColorSpace targetColorSpace = ColorSpace == ViewModels.ScopeColorSpace.Linear
+            ? BitmapColorSpace.LinearSrgb
+            : BitmapColorSpace.Srgb;
         BtlBitmap rgbaF16;
         bool requireDispose = false;
-        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == BitmapColorSpace.Srgb)
+        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == targetColorSpace)
         {
             rgbaF16 = sourceBitmap;
         }
         else
         {
-            rgbaF16 = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, BitmapColorSpace.Srgb);
+            rgbaF16 = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, targetColorSpace);
             requireDispose = true;
         }
 

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeColorSpaceConverter.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeColorSpaceConverter.cs
@@ -1,0 +1,29 @@
+using Avalonia.Data.Converters;
+using Beutl.Editor.Components.ColorScopesTab.ViewModels;
+
+namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;
+
+public sealed class ScopeColorSpaceConverter : IValueConverter
+{
+    public static readonly ScopeColorSpaceConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is ScopeColorSpace colorSpace)
+        {
+            return (int)colorSpace;
+        }
+
+        return 0;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int index && Enum.IsDefined(typeof(ScopeColorSpace), index))
+        {
+            return (ScopeColorSpace)index;
+        }
+
+        return ScopeColorSpace.Gamma;
+    }
+}

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeColorSpaceConverter.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeColorSpaceConverter.cs
@@ -1,4 +1,4 @@
-using Avalonia.Data.Converters;
+﻿using Avalonia.Data.Converters;
 using Beutl.Editor.Components.ColorScopesTab.ViewModels;
 
 namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeControlBase.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeControlBase.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System.Runtime.CompilerServices;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -308,11 +309,13 @@ public abstract class ScopeControlBase : Control
         _backBuffer = null;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static uint PackColor(byte r, byte g, byte b, byte a = 255)
     {
         return (uint)(b | (g << 8) | (r << 16) | (a << 24));
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static void PlotPoint(Span<uint> dest, int stride, int x, int y, uint color)
     {
         int height = dest.Length / stride;
@@ -325,6 +328,7 @@ public abstract class ScopeControlBase : Control
         dest[idx] = newA > existingA ? color : BlendAdd(existing, color);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static uint BlendAdd(uint dst, uint src)
     {
         byte db = (byte)(dst);

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeControlBase.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ScopeControlBase.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using Beutl.Editor.Components.ColorScopesTab.ViewModels;
 using Beutl.Media.Source;
 using BtlBitmap = Beutl.Media.Bitmap;
 
@@ -26,6 +27,12 @@ public abstract class ScopeControlBase : Control
     public static readonly StyledProperty<double> AxisMarginProperty =
         AvaloniaProperty.Register<ScopeControlBase, double>(nameof(AxisMargin), 32);
 
+    public static readonly DirectProperty<ScopeControlBase, ScopeColorSpace> ColorSpaceProperty =
+        AvaloniaProperty.RegisterDirect<ScopeControlBase, ScopeColorSpace>(
+            nameof(ColorSpace), o => o.ColorSpace, (o, v) => o.ColorSpace = v, ScopeColorSpace.Gamma);
+
+    private ScopeColorSpace _colorSpace = ScopeColorSpace.Gamma;
+
     protected static readonly Typeface DefaultTypeface = new(FontFamily.Default, FontStyle.Normal, FontWeight.Normal);
 
     private readonly Pen _axisPen = new(Brushes.Gray, 1.5);
@@ -47,10 +54,13 @@ public abstract class ScopeControlBase : Control
             AxisBrushProperty,
             LabelBrushProperty,
             BackgroundBrushProperty,
-            AxisMarginProperty);
+            AxisMarginProperty,
+            ColorSpaceProperty);
 
         AxisBrushProperty.Changed.AddClassHandler<ScopeControlBase>((s, e) =>
             s._axisPen.Brush = (e.NewValue as IBrush) ?? Brushes.Gray);
+
+        ColorSpaceProperty.Changed.AddClassHandler<ScopeControlBase>((o, _) => o.Refresh());
     }
 
     public Ref<BtlBitmap>? SourceBitmap
@@ -81,6 +91,12 @@ public abstract class ScopeControlBase : Control
     {
         get => GetValue(AxisMarginProperty);
         set => SetValue(AxisMarginProperty, value);
+    }
+
+    public ScopeColorSpace ColorSpace
+    {
+        get => _colorSpace;
+        set => SetAndRaise(ColorSpaceProperty, ref _colorSpace, value);
     }
 
     protected abstract string[]? VerticalAxisLabels { get; }

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/VectorscopeControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/VectorscopeControl.cs
@@ -2,6 +2,7 @@
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using Beutl.Editor.Components.ColorScopesTab.ViewModels;
 using Beutl.Media;
 using Beutl.Media.Pixel;
 using Brushes = Avalonia.Media.Brushes;
@@ -78,23 +79,25 @@ public class VectorscopeControl : ScopeControlBase
         int sourceHeight = sourceBitmap.Height;
         int step = Math.Max(1, Math.Max(sourceWidth, sourceHeight) / size);
 
-        BtlBitmap rgbaGamma;
+        BitmapColorSpace targetColorSpace = ColorSpace == ViewModels.ScopeColorSpace.Linear
+            ? BitmapColorSpace.LinearSrgb
+            : BitmapColorSpace.Srgb;
+        BtlBitmap rgbaConverted;
         bool requireDispose = false;
-        // TODO: Linear/Gammaを切り替えられるようにする
-        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == BitmapColorSpace.Srgb)
+        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == targetColorSpace)
         {
-            rgbaGamma = sourceBitmap;
+            rgbaConverted = sourceBitmap;
         }
         else
         {
-            rgbaGamma = sourceBitmap.Convert(BitmapColorType.RgbaF16, colorSpace: BitmapColorSpace.Srgb);
+            rgbaConverted = sourceBitmap.Convert(BitmapColorType.RgbaF16, colorSpace: targetColorSpace);
             requireDispose = true;
         }
 
         try
         {
             int rowCount = (sourceHeight + step - 1) / step;
-            var rgbaGammaLocal = rgbaGamma;
+            var rgbaConvertedLocal = rgbaConverted;
             int sizeMinus1 = size - 1;
 
             // Parallelize row scanning. The read-modify-write on destPtr[idx] is NOT atomic,
@@ -107,7 +110,7 @@ public class VectorscopeControl : ScopeControlBase
                 int y = yi * step;
                 if (y >= sourceHeight) return;
                 // ReSharper disable once AccessToDisposedClosure
-                var row = rgbaGammaLocal.GetRow<RgbaF16>(y);
+                var row = rgbaConvertedLocal.GetRow<RgbaF16>(y);
                 for (int x = 0; x < sourceWidth; x += step)
                 {
                     RgbaF16 pixel = row[x];
@@ -145,7 +148,7 @@ public class VectorscopeControl : ScopeControlBase
         {
             if (requireDispose)
             {
-                rgbaGamma.Dispose();
+                rgbaConverted.Dispose();
             }
         }
 

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/VectorscopeControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/VectorscopeControl.cs
@@ -68,9 +68,11 @@ public class VectorscopeControl : ScopeControlBase
                 AlphaFormat.Premul);
 
         using ILockedFramebuffer fb = bitmap.Lock();
-        var dest = new Span<uint>((void*)fb.Address, (fb.RowBytes * fb.Size.Height) / sizeof(uint));
-        dest.Fill(PackColor(0, 0, 0, 0));
+        uint* destPtr = (uint*)fb.Address;
         int stridePixels = fb.RowBytes / sizeof(uint);
+        int destHeight = fb.Size.Height;
+        int destLength = stridePixels * destHeight;
+        new Span<uint>(destPtr, destLength).Fill(PackColor(0, 0, 0, 0));
 
         int sourceWidth = sourceBitmap.Width;
         int sourceHeight = sourceBitmap.Height;
@@ -91,15 +93,27 @@ public class VectorscopeControl : ScopeControlBase
 
         try
         {
-            for (int y = 0; y < sourceHeight; y += step)
+            int rowCount = (sourceHeight + step - 1) / step;
+            var rgbaGammaLocal = rgbaGamma;
+            int sizeMinus1 = size - 1;
+
+            // Parallelize row scanning. The read-modify-write on destPtr[idx] is NOT atomic,
+            // so concurrent threads may overwrite each other's BlendAdd contributions at the same
+            // pixel. This is a deliberate trade-off: collisions are rare (230K samples → 262K pixels),
+            // and the visual impact of occasionally losing one sample contribution is imperceptible
+            // on a dense vectorscope display.
+            Parallel.For(0, rowCount, yi =>
             {
-                var row = rgbaGamma.GetRow<RgbaF16>(y);
+                int y = yi * step;
+                if (y >= sourceHeight) return;
+                // ReSharper disable once AccessToDisposedClosure
+                var row = rgbaGammaLocal.GetRow<RgbaF16>(y);
                 for (int x = 0; x < sourceWidth; x += step)
                 {
                     RgbaF16 pixel = row[x];
-                    var r = (float)pixel.R;
-                    var g = (float)pixel.G;
-                    var b = (float)pixel.B;
+                    float r = (float)pixel.R;
+                    float g = (float)pixel.G;
+                    float b = (float)pixel.B;
 
                     // Convert RGB to CbCr (YCbCr color space)
                     float cb = -0.11457f * r - 0.38543f * g + 0.5f * b;
@@ -108,13 +122,24 @@ public class VectorscopeControl : ScopeControlBase
                     byte cb8 = (byte)Math.Clamp(MathF.Round(cb * 255f + 128f), 0, 255);
                     byte cr8 = (byte)Math.Clamp(MathF.Round(cr * 255f + 128f), 0, 255);
 
-                    int vx = cb8 * (size - 1) / 255;
-                    int vy = (255 - cr8) * (size - 1) / 255;
+                    int vx = cb8 * sizeMinus1 / 255;
+                    int vy = (255 - cr8) * sizeMinus1 / 255;
 
-                    var c = Media.Color.FromRgb((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
-                    PlotPoint(dest, stridePixels, vx, vy, PackColor(c.R, c.G, c.B, 180));
+                    // Inline byte conversion (no Color.FromRgb allocation)
+                    byte r8 = (byte)Math.Clamp((int)(r * 255f), 0, 255);
+                    byte g8 = (byte)Math.Clamp((int)(g * 255f), 0, 255);
+                    byte b8 = (byte)Math.Clamp((int)(b * 255f), 0, 255);
+                    uint color = PackColor(r8, g8, b8, 180);
+
+                    if ((uint)vx < (uint)stridePixels && (uint)vy < (uint)destHeight)
+                    {
+                        int idx = vy * stridePixels + vx;
+                        uint existing = destPtr[idx];
+                        byte existingA = (byte)(existing >> 24);
+                        destPtr[idx] = 180 > existingA ? color : BlendAdd(existing, color);
+                    }
                 }
-            }
+            });
         }
         finally
         {

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+using System.Runtime.CompilerServices;
+using Avalonia;
 using Avalonia.Layout;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -118,10 +119,8 @@ public class WaveformControl : HdrScopeControlBase
         float[]? gridStrength = showGrid ? GetGridStrength(targetHeight, hdrRange) : null;
         int sampleCount = (int)Math.Clamp(sourceBitmap.Height * 0.25f, 32f, 1024f);
         float invSamplesGain = gain / Math.Max(sampleCount, 1);
-
-        // Pre-compute inverse values to avoid division in hot loops
         float invTargetWidth = 1f / targetWidth;
-        float invSampleCount = 1f / sampleCount;
+        float invHdr = 1f / MathF.Max(hdrRange, 1e-6f);
 
         // Pre-compute Gaussian kernel LUT (shared across all samples since thickness is constant per frame)
         int kernelRadius = Math.Max((int)MathF.Ceiling(thickness * 3f), 1);
@@ -133,6 +132,28 @@ public class WaveformControl : HdrScopeControlBase
             float dv = (k - kernelRadius) * invKernelDenom;
             float dSq = dv * dv;
             kernelArr[k] = 1f / (1f + dSq + 0.5f * dSq * dSq);
+        }
+
+        // Pre-compute srcY indices (shared across all columns)
+        float invSampleCount = 1f / sampleCount;
+        int[] srcYArr = new int[sampleCount];
+        for (int i = 0; i < sampleCount; i++)
+            srcYArr[i] = Math.Clamp((int)((i + 0.5f) * invSampleCount * sourceHeight), 0, sourceHeight - 1);
+
+        // Pre-compute srcX and parade band per column
+        int[] srcXArr = new int[targetWidth];
+        int[]? paradeBandArr = mode == WaveformMode.RgbParade ? new int[targetWidth] : null;
+        for (int x = 0; x < targetWidth; x++)
+        {
+            float x01 = (x + 0.5f) * invTargetWidth;
+            if (paradeBandArr != null)
+            {
+                float x3 = x01 * 3f;
+                int band = Math.Min(2, (int)MathF.Floor(x3));
+                paradeBandArr[x] = band;
+                x01 = x3 - band;
+            }
+            srcXArr[x] = Math.Clamp((int)(x01 * sourceWidth), 0, sourceWidth - 1);
         }
 
         using ILockedFramebuffer fb = result.Lock();
@@ -152,8 +173,10 @@ public class WaveformControl : HdrScopeControlBase
         {
             byte* destPtr = (byte*)fb.Address;
             int destRowBytes = fb.RowBytes;
+            // Direct data access — bypasses GetRow overhead (ThrowIfDisposed + ThrowRowOutOfRange + MemoryMarshal.Cast) per sample
+            byte* srcData = (byte*)rgbaSrgb.Data;
+            int srcRowBytes = rgbaSrgb.RowBytes;
             bool premul = rgbaSrgb.AlphaType == BitmapAlphaType.Premul;
-            var rgbaSrgbLocal = rgbaSrgb; // capture stable reference for closure
 
             Parallel.For(0, targetWidth,
                 // Per-thread local: reuse 4 float buffers across columns to avoid stackalloc / heap alloc per iteration
@@ -173,52 +196,25 @@ public class WaveformControl : HdrScopeControlBase
                     Array.Clear(bBuf);
                     Array.Clear(yBuf);
 
-                    float x01 = (x + 0.5f) * invTargetWidth;
-                    float paradeBand = 0f;
+                    int srcX = srcXArr[x];
 
-                    if (mode == WaveformMode.RgbParade)
+                    // Mode-specific sampling — eliminates per-sample branching
+                    if (mode == WaveformMode.Luma)
                     {
-                        float x3 = x01 * 3f;
-                        paradeBand = MathF.Min(2f, MathF.Floor(x3));
-                        x01 = x3 - paradeBand;
+                        SampleLuma(srcData, srcRowBytes, srcX, srcYArr, sampleCount, premul,
+                            yBuf, targetHeight, invHdr, kernelArr, kernelRadius);
                     }
-
-                    int srcX = Math.Clamp((int)(x01 * sourceWidth), 0, sourceWidth - 1);
-
-                    for (int i = 0; i < sampleCount; i++)
+                    else if (mode == WaveformMode.RgbOverlay)
                     {
-                        int srcY = Math.Clamp((int)((i + 0.5f) * invSampleCount * sourceHeight), 0, sourceHeight - 1);
-
-                        // ReSharper disable once AccessToDisposedClosure
-                        RgbaF16 sample = rgbaSrgbLocal.GetRow<RgbaF16>(srcY)[srcX];
-                        float r = (float)sample.R;
-                        float g = (float)sample.G;
-                        float b = (float)sample.B;
-                        float a = (float)sample.A;
-
-                        if (a > 0f && a < 1f && premul)
-                        {
-                            float invA = 1f / a;
-                            r *= invA;
-                            g *= invA;
-                            b *= invA;
-                        }
-
-                        if (mode == WaveformMode.Luma)
-                        {
-                            float y = (0.2126f * r) + (0.7152f * g) + (0.0722f * b);
-                            AddContribution(yBuf, y, targetHeight, hdrRange, kernelArr, kernelRadius);
-                        }
-                        else if (mode == WaveformMode.RgbOverlay)
-                        {
-                            AddContributionRgb(rBuf, gBuf, bBuf, r, g, b, targetHeight, hdrRange, kernelArr, kernelRadius);
-                        }
-                        else
-                        {
-                            float channel = paradeBand < 0.5f ? r : paradeBand < 1.5f ? g : b;
-                            float[] target = paradeBand < 0.5f ? rBuf : paradeBand < 1.5f ? gBuf : bBuf;
-                            AddContribution(target, channel, targetHeight, hdrRange, kernelArr, kernelRadius);
-                        }
+                        SampleRgbOverlay(srcData, srcRowBytes, srcX, srcYArr, sampleCount, premul,
+                            rBuf, gBuf, bBuf, targetHeight, invHdr, kernelArr, kernelRadius);
+                    }
+                    else
+                    {
+                        int band = paradeBandArr![x];
+                        float[] target = band == 0 ? rBuf : band == 1 ? gBuf : bBuf;
+                        SampleParade(srcData, srcRowBytes, srcX, srcYArr, sampleCount, premul, band,
+                            target, targetHeight, invHdr, kernelArr, kernelRadius);
                     }
 
                     WriteColumn(
@@ -237,6 +233,90 @@ public class WaveformControl : HdrScopeControlBase
         }
 
         return result;
+    }
+
+    private static unsafe void SampleLuma(
+        byte* srcData, int srcRowBytes, int srcX, int[] srcYArr, int sampleCount, bool premul,
+        float[] yBuf, int height, float invHdr, float[] kernel, int radius)
+    {
+        for (int i = 0; i < sampleCount; i++)
+        {
+            RgbaF16* pixel = (RgbaF16*)(srcData + (long)srcYArr[i] * srcRowBytes) + srcX;
+            float r = (float)pixel->R;
+            float g = (float)pixel->G;
+            float b = (float)pixel->B;
+
+            if (premul)
+            {
+                float a = (float)pixel->A;
+                if (a > 0f && a < 1f)
+                {
+                    float invA = 1f / a;
+                    r *= invA;
+                    g *= invA;
+                    b *= invA;
+                }
+            }
+
+            float y = 0.2126f * r + 0.7152f * g + 0.0722f * b;
+            AddContribution(yBuf, y, height, invHdr, kernel, radius);
+        }
+    }
+
+    private static unsafe void SampleRgbOverlay(
+        byte* srcData, int srcRowBytes, int srcX, int[] srcYArr, int sampleCount, bool premul,
+        float[] rBuf, float[] gBuf, float[] bBuf,
+        int height, float invHdr, float[] kernel, int radius)
+    {
+        for (int i = 0; i < sampleCount; i++)
+        {
+            RgbaF16* pixel = (RgbaF16*)(srcData + (long)srcYArr[i] * srcRowBytes) + srcX;
+            float r = (float)pixel->R;
+            float g = (float)pixel->G;
+            float b = (float)pixel->B;
+
+            if (premul)
+            {
+                float a = (float)pixel->A;
+                if (a > 0f && a < 1f)
+                {
+                    float invA = 1f / a;
+                    r *= invA;
+                    g *= invA;
+                    b *= invA;
+                }
+            }
+
+            AddContributionRgb(rBuf, gBuf, bBuf, r, g, b, height, invHdr, kernel, radius);
+        }
+    }
+
+    private static unsafe void SampleParade(
+        byte* srcData, int srcRowBytes, int srcX, int[] srcYArr, int sampleCount, bool premul,
+        int band, float[] target, int height, float invHdr, float[] kernel, int radius)
+    {
+        for (int i = 0; i < sampleCount; i++)
+        {
+            RgbaF16* pixel = (RgbaF16*)(srcData + (long)srcYArr[i] * srcRowBytes) + srcX;
+            float r = (float)pixel->R;
+            float g = (float)pixel->G;
+            float b = (float)pixel->B;
+
+            if (premul)
+            {
+                float a = (float)pixel->A;
+                if (a > 0f && a < 1f)
+                {
+                    float invA = 1f / a;
+                    r *= invA;
+                    g *= invA;
+                    b *= invA;
+                }
+            }
+
+            float channel = band == 0 ? r : band == 1 ? g : b;
+            AddContribution(target, channel, height, invHdr, kernel, radius);
+        }
     }
 
     private static unsafe void WriteColumn(
@@ -385,9 +465,10 @@ public class WaveformControl : HdrScopeControlBase
         }
     }
 
-    private static void AddContribution(float[] buffer, float value, int height, float hdrRange, float[] kernel, int radius)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddContribution(float[] buffer, float value, int height, float invHdr, float[] kernel, int radius)
     {
-        float normalized = Math.Clamp(value / hdrRange, 0f, 1f);
+        float normalized = Math.Clamp(value * invHdr, 0f, 1f);
         float center = (1f - normalized) * height;
         int centerInt = (int)MathF.Round(center);
         int start = Math.Max(0, centerInt - radius);
@@ -399,12 +480,12 @@ public class WaveformControl : HdrScopeControlBase
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AddContributionRgb(
         float[] rBuf, float[] gBuf, float[] bBuf,
         float r, float g, float b,
-        int height, float hdrRange, float[] kernel, int radius)
+        int height, float invHdr, float[] kernel, int radius)
     {
-        float invHdr = 1f / hdrRange;
         float rNorm = Math.Clamp(r * invHdr, 0f, 1f);
         float gNorm = Math.Clamp(g * invHdr, 0f, 1f);
         float bNorm = Math.Clamp(b * invHdr, 0f, 1f);
@@ -475,7 +556,7 @@ public class WaveformControl : HdrScopeControlBase
         float d = MathF.Abs(v - t);
         float k = (d * height) / MathF.Max(px, 1e-3f);
         float kSq = k * k;
-        // Fast Gaussian approximation: exp(-x²) ≈ 1/(1 + x² + 0.5*x⁴)
+        // Fast Gaussian approximation: exp(-x^2) ≈ 1/(1 + x^2 + 0.5*x^4)
         return 1f / (1f + kSq + 0.5f * kSq * kSq);
     }
 }

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
@@ -7,6 +7,8 @@ using Beutl.Media;
 using Beutl.Media.Pixel;
 using BtlBitmap = Beutl.Media.Bitmap;
 using PixelSize = Avalonia.PixelSize;
+using SysVector = System.Numerics.Vector;
+using VectorF = System.Numerics.Vector<float>;
 
 namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;
 
@@ -32,6 +34,11 @@ public class WaveformControl : HdrScopeControlBase
     private float _thickness = 5f;
     private float _gain = 10.0f;
     private bool _showGrid = true;
+
+    // Cached gridStrength array (invalidated on height/hdrRange change)
+    private float[]? _cachedGridStrength;
+    private int _cachedGridHeight;
+    private float _cachedGridHdrRange = float.NaN;
 
     private static readonly string[] s_verticalLabelsSdr = ["1.0", "0.8", "0.5", "0.3", "0"];
     private static readonly (float R, float G, float B) s_colorLuma = (0.85f, 0.92f, 1.00f);
@@ -108,7 +115,7 @@ public class WaveformControl : HdrScopeControlBase
         float gain = Gain;
         bool showGrid = ShowGrid;
         float hdrRange = HdrRange;
-        float[]? gridStrength = showGrid ? CreateGridStrength(targetHeight, hdrRange) : null;
+        float[]? gridStrength = showGrid ? GetGridStrength(targetHeight, hdrRange) : null;
         int sampleCount = (int)Math.Clamp(sourceBitmap.Height * 0.25f, 32f, 1024f);
         float invSamplesGain = gain / Math.Max(sampleCount, 1);
 
@@ -116,18 +123,28 @@ public class WaveformControl : HdrScopeControlBase
         float invTargetWidth = 1f / targetWidth;
         float invSampleCount = 1f / sampleCount;
 
-        using ILockedFramebuffer fb = result.Lock();
-        BtlBitmap rgbaGammaOrLinear;
-        bool requireDispose = false;
-        // TODO: Linear/Gammaを切り替えられるようにする
-        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 &&
-            (sourceBitmap.ColorSpace == BitmapColorSpace.Srgb || sourceBitmap.ColorSpace == BitmapColorSpace.LinearSrgb))
+        // Pre-compute Gaussian kernel LUT (shared across all samples since thickness is constant per frame)
+        int kernelRadius = Math.Max((int)MathF.Ceiling(thickness * 3f), 1);
+        int kernelSize = 2 * kernelRadius + 1;
+        float[] kernelArr = new float[kernelSize];
+        float invKernelDenom = 1f / MathF.Max(thickness, 1e-3f);
+        for (int k = 0; k < kernelSize; k++)
         {
-            rgbaGammaOrLinear = sourceBitmap;
+            float dv = (k - kernelRadius) * invKernelDenom;
+            float dSq = dv * dv;
+            kernelArr[k] = 1f / (1f + dSq + 0.5f * dSq * dSq);
+        }
+
+        using ILockedFramebuffer fb = result.Lock();
+        BtlBitmap rgbaSrgb;
+        bool requireDispose = false;
+        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == BitmapColorSpace.Srgb)
+        {
+            rgbaSrgb = sourceBitmap;
         }
         else
         {
-            rgbaGammaOrLinear = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, BitmapColorSpace.Srgb);
+            rgbaSrgb = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, BitmapColorSpace.Srgb);
             requireDispose = true;
         }
 
@@ -135,171 +152,294 @@ public class WaveformControl : HdrScopeControlBase
         {
             byte* destPtr = (byte*)fb.Address;
             int destRowBytes = fb.RowBytes;
-            bool premul = rgbaGammaOrLinear.AlphaType == BitmapAlphaType.Premul;
-            bool linear = rgbaGammaOrLinear.ColorSpace == BitmapColorSpace.LinearSrgb;
+            bool premul = rgbaSrgb.AlphaType == BitmapAlphaType.Premul;
+            var rgbaSrgbLocal = rgbaSrgb; // capture stable reference for closure
 
-            Parallel.For(0, targetWidth, x =>
-            {
-                float x01 = (x + 0.5f) * invTargetWidth;
-                float paradeBand = 0f;
-
-                if (mode == WaveformMode.RgbParade)
+            Parallel.For(0, targetWidth,
+                // Per-thread local: reuse 4 float buffers across columns to avoid stackalloc / heap alloc per iteration
+                () => new[]
                 {
-                    float x3 = x01 * 3f;
-                    paradeBand = MathF.Min(2f, MathF.Floor(x3));
-                    x01 = x3 - paradeBand;
-                }
-
-                Span<float> rBuffer = targetHeight <= 1024 ? stackalloc float[targetHeight] : new float[targetHeight];
-                Span<float> gBuffer = targetHeight <= 1024 ? stackalloc float[targetHeight] : new float[targetHeight];
-                Span<float> bBuffer = targetHeight <= 1024 ? stackalloc float[targetHeight] : new float[targetHeight];
-                Span<float> yBuffer = targetHeight <= 1024 ? stackalloc float[targetHeight] : new float[targetHeight];
-
-                int srcX = Math.Clamp((int)(x01 * sourceWidth), 0, sourceWidth - 1);
-
-                for (int i = 0; i < sampleCount; i++)
+                    new float[targetHeight], new float[targetHeight],
+                    new float[targetHeight], new float[targetHeight]
+                },
+                (x, _, bufs) =>
                 {
-                    int srcY = Math.Clamp((int)((i + 0.5f) * invSampleCount * sourceHeight), 0, sourceHeight - 1);
+                    float[] rBuf = bufs[0];
+                    float[] gBuf = bufs[1];
+                    float[] bBuf = bufs[2];
+                    float[] yBuf = bufs[3];
+                    Array.Clear(rBuf);
+                    Array.Clear(gBuf);
+                    Array.Clear(bBuf);
+                    Array.Clear(yBuf);
 
-                    // ReSharper disable once AccessToDisposedClosure
-                    RgbaF16 sample = rgbaGammaOrLinear.GetRow<RgbaF16>(srcY)[srcX];
-                    if (linear)
+                    float x01 = (x + 0.5f) * invTargetWidth;
+                    float paradeBand = 0f;
+
+                    if (mode == WaveformMode.RgbParade)
                     {
-                        sample = sample.LinearToSrgb();
+                        float x3 = x01 * 3f;
+                        paradeBand = MathF.Min(2f, MathF.Floor(x3));
+                        x01 = x3 - paradeBand;
                     }
 
-                    float r = (float)sample.R;
-                    float g = (float)sample.G;
-                    float b = (float)sample.B;
-                    float a = (float)sample.A;
+                    int srcX = Math.Clamp((int)(x01 * sourceWidth), 0, sourceWidth - 1);
 
-                    if (a > 0f && a < 1f && premul)
+                    for (int i = 0; i < sampleCount; i++)
                     {
-                        float invA = 1f / a;
-                        r *= invA;
-                        g *= invA;
-                        b *= invA;
-                    }
+                        int srcY = Math.Clamp((int)((i + 0.5f) * invSampleCount * sourceHeight), 0, sourceHeight - 1);
 
-                    float y = (0.2126f * r) + (0.7152f * g) + (0.0722f * b);
+                        // ReSharper disable once AccessToDisposedClosure
+                        RgbaF16 sample = rgbaSrgbLocal.GetRow<RgbaF16>(srcY)[srcX];
+                        float r = (float)sample.R;
+                        float g = (float)sample.G;
+                        float b = (float)sample.B;
+                        float a = (float)sample.A;
 
-                    if (mode == WaveformMode.Luma)
-                    {
-                        AddContribution(yBuffer, y, targetHeight, thickness, hdrRange);
-                    }
-                    else if (mode == WaveformMode.RgbOverlay)
-                    {
-                        AddContribution(rBuffer, r, targetHeight, thickness, hdrRange);
-                        AddContribution(gBuffer, g, targetHeight, thickness, hdrRange);
-                        AddContribution(bBuffer, b, targetHeight, thickness, hdrRange);
-                    }
-                    else
-                    {
-                        float channel = paradeBand < 0.5f ? r : paradeBand < 1.5f ? g : b;
-
-                        if (paradeBand < 0.5f)
+                        if (a > 0f && a < 1f && premul)
                         {
-                            AddContribution(rBuffer, channel, targetHeight, thickness, hdrRange);
+                            float invA = 1f / a;
+                            r *= invA;
+                            g *= invA;
+                            b *= invA;
                         }
-                        else if (paradeBand < 1.5f)
+
+                        if (mode == WaveformMode.Luma)
                         {
-                            AddContribution(gBuffer, channel, targetHeight, thickness, hdrRange);
+                            float y = (0.2126f * r) + (0.7152f * g) + (0.0722f * b);
+                            AddContribution(yBuf, y, targetHeight, hdrRange, kernelArr, kernelRadius);
+                        }
+                        else if (mode == WaveformMode.RgbOverlay)
+                        {
+                            AddContributionRgb(rBuf, gBuf, bBuf, r, g, b, targetHeight, hdrRange, kernelArr, kernelRadius);
                         }
                         else
                         {
-                            AddContribution(bBuffer, channel, targetHeight, thickness, hdrRange);
+                            float channel = paradeBand < 0.5f ? r : paradeBand < 1.5f ? g : b;
+                            float[] target = paradeBand < 0.5f ? rBuf : paradeBand < 1.5f ? gBuf : bBuf;
+                            AddContribution(target, channel, targetHeight, hdrRange, kernelArr, kernelRadius);
                         }
                     }
-                }
 
-                for (int y = 0; y < targetHeight; y++)
-                {
-                    float gridVal = showGrid && gridStrength is not null ? gridStrength[y] : 0f;
-                    float gridR = gridVal * s_colorGrid.R;
-                    float gridG = gridVal * s_colorGrid.G;
-                    float gridB = gridVal * s_colorGrid.B;
+                    WriteColumn(
+                        destPtr, destRowBytes, x, targetHeight,
+                        rBuf, gBuf, bBuf, yBuf,
+                        invSamplesGain, mode, showGrid, gridStrength);
 
-                    // Fast tone mapping: 1 - exp(-x) ≈ x / (1 + x * 0.5) for brighter results
-                    float rrIn = rBuffer[y] * invSamplesGain;
-                    float ggIn = gBuffer[y] * invSamplesGain;
-                    float bbIn = bBuffer[y] * invSamplesGain;
-                    float yyIn = yBuffer[y] * invSamplesGain;
-
-                    float rr = rrIn / (1f + rrIn * 0.5f);
-                    float gg = ggIn / (1f + ggIn * 0.5f);
-                    float bb = bbIn / (1f + bbIn * 0.5f);
-                    float yy = yyIn / (1f + yyIn * 0.5f);
-
-                    float colR;
-                    float colG;
-                    float colB;
-
-                    if (mode == WaveformMode.Luma)
-                    {
-                        colR = yy * s_colorLuma.R;
-                        colG = yy * s_colorLuma.G;
-                        colB = yy * s_colorLuma.B;
-                    }
-                    else if (mode == WaveformMode.RgbOverlay)
-                    {
-                        colR = rr * s_colorRed.R + gg * s_colorGreen.R + bb * s_colorBlue.R;
-                        colG = rr * s_colorRed.G + gg * s_colorGreen.G + bb * s_colorBlue.G;
-                        colB = rr * s_colorRed.B + gg * s_colorGreen.B + bb * s_colorBlue.B;
-                    }
-                    else
-                    {
-                        colR = rr * s_colorRed.R + gg * s_colorGreen.R + bb * s_colorBlue.R;
-                        colG = rr * s_colorRed.G + gg * s_colorGreen.G + bb * s_colorBlue.G;
-                        colB = rr * s_colorRed.B + gg * s_colorGreen.B + bb * s_colorBlue.B;
-                    }
-
-                    // Fast gamma correction: pow(x, 0.769) ≈ sqrt(x) * (0.65 + 0.35*x) for brighter results
-                    float valR = MathF.Max(0f, colR + gridR);
-                    float valG = MathF.Max(0f, colG + gridG);
-                    float valB = MathF.Max(0f, colB + gridB);
-
-                    colR = MathF.Sqrt(valR) * (0.65f + 0.35f * valR);
-                    colG = MathF.Sqrt(valG) * (0.65f + 0.35f * valG);
-                    colB = MathF.Sqrt(valB) * (0.65f + 0.35f * valB);
-
-                    int destIndex = (y * destRowBytes) + (x * 4);
-                    destPtr[destIndex + 0] = (byte)(Math.Clamp(colB, 0f, 1f) * 255f);
-                    destPtr[destIndex + 1] = (byte)(Math.Clamp(colG, 0f, 1f) * 255f);
-                    destPtr[destIndex + 2] = (byte)(Math.Clamp(colR, 0f, 1f) * 255f);
-                    destPtr[destIndex + 3] = 255;
-                }
-            });
+                    return bufs;
+                },
+                _ => { });
         }
         finally
         {
             if (requireDispose)
-                rgbaGammaOrLinear.Dispose();
+                rgbaSrgb.Dispose();
         }
 
         return result;
     }
 
-    private static void AddContribution(Span<float> buffer, float value, int height, float thickness, float hdrRange = 1f)
+    private static unsafe void WriteColumn(
+        byte* destPtr, int destRowBytes, int x, int targetHeight,
+        float[] rBuf, float[] gBuf, float[] bBuf, float[] yBuf,
+        float invSamplesGain, WaveformMode mode, bool showGrid, float[]? gridStrength)
+    {
+        bool isLuma = mode == WaveformMode.Luma;
+        bool useGrid = showGrid && gridStrength is not null;
+
+        int simdCount = VectorF.Count;
+        int vectorizedEnd = SysVector.IsHardwareAccelerated ? (targetHeight / simdCount) * simdCount : 0;
+
+        if (vectorizedEnd > 0)
+        {
+            var vInvGain = new VectorF(invSamplesGain);
+            var vHalf = new VectorF(0.5f);
+            var vOne = VectorF.One;
+            var vZero = VectorF.Zero;
+            var v255 = new VectorF(255f);
+            var v065 = new VectorF(0.65f);
+            var v035 = new VectorF(0.35f);
+
+            var vLumaR = new VectorF(s_colorLuma.R);
+            var vLumaG = new VectorF(s_colorLuma.G);
+            var vLumaB = new VectorF(s_colorLuma.B);
+            var vRedR = new VectorF(s_colorRed.R);
+            var vRedG = new VectorF(s_colorRed.G);
+            var vRedB = new VectorF(s_colorRed.B);
+            var vGreenR = new VectorF(s_colorGreen.R);
+            var vGreenG = new VectorF(s_colorGreen.G);
+            var vGreenB = new VectorF(s_colorGreen.B);
+            var vBlueR = new VectorF(s_colorBlue.R);
+            var vBlueG = new VectorF(s_colorBlue.G);
+            var vBlueB = new VectorF(s_colorBlue.B);
+            var vGridR = new VectorF(s_colorGrid.R);
+            var vGridG = new VectorF(s_colorGrid.G);
+            var vGridB = new VectorF(s_colorGrid.B);
+
+            Span<float> rSpan = stackalloc float[simdCount];
+            Span<float> gSpan = stackalloc float[simdCount];
+            Span<float> bSpan = stackalloc float[simdCount];
+
+            for (int y = 0; y < vectorizedEnd; y += simdCount)
+            {
+                VectorF rrIn = new VectorF(rBuf, y) * vInvGain;
+                VectorF ggIn = new VectorF(gBuf, y) * vInvGain;
+                VectorF bbIn = new VectorF(bBuf, y) * vInvGain;
+                VectorF yyIn = new VectorF(yBuf, y) * vInvGain;
+
+                // Fast tone-mapping: x / (1 + x * 0.5)
+                VectorF rr = rrIn / (vOne + rrIn * vHalf);
+                VectorF gg = ggIn / (vOne + ggIn * vHalf);
+                VectorF bb = bbIn / (vOne + bbIn * vHalf);
+                VectorF yy = yyIn / (vOne + yyIn * vHalf);
+
+                VectorF colR, colG, colB;
+                if (isLuma)
+                {
+                    colR = yy * vLumaR;
+                    colG = yy * vLumaG;
+                    colB = yy * vLumaB;
+                }
+                else
+                {
+                    colR = rr * vRedR + gg * vGreenR + bb * vBlueR;
+                    colG = rr * vRedG + gg * vGreenG + bb * vBlueG;
+                    colB = rr * vRedB + gg * vGreenB + bb * vBlueB;
+                }
+
+                VectorF gridVec = useGrid ? new VectorF(gridStrength!, y) : vZero;
+                VectorF valR = SysVector.Max(vZero, colR + gridVec * vGridR);
+                VectorF valG = SysVector.Max(vZero, colG + gridVec * vGridG);
+                VectorF valB = SysVector.Max(vZero, colB + gridVec * vGridB);
+
+                // Fast gamma: sqrt(v) * (0.65 + 0.35*v)
+                colR = SysVector.SquareRoot(valR) * (v065 + v035 * valR);
+                colG = SysVector.SquareRoot(valG) * (v065 + v035 * valG);
+                colB = SysVector.SquareRoot(valB) * (v065 + v035 * valB);
+
+                // Clamp to [0,1] and scale to 0-255
+                colR = SysVector.Min(vOne, SysVector.Max(vZero, colR)) * v255;
+                colG = SysVector.Min(vOne, SysVector.Max(vZero, colG)) * v255;
+                colB = SysVector.Min(vOne, SysVector.Max(vZero, colB)) * v255;
+
+                colR.CopyTo(rSpan);
+                colG.CopyTo(gSpan);
+                colB.CopyTo(bSpan);
+
+                for (int k = 0; k < simdCount; k++)
+                {
+                    int destIndex = ((y + k) * destRowBytes) + (x * 4);
+                    destPtr[destIndex + 0] = (byte)bSpan[k];
+                    destPtr[destIndex + 1] = (byte)gSpan[k];
+                    destPtr[destIndex + 2] = (byte)rSpan[k];
+                    destPtr[destIndex + 3] = 255;
+                }
+            }
+        }
+
+        // Scalar tail
+        for (int y = vectorizedEnd; y < targetHeight; y++)
+        {
+            float gridVal = useGrid ? gridStrength![y] : 0f;
+            float gridR = gridVal * s_colorGrid.R;
+            float gridG = gridVal * s_colorGrid.G;
+            float gridB = gridVal * s_colorGrid.B;
+
+            float rrIn = rBuf[y] * invSamplesGain;
+            float ggIn = gBuf[y] * invSamplesGain;
+            float bbIn = bBuf[y] * invSamplesGain;
+            float yyIn = yBuf[y] * invSamplesGain;
+
+            float rr = rrIn / (1f + rrIn * 0.5f);
+            float gg = ggIn / (1f + ggIn * 0.5f);
+            float bb = bbIn / (1f + bbIn * 0.5f);
+            float yy = yyIn / (1f + yyIn * 0.5f);
+
+            float colR, colG, colB;
+            if (isLuma)
+            {
+                colR = yy * s_colorLuma.R;
+                colG = yy * s_colorLuma.G;
+                colB = yy * s_colorLuma.B;
+            }
+            else
+            {
+                colR = rr * s_colorRed.R + gg * s_colorGreen.R + bb * s_colorBlue.R;
+                colG = rr * s_colorRed.G + gg * s_colorGreen.G + bb * s_colorBlue.G;
+                colB = rr * s_colorRed.B + gg * s_colorGreen.B + bb * s_colorBlue.B;
+            }
+
+            float valR = MathF.Max(0f, colR + gridR);
+            float valG = MathF.Max(0f, colG + gridG);
+            float valB = MathF.Max(0f, colB + gridB);
+
+            colR = MathF.Sqrt(valR) * (0.65f + 0.35f * valR);
+            colG = MathF.Sqrt(valG) * (0.65f + 0.35f * valG);
+            colB = MathF.Sqrt(valB) * (0.65f + 0.35f * valB);
+
+            int destIndex = (y * destRowBytes) + (x * 4);
+            destPtr[destIndex + 0] = (byte)(Math.Clamp(colB, 0f, 1f) * 255f);
+            destPtr[destIndex + 1] = (byte)(Math.Clamp(colG, 0f, 1f) * 255f);
+            destPtr[destIndex + 2] = (byte)(Math.Clamp(colR, 0f, 1f) * 255f);
+            destPtr[destIndex + 3] = 255;
+        }
+    }
+
+    private static void AddContribution(float[] buffer, float value, int height, float hdrRange, float[] kernel, int radius)
     {
         float normalized = Math.Clamp(value / hdrRange, 0f, 1f);
-        float yPos = 1f - normalized;
-        float center = yPos * height;
-        float radius = MathF.Max(thickness * 3f, 1f);
-        int start = Math.Max(0, (int)MathF.Floor(center - radius));
-        int end = Math.Min(height - 1, (int)MathF.Ceiling(center + radius));
-        float invDenom = 1f / MathF.Max(thickness, 1e-3f);
-        float invHeight = 1f / height;
-
-        for (int y = start; y <= end; y++)
+        float center = (1f - normalized) * height;
+        int centerInt = (int)MathF.Round(center);
+        int start = Math.Max(0, centerInt - radius);
+        int end = Math.Min(height - 1, centerInt + radius);
+        int kOffset = start - (centerInt - radius);
+        for (int y = start, k = kOffset; y <= end; y++, k++)
         {
-            float y01 = (y + 0.5f) * invHeight;
-            float k = MathF.Abs(y01 - yPos) * height * invDenom;
-            float kSq = k * k;
-            // Fast Gaussian approximation: exp(-x²) ≈ 1/(1 + x² + 0.5*x⁴) for small x
-            // More accurate and faster than MathF.Exp for this use case
-            float contribution = 1f / (1f + kSq + 0.5f * kSq * kSq);
-            buffer[y] += contribution;
+            buffer[y] += kernel[k];
         }
+    }
+
+    private static void AddContributionRgb(
+        float[] rBuf, float[] gBuf, float[] bBuf,
+        float r, float g, float b,
+        int height, float hdrRange, float[] kernel, int radius)
+    {
+        float invHdr = 1f / hdrRange;
+        float rNorm = Math.Clamp(r * invHdr, 0f, 1f);
+        float gNorm = Math.Clamp(g * invHdr, 0f, 1f);
+        float bNorm = Math.Clamp(b * invHdr, 0f, 1f);
+        int rCenter = (int)MathF.Round((1f - rNorm) * height);
+        int gCenter = (int)MathF.Round((1f - gNorm) * height);
+        int bCenter = (int)MathF.Round((1f - bNorm) * height);
+
+        int rStart = Math.Max(0, rCenter - radius);
+        int rEnd = Math.Min(height - 1, rCenter + radius);
+        int rKOffset = rStart - (rCenter - radius);
+        for (int y = rStart, k = rKOffset; y <= rEnd; y++, k++)
+            rBuf[y] += kernel[k];
+
+        int gStart = Math.Max(0, gCenter - radius);
+        int gEnd = Math.Min(height - 1, gCenter + radius);
+        int gKOffset = gStart - (gCenter - radius);
+        for (int y = gStart, k = gKOffset; y <= gEnd; y++, k++)
+            gBuf[y] += kernel[k];
+
+        int bStart = Math.Max(0, bCenter - radius);
+        int bEnd = Math.Min(height - 1, bCenter + radius);
+        int bKOffset = bStart - (bCenter - radius);
+        for (int y = bStart, k = bKOffset; y <= bEnd; y++, k++)
+            bBuf[y] += kernel[k];
+    }
+
+    private float[] GetGridStrength(int height, float hdrRange)
+    {
+        if (_cachedGridStrength != null && _cachedGridHeight == height && _cachedGridHdrRange == hdrRange)
+            return _cachedGridStrength;
+
+        _cachedGridStrength = CreateGridStrength(height, hdrRange);
+        _cachedGridHeight = height;
+        _cachedGridHdrRange = hdrRange;
+        return _cachedGridStrength;
     }
 
     private static float[] CreateGridStrength(int height, float hdrRange = 1f)

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
@@ -157,15 +157,18 @@ public class WaveformControl : HdrScopeControlBase
         }
 
         using ILockedFramebuffer fb = result.Lock();
-        BtlBitmap rgbaSrgb;
+        BitmapColorSpace targetColorSpace = ColorSpace == ViewModels.ScopeColorSpace.Linear
+            ? BitmapColorSpace.LinearSrgb
+            : BitmapColorSpace.Srgb;
+        BtlBitmap rgbaConverted;
         bool requireDispose = false;
-        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == BitmapColorSpace.Srgb)
+        if (sourceBitmap.ColorType == BitmapColorType.RgbaF16 && sourceBitmap.ColorSpace == targetColorSpace)
         {
-            rgbaSrgb = sourceBitmap;
+            rgbaConverted = sourceBitmap;
         }
         else
         {
-            rgbaSrgb = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, BitmapColorSpace.Srgb);
+            rgbaConverted = sourceBitmap.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, targetColorSpace);
             requireDispose = true;
         }
 
@@ -174,9 +177,9 @@ public class WaveformControl : HdrScopeControlBase
             byte* destPtr = (byte*)fb.Address;
             int destRowBytes = fb.RowBytes;
             // Direct data access — bypasses GetRow overhead (ThrowIfDisposed + ThrowRowOutOfRange + MemoryMarshal.Cast) per sample
-            byte* srcData = (byte*)rgbaSrgb.Data;
-            int srcRowBytes = rgbaSrgb.RowBytes;
-            bool premul = rgbaSrgb.AlphaType == BitmapAlphaType.Premul;
+            byte* srcData = (byte*)rgbaConverted.Data;
+            int srcRowBytes = rgbaConverted.RowBytes;
+            bool premul = rgbaConverted.AlphaType == BitmapAlphaType.Premul;
 
             Parallel.For(0, targetWidth,
                 // Per-thread local: reuse 4 float buffers across columns to avoid stackalloc / heap alloc per iteration
@@ -229,7 +232,7 @@ public class WaveformControl : HdrScopeControlBase
         finally
         {
             if (requireDispose)
-                rgbaSrgb.Dispose();
+                rgbaConverted.Dispose();
         }
 
         return result;

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/WaveformControl.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Layout;
 using Avalonia.Media.Imaging;

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -802,6 +802,9 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="RgbParade" xml:space="preserve">
     <value>RGBパレード</value>
   </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>ガンマ</value>
+  </data>
   <data name="AVFoundationEncoder" xml:space="preserve">
     <value>AVFoundation エンコーダー</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -807,6 +807,9 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="RgbParade" xml:space="preserve">
     <value>RGB Parade</value>
   </data>
+  <data name="Gamma" xml:space="preserve">
+    <value>Gamma</value>
+  </data>
   <data name="AVFoundationEncoder" xml:space="preserve">
     <value>AVFoundation Encoder</value>
   </data>


### PR DESCRIPTION
## Description

- Optimize color scopes (Waveform, Histogram, Vectorscope) rendering performance with parallelization, SIMD vectorization, and caching
- Refactor waveform sampling into dedicated helper methods with pre-computed kernel LUT and index arrays
- Add Gamma/Linear color space selection to all color scope controls

## Breaking changes

None

## Fixed issues

None