### PR TITLE
feat: Add object template system for saving and reusing objects

### DIFF
--- a/src/Beutl.Controls/SaveAsTemplateFlyout.cs
+++ b/src/Beutl.Controls/SaveAsTemplateFlyout.cs
@@ -1,0 +1,65 @@
+#nullable enable
+
+using System.ComponentModel;
+using Avalonia.Controls;
+using Beutl.Language;
+using FluentAvalonia.UI.Controls;
+using FluentAvalonia.UI.Controls.Primitives;
+
+namespace Beutl.Controls;
+
+public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
+{
+    private TextBox? _textBox;
+
+    public event EventHandler<string?>? Confirmed;
+
+    protected override Control CreatePresenter()
+    {
+        _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
+        var pfp = new PickerFlyoutPresenter()
+        {
+            Width = 280,
+            Padding = new(8, 4),
+            Content = new StackPanel
+            {
+                Spacing = 4,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = Strings.SaveAsTemplate
+                    },
+                    _textBox
+                }
+            }
+        };
+        pfp.Confirmed += OnFlyoutConfirmed;
+        pfp.Dismissed += OnFlyoutDismissed;
+
+        return pfp;
+    }
+
+    protected override void OnConfirmed()
+    {
+        Confirmed?.Invoke(this, _textBox?.Text);
+        Hide();
+    }
+
+    protected override void OnOpening(CancelEventArgs args)
+    {
+        base.OnOpening(args);
+        _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
+        _textBox.Text = string.Empty;
+    }
+
+    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    {
+        Hide();
+    }
+
+    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    {
+        OnConfirmed();
+    }
+}

--- a/src/Beutl.Controls/SaveAsTemplateFlyout.cs
+++ b/src/Beutl.Controls/SaveAsTemplateFlyout.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.ComponentModel;
 using Avalonia.Controls;

--- a/src/Beutl.Controls/SaveAsTemplateFlyout.cs
+++ b/src/Beutl.Controls/SaveAsTemplateFlyout.cs
@@ -11,12 +11,25 @@ namespace Beutl.Controls;
 public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
 {
     private TextBox? _textBox;
+    private string _text = string.Empty;
 
     public event EventHandler<string?>? Confirmed;
+
+    public string Text
+    {
+        get => _textBox?.Text ?? _text;
+        set
+        {
+            _text = value ?? string.Empty;
+            if (_textBox != null)
+                _textBox.Text = _text;
+        }
+    }
 
     protected override Control CreatePresenter()
     {
         _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
+        _textBox.Text = _text;
         var pfp = new PickerFlyoutPresenter()
         {
             Width = 280,
@@ -50,7 +63,9 @@ public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
     {
         base.OnOpening(args);
         _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
-        _textBox.Text = string.Empty;
+        _textBox.Text = _text;
+        _textBox.SelectAll();
+        _textBox.Focus();
     }
 
     private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)

--- a/src/Beutl.Editor.Components/BeutlDataFormats.cs
+++ b/src/Beutl.Editor.Components/BeutlDataFormats.cs
@@ -23,4 +23,5 @@ public static class BeutlDataFormats
     public static readonly DataFormat<string> Easing = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Easing);
     public static readonly DataFormat<string> Geometry = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Geometry);
     public static readonly DataFormat<string> Pen = DataFormat.CreateStringApplicationFormat(KnownLibraryItemFormats.Pen);
+    public static readonly DataFormat<string> ObjectTemplate = DataFormat.CreateStringApplicationFormat("Beutl.ObjectTemplate");
 }

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
@@ -43,6 +43,11 @@
                                 <icons:SymbolIcon Symbol="Delete" />
                             </MenuItem.Icon>
                         </MenuItem>
+                        <MenuItem Click="SaveAsTemplate_Click" Header="{x:Static lang:Strings.SaveAsTemplate}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="DocumentCopy" />
+                            </MenuItem.Icon>
+                        </MenuItem>
                     </ContextMenu>
                 </StackPanel.ContextMenu>
                 <Border x:Name="dragBorder"

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
@@ -35,7 +35,10 @@ public sealed partial class EngineObjectPropertyView : UserControl
     {
         if (DataContext is not EngineObjectPropertyViewModel viewModel) return;
 
-        var flyout = new SaveAsTemplateFlyout();
+        string defaultName = TypeDisplayHelpers.GetLocalizedName(viewModel.Model.GetType());
+        string uniqueName = ObjectTemplateService.Instance.GetUniqueName(defaultName);
+
+        var flyout = new SaveAsTemplateFlyout { Text = uniqueName };
         flyout.Confirmed += (_, name) =>
         {
             if (!string.IsNullOrWhiteSpace(name))

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
@@ -6,9 +6,11 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Xaml.Interactivity;
+using Beutl.Controls;
 using Beutl.Controls.Behaviors;
 using Beutl.Editor.Components.ElementPropertyTab.ViewModels;
 using Beutl.Editor.Components.Views;
+using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +29,21 @@ public sealed partial class EngineObjectPropertyView : UserControl
         ]);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
+    }
+
+    private void SaveAsTemplate_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not EngineObjectPropertyViewModel viewModel) return;
+
+        var flyout = new SaveAsTemplateFlyout();
+        flyout.Confirmed += (_, name) =>
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                ObjectTemplateService.Instance.AddFromInstance(viewModel.Model, name);
+            }
+        };
+        flyout.ShowAt(this);
     }
 
     public void Remove_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Threading;
+using Beutl.Editor.Services;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -51,6 +52,12 @@ internal sealed class DirectoryWatcherService : IDisposable
     // プロジェクト、シーン、要素のファイルは頻繁に変更されるため除外
     private bool ShouldExcludePath(string path)
     {
+        // templatesディレクトリは例外
+        if (path.StartsWith(ObjectTemplateService.Instance.DirectoryPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
         return path.EndsWith(".bep", StringComparison.OrdinalIgnoreCase) ||
                path.EndsWith(".scene", StringComparison.OrdinalIgnoreCase) ||
                path.EndsWith(".belm", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/DirectoryWatcherService.cs
@@ -53,7 +53,7 @@ internal sealed class DirectoryWatcherService : IDisposable
     private bool ShouldExcludePath(string path)
     {
         // templatesディレクトリは例外
-        if (path.StartsWith(ObjectTemplateService.Instance.DirectoryPath, StringComparison.OrdinalIgnoreCase))
+        if (IsUnderDirectory(path, ObjectTemplateService.Instance.DirectoryPath))
         {
             return false;
         }
@@ -62,6 +62,17 @@ internal sealed class DirectoryWatcherService : IDisposable
                path.EndsWith(".scene", StringComparison.OrdinalIgnoreCase) ||
                path.EndsWith(".belm", StringComparison.OrdinalIgnoreCase) ||
                path.Contains(".beutl");
+    }
+
+    private static bool IsUnderDirectory(string path, string directory)
+    {
+        string normalizedDir = Path.GetFullPath(directory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        string normalizedPath = Path.GetFullPath(path);
+
+        return normalizedPath.StartsWith(normalizedDir, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(normalizedPath + Path.DirectorySeparatorChar, normalizedDir, StringComparison.OrdinalIgnoreCase);
     }
 
     private void OnFileSystemEvent(object sender, FileSystemEventArgs e)

--- a/src/Beutl.Editor.Components/FileBrowserTab/Services/FavoritesManager.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Services/FavoritesManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Text.Json;
 using Beutl.Configuration;
 using Beutl.Editor.Components.FileBrowserTab.ViewModels;
+using Beutl.Editor.Services;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -47,6 +48,14 @@ internal sealed class FavoritesManager : IDisposable
     public void RefreshFavoriteItems()
     {
         DisposeAndClearItems();
+
+        // テンプレートフォルダを常に先頭に表示（ローカライズ名で）
+        string templatesDir = ObjectTemplateService.Instance.DirectoryPath;
+        Directory.CreateDirectory(templatesDir);
+        var templatesItem = new FileSystemItemViewModel(templatesDir, true);
+        templatesItem.Name.Value = Strings.Templates;
+        FavoriteItems.Add(templatesItem);
+
         foreach (string path in Favorites)
         {
             if (Directory.Exists(path))

--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
@@ -74,6 +74,7 @@ public sealed class FileBrowserTabViewModel : IToolContext
         {
             if (isHome)
             {
+                RootPath.Value = string.Empty;
                 RefreshHomeView();
                 _directoryWatcher.Watch(_projectDirectory);
             }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -127,6 +127,12 @@
                     </ui:ToggleMenuFlyoutItem.Styles>
                 </ui:ToggleMenuFlyoutItem>
                 <ui:MenuFlyoutSeparator />
+                <ui:MenuFlyoutItem Click="SaveAsTemplate_Click" Text="{x:Static lang:Strings.SaveAsTemplate}">
+                    <ui:MenuFlyoutItem.IconSource>
+                        <icons:SymbolIconSource Symbol="DocumentCopy" />
+                    </ui:MenuFlyoutItem.IconSource>
+                </ui:MenuFlyoutItem>
+                <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.Animation}">
                     <ui:MenuFlyoutItem Command="{Binding FinishEditingAnimation}" Text="{x:Static lang:Strings.FinishEditing}" />
                     <ui:MenuFlyoutItem Command="{Binding BringAnimationToTop}" Text="{x:Static lang:Strings.BringToTop}" />

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Avalonia.Xaml.Interactivity;
 using Beutl.Configuration;
+using Beutl.Controls;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
@@ -187,6 +188,21 @@ public sealed partial class ElementView : UserControl
         textBox.IsVisible = true;
         textBox.SelectAll();
         textBox.Focus();
+    }
+
+    private void SaveAsTemplate_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ElementViewModel viewModel) return;
+
+        var flyout = new SaveAsTemplateFlyout();
+        flyout.Confirmed += (_, name) =>
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                ObjectTemplateService.Instance.AddFromInstance(viewModel.Model, name);
+            }
+        };
+        flyout.ShowAt(this, true);
     }
 
     private void ChangeColor_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -194,7 +194,12 @@ public sealed partial class ElementView : UserControl
     {
         if (DataContext is not ElementViewModel viewModel) return;
 
-        var flyout = new SaveAsTemplateFlyout();
+        string defaultName = !string.IsNullOrWhiteSpace(viewModel.Model.Name)
+            ? viewModel.Model.Name
+            : TypeDisplayHelpers.GetLocalizedName(viewModel.Model.GetType());
+        string uniqueName = ObjectTemplateService.Instance.GetUniqueName(defaultName);
+
+        var flyout = new SaveAsTemplateFlyout { Text = uniqueName };
         flyout.Confirmed += (_, name) =>
         {
             if (!string.IsNullOrWhiteSpace(name))

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -124,6 +124,7 @@
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
                         <ui:MenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
+                        <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{h:GetCommandGesture Paste}"
                                            Text="{x:Static lang:Strings.Paste}">

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -486,24 +486,16 @@ public sealed partial class TimelineTabView : UserControl
 
         if (template != null)
         {
-            if (template.BaseType == typeof(Element))
+            if (viewModel.EditorContext.GetService(typeof(IElementAdder))
+                is IElementAdder adder
+                && (template.BaseType == typeof(Element)
+                    || template.BaseType.IsAssignableTo(typeof(EngineObject))))
             {
-                // Element テンプレート → Element として配置
-                if (viewModel.EditorContext.GetService(typeof(IElementAdder))
-                    is IElementAdder adder)
-                {
-                    adder.AddElementFromTemplate(
-                        template,
-                        viewModel.ClickedFrame,
-                        viewModel.CalculateClickedLayer());
-                }
-            }
-            else if (template.CreateInstance() is EngineObject)
-            {
-                // EngineObject テンプレート → 新しい Element を作って配置
-                viewModel.AddElement.Execute(new ElementDescription(
-                    viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
-                    InitialObject: template.ActualType));
+                // Element テンプレート、もしくは EngineObject テンプレート → 新しい Element を作って配置
+                adder.AddElementFromTemplate(
+                    template,
+                    viewModel.ClickedFrame,
+                    viewModel.CalculateClickedLayer());
             }
 
             e.Handled = true;

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -55,8 +55,10 @@ public sealed partial class TimelineTabView : UserControl
 
         PopulateAddElementSubMenu();
 
-        PopulateAddFromTemplateSubMenu();
-        ObjectTemplateService.Instance.Items.CollectionChanged += (_, _) => PopulateAddFromTemplateSubMenu();
+        if (TimelinePanel.ContextFlyout is FAMenuFlyout contextFlyout)
+        {
+            contextFlyout.Opening += (_, _) => PopulateAddFromTemplateSubMenu();
+        }
     }
 
     private void OnDataContextDetached(TimelineTabViewModel obj)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -505,6 +505,8 @@ public sealed partial class TimelineTabView : UserControl
                     viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
                     InitialObject: template.ActualType));
             }
+
+            e.Handled = true;
         }
         else if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
             && TypeFormat.ToType(typeName) is { } type)
@@ -512,12 +514,16 @@ public sealed partial class TimelineTabView : UserControl
             viewModel.AddElement.Execute(new ElementDescription(
                 viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
                 InitialObject: type));
+
+            e.Handled = true;
         }
         else if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } fileName)
         {
             viewModel.AddElement.Execute(new ElementDescription(
                 viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
                 FileName: fileName));
+
+            e.Handled = true;
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -13,6 +13,7 @@ using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.SceneSettingsTab.ViewModels;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
+using Beutl.Engine;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.ProjectSystem;
@@ -53,6 +54,9 @@ public sealed partial class TimelineTabView : UserControl
         this.SubscribeDataContextChange<TimelineTabViewModel>(OnDataContextAttached, OnDataContextDetached);
 
         PopulateAddElementSubMenu();
+
+        PopulateAddFromTemplateSubMenu();
+        ObjectTemplateService.Instance.Items.CollectionChanged += (_, _) => PopulateAddFromTemplateSubMenu();
     }
 
     private void OnDataContextDetached(TimelineTabViewModel obj)
@@ -463,7 +467,32 @@ public sealed partial class TimelineTabView : UserControl
             .RoundToRate(viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30);
         viewModel.ClickedPosition = pt;
 
-        if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
+        // テンプレート経路（優先）
+        if (e.DataTransfer.TryGetValue(BeutlDataFormats.ObjectTemplate) is { } idStr
+            && Guid.TryParse(idStr, out Guid templateId)
+            && ObjectTemplateService.Instance.FindById(templateId) is { } template)
+        {
+            if (template.BaseType == typeof(Element))
+            {
+                // Element テンプレート → Element として配置
+                if (viewModel.EditorContext.GetService(typeof(IElementAdder))
+                    is IElementAdder adder)
+                {
+                    adder.AddElementFromTemplate(
+                        template,
+                        viewModel.ClickedFrame,
+                        viewModel.CalculateClickedLayer());
+                }
+            }
+            else if (template.CreateInstance() is EngineObject)
+            {
+                // EngineObject テンプレート → 新しい Element を作って配置
+                viewModel.AddElement.Execute(new ElementDescription(
+                    viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
+                    InitialObject: template.ActualType));
+            }
+        }
+        else if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
             && TypeFormat.ToType(typeName) is { } type)
         {
             viewModel.AddElement.Execute(new ElementDescription(
@@ -480,7 +509,8 @@ public sealed partial class TimelineTabView : UserControl
 
     private void TimelinePanel_DragOver(object? sender, DragEventArgs e)
     {
-        if (e.DataTransfer.Contains(BeutlDataFormats.EngineObject)
+        if (e.DataTransfer.Contains(BeutlDataFormats.ObjectTemplate)
+            || e.DataTransfer.Contains(BeutlDataFormats.EngineObject)
             || e.DataTransfer.Contains(DataFormat.File))
         {
             e.DragEffects = DragDropEffects.Copy;
@@ -555,6 +585,35 @@ public sealed partial class TimelineTabView : UserControl
             TimeSpan.FromSeconds(5),
             ViewModel.CalculateClickedLayer(),
             InitialObject: operatorType));
+    }
+
+    private void PopulateAddFromTemplateSubMenu()
+    {
+        AddFromTemplateSubMenu.Items.Clear();
+        foreach (ObjectTemplateItem template in ObjectTemplateService.Instance
+            .FindByBaseType(typeof(Element)))
+        {
+            var menuItem = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+            menuItem.Click += AddElementFromTemplateClick;
+            AddFromTemplateSubMenu.Items.Add(menuItem);
+        }
+
+        AddFromTemplateSubMenu.IsEnabled = AddFromTemplateSubMenu.Items.Count > 0;
+    }
+
+    private void AddElementFromTemplateClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel == null) return;
+        if (sender is not MenuFlyoutItem { Tag: ObjectTemplateItem template }) return;
+
+        if (ViewModel.EditorContext.GetService(typeof(IElementAdder))
+            is IElementAdder adder)
+        {
+            adder.AddElementFromTemplate(
+                template,
+                ViewModel.ClickedFrame,
+                ViewModel.CalculateClickedLayer());
+        }
     }
 
     private void ShowSceneSettings(object? sender, RoutedEventArgs e)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -468,9 +468,21 @@ public sealed partial class TimelineTabView : UserControl
         viewModel.ClickedPosition = pt;
 
         // テンプレート経路（優先）
+        ObjectTemplateItem? template = null;
         if (e.DataTransfer.TryGetValue(BeutlDataFormats.ObjectTemplate) is { } idStr
-            && Guid.TryParse(idStr, out Guid templateId)
-            && ObjectTemplateService.Instance.FindById(templateId) is { } template)
+            && Guid.TryParse(idStr, out Guid templateId))
+        {
+            template = ObjectTemplateService.Instance.FindById(templateId);
+        }
+
+        // テンプレートファイルのドロップもテンプレート経路で処理
+        if (template == null && e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            template = ObjectTemplateService.Instance.TryLoadFromFile(droppedFile);
+        }
+
+        if (template != null)
         {
             if (template.BaseType == typeof(Element))
             {

--- a/src/Beutl.Editor/Services/IElementAdder.cs
+++ b/src/Beutl.Editor/Services/IElementAdder.cs
@@ -3,4 +3,6 @@
 public interface IElementAdder
 {
     void AddElement(ElementDescription desc);
+
+    void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer);
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateCategoryResolver.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateCategoryResolver.cs
@@ -1,0 +1,42 @@
+﻿using Beutl.Audio;
+using Beutl.Audio.Effects;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Transformation;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+
+namespace Beutl.Editor.Services;
+
+public static class ObjectTemplateCategoryResolver
+{
+    public const string ElementFormat = "Beutl.ProjectSystem.Element";
+
+    public static (Type BaseType, string Format) Resolve(Type actualType)
+    {
+        if (actualType.IsAssignableTo(typeof(Element)))
+            return (typeof(Element), ElementFormat);
+        if (actualType.IsAssignableTo(typeof(FilterEffect)))
+            return (typeof(FilterEffect), KnownLibraryItemFormats.FilterEffect);
+        if (actualType.IsAssignableTo(typeof(Transform)))
+            return (typeof(Transform), KnownLibraryItemFormats.Transform);
+        if (actualType.IsAssignableTo(typeof(Drawable)))
+            return (typeof(Drawable), KnownLibraryItemFormats.Drawable);
+        if (actualType.IsAssignableTo(typeof(Sound)))
+            return (typeof(Sound), KnownLibraryItemFormats.Sound);
+        if (actualType.IsAssignableTo(typeof(AudioEffect)))
+            return (typeof(AudioEffect), KnownLibraryItemFormats.AudioEffect);
+        if (actualType.IsAssignableTo(typeof(Brush)))
+            return (typeof(Brush), KnownLibraryItemFormats.Brush);
+        if (actualType.IsAssignableTo(typeof(Geometry)))
+            return (typeof(Geometry), KnownLibraryItemFormats.Geometry);
+        if (actualType.IsAssignableTo(typeof(Pen)))
+            return (typeof(Pen), KnownLibraryItemFormats.Pen);
+        if (actualType.IsAssignableTo(typeof(EngineObject)))
+            return (typeof(EngineObject), KnownLibraryItemFormats.EngineObject);
+
+        return (actualType, actualType.FullName ?? actualType.Name);
+    }
+}

--- a/src/Beutl.Editor/Services/ObjectTemplateItem.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
@@ -11,7 +11,8 @@ public sealed class ObjectTemplateItem(
     Type actualType,
     JsonObject json,
     string name,
-    string categoryFormat)
+    string categoryFormat,
+    string? filePath)
 {
     public Guid Id { get; } = id;
 
@@ -24,6 +25,8 @@ public sealed class ObjectTemplateItem(
     public ReactiveProperty<string> Name { get; } = new(name);
 
     public string CategoryFormat { get; } = categoryFormat;
+
+    public string? FilePath { get; internal set; } = filePath;
 
     public ICoreSerializable? CreateInstance()
     {
@@ -44,7 +47,7 @@ public sealed class ObjectTemplateItem(
         (Type baseType, string format) = ObjectTemplateCategoryResolver.Resolve(actual);
         JsonObject json = CoreSerializer.SerializeToJsonObject(obj);
 
-        return new ObjectTemplateItem(Guid.NewGuid(), baseType, actual, json, name, format);
+        return new ObjectTemplateItem(Guid.NewGuid(), baseType, actual, json, name, format, null);
     }
 
     public static JsonNode ToJson(ObjectTemplateItem item)
@@ -55,12 +58,11 @@ public sealed class ObjectTemplateItem(
             [nameof(BaseType)] = TypeFormat.ToString(item.BaseType),
             [nameof(ActualType)] = TypeFormat.ToString(item.ActualType),
             [nameof(Json)] = item.Json.DeepClone(),
-            [nameof(Name)] = item.Name.Value,
             [nameof(CategoryFormat)] = item.CategoryFormat
         };
     }
 
-    public static ObjectTemplateItem? FromJson(JsonNode json, ILogger logger)
+    public static ObjectTemplateItem? FromJson(JsonNode json, string name, string filePath, ILogger logger)
     {
         try
         {
@@ -105,16 +107,10 @@ public sealed class ObjectTemplateItem(
                 return null;
             }
 
-            if (json[nameof(Name)] is not JsonValue jsonValue || !jsonValue.TryGetValue(out string? name))
-            {
-                logger.LogError("Name is null.");
-                return null;
-            }
-
             string categoryFormat = json[nameof(CategoryFormat)]?.GetValue<string>()
                                     ?? ObjectTemplateCategoryResolver.Resolve(actualType).Format;
 
-            return new ObjectTemplateItem(id, baseType, actualType, jsonObject, name, categoryFormat);
+            return new ObjectTemplateItem(id, baseType, actualType, jsonObject, name, categoryFormat, filePath);
         }
         catch (Exception ex)
         {

--- a/src/Beutl.Editor/Services/ObjectTemplateItem.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateItem.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
@@ -27,6 +27,8 @@ public sealed class ObjectTemplateItem(
     public string CategoryFormat { get; } = categoryFormat;
 
     public string? FilePath { get; internal set; } = filePath;
+
+    public DateTime LastWriteTimeUtc { get; internal set; }
 
     public ICoreSerializable? CreateInstance()
     {

--- a/src/Beutl.Editor/Services/ObjectTemplateItem.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateItem.cs
@@ -1,0 +1,125 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.Editor.Services;
+
+public sealed class ObjectTemplateItem(
+    Guid id,
+    Type baseType,
+    Type actualType,
+    JsonObject json,
+    string name,
+    string categoryFormat)
+{
+    public Guid Id { get; } = id;
+
+    public Type BaseType { get; } = baseType;
+
+    public Type ActualType { get; } = actualType;
+
+    public JsonObject Json { get; } = json;
+
+    public ReactiveProperty<string> Name { get; } = new(name);
+
+    public string CategoryFormat { get; } = categoryFormat;
+
+    public ICoreSerializable? CreateInstance()
+    {
+        try
+        {
+            return CoreSerializer.DeserializeFromJsonObject(
+                (JsonObject)Json.DeepClone(), BaseType) as ICoreSerializable;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static ObjectTemplateItem CreateFromInstance(ICoreSerializable obj, string name)
+    {
+        Type actual = obj.GetType();
+        (Type baseType, string format) = ObjectTemplateCategoryResolver.Resolve(actual);
+        JsonObject json = CoreSerializer.SerializeToJsonObject(obj);
+
+        return new ObjectTemplateItem(Guid.NewGuid(), baseType, actual, json, name, format);
+    }
+
+    public static JsonNode ToJson(ObjectTemplateItem item)
+    {
+        return new JsonObject
+        {
+            [nameof(Id)] = item.Id.ToString(),
+            [nameof(BaseType)] = TypeFormat.ToString(item.BaseType),
+            [nameof(ActualType)] = TypeFormat.ToString(item.ActualType),
+            [nameof(Json)] = item.Json.DeepClone(),
+            [nameof(Name)] = item.Name.Value,
+            [nameof(CategoryFormat)] = item.CategoryFormat
+        };
+    }
+
+    public static ObjectTemplateItem? FromJson(JsonNode json, ILogger logger)
+    {
+        try
+        {
+            if (json[nameof(Id)]?.GetValue<string>() is not { } idStr
+                || !Guid.TryParse(idStr, out Guid id))
+            {
+                logger.LogError("Invalid or missing Id in template JSON.");
+                return null;
+            }
+
+            string? baseTypeName = json[nameof(BaseType)]?.ToString();
+            if (baseTypeName == null)
+            {
+                logger.LogError("BaseType is null.");
+                return null;
+            }
+
+            Type? baseType = TypeFormat.ToType(baseTypeName);
+            if (baseType == null)
+            {
+                logger.LogError("BaseType not found: {TypeName}", baseTypeName);
+                return null;
+            }
+
+            string? actualTypeName = json[nameof(ActualType)]?.ToString();
+            if (actualTypeName == null)
+            {
+                logger.LogError("ActualType is null.");
+                return null;
+            }
+
+            Type? actualType = TypeFormat.ToType(actualTypeName);
+            if (actualType == null)
+            {
+                logger.LogError("ActualType not found: {TypeName}", actualTypeName);
+                return null;
+            }
+
+            if (json[nameof(Json)] is not JsonObject jsonObject)
+            {
+                logger.LogError("Json object is null.");
+                return null;
+            }
+
+            if (json[nameof(Name)] is not JsonValue jsonValue || !jsonValue.TryGetValue(out string? name))
+            {
+                logger.LogError("Name is null.");
+                return null;
+            }
+
+            string categoryFormat = json[nameof(CategoryFormat)]?.GetValue<string>()
+                                    ?? ObjectTemplateCategoryResolver.Resolve(actualType).Format;
+
+            return new ObjectTemplateItem(id, baseType, actualType, jsonObject, name, categoryFormat);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception has occurred while creating ObjectTemplateItem from JSON.");
+            return null;
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using Beutl.Collections;
 using Beutl.Logging;
@@ -30,13 +30,17 @@ public sealed class ObjectTemplateService
 
     public string DirectoryPath => _directoryPath;
 
-    public ObjectTemplateItem AddFromInstance(ICoreSerializable instance, string name)
+    public ObjectTemplateItem? AddFromInstance(ICoreSerializable instance, string name)
     {
         lock (_lock)
         {
             string uniqueName = GetUniqueNameLocked(name);
             var item = ObjectTemplateItem.CreateFromInstance(instance, uniqueName);
-            SaveItemToFile(item);
+            if (!SaveItemToFile(item))
+            {
+                return null;
+            }
+
             _items.Add(item);
             _logger.LogInformation("Added new ObjectTemplateItem: {Name}", uniqueName);
             return item;
@@ -81,43 +85,6 @@ public sealed class ObjectTemplateService
         return false;
     }
 
-    public void Remove(ObjectTemplateItem item)
-    {
-        lock (_lock)
-        {
-            _items.Remove(item);
-            DeleteItemFile(item);
-        }
-        _logger.LogInformation("Removed ObjectTemplateItem: {Name}", item.Name.Value);
-    }
-
-    public void Rename(ObjectTemplateItem item, string newName)
-    {
-        string oldName = item.Name.Value;
-        lock (_lock)
-        {
-            string? oldPath = item.FilePath;
-
-            if (oldPath != null && File.Exists(oldPath))
-            {
-                try
-                {
-                    string directory = Path.GetDirectoryName(oldPath)!;
-                    string newPath = Path.Combine(directory, newName + ".json");
-                    File.Move(oldPath, newPath);
-                    item.FilePath = newPath;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to rename template file: {OldName} -> {NewName}", oldName, newName);
-                }
-            }
-
-            item.Name.Value = newName;
-        }
-        _logger.LogInformation("Renamed ObjectTemplateItem from {OldName} to {NewName}", oldName, newName);
-    }
-
     public ObjectTemplateItem? FindById(Guid id)
     {
         lock (_lock)
@@ -145,26 +112,34 @@ public sealed class ObjectTemplateService
         }
     }
 
-    public IEnumerable<ObjectTemplateItem> FindByCategory(string categoryFormat)
-    {
-        lock (_lock)
-        {
-            var result = new List<ObjectTemplateItem>();
-            foreach (ObjectTemplateItem item in _items)
-            {
-                if (item.CategoryFormat == categoryFormat)
-                    result.Add(item);
-            }
-            return result;
-        }
-    }
-
     public ObjectTemplateItem? TryLoadFromFile(string filePath)
     {
         lock (_lock)
         {
-            ObjectTemplateItem? item = FindByFilePathLocked(filePath);
-            if (item != null) return item;
+            ObjectTemplateItem? cached = FindByFilePathLocked(filePath);
+            if (cached != null)
+            {
+                DateTime diskTime = GetLastWriteTimeOrDefault(filePath);
+                if (diskTime != default && diskTime <= cached.LastWriteTimeUtc)
+                {
+                    return cached;
+                }
+
+                // 外部変更されているので再読み込み
+                ObjectTemplateItem? reloaded = LoadFromFile(filePath);
+                if (reloaded != null)
+                {
+                    int index = _items.IndexOf(cached);
+                    if (index >= 0)
+                    {
+                        _items[index] = reloaded;
+                    }
+
+                    return reloaded;
+                }
+
+                return cached;
+            }
         }
 
         return LoadFromFile(filePath);
@@ -177,11 +152,18 @@ public sealed class ObjectTemplateService
             if (!File.Exists(filePath)) return null;
 
             string name = Path.GetFileNameWithoutExtension(filePath);
+            DateTime lastWriteTime = File.GetLastWriteTimeUtc(filePath);
             using FileStream stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             var jsonNode = JsonNode.Parse(stream);
             if (jsonNode == null) return null;
 
-            return ObjectTemplateItem.FromJson(jsonNode, name, filePath, _logger);
+            ObjectTemplateItem? item = ObjectTemplateItem.FromJson(jsonNode, name, filePath, _logger);
+            if (item != null)
+            {
+                item.LastWriteTimeUtc = lastWriteTime;
+            }
+
+            return item;
         }
         catch (Exception ex)
         {
@@ -190,7 +172,19 @@ public sealed class ObjectTemplateService
         }
     }
 
-    private void SaveItemToFile(ObjectTemplateItem item)
+    private static DateTime GetLastWriteTimeOrDefault(string filePath)
+    {
+        try
+        {
+            return File.Exists(filePath) ? File.GetLastWriteTimeUtc(filePath) : default;
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private bool SaveItemToFile(ObjectTemplateItem item)
     {
         try
         {
@@ -198,33 +192,21 @@ public sealed class ObjectTemplateService
             string filePath = Path.Combine(_directoryPath, item.Name.Value + ".json");
             JsonNode json = ObjectTemplateItem.ToJson(item);
 
-            using FileStream stream = File.Create(filePath);
-            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
-            json.WriteTo(writer);
+            using (FileStream stream = File.Create(filePath))
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+            {
+                json.WriteTo(writer);
+            }
 
             item.FilePath = filePath;
+            item.LastWriteTimeUtc = File.GetLastWriteTimeUtc(filePath);
             _logger.LogInformation("Saved ObjectTemplateItem to file: {FilePath}", filePath);
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to save ObjectTemplateItem: {Name}", item.Name.Value);
-        }
-    }
-
-    private void DeleteItemFile(ObjectTemplateItem item)
-    {
-        try
-        {
-            string? filePath = item.FilePath;
-            if (filePath != null && File.Exists(filePath))
-            {
-                File.Delete(filePath);
-                _logger.LogInformation("Deleted ObjectTemplateItem file: {FilePath}", filePath);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to delete ObjectTemplateItem file: {Name}", item.Name.Value);
+            return false;
         }
     }
 
@@ -344,12 +326,25 @@ public sealed class ObjectTemplateService
                     }
                 }
 
-                // 既に読み込まれているファイルパスを集める
+                // 外部変更を検知したら再読み込み、既読パスを収集
                 var loadedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (ObjectTemplateItem item in _items)
+                for (int i = 0; i < _items.Count; i++)
                 {
-                    if (item.FilePath != null)
-                        loadedPaths.Add(item.FilePath);
+                    ObjectTemplateItem item = _items[i];
+                    if (item.FilePath == null) continue;
+
+                    loadedPaths.Add(item.FilePath);
+
+                    DateTime diskTime = GetLastWriteTimeOrDefault(item.FilePath);
+                    if (diskTime == default || diskTime <= item.LastWriteTimeUtc)
+                        continue;
+
+                    ObjectTemplateItem? reloaded = LoadFromFile(item.FilePath);
+                    if (reloaded != null)
+                    {
+                        _items[i] = reloaded;
+                        _logger.LogInformation("Reloaded template (file changed): {FilePath}", item.FilePath);
+                    }
                 }
 
                 // 新しいファイルを読み込んで追加

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -12,24 +12,25 @@ public sealed class ObjectTemplateService
     public static readonly ObjectTemplateService Instance = new();
     private readonly CoreList<ObjectTemplateItem> _items = [];
 
-    private readonly string _filePath = Path.Combine(
-        BeutlEnvironment.GetHomeDirectoryPath(), "object-templates.json");
+    private readonly string _directoryPath = Path.Combine(
+        BeutlEnvironment.GetHomeDirectoryPath(), "templates");
 
     private readonly ILogger _logger = Log.CreateLogger<ObjectTemplateService>();
-    private bool _isRestored;
 
     private ObjectTemplateService()
     {
         RestoreItems();
     }
 
+    public string DirectoryPath => _directoryPath;
+
     public ICoreList<ObjectTemplateItem> Items => _items;
 
     public ObjectTemplateItem AddFromInstance(ICoreSerializable instance, string name)
     {
         var item = ObjectTemplateItem.CreateFromInstance(instance, name);
+        SaveItemToFile(item);
         _items.Add(item);
-        SaveItems();
         _logger.LogInformation("Added new ObjectTemplateItem: {Name}", name);
         return item;
     }
@@ -37,15 +38,32 @@ public sealed class ObjectTemplateService
     public void Remove(ObjectTemplateItem item)
     {
         _items.Remove(item);
-        SaveItems();
+        DeleteItemFile(item);
         _logger.LogInformation("Removed ObjectTemplateItem: {Name}", item.Name.Value);
     }
 
     public void Rename(ObjectTemplateItem item, string newName)
     {
+        string oldName = item.Name.Value;
+        string? oldPath = item.FilePath;
+
+        if (oldPath != null && File.Exists(oldPath))
+        {
+            try
+            {
+                string directory = Path.GetDirectoryName(oldPath)!;
+                string newPath = Path.Combine(directory, newName + ".json");
+                File.Move(oldPath, newPath);
+                item.FilePath = newPath;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rename template file: {OldName} -> {NewName}", oldName, newName);
+            }
+        }
+
         item.Name.Value = newName;
-        SaveItems();
-        _logger.LogInformation("Renamed ObjectTemplateItem to: {Name}", newName);
+        _logger.LogInformation("Renamed ObjectTemplateItem from {OldName} to {NewName}", oldName, newName);
     }
 
     public ObjectTemplateItem? FindById(Guid id)
@@ -76,61 +94,114 @@ public sealed class ObjectTemplateService
         }
     }
 
-    public void SaveItems()
+    /// <summary>
+    /// ファイルパスからテンプレートを取得する。登録済みのアイテムから検索し、
+    /// 見つからなければファイルを直接読み込む。
+    /// </summary>
+    public ObjectTemplateItem? TryLoadFromFile(string filePath)
     {
-        if (!_isRestored) return;
-
-        var array = new JsonArray();
         foreach (ObjectTemplateItem item in _items)
         {
-            JsonNode json = ObjectTemplateItem.ToJson(item);
-            array.Add(json);
+            if (string.Equals(item.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                return item;
         }
 
-        using FileStream stream = File.Create(_filePath);
-        using var writer = new Utf8JsonWriter(stream);
-        array.WriteTo(writer);
-        _logger.LogInformation("Saved {Count} ObjectTemplateItem to file: {FilePath}", _items.Count, _filePath);
+        try
+        {
+            if (!File.Exists(filePath)) return null;
+
+            string name = Path.GetFileNameWithoutExtension(filePath);
+            using FileStream stream = File.Open(filePath, FileMode.Open);
+            var jsonNode = JsonNode.Parse(stream);
+            if (jsonNode == null) return null;
+
+            return ObjectTemplateItem.FromJson(jsonNode, name, filePath, _logger);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load template from file: {FilePath}", filePath);
+            return null;
+        }
+    }
+
+    private void SaveItemToFile(ObjectTemplateItem item)
+    {
+        try
+        {
+            Directory.CreateDirectory(_directoryPath);
+            string filePath = Path.Combine(_directoryPath, item.Name.Value + ".json");
+            JsonNode json = ObjectTemplateItem.ToJson(item);
+
+            using FileStream stream = File.Create(filePath);
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+            json.WriteTo(writer);
+
+            item.FilePath = filePath;
+            _logger.LogInformation("Saved ObjectTemplateItem to file: {FilePath}", filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save ObjectTemplateItem: {Name}", item.Name.Value);
+        }
+    }
+
+    private void DeleteItemFile(ObjectTemplateItem item)
+    {
+        try
+        {
+            string? filePath = item.FilePath;
+            if (filePath != null && File.Exists(filePath))
+            {
+                File.Delete(filePath);
+                _logger.LogInformation("Deleted ObjectTemplateItem file: {FilePath}", filePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete ObjectTemplateItem file: {Name}", item.Name.Value);
+        }
     }
 
     public void RestoreItems()
     {
         try
         {
-            _isRestored = true;
-            if (!File.Exists(_filePath))
+            if (!Directory.Exists(_directoryPath))
             {
-                _logger.LogInformation("Object template file not found: {FilePath}", _filePath);
-                return;
-            }
-
-            using FileStream stream = File.Open(_filePath, FileMode.Open);
-            var jsonNode = JsonNode.Parse(stream);
-            if (jsonNode is not JsonArray jsonArray)
-            {
-                _logger.LogWarning("Invalid JSON format in object template file: {FilePath}", _filePath);
+                _logger.LogInformation("Templates directory not found: {DirectoryPath}", _directoryPath);
                 return;
             }
 
             _items.Clear();
-            _items.EnsureCapacity(jsonArray.Count);
 
-            foreach (JsonNode? jsonItem in jsonArray)
+            foreach (string filePath in Directory.EnumerateFiles(
+                         _directoryPath, "*.json", SearchOption.AllDirectories))
             {
-                if (jsonItem == null) continue;
-
-                var item = ObjectTemplateItem.FromJson(jsonItem, _logger);
-                if (item != null)
+                try
                 {
-                    _items.Add(item);
+                    string name = Path.GetFileNameWithoutExtension(filePath);
+                    using FileStream stream = File.Open(filePath, FileMode.Open);
+                    var jsonNode = JsonNode.Parse(stream);
+                    if (jsonNode == null) continue;
+
+                    var item = ObjectTemplateItem.FromJson(jsonNode, name, filePath, _logger);
+                    if (item != null)
+                    {
+                        _items.Add(item);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to restore template from file: {FilePath}", filePath);
                 }
             }
 
-            _logger.LogInformation("Restored {Count} ObjectTemplateItem from file: {FilePath}", _items.Count, _filePath);
+            _logger.LogInformation("Restored {Count} ObjectTemplateItem from directory: {DirectoryPath}",
+                _items.Count, _directoryPath);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception has occurred while restoring object template file.");
+            _logger.LogError(ex, "An exception has occurred while restoring templates.");
         }
     }
 }

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Beutl.Collections;
+using Beutl.Logging;
+using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Editor.Services;
+
+public sealed class ObjectTemplateService
+{
+    public static readonly ObjectTemplateService Instance = new();
+    private readonly CoreList<ObjectTemplateItem> _items = [];
+
+    private readonly string _filePath = Path.Combine(
+        BeutlEnvironment.GetHomeDirectoryPath(), "object-templates.json");
+
+    private readonly ILogger _logger = Log.CreateLogger<ObjectTemplateService>();
+    private bool _isRestored;
+
+    private ObjectTemplateService()
+    {
+        RestoreItems();
+    }
+
+    public ICoreList<ObjectTemplateItem> Items => _items;
+
+    public ObjectTemplateItem AddFromInstance(ICoreSerializable instance, string name)
+    {
+        var item = ObjectTemplateItem.CreateFromInstance(instance, name);
+        _items.Add(item);
+        SaveItems();
+        _logger.LogInformation("Added new ObjectTemplateItem: {Name}", name);
+        return item;
+    }
+
+    public void Remove(ObjectTemplateItem item)
+    {
+        _items.Remove(item);
+        SaveItems();
+        _logger.LogInformation("Removed ObjectTemplateItem: {Name}", item.Name.Value);
+    }
+
+    public void Rename(ObjectTemplateItem item, string newName)
+    {
+        item.Name.Value = newName;
+        SaveItems();
+        _logger.LogInformation("Renamed ObjectTemplateItem to: {Name}", newName);
+    }
+
+    public ObjectTemplateItem? FindById(Guid id)
+    {
+        foreach (ObjectTemplateItem item in _items)
+        {
+            if (item.Id == id) return item;
+        }
+
+        return null;
+    }
+
+    public IEnumerable<ObjectTemplateItem> FindByBaseType(Type baseType)
+    {
+        foreach (ObjectTemplateItem item in _items)
+        {
+            if (item.BaseType == baseType)
+                yield return item;
+        }
+    }
+
+    public IEnumerable<ObjectTemplateItem> FindByCategory(string categoryFormat)
+    {
+        foreach (ObjectTemplateItem item in _items)
+        {
+            if (item.CategoryFormat == categoryFormat)
+                yield return item;
+        }
+    }
+
+    public void SaveItems()
+    {
+        if (!_isRestored) return;
+
+        var array = new JsonArray();
+        foreach (ObjectTemplateItem item in _items)
+        {
+            JsonNode json = ObjectTemplateItem.ToJson(item);
+            array.Add(json);
+        }
+
+        using FileStream stream = File.Create(_filePath);
+        using var writer = new Utf8JsonWriter(stream);
+        array.WriteTo(writer);
+        _logger.LogInformation("Saved {Count} ObjectTemplateItem to file: {FilePath}", _items.Count, _filePath);
+    }
+
+    public void RestoreItems()
+    {
+        try
+        {
+            _isRestored = true;
+            if (!File.Exists(_filePath))
+            {
+                _logger.LogInformation("Object template file not found: {FilePath}", _filePath);
+                return;
+            }
+
+            using FileStream stream = File.Open(_filePath, FileMode.Open);
+            var jsonNode = JsonNode.Parse(stream);
+            if (jsonNode is not JsonArray jsonArray)
+            {
+                _logger.LogWarning("Invalid JSON format in object template file: {FilePath}", _filePath);
+                return;
+            }
+
+            _items.Clear();
+            _items.EnsureCapacity(jsonArray.Count);
+
+            foreach (JsonNode? jsonItem in jsonArray)
+            {
+                if (jsonItem == null) continue;
+
+                var item = ObjectTemplateItem.FromJson(jsonItem, _logger);
+                if (item != null)
+                {
+                    _items.Add(item);
+                }
+            }
+
+            _logger.LogInformation("Restored {Count} ObjectTemplateItem from file: {FilePath}", _items.Count, _filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while restoring object template file.");
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -32,14 +32,53 @@ public sealed class ObjectTemplateService
 
     public ObjectTemplateItem AddFromInstance(ICoreSerializable instance, string name)
     {
-        var item = ObjectTemplateItem.CreateFromInstance(instance, name);
         lock (_lock)
         {
+            string uniqueName = GetUniqueNameLocked(name);
+            var item = ObjectTemplateItem.CreateFromInstance(instance, uniqueName);
             SaveItemToFile(item);
             _items.Add(item);
+            _logger.LogInformation("Added new ObjectTemplateItem: {Name}", uniqueName);
+            return item;
         }
-        _logger.LogInformation("Added new ObjectTemplateItem: {Name}", name);
-        return item;
+    }
+
+    public string GetUniqueName(string baseName)
+    {
+        lock (_lock)
+        {
+            return GetUniqueNameLocked(baseName);
+        }
+    }
+
+    private string GetUniqueNameLocked(string baseName)
+    {
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "Template";
+
+        string candidate = baseName;
+        int counter = 2;
+        while (NameExistsLocked(candidate))
+        {
+            candidate = $"{baseName} ({counter})";
+            counter++;
+        }
+
+        return candidate;
+    }
+
+    private bool NameExistsLocked(string name)
+    {
+        string filePath = Path.Combine(_directoryPath, name + ".json");
+        if (File.Exists(filePath)) return true;
+
+        foreach (ObjectTemplateItem item in _items)
+        {
+            if (string.Equals(item.Name.Value, name, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     public void Remove(ObjectTemplateItem item)

--- a/src/Beutl.Editor/Services/ObjectTemplateService.cs
+++ b/src/Beutl.Editor/Services/ObjectTemplateService.cs
@@ -15,62 +15,78 @@ public sealed class ObjectTemplateService
     private readonly string _directoryPath = Path.Combine(
         BeutlEnvironment.GetHomeDirectoryPath(), "templates");
 
+    private static readonly TimeSpan s_debounceInterval = TimeSpan.FromMilliseconds(300);
+
     private readonly ILogger _logger = Log.CreateLogger<ObjectTemplateService>();
+    private readonly Lock _lock = new();
+    private FileSystemWatcher? _watcher;
+    private CancellationTokenSource? _debounceCts;
 
     private ObjectTemplateService()
     {
         RestoreItems();
+        StartWatching();
     }
 
     public string DirectoryPath => _directoryPath;
 
-    public ICoreList<ObjectTemplateItem> Items => _items;
-
     public ObjectTemplateItem AddFromInstance(ICoreSerializable instance, string name)
     {
         var item = ObjectTemplateItem.CreateFromInstance(instance, name);
-        SaveItemToFile(item);
-        _items.Add(item);
+        lock (_lock)
+        {
+            SaveItemToFile(item);
+            _items.Add(item);
+        }
         _logger.LogInformation("Added new ObjectTemplateItem: {Name}", name);
         return item;
     }
 
     public void Remove(ObjectTemplateItem item)
     {
-        _items.Remove(item);
-        DeleteItemFile(item);
+        lock (_lock)
+        {
+            _items.Remove(item);
+            DeleteItemFile(item);
+        }
         _logger.LogInformation("Removed ObjectTemplateItem: {Name}", item.Name.Value);
     }
 
     public void Rename(ObjectTemplateItem item, string newName)
     {
         string oldName = item.Name.Value;
-        string? oldPath = item.FilePath;
-
-        if (oldPath != null && File.Exists(oldPath))
+        lock (_lock)
         {
-            try
-            {
-                string directory = Path.GetDirectoryName(oldPath)!;
-                string newPath = Path.Combine(directory, newName + ".json");
-                File.Move(oldPath, newPath);
-                item.FilePath = newPath;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to rename template file: {OldName} -> {NewName}", oldName, newName);
-            }
-        }
+            string? oldPath = item.FilePath;
 
-        item.Name.Value = newName;
+            if (oldPath != null && File.Exists(oldPath))
+            {
+                try
+                {
+                    string directory = Path.GetDirectoryName(oldPath)!;
+                    string newPath = Path.Combine(directory, newName + ".json");
+                    File.Move(oldPath, newPath);
+                    item.FilePath = newPath;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to rename template file: {OldName} -> {NewName}", oldName, newName);
+                }
+            }
+
+            item.Name.Value = newName;
+        }
         _logger.LogInformation("Renamed ObjectTemplateItem from {OldName} to {NewName}", oldName, newName);
     }
 
     public ObjectTemplateItem? FindById(Guid id)
     {
-        foreach (ObjectTemplateItem item in _items)
+        lock (_lock)
         {
-            if (item.Id == id) return item;
+            foreach (ObjectTemplateItem item in _items)
+            {
+                if (item.Id == id) return item;
+            }
         }
 
         return null;
@@ -78,40 +94,51 @@ public sealed class ObjectTemplateService
 
     public IEnumerable<ObjectTemplateItem> FindByBaseType(Type baseType)
     {
-        foreach (ObjectTemplateItem item in _items)
+        lock (_lock)
         {
-            if (item.BaseType == baseType)
-                yield return item;
+            var result = new List<ObjectTemplateItem>();
+            foreach (ObjectTemplateItem item in _items)
+            {
+                if (item.BaseType == baseType)
+                    result.Add(item);
+            }
+            return result;
         }
     }
 
     public IEnumerable<ObjectTemplateItem> FindByCategory(string categoryFormat)
     {
-        foreach (ObjectTemplateItem item in _items)
+        lock (_lock)
         {
-            if (item.CategoryFormat == categoryFormat)
-                yield return item;
+            var result = new List<ObjectTemplateItem>();
+            foreach (ObjectTemplateItem item in _items)
+            {
+                if (item.CategoryFormat == categoryFormat)
+                    result.Add(item);
+            }
+            return result;
         }
     }
 
-    /// <summary>
-    /// ファイルパスからテンプレートを取得する。登録済みのアイテムから検索し、
-    /// 見つからなければファイルを直接読み込む。
-    /// </summary>
     public ObjectTemplateItem? TryLoadFromFile(string filePath)
     {
-        foreach (ObjectTemplateItem item in _items)
+        lock (_lock)
         {
-            if (string.Equals(item.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
-                return item;
+            ObjectTemplateItem? item = FindByFilePathLocked(filePath);
+            if (item != null) return item;
         }
 
+        return LoadFromFile(filePath);
+    }
+
+    private ObjectTemplateItem? LoadFromFile(string filePath)
+    {
         try
         {
             if (!File.Exists(filePath)) return null;
 
             string name = Path.GetFileNameWithoutExtension(filePath);
-            using FileStream stream = File.Open(filePath, FileMode.Open);
+            using FileStream stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             var jsonNode = JsonNode.Parse(stream);
             if (jsonNode == null) return null;
 
@@ -172,36 +199,137 @@ public sealed class ObjectTemplateService
                 return;
             }
 
-            _items.Clear();
-
-            foreach (string filePath in Directory.EnumerateFiles(
-                         _directoryPath, "*.json", SearchOption.AllDirectories))
+            lock (_lock)
             {
-                try
-                {
-                    string name = Path.GetFileNameWithoutExtension(filePath);
-                    using FileStream stream = File.Open(filePath, FileMode.Open);
-                    var jsonNode = JsonNode.Parse(stream);
-                    if (jsonNode == null) continue;
+                _items.Clear();
 
-                    var item = ObjectTemplateItem.FromJson(jsonNode, name, filePath, _logger);
+                foreach (string filePath in Directory.EnumerateFiles(
+                             _directoryPath, "*.json", SearchOption.AllDirectories))
+                {
+                    var item = LoadFromFile(filePath);
                     if (item != null)
                     {
                         _items.Add(item);
                     }
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to restore template from file: {FilePath}", filePath);
-                }
-            }
 
-            _logger.LogInformation("Restored {Count} ObjectTemplateItem from directory: {DirectoryPath}",
-                _items.Count, _directoryPath);
+                _logger.LogInformation("Restored {Count} ObjectTemplateItem from directory: {DirectoryPath}",
+                    _items.Count, _directoryPath);
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception has occurred while restoring templates.");
+        }
+    }
+
+    private void StartWatching()
+    {
+        try
+        {
+            Directory.CreateDirectory(_directoryPath);
+            _watcher = new FileSystemWatcher(_directoryPath)
+            {
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                Filter = "*.json",
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true
+            };
+
+            _watcher.Created += OnFileSystemEvent;
+            _watcher.Deleted += OnFileSystemEvent;
+            _watcher.Renamed += OnFileSystemEvent;
+            _watcher.Changed += OnFileSystemEvent;
+
+            _logger.LogInformation("Started watching templates directory: {DirectoryPath}", _directoryPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create FileSystemWatcher for {Path}", _directoryPath);
+        }
+    }
+
+    private ObjectTemplateItem? FindByFilePathLocked(string filePath)
+    {
+        foreach (ObjectTemplateItem item in _items)
+        {
+            if (string.Equals(item.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                return item;
+        }
+
+        return null;
+    }
+
+    private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
+    {
+        lock (_lock)
+        {
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = new CancellationTokenSource();
+            CancellationToken token = _debounceCts.Token;
+
+            Task.Delay(s_debounceInterval, token).ContinueWith(_ =>
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        RefreshFromFileSystem();
+                    }
+                },
+                token,
+                TaskContinuationOptions.OnlyOnRanToCompletion,
+                TaskScheduler.Default);
+        }
+    }
+
+    private void RefreshFromFileSystem()
+    {
+        try
+        {
+            if (!Directory.Exists(_directoryPath)) return;
+
+            var diskFiles = new HashSet<string>(
+                Directory.EnumerateFiles(_directoryPath, "*.json", SearchOption.AllDirectories),
+                StringComparer.OrdinalIgnoreCase);
+
+            lock (_lock)
+            {
+                // 削除されたファイルに対応するアイテムを削除
+                for (int i = _items.Count - 1; i >= 0; i--)
+                {
+                    ObjectTemplateItem item = _items[i];
+                    if (item.FilePath == null || !diskFiles.Contains(item.FilePath))
+                    {
+                        _items.RemoveAt(i);
+                        _logger.LogInformation("Removed template (file gone): {FilePath}", item.FilePath);
+                    }
+                }
+
+                // 既に読み込まれているファイルパスを集める
+                var loadedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (ObjectTemplateItem item in _items)
+                {
+                    if (item.FilePath != null)
+                        loadedPaths.Add(item.FilePath);
+                }
+
+                // 新しいファイルを読み込んで追加
+                foreach (string filePath in diskFiles)
+                {
+                    if (loadedPaths.Contains(filePath)) continue;
+
+                    ObjectTemplateItem? newItem = LoadFromFile(filePath);
+                    if (newItem != null)
+                    {
+                        _items.Add(newItem);
+                        _logger.LogInformation("Added template (new file): {FilePath}", filePath);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh templates from filesystem.");
         }
     }
 }

--- a/src/Beutl.Language/CommandNames.ja.resx
+++ b/src/Beutl.Language/CommandNames.ja.resx
@@ -151,4 +151,10 @@
   <data name="EditProperty" xml:space="preserve">
     <value>プロパティを編集</value>
   </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>テンプレートを適用</value>
+  </data>
+  <data name="AddElementFromTemplate" xml:space="preserve">
+    <value>テンプレートから要素を追加</value>
+  </data>
 </root>

--- a/src/Beutl.Language/CommandNames.resx
+++ b/src/Beutl.Language/CommandNames.resx
@@ -155,4 +155,10 @@
   <data name="EditProperty" xml:space="preserve">
     <value>Edit Property</value>
   </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>Apply Template</value>
+  </data>
+  <data name="AddElementFromTemplate" xml:space="preserve">
+    <value>Add Element from Template</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -919,4 +919,25 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="Preview" xml:space="preserve">
     <value>プレビュー</value>
   </data>
+  <data name="Templates" xml:space="preserve">
+    <value>テンプレート</value>
+  </data>
+  <data name="SaveAsTemplate" xml:space="preserve">
+    <value>テンプレートとして保存</value>
+  </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>テンプレートを適用</value>
+  </data>
+  <data name="AddFromTemplate" xml:space="preserve">
+    <value>テンプレートから追加</value>
+  </data>
+  <data name="TemplateSaved" xml:space="preserve">
+    <value>テンプレートが保存されました。</value>
+  </data>
+  <data name="DeleteTemplateConfirm" xml:space="preserve">
+    <value>このテンプレートを削除しますか？</value>
+  </data>
+  <data name="EnterTemplateName" xml:space="preserve">
+    <value>テンプレート名を入力</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -925,4 +925,25 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="Preview" xml:space="preserve">
     <value>Preview</value>
   </data>
+  <data name="Templates" xml:space="preserve">
+    <value>Templates</value>
+  </data>
+  <data name="SaveAsTemplate" xml:space="preserve">
+    <value>Save as Template</value>
+  </data>
+  <data name="ApplyTemplate" xml:space="preserve">
+    <value>Apply Template</value>
+  </data>
+  <data name="AddFromTemplate" xml:space="preserve">
+    <value>Add from Template</value>
+  </data>
+  <data name="TemplateSaved" xml:space="preserve">
+    <value>Template has been saved.</value>
+  </data>
+  <data name="DeleteTemplateConfirm" xml:space="preserve">
+    <value>Are you sure you want to delete this template?</value>
+  </data>
+  <data name="EnterTemplateName" xml:space="preserve">
+    <value>Enter template name</value>
+  </data>
 </root>

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -839,6 +839,33 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         _logger.LogInformation("Element added successfully.");
     }
 
+    public void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer)
+    {
+        _logger.LogInformation("Adding element from template: {TemplateName}", template.Name.Value);
+
+        if (template.CreateInstance() is not Element templateElement)
+        {
+            _logger.LogWarning("Failed to create element from template.");
+            return;
+        }
+
+        // ObjectRegenerator で ID を再生成
+        ObjectRegenerator.Regenerate(templateElement, out Element newElement);
+
+        newElement.Start = start;
+        newElement.ZIndex = layer;
+        newElement.Uri = RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension);
+
+        CoreSerializer.StoreToUri(newElement, newElement.Uri!);
+        Scene.AddChild(newElement);
+        HistoryManager.Commit(CommandNames.AddElementFromTemplate);
+
+        TimelineTabViewModel? timeline = FindToolTab<TimelineTabViewModel>();
+        timeline?.ScrollTo.Execute((newElement.Range, newElement.ZIndex));
+
+        _logger.LogInformation("Element from template added successfully.");
+    }
+
     private static bool MatchFileExtensions(string filePath, IEnumerable<string> extensions)
     {
         string ext = Path.GetExtension(filePath);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -843,17 +843,39 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
     {
         _logger.LogInformation("Adding element from template: {TemplateName}", template.Name.Value);
 
-        if (template.CreateInstance() is not Element templateElement)
+        ICoreSerializable? instance = template.CreateInstance();
+        Element newElement;
+        if (instance is Element templateElement)
+        {
+            // ObjectRegenerator で ID を再生成
+            ObjectRegenerator.Regenerate(templateElement, out newElement);
+
+            newElement.Start = start;
+            newElement.ZIndex = layer;
+        }
+        else if (instance is EngineObject templateEngineObject)
+        {
+            ObjectRegenerator.Regenerate(
+                templateEngineObject, templateEngineObject.GetType(), out ICoreSerializable regenerated);
+            var newEngineObject = (EngineObject)regenerated;
+
+            newElement = new Element
+            {
+                Start = start,
+                Length = TimeSpan.FromSeconds(5),
+                ZIndex = layer,
+                Name = template.Name.Value,
+                AccentColor = ColorGenerator.GenerateColor(
+                    template.ActualType.FullName ?? template.ActualType.Name),
+            };
+            newElement.AddObject(newEngineObject);
+        }
+        else
         {
             _logger.LogWarning("Failed to create element from template.");
             return;
         }
 
-        // ObjectRegenerator で ID を再生成
-        ObjectRegenerator.Regenerate(templateElement, out Element newElement);
-
-        newElement.Start = start;
-        newElement.ZIndex = layer;
         newElement.Uri = RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension);
 
         CoreSerializer.StoreToUri(newElement, newElement.Uri!);

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -214,6 +214,8 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         return true;
     }
 
+    public override bool IsTemplateGroup => Value.Value is AudioEffectGroup;
+
     public override bool ApplyTemplate(ObjectTemplateItem template)
     {
         if (template.CreateInstance() is not AudioEffect instance) return false;

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -92,6 +92,10 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(AudioEffect);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.AudioEffect;
 
     public ReadOnlyReactivePropertySlim<string?> FilterName { get; }
@@ -167,17 +171,22 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         }
     }
 
+    public void ChangeAudioEffect(AudioEffect instance)
+    {
+        IsExpanded.Value = true;
+        SetValue(Value.Value, instance);
+    }
+
     public void ChangeFilterType(Type type)
     {
         if (Activator.CreateInstance(type) is AudioEffect instance)
-        {
-            IsExpanded.Value = true;
-            SetValue(Value.Value, instance);
-        }
+            ChangeAudioEffect(instance);
     }
 
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is AudioEffect ae and not FallbackAudioEffect ? ae : null;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
 
     public override bool TryPasteJson(string json)
     {
@@ -205,10 +214,21 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
         return true;
     }
 
-    public void AddItem(Type type)
+    public override bool ApplyTemplate(ObjectTemplateItem template)
     {
-        if (Value.Value is AudioEffectGroup group
-            && Activator.CreateInstance(type) is AudioEffect instance)
+        if (template.CreateInstance() is not AudioEffect instance) return false;
+        IsExpanded.Value = true;
+        if (Value.Value is AudioEffectGroup)
+            AddItem(instance);
+        else
+            ChangeAudioEffect(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
+
+    public void AddItem(AudioEffect instance)
+    {
+        if (Value.Value is AudioEffectGroup group)
         {
             IsExpanded.Value = true;
             group.Children.Add(instance);
@@ -223,6 +243,12 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
                 }
             }
         }
+    }
+
+    public void AddItem(Type type)
+    {
+        if (Activator.CreateInstance(type) is AudioEffect instance)
+            AddItem(instance);
     }
 
     public void SetNull()

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -361,6 +361,25 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         return json != null && TryPasteJson(json);
     }
 
+    // テンプレート保存・適用対応
+    public virtual IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => s_alwaysFalse;
+
+    protected virtual Type? TemplateBaseType => null;
+
+    protected virtual ICoreSerializable? GetTemplateTarget() => null;
+
+    public virtual bool ApplyTemplate(ObjectTemplateItem template) => false;
+
+    public IEnumerable<ObjectTemplateItem> GetApplicableTemplates()
+        => TemplateBaseType is { } t ? ObjectTemplateService.Instance.FindByBaseType(t) : [];
+
+    public ValueTask<bool> SaveAsTemplateAsync(string name)
+    {
+        if (GetTemplateTarget() is not { } target) return new(false);
+        ObjectTemplateService.Instance.AddFromInstance(target, name);
+        return new(true);
+    }
+
     public async ValueTask RefreshCanPasteAsync()
     {
         if (PasteFormat is not { } format)

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -394,6 +394,13 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     public IEnumerable<ObjectTemplateItem> GetApplicableTemplates()
         => TemplateBaseType is { } t ? ObjectTemplateService.Instance.FindByBaseType(t) : [];
 
+    public virtual string GetTemplateDefaultName()
+    {
+        if (GetTemplateTarget() is { } target)
+            return TypeDisplayHelpers.GetLocalizedName(target.GetType());
+        return string.Empty;
+    }
+
     public ValueTask<bool> SaveAsTemplateAsync(string name)
     {
         if (GetTemplateTarget() is not { } target) return new(false);

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -381,7 +381,8 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
         try
         {
-            accessor.List.Add(instance);
+            int insertIndex = Math.Clamp(accessor.Index, 0, accessor.List.Count);
+            accessor.List.Insert(insertIndex, instance);
             Commit(CommandNames.ApplyTemplate);
             return true;
         }
@@ -391,7 +392,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         }
     }
 
-    public IEnumerable<ObjectTemplateItem> GetApplicableTemplates()
+    public virtual IEnumerable<ObjectTemplateItem> GetApplicableTemplates()
         => TemplateBaseType is { } t ? ObjectTemplateService.Instance.FindByBaseType(t) : [];
 
     public virtual string GetTemplateDefaultName()
@@ -404,8 +405,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     public ValueTask<bool> SaveAsTemplateAsync(string name)
     {
         if (GetTemplateTarget() is not { } target) return new(false);
-        ObjectTemplateService.Instance.AddFromInstance(target, name);
-        return new(true);
+        return new(ObjectTemplateService.Instance.AddFromInstance(target, name) != null);
     }
 
     public async ValueTask RefreshCanPasteAsync()

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -370,6 +370,27 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     public virtual bool ApplyTemplate(ObjectTemplateItem template) => false;
 
+    public bool IsListItemAdapter => PropertyAdapter is IListItemAccessor;
+
+    public virtual bool IsTemplateGroup => false;
+
+    public virtual bool AddTemplateAsListItem(ObjectTemplateItem template)
+    {
+        if (PropertyAdapter is not IListItemAccessor accessor) return false;
+        if (template.CreateInstance() is not { } instance) return false;
+
+        try
+        {
+            accessor.List.Add(instance);
+            Commit(CommandNames.ApplyTemplate);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public IEnumerable<ObjectTemplateItem> GetApplicableTemplates()
         => TemplateBaseType is { } t ? ObjectTemplateService.Instance.FindByBaseType(t) : [];
 

--- a/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
@@ -121,6 +121,10 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(Brush);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Brush;
 
     public ReadOnlyReactivePropertySlim<bool> IsSolid { get; }
@@ -204,6 +208,17 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
 
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is Brush brush and not FallbackBrush ? brush : null;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not Brush instance) return false;
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
 
     public override bool TryPasteJson(string json)
     {

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -196,6 +196,8 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is T obj and not IFallback ? obj : null;
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
     protected override Type? TemplateBaseType => typeof(T);
 
     protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -196,6 +196,19 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is T obj and not IFallback ? obj : null;
 
+    protected override Type? TemplateBaseType => typeof(T);
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not T instance) return false;
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
+
     public override bool TryPasteJson(string json)
     {
         if (!CoreObjectClipboard.TryDeserializeJson<T>(json, out var pasted)) return false;

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -190,6 +190,8 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
 
     protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
 
+    public override bool IsTemplateGroup => Value.Value is FilterEffectGroup;
+
     public override bool ApplyTemplate(ObjectTemplateItem template)
     {
         if (template.CreateInstance() is not FilterEffect instance) return false;

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -123,6 +123,10 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(FilterEffect);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.FilterEffect;
 
     public ReadOnlyReactivePropertySlim<string?> FilterName { get; }
@@ -169,17 +173,34 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
         }
     }
 
+    public void ChangeFilter(FilterEffect instance)
+    {
+        IsExpanded.Value = true;
+        SetValue(Value.Value, instance);
+    }
+
     public void ChangeFilterType(Type type)
     {
         if (Activator.CreateInstance(type) is FilterEffect instance)
-        {
-            IsExpanded.Value = true;
-            SetValue(Value.Value, instance);
-        }
+            ChangeFilter(instance);
     }
 
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is FilterEffect fe and not FallbackFilterEffect ? fe : null;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not FilterEffect instance) return false;
+        IsExpanded.Value = true;
+        if (Value.Value is FilterEffectGroup group)
+            AddItem(instance);
+        else
+            ChangeFilter(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
 
     // Drop時にも利用できる、JSON文字列からの貼り付け処理
     public override bool TryPasteJson(string json)
@@ -208,16 +229,14 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
         return true;
     }
 
-    public void AddItem(Type type)
+    public void AddItem(FilterEffect instance)
     {
-        if (Value.Value is FilterEffectGroup group
-            && Activator.CreateInstance(type) is FilterEffect instance)
+        if (Value.Value is FilterEffectGroup group)
         {
             IsExpanded.Value = true;
             group.Children.Add(instance);
             Commit();
 
-            // 追加されたアイテムのViewModelを探して展開する
             if (Group.Value is { } listEditor)
             {
                 var addedItem = listEditor.Items.LastOrDefault();
@@ -227,6 +246,12 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
                 }
             }
         }
+    }
+
+    public void AddItem(Type type)
+    {
+        if (Activator.CreateInstance(type) is FilterEffect instance)
+            AddItem(instance);
     }
 
     public void AddTarget(Type presenterType, FilterEffect target)

--- a/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
@@ -81,6 +81,10 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(Geometry);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Geometry;
 
     public ReactivePropertySlim<PropertiesEditorViewModel?> Properties { get; } = new();
@@ -156,6 +160,17 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
 
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is Geometry geom and not FallbackGeometry ? geom : null;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not Geometry instance) return false;
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
 
     public override bool TryPasteJson(string json)
     {

--- a/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
@@ -7,7 +7,14 @@ using Reactive.Bindings;
 
 namespace Beutl.ViewModels.Editors;
 
-public sealed class ListItemAccessorImpl<T> : IPropertyAdapter<T>
+public interface IListItemAccessor
+{
+    int Index { get; }
+
+    System.Collections.IList List { get; }
+}
+
+public sealed class ListItemAccessorImpl<T> : IPropertyAdapter<T>, IListItemAccessor
 {
     private readonly ReactivePropertySlim<T?> _inner = new();
 
@@ -19,6 +26,8 @@ public sealed class ListItemAccessorImpl<T> : IPropertyAdapter<T>
     }
 
     public IList<T?> List { get; }
+
+    System.Collections.IList IListItemAccessor.List => (System.Collections.IList)List;
 
     public Type ImplementedType => throw new InvalidOperationException();
 

--- a/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
@@ -104,6 +104,10 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(Pen);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Pen;
 
     public CoreList<IPropertyEditorContext> MajorProperties { get; } = [];
@@ -128,6 +132,17 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
     }
 
     protected override ICoreSerializable? GetCopyTarget() => Value.Value;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not Pen instance) return false;
+        IsExpanded.Value = true;
+        PropertyAdapter.SetValue(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
 
     public override bool TryPasteJson(string json)
     {

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -303,6 +303,8 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
 
     protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
 
+    public override bool IsTemplateGroup => Value.Value is TransformGroup;
+
     public override bool ApplyTemplate(ObjectTemplateItem template)
     {
         if (template.CreateInstance() is not Transform instance) return false;

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -178,6 +178,10 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
 
     public override IReadOnlyReactiveProperty<bool> CanCopy { get; }
 
+    public override IReadOnlyReactiveProperty<bool> CanSaveAsTemplate => CanCopy;
+
+    protected override Type? TemplateBaseType => typeof(Transform);
+
     protected override DataFormat<string>? PasteFormat => BeutlDataFormats.Transform;
 
     public ReadOnlyReactivePropertySlim<KnownTransformType> TransformType { get; }
@@ -257,23 +261,24 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
         }
     }
 
-    public void ChangeType(KnownTransformType type)
+    public void ChangeTransform(Transform instance)
     {
-        Transform? obj = CreateTransform(type);
-        if (obj != null)
-        {
-            IsExpanded.Value = true;
-            SetValue(Value.Value, obj);
-        }
+        IsExpanded.Value = true;
+        SetValue(Value.Value, instance);
     }
 
-    public void AddItem(KnownTransformType type)
+    public void ChangeType(KnownTransformType type)
     {
-        if (Value.Value is TransformGroup group
-            && CreateTransform(type) is { } obj)
+        if (CreateTransform(type) is { } obj)
+            ChangeTransform(obj);
+    }
+
+    public void AddItem(Transform instance)
+    {
+        if (Value.Value is TransformGroup group)
         {
             IsExpanded.Value = true;
-            group.Children.Add(obj);
+            group.Children.Add(instance);
             Commit();
 
             if (Group.Value is { } listEditor)
@@ -287,8 +292,28 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
         }
     }
 
+    public void AddItem(KnownTransformType type)
+    {
+        if (CreateTransform(type) is { } obj)
+            AddItem(obj);
+    }
+
     protected override ICoreSerializable? GetCopyTarget()
         => Value.Value is { } tf and not FallbackTransform ? tf : null;
+
+    protected override ICoreSerializable? GetTemplateTarget() => GetCopyTarget();
+
+    public override bool ApplyTemplate(ObjectTemplateItem template)
+    {
+        if (template.CreateInstance() is not Transform instance) return false;
+        IsExpanded.Value = true;
+        if (Value.Value is TransformGroup)
+            AddItem(instance);
+        else
+            ChangeTransform(instance);
+        Commit(CommandNames.ApplyTemplate);
+        return true;
+    }
 
     public override bool TryPasteJson(string json)
     {

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Beutl.Audio.Effects;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Services;
@@ -64,6 +66,26 @@ public partial class AudioEffectEditor : UserControl
     private void Drop(object? sender, DragEventArgs e)
     {
         if (DataContext is not AudioEffectEditorViewModel { IsDisposed: false } viewModel) return;
+
+        // テンプレートファイルのドロップ
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && template.CreateInstance() is AudioEffect instance)
+        {
+            if (viewModel.IsGroup.Value)
+            {
+                viewModel.AddItem(instance);
+            }
+            else
+            {
+                viewModel.ChangeAudioEffect(instance);
+            }
+
+            e.Handled = true;
+            return;
+        }
+
         if (e.DataTransfer.TryGetValue(BeutlDataFormats.AudioEffect) is not { } data) return;
 
         if (CoreObjectClipboard.IsJsonData(data))
@@ -90,7 +112,8 @@ public partial class AudioEffectEditor : UserControl
 
     private void DragOver(object? sender, DragEventArgs e)
     {
-        if (e.DataTransfer.Contains(BeutlDataFormats.AudioEffect))
+        if (e.DataTransfer.Contains(BeutlDataFormats.AudioEffect)
+            || e.DataTransfer.Contains(DataFormat.File))
         {
             e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
             e.Handled = true;

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -58,6 +58,7 @@ public partial class AudioEffectEditor : UserControl
         AddHandler(DragDrop.DropEvent, Drop);
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
@@ -49,6 +49,7 @@ public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle => reorderHandle;

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Beutl.Controls;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
@@ -73,6 +74,32 @@ public sealed partial class BrushEditor : UserControl
         TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
         TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, DragOver);
+        AddHandler(DragDrop.DropEvent, Drop);
+    }
+
+    private void Drop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
+
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && viewModel.ApplyTemplate(template))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void DragOver(object? sender, DragEventArgs e)
+    {
+        if (e.DataTransfer.Contains(DataFormat.File))
+        {
+            e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     public Avalonia.Media.Brush? Brush

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -70,7 +70,9 @@ public sealed partial class BrushEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     public Avalonia.Media.Brush? Brush

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -2,7 +2,9 @@
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
 using Beutl.Editor.Components.Views;
 using Beutl.Engine;
@@ -58,6 +60,32 @@ public partial class CoreObjectEditor : UserControl
         TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
         TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, DragOver);
+        AddHandler(DragDrop.DropEvent, Drop);
+    }
+
+    private void Drop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not BaseEditorViewModel { IsDisposed: false } viewModel) return;
+
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && viewModel.ApplyTemplate(template))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void DragOver(object? sender, DragEventArgs e)
+    {
+        if (e.DataTransfer.Contains(DataFormat.File))
+        {
+            e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     private void Navigate_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -55,7 +55,9 @@ public partial class CoreObjectEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Navigate_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -53,6 +53,7 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle => reorderHandle;

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -34,6 +34,7 @@ public partial class DisplacementMapTransformEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Engine;
@@ -69,6 +70,26 @@ public partial class FilterEffectEditor : UserControl
     private void Drop(object? sender, DragEventArgs e)
     {
         if (DataContext is not FilterEffectEditorViewModel { IsDisposed: false } viewModel) return;
+
+        // テンプレートファイルのドロップ
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && template.CreateInstance() is FilterEffect instance)
+        {
+            if (viewModel.IsGroup.Value)
+            {
+                viewModel.AddItem(instance);
+            }
+            else
+            {
+                viewModel.ChangeFilter(instance);
+            }
+
+            e.Handled = true;
+            return;
+        }
+
         if (e.DataTransfer.TryGetValue(BeutlDataFormats.FilterEffect) is not { } data) return;
 
         if (CoreObjectClipboard.IsJsonData(data))
@@ -95,10 +116,12 @@ public partial class FilterEffectEditor : UserControl
 
     private void DragOver(object? sender, DragEventArgs e)
     {
-        if (!e.DataTransfer.Contains(BeutlDataFormats.FilterEffect)) return;
-
-        e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
-        e.Handled = true;
+        if (e.DataTransfer.Contains(BeutlDataFormats.FilterEffect)
+            || e.DataTransfer.Contains(DataFormat.File))
+        {
+            e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     private async void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -61,7 +61,9 @@ public partial class FilterEffectEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
@@ -64,6 +64,7 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -55,6 +55,7 @@ public partial class GeometryEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -2,7 +2,9 @@
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Views;
 using Beutl.Language;
 using Beutl.Logging;
@@ -56,6 +58,32 @@ public partial class GeometryEditor : UserControl
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
         TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, DragOver);
+        AddHandler(DragDrop.DropEvent, Drop);
+    }
+
+    private void Drop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
+
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && viewModel.ApplyTemplate(template))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void DragOver(object? sender, DragEventArgs e)
+    {
+        if (e.DataTransfer.Contains(DataFormat.File))
+        {
+            e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -2,7 +2,9 @@
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 
 using Beutl.Media;
 using Beutl.Services;
@@ -59,6 +61,32 @@ public sealed partial class PenEditor : UserControl
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
         TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
+
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, DragOver);
+        AddHandler(DragDrop.DropEvent, Drop);
+    }
+
+    private void Drop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not PenEditorViewModel { IsDisposed: false } viewModel) return;
+
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && viewModel.ApplyTemplate(template))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void DragOver(object? sender, DragEventArgs e)
+    {
+        if (e.DataTransfer.Contains(DataFormat.File))
+        {
+            e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
+            e.Handled = true;
+        }
     }
 
     private void InitializeClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -58,6 +58,7 @@ public sealed partial class PenEditor : UserControl
             });
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
     }
 
     private void InitializeClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -22,7 +22,11 @@ public static class TemplateMenuHelper
         saveMenu.Click += (_, _) =>
         {
             if (control.DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
-            var flyout = new SaveAsTemplateFlyout();
+
+            string defaultName = vm.GetTemplateDefaultName();
+            string uniqueName = ObjectTemplateService.Instance.GetUniqueName(defaultName);
+
+            var flyout = new SaveAsTemplateFlyout { Text = uniqueName };
             flyout.Confirmed += async (_, name) =>
             {
                 if (!string.IsNullOrWhiteSpace(name))

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Beutl.Controls;

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -35,25 +35,62 @@ public static class TemplateMenuHelper
         };
 
         var applySubMenu = new MenuFlyoutSubItem { Text = Strings.ApplyTemplate };
+        var addSubMenu = new MenuFlyoutSubItem { Text = Strings.AddFromTemplate };
 
         menuFlyout.Opening += (_, _) =>
         {
             applySubMenu.Items.Clear();
-            if (control.DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+            addSubMenu.Items.Clear();
+
+            if (control.DataContext is not BaseEditorViewModel { IsDisposed: false } vm)
             {
-                foreach (ObjectTemplateItem t in vm.GetApplicableTemplates())
+                applySubMenu.IsVisible = true;
+                addSubMenu.IsVisible = false;
+                applySubMenu.IsEnabled = false;
+                return;
+            }
+
+            bool isListItem = vm.IsListItemAdapter;
+            bool isGroup = vm.IsTemplateGroup;
+            var templates = vm.GetApplicableTemplates().ToList();
+
+            if (isListItem)
+            {
+                // ListItem: 「テンプレートを適用」(置き換え) と「テンプレートから追加」(親リストに追加) の2つを表示
+                applySubMenu.IsVisible = true;
+                addSubMenu.IsVisible = true;
+
+                foreach (ObjectTemplateItem t in templates)
                 {
-                    var mi = new MenuFlyoutItem { Text = t.Name.Value, Tag = t };
-                    mi.Click += (s, _) =>
-                    {
-                        if (s is MenuFlyoutItem { Tag: ObjectTemplateItem item })
-                            vm.ApplyTemplate(item);
-                    };
-                    applySubMenu.Items.Add(mi);
+                    applySubMenu.Items.Add(CreateApplyMenuItem(t, vm));
+                    addSubMenu.Items.Add(CreateAddMenuItem(t, vm, useApplyTemplate: false));
+                }
+            }
+            else if (isGroup)
+            {
+                // Group: 「テンプレートから追加」のみ表示（ApplyTemplate がグループに追加する）
+                applySubMenu.IsVisible = false;
+                addSubMenu.IsVisible = true;
+
+                foreach (ObjectTemplateItem t in templates)
+                {
+                    addSubMenu.Items.Add(CreateAddMenuItem(t, vm, useApplyTemplate: true));
+                }
+            }
+            else
+            {
+                // 通常: 「テンプレートを適用」のみ
+                applySubMenu.IsVisible = true;
+                addSubMenu.IsVisible = false;
+
+                foreach (ObjectTemplateItem t in templates)
+                {
+                    applySubMenu.Items.Add(CreateApplyMenuItem(t, vm));
                 }
             }
 
             applySubMenu.IsEnabled = applySubMenu.Items.Count > 0;
+            addSubMenu.IsEnabled = addSubMenu.Items.Count > 0;
         };
 
         var separator = new MenuFlyoutSeparator();
@@ -65,5 +102,31 @@ public static class TemplateMenuHelper
         menuFlyout.Items.Add(separator);
         menuFlyout.Items.Add(saveMenu);
         menuFlyout.Items.Add(applySubMenu);
+        menuFlyout.Items.Add(addSubMenu);
+    }
+
+    private static MenuFlyoutItem CreateApplyMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm)
+    {
+        var mi = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+        mi.Click += (s, _) =>
+        {
+            if (s is MenuFlyoutItem { Tag: ObjectTemplateItem item })
+                vm.ApplyTemplate(item);
+        };
+        return mi;
+    }
+
+    private static MenuFlyoutItem CreateAddMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm, bool useApplyTemplate)
+    {
+        var mi = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+        mi.Click += (s, _) =>
+        {
+            if (s is not MenuFlyoutItem { Tag: ObjectTemplateItem item }) return;
+            if (useApplyTemplate)
+                vm.ApplyTemplate(item);
+            else
+                vm.AddTemplateAsListItem(item);
+        };
+        return mi;
     }
 }

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -1,0 +1,69 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Beutl.Controls;
+using Beutl.Services;
+using Beutl.ViewModels.Editors;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.Views.Editors;
+
+public static class TemplateMenuHelper
+{
+    public static void AddMenus(FAMenuFlyout menuFlyout, Control control)
+    {
+        var dataContext = control.GetObservable(StyledElement.DataContextProperty)
+            .Select(obj => obj as BaseEditorViewModel);
+
+        var saveMenu = new MenuFlyoutItem { Text = Strings.SaveAsTemplate };
+        saveMenu.Bind(
+            InputElement.IsEnabledProperty,
+            dataContext.Select(d => d?.CanSaveAsTemplate ?? Observable.ReturnThenNever(false)).Switch());
+        saveMenu.Click += (_, _) =>
+        {
+            if (control.DataContext is not BaseEditorViewModel { IsDisposed: false } vm) return;
+            var flyout = new SaveAsTemplateFlyout();
+            flyout.Confirmed += async (_, name) =>
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    await vm.SaveAsTemplateAsync(name);
+                    NotificationService.ShowInformation(Strings.Templates, Strings.TemplateSaved);
+                }
+            };
+            flyout.ShowAt(control);
+        };
+
+        var applySubMenu = new MenuFlyoutSubItem { Text = Strings.ApplyTemplate };
+
+        menuFlyout.Opening += (_, _) =>
+        {
+            applySubMenu.Items.Clear();
+            if (control.DataContext is BaseEditorViewModel { IsDisposed: false } vm)
+            {
+                foreach (ObjectTemplateItem t in vm.GetApplicableTemplates())
+                {
+                    var mi = new MenuFlyoutItem { Text = t.Name.Value, Tag = t };
+                    mi.Click += (s, _) =>
+                    {
+                        if (s is MenuFlyoutItem { Tag: ObjectTemplateItem item })
+                            vm.ApplyTemplate(item);
+                    };
+                    applySubMenu.Items.Add(mi);
+                }
+            }
+
+            applySubMenu.IsEnabled = applySubMenu.Items.Count > 0;
+        };
+
+        var separator = new MenuFlyoutSeparator();
+        separator.Bind(
+            Visual.IsVisibleProperty,
+            dataContext
+                .Select(d => d?.CanSaveAsTemplate ?? Observable.ReturnThenNever(false))
+                .Switch());
+        menuFlyout.Items.Add(separator);
+        menuFlyout.Items.Add(saveMenu);
+        menuFlyout.Items.Add(applySubMenu);
+    }
+}

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
@@ -89,6 +90,26 @@ public partial class TransformEditor : UserControl
         }
 
         if (DataContext is not TransformEditorViewModel { IsDisposed: false } viewModel) return;
+
+        // テンプレートファイルのドロップ
+        if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } droppedFile
+            && string.Equals(Path.GetExtension(droppedFile), ".json", StringComparison.OrdinalIgnoreCase)
+            && ObjectTemplateService.Instance.TryLoadFromFile(droppedFile) is { } template
+            && template.CreateInstance() is Transform instance)
+        {
+            if (viewModel.IsGroup.Value)
+            {
+                viewModel.AddItem(instance);
+            }
+            else
+            {
+                viewModel.ChangeTransform(instance);
+            }
+
+            e.Handled = true;
+            return;
+        }
+
         if (e.DataTransfer.TryGetValue(BeutlDataFormats.Transform) is not { } data) return;
 
         if (CoreObjectClipboard.IsJsonData(data))
@@ -121,7 +142,8 @@ public partial class TransformEditor : UserControl
 
     private void DragOver(object? sender, DragEventArgs e)
     {
-        if (e.DataTransfer.Contains(BeutlDataFormats.Transform))
+        if (e.DataTransfer.Contains(BeutlDataFormats.Transform)
+            || e.DataTransfer.Contains(DataFormat.File))
         {
             e.DragEffects = DragDropEffects.Copy | DragDropEffects.Link;
             e.Handled = true;

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -63,7 +63,9 @@ public partial class TransformEditor : UserControl
         AddHandler(DragDrop.DropEvent, Drop);
 
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
     }
 
     private void Drop(object? sender, DragEventArgs e)

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
@@ -66,6 +66,7 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
         CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
     }
 
     public Control? ReorderHandle


### PR DESCRIPTION
## Description

- Adds an object template system that lets users save any configured object (brush, pen, transform, filter effect, audio effect, geometry, generic core objects) as a reusable template and re-apply it anywhere in the project, reducing repeat configuration and enabling reuse across scenes.
- Templates persist as JSON files under the user's Beutl templates directory, with a debounced `FileSystemWatcher` so externally added or edited template files show up live in the UI. Duplicate names are auto-suffixed so saving never overwrites silently.
- Integrates template workflows into existing editors and the timeline: save-as-template / apply-template context menus on property editors, "Add from Template" for list items and timeline elements, drag-and-drop of template JSON files onto editors and the timeline, and localized strings for the new commands and messages.

## Breaking changes

None

## Fixed issues

None