### PR TITLE
feat: Add file move via drag-and-drop in file browser

### DIFF
--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
@@ -500,6 +500,75 @@ public sealed class FileBrowserTabViewModel : IToolContext
         CopyFilesToDirectory(files, resourcesDir);
     }
 
+    public void MoveFilesToDirectory(IEnumerable<(string LocalPath, bool IsDirectory)> files, string targetDir)
+    {
+        string normalizedTargetDir = Path.GetFullPath(targetDir);
+        string targetDirWithSep = normalizedTargetDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        foreach (var (localPath, isDir) in files)
+        {
+            string normalizedSource = Path.GetFullPath(localPath);
+
+            // 同じ親ディレクトリ内での自己ドロップはスキップ
+            string? sourceParent = Path.GetDirectoryName(normalizedSource);
+            if (sourceParent != null
+                && string.Equals(
+                    Path.GetFullPath(sourceParent).TrimEnd(Path.DirectorySeparatorChar),
+                    normalizedTargetDir.TrimEnd(Path.DirectorySeparatorChar),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // ディレクトリを自身または子孫に移動することはできない
+            if (isDir)
+            {
+                string sourceWithSep = normalizedSource.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                if (targetDirWithSep.StartsWith(sourceWithSep, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError("Cannot move {Source} into itself or a descendant directory.", normalizedSource);
+                    NotificationService.ShowError(Strings.Move, MessageStrings.OperationFailed);
+                    continue;
+                }
+            }
+
+            string destPath = Path.Combine(normalizedTargetDir, Path.GetFileName(normalizedSource));
+
+            try
+            {
+                if (!isDir)
+                {
+                    if (!File.Exists(destPath))
+                    {
+                        File.Move(normalizedSource, destPath);
+                    }
+                }
+                else if (Directory.Exists(normalizedSource))
+                {
+                    if (!Directory.Exists(destPath))
+                    {
+                        Directory.Move(normalizedSource, destPath);
+                    }
+                }
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "Failed to move {Source} to {Dest}", normalizedSource, destPath);
+                NotificationService.ShowError(Strings.Move, MessageStrings.OperationFailed);
+            }
+        }
+    }
+
+    public void MoveFilesToResources(IEnumerable<(string LocalPath, bool IsDirectory)> files)
+    {
+        if (string.IsNullOrEmpty(_projectDirectory))
+            return;
+
+        string resourcesDir = Path.Combine(_projectDirectory, "resources");
+        Directory.CreateDirectory(resourcesDir);
+        MoveFilesToDirectory(files, resourcesDir);
+    }
+
     public void WriteToJson(JsonObject json)
     {
         json["RootPath"] = RootPath.Value;

--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
@@ -551,7 +551,7 @@ public sealed class FileBrowserTabViewModel : IToolContext
                     }
                 }
             }
-            catch (IOException ex)
+            catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to move {Source} to {Dest}", normalizedSource, destPath);
                 NotificationService.ShowError(Strings.Move, MessageStrings.OperationFailed);

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
@@ -213,12 +213,10 @@ public partial class FileBrowserTabView : UserControl
         {
             e.DragEffects = DragDropEffects.Link;
         }
-        else if (FileItemDragBehavior.IsInternalDragInProgress)
-        {
-            e.DragEffects = DragDropEffects.Move;
-        }
         else
         {
+            // 内部ドラッグでもソース側はCopyのみをアドバタイズしているため、ここではCopyを設定する。
+            // 実際の移動判定はドロップ時に IsInternalDragInProgress を見て行う。
             e.DragEffects = DragDropEffects.Copy;
         }
     }

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
@@ -213,6 +213,10 @@ public partial class FileBrowserTabView : UserControl
         {
             e.DragEffects = DragDropEffects.Link;
         }
+        else if (FileItemDragBehavior.IsInternalDragInProgress)
+        {
+            e.DragEffects = DragDropEffects.Move;
+        }
         else
         {
             e.DragEffects = DragDropEffects.Copy;
@@ -240,6 +244,7 @@ public partial class FileBrowserTabView : UserControl
             return;
 
         var files = GetDroppedFiles(e);
+        bool isInternal = FileItemDragBehavior.IsInternalDragInProgress;
 
         // お気に入りセクション上にドロップ → お気に入りに追加
         if (IsDropOverElement(favoritesSection, e))
@@ -254,21 +259,29 @@ public partial class FileBrowserTabView : UserControl
             FileSystemItemViewModel? folderItem = FindFolderItemUnderCursor(e);
             if (folderItem != null && Directory.Exists(folderItem.FullPath))
             {
-                ViewModel.CopyFilesToDirectory(files.Select(f => (f.LocalPath, f.IsDirectory)), folderItem.FullPath);
+                TransferFiles(files, folderItem.FullPath, isInternal);
                 return;
             }
 
             string? targetDir = ViewModel.ProjectDirectory;
             if (!string.IsNullOrEmpty(targetDir) && Directory.Exists(targetDir))
             {
-                ViewModel.CopyFilesToDirectory(files.Select(f => (f.LocalPath, f.IsDirectory)), targetDir);
+                TransferFiles(files, targetDir, isInternal);
             }
 
             return;
         }
 
-        // メディアファイルセクション上にドロップ → resources フォルダにコピー
-        ViewModel.CopyFilesToResources(files.Select(f => (f.LocalPath, f.IsDirectory)));
+        // メディアファイルセクション上にドロップ → resources フォルダへ
+        var payload = files.Select(f => (f.LocalPath, f.IsDirectory));
+        if (isInternal)
+        {
+            ViewModel.MoveFilesToResources(payload);
+        }
+        else
+        {
+            ViewModel.CopyFilesToResources(payload);
+        }
     }
 
     private void HandleBrowseViewDrop(DragEventArgs e)
@@ -277,18 +290,35 @@ public partial class FileBrowserTabView : UserControl
             return;
 
         var files = GetDroppedFiles(e);
+        bool isInternal = FileItemDragBehavior.IsInternalDragInProgress;
 
         FileSystemItemViewModel? folderItem = FindFolderItemUnderCursor(e);
         if (folderItem != null && Directory.Exists(folderItem.FullPath))
         {
-            ViewModel.CopyFilesToDirectory(files.Select(f => (f.LocalPath, f.IsDirectory)), folderItem.FullPath);
+            TransferFiles(files, folderItem.FullPath, isInternal);
             return;
         }
 
         string? rootPath = ViewModel.RootPath.Value;
         if (!string.IsNullOrEmpty(rootPath) && Directory.Exists(rootPath))
         {
-            ViewModel.CopyFilesToDirectory(files.Select(f => (f.LocalPath, f.IsDirectory)), rootPath);
+            TransferFiles(files, rootPath, isInternal);
+        }
+    }
+
+    private void TransferFiles(List<(string LocalPath, bool IsDirectory)> files, string targetDir, bool isInternal)
+    {
+        if (ViewModel == null)
+            return;
+
+        var payload = files.Select(f => (f.LocalPath, f.IsDirectory));
+        if (isInternal)
+        {
+            ViewModel.MoveFilesToDirectory(payload, targetDir);
+        }
+        else
+        {
+            ViewModel.CopyFilesToDirectory(payload, targetDir);
         }
     }
 

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
@@ -16,6 +16,10 @@ public class FileItemDragBehavior : Behavior<Control>
     private FileSystemItemViewModel? _dragItem;
     private bool _isDragStarting;
 
+    // FileBrowserTab内部から開始されたドラッグ操作が進行中かどうかを示す。
+    // ドロップ時にコピーではなく移動として扱うべきかの判定に用いる。
+    public static bool IsInternalDragInProgress { get; private set; }
+
     protected override void OnAttached()
     {
         base.OnAttached();
@@ -73,6 +77,7 @@ public class FileItemDragBehavior : Behavior<Control>
             return;
 
         _isDragStarting = true;
+        IsInternalDragInProgress = true;
         try
         {
             var data = new DataTransfer();
@@ -96,13 +101,14 @@ public class FileItemDragBehavior : Behavior<Control>
                 }
             }
 
-            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
+            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Move | DragDropEffects.Copy);
         }
         finally
         {
             _dragStartPoint = null;
             _dragItem = null;
             _isDragStarting = false;
+            IsInternalDragInProgress = false;
         }
     }
 

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
@@ -101,7 +101,9 @@ public class FileItemDragBehavior : Behavior<Control>
                 }
             }
 
-            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Move | DragDropEffects.Copy);
+            // 外部アプリ（Finder/Explorer等）にMoveを要求させないため、ソース側ではCopyのみを許可する。
+            // FileBrowserTab内部での移動は、ドロップハンドラ側で IsInternalDragInProgress を見て実施する。
+            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
         }
         finally
         {


### PR DESCRIPTION
## Description
- Drag-and-drop within the file browser tab now moves files/folders instead of copying, matching standard file-manager conventions.
- External drops (from outside the app) still perform a copy, so existing import workflows are unaffected.
- Guards prevent self-drops into the same parent directory and moving a directory into itself or a descendant.

## Breaking changes
None

## Fixed issues
None