### PR TITLE
refactor: standardize editor views with shared helper classes

### DIFF
--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
@@ -193,7 +193,7 @@ public partial class FileBrowserTabView : UserControl
         var target = (Control?)sourceControl?.FindLogicalAncestorOfType<TreeViewItem>()
                      ?? (Control?)sourceControl?.FindLogicalAncestorOfType<ListBoxItem>()
                      ?? this;
-        flyout.ShowAt(target);
+        flyout.ShowAt(target, true);
     }
 
     private void BreadcrumbBarItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -232,7 +232,7 @@ public sealed partial class ElementView : UserControl
         s_colorPickerFlyout.Confirmed += OnColorPickerFlyoutConfirmed;
         s_colorPickerFlyout.Closed += OnColorPickerFlyoutClosed;
 
-        s_colorPickerFlyout.ShowAt(border);
+        s_colorPickerFlyout.ShowAt(border, true);
     }
 
     private void OnColorPickerFlyoutClosed(object? sender, EventArgs e)

--- a/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
@@ -27,7 +27,7 @@ public partial class KeyMapSettingsPage : UserControl
             var flyout = new KeyMapFlyout();
             _keyGesture.Value = item.KeyGesture.Value;
             flyout.Bind(KeyMapFlyout.GestureProperty, _keyGesture);
-            flyout.ShowAt(control);
+            flyout.ShowAt(control, true);
             flyout.Confirmed += (_, _) => item.SetKeyGesture(flyout.Gesture);
 
             e.Handled = true;

--- a/src/Beutl/ViewModels/Editors/CornerRadiusEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CornerRadiusEditorViewModel.cs
@@ -49,12 +49,7 @@ public sealed class CornerRadiusEditorViewModel : ValueEditorViewModel<Media.Cor
         base.Accept(visitor);
         if (visitor is Vector4Editor<float> editor && !Disposables.IsDisposed)
         {
-            var stepAttr = PropertyAdapter.GetAttributes().OfType<NumberStepAttribute>().FirstOrDefault();
-            if (stepAttr != null)
-            {
-                editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-            }
+            VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
             editor.Bind(Vector4Editor<float>.FirstValueProperty, FirstValue.ToBinding())
                 .DisposeWith(Disposables);

--- a/src/Beutl/ViewModels/Editors/ThicknessEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ThicknessEditorViewModel.cs
@@ -49,12 +49,7 @@ public sealed class ThicknessEditorViewModel : ValueEditorViewModel<Graphics.Thi
         base.Accept(visitor);
         if (visitor is Vector4Editor<float> editor && !Disposables.IsDisposed)
         {
-            var stepAttr = PropertyAdapter.GetAttributes().OfType<NumberStepAttribute>().FirstOrDefault();
-            if (stepAttr != null)
-            {
-                editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-            }
+            VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
             editor.Bind(Vector4Editor<float>.FirstValueProperty, FirstValue.ToBinding())
                 .DisposeWith(Disposables);

--- a/src/Beutl/ViewModels/Editors/VectorEditorBindingHelper.cs
+++ b/src/Beutl/ViewModels/Editors/VectorEditorBindingHelper.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Numerics;
 using Beutl.Controls.PropertyEditors;
 

--- a/src/Beutl/ViewModels/Editors/VectorEditorBindingHelper.cs
+++ b/src/Beutl/ViewModels/Editors/VectorEditorBindingHelper.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using System.Numerics;
+using Beutl.Controls.PropertyEditors;
+
+namespace Beutl.ViewModels.Editors;
+
+internal static class VectorEditorBindingHelper
+{
+    public static void ApplyNumberAttributes<TElement>(Vector2Editor<TElement> editor, IPropertyAdapter adapter)
+        where TElement : INumber<TElement>
+    {
+        var attrs = adapter.GetAttributes();
+        var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
+        if (stepAttr != null)
+        {
+            editor.LargeChange = TElement.CreateTruncating(stepAttr.LargeChange);
+            editor.SmallChange = TElement.CreateTruncating(stepAttr.SmallChange);
+        }
+
+        var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
+        if (formatAttr != null)
+        {
+            editor.NumberFormat = formatAttr.DataFormatString;
+        }
+    }
+
+    public static void ApplyNumberAttributes<TElement>(Vector3Editor<TElement> editor, IPropertyAdapter adapter)
+        where TElement : INumber<TElement>
+    {
+        var attrs = adapter.GetAttributes();
+        var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
+        if (stepAttr != null)
+        {
+            editor.LargeChange = TElement.CreateTruncating(stepAttr.LargeChange);
+            editor.SmallChange = TElement.CreateTruncating(stepAttr.SmallChange);
+        }
+
+        var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
+        if (formatAttr != null)
+        {
+            editor.NumberFormat = formatAttr.DataFormatString;
+        }
+    }
+
+    public static void ApplyNumberAttributes<TElement>(Vector4Editor<TElement> editor, IPropertyAdapter adapter)
+        where TElement : INumber<TElement>
+    {
+        var attrs = adapter.GetAttributes();
+        var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
+        if (stepAttr != null)
+        {
+            editor.LargeChange = TElement.CreateTruncating(stepAttr.LargeChange);
+            editor.SmallChange = TElement.CreateTruncating(stepAttr.SmallChange);
+        }
+
+        var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
+        if (formatAttr != null)
+        {
+            editor.NumberFormat = formatAttr.DataFormatString;
+        }
+    }
+}

--- a/src/Beutl/ViewModels/Editors/VectorEditorViewModels.cs
+++ b/src/Beutl/ViewModels/Editors/VectorEditorViewModels.cs
@@ -1,9 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Interactivity;
 
 using Beutl.Controls.PropertyEditors;
-using Beutl.Extensibility;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 
@@ -37,19 +35,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<int> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = int.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = int.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -113,19 +99,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<int> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = int.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = int.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = Strings.Width;
                 editor.SecondHeader = Strings.Height;
@@ -189,19 +163,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -265,19 +227,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = Strings.Width;
                 editor.SecondHeader = Strings.Height;
@@ -341,19 +291,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -417,19 +355,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -502,19 +428,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector3Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -599,19 +513,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector4Editor<int> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = int.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = int.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -698,19 +600,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector4Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -797,19 +687,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector4Editor<float> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = float.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = float.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";

--- a/src/Beutl/ViewModels/Editors/VectorEditorViewModels.tt
+++ b/src/Beutl/ViewModels/Editors/VectorEditorViewModels.tt
@@ -24,12 +24,10 @@
         ("System.Numerics", "Vector4", "float", "X", "Y", "Z", "W", false),
     };
 #>
-using System.ComponentModel.DataAnnotations;
 using Avalonia;
 using Avalonia.Interactivity;
 
 using Beutl.Controls.PropertyEditors;
-using Beutl.Extensibility;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 
@@ -65,19 +63,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector2Editor<<#= t.Element #>> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = <#= t.Element #>.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = <#= t.Element #>.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
 <# if (t.IsSize) { #>
                 editor.FirstHeader = Strings.Width;
@@ -158,19 +144,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector3Editor<<#= t.Element #>> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = <#= t.Element #>.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = <#= t.Element #>.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";
@@ -258,19 +232,7 @@ namespace Beutl.ViewModels.Editors
             base.Accept(visitor);
             if (visitor is Vector4Editor<<#= t.Element #>> editor && !Disposables.IsDisposed)
             {
-                var attrs = PropertyAdapter.GetAttributes();
-                var stepAttr = attrs.OfType<NumberStepAttribute>().FirstOrDefault();
-                if (stepAttr != null)
-                {
-                    editor.LargeChange = <#= t.Element #>.CreateTruncating(stepAttr.LargeChange);
-                    editor.SmallChange = <#= t.Element #>.CreateTruncating(stepAttr.SmallChange);
-                }
-
-                var formatAttr = attrs.OfType<DisplayFormatAttribute>().FirstOrDefault();
-                if (formatAttr != null)
-                {
-                    editor.NumberFormat = formatAttr.DataFormatString;
-                }
+                VectorEditorBindingHelper.ApplyNumberAttributes(editor, PropertyAdapter);
 
                 editor.FirstHeader = "X";
                 editor.SecondHeader = "Y";

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -1,13 +1,9 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Audio.Effects;
 using Beutl.Editor.Components.Helpers;
-using Beutl.Editor.Components.Views;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
@@ -17,50 +13,19 @@ namespace Beutl.Views.Editors;
 
 public partial class AudioEffectEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
     private bool _flyoutOpen;
 
     public AudioEffectEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as AudioEffectEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<AudioEffectEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
 
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)expandToggle.ContextFlyout!);
     }
 
     private void Drop(object? sender, DragEventArgs e)

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml.cs
@@ -118,29 +118,7 @@ public partial class AudioEffectEditor : UserControl
         {
             _flyoutOpen = true;
             var viewModel = new SelectAudioEffectTypeViewModel();
-            var dialog = new LibraryItemPickerFlyout(viewModel);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<Type?>();
-            dialog.Pinned += (_, item) => viewModel.Pin(item);
-            dialog.Unpinned += (_, item) => viewModel.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (viewModel.SelectedItem.Value?.UserData)
-                {
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(KnownLibraryItemFormats.AudioEffect));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowTypeOnlyAsync(this, viewModel, KnownLibraryItemFormats.AudioEffect);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
@@ -12,7 +12,7 @@ public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
         ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
         FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
-        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        reorderHandle.ContextFlyout = new FAMenuFlyout { Placement = PlacementMode.Pointer };
         EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml.cs
@@ -1,55 +1,19 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Beutl.Editor.Components.Views;
-using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;
 
 public partial class AudioEffectListItemEditor : UserControl, IListItemEditor
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
-
     public AudioEffectListItemEditor()
     {
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as AudioEffectEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<AudioEffectEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 
     public Control? ReorderHandle => reorderHandle;

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -53,7 +53,7 @@
                             Click="Menu_Click"
                             Theme="{StaticResource TransparentButton}">
                         <Button.ContextFlyout>
-                            <ui:FAMenuFlyout>
+                            <ui:FAMenuFlyout Placement="Pointer">
                                 <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                         Tag="Solid"
@@ -106,7 +106,7 @@
                         Classes="size-24x24"
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
-                        <ui:FAMenuFlyout>
+                        <ui:FAMenuFlyout Placement="Pointer">
                             <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                     Tag="Solid"

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -1,14 +1,11 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Controls;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
-using Beutl.Editor.Components.Views;
 using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.Media;
@@ -30,50 +27,19 @@ public sealed partial class BrushEditor : UserControl
     public static readonly StyledProperty<Media.Brush?> OriginalBrushProperty =
         AvaloniaProperty.Register<BrushEditor, Media.Brush?>(nameof(OriginalBrush));
 
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts;
-
     private BrushEditorFlyout? _flyout;
-    private FallbackObjectView? _fallbackObjectView;
     private bool _flyoutOpen;
 
     public BrushEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        FallbackObjectViewHelper.Attach(this, view => (content.Child as Panel)?.Children.Add(view));
 
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as BrushEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<BrushEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                (content.Child as Panel)?.Children.Add(_fallbackObjectView);
-            });
-
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(
+            this,
+            (FAMenuFlyout)ExpandMenuButton.ContextFlyout!,
+            (FAMenuFlyout)ReferenceMenuButton.Flyout!);
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
@@ -189,32 +155,7 @@ public sealed partial class BrushEditor : UserControl
                 selectVm.InitializeReferences(targets);
             }
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case TargetObjectInfo target:
-                        tcs.SetResult(target.Object);
-                        break;
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(KnownLibraryItemFormats.Drawable));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, KnownLibraryItemFormats.Drawable);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -186,7 +186,7 @@ public sealed partial class BrushEditor : UserControl
         _flyout.DrawableName = GetDrawableName((OriginalBrush as Media.DrawableBrush)?.Drawable.CurrentValue);
         _flyout.CanEditDrawable = (OriginalBrush as Media.DrawableBrush)?.Drawable.CurrentValue is not null;
 
-        _flyout.ShowAt(this);
+        _flyout.ShowAt(this, true);
     }
 
     private void OnEditDrawableClicked(object? sender, EventArgs e)

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -1,12 +1,8 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
-using Beutl.Editor.Components.Views;
 using Beutl.Engine;
 using Beutl.Services;
 using Beutl.ViewModels;
@@ -19,47 +15,18 @@ namespace Beutl.Views.Editors;
 
 public partial class CoreObjectEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
     private bool _flyoutOpen;
 
     public CoreObjectEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as IFallbackObjectViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<IFallbackObjectViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
-
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(
+            this,
+            (FAMenuFlyout)expandToggle.ContextFlyout!,
+            (FAMenuFlyout)ReferenceMenuButton.Flyout!);
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
@@ -157,32 +124,7 @@ public partial class CoreObjectEditor : UserControl
                 selectVm.InitializeReferences(targets);
             }
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case TargetObjectInfo target:
-                        tcs.SetResult(target.Object);
-                        break;
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(format));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, format);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -145,7 +145,7 @@ public partial class CoreObjectEditor : UserControl
             pickerVm.Initialize(targets);
 
             var flyout = new TargetPickerFlyout(pickerVm);
-            flyout.ShowAt(this);
+            flyout.ShowAt(this, true);
 
             var tcs = new TaskCompletionSource<CoreObject?>();
             flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -17,7 +17,7 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
         ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
         FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
-        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        reorderHandle.ContextFlyout = new FAMenuFlyout { Placement = PlacementMode.Pointer };
         EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -68,7 +68,7 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
             pickerVm.Initialize(targets);
 
             var flyout = new TargetPickerFlyout(pickerVm);
-            flyout.ShowAt(this);
+            flyout.ShowAt(this, true);
 
             var tcs = new TaskCompletionSource<CoreObject?>();
             flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml.cs
@@ -1,11 +1,6 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Beutl.Editor.Components.Views;
 using Beutl.Engine;
-using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
@@ -14,46 +9,16 @@ namespace Beutl.Views.Editors;
 
 public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
     private bool _flyoutOpen;
 
     public CoreObjectListItemEditor()
     {
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as IFallbackObjectViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<IFallbackObjectViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 
     public Control? ReorderHandle => reorderHandle;
@@ -140,32 +105,7 @@ public partial class CoreObjectListItemEditor : UserControl, IListItemEditor
                 selectVm.InitializeReferences(targets);
             }
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case TargetObjectInfo target:
-                        tcs.SetResult(target.Object);
-                        break;
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(format));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, format);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -1,7 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
@@ -10,31 +7,11 @@ namespace Beutl.Views.Editors;
 
 public partial class DisplacementMapTransformEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-    private CancellationTokenSource? _lastTransitionCts;
-
     public DisplacementMapTransformEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)expandToggle.ContextFlyout!);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/EditorMenuHelper.cs
+++ b/src/Beutl/Views/Editors/EditorMenuHelper.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.Views.Editors;
+
+public static class EditorMenuHelper
+{
+    public static void AttachCopyPasteAndTemplateMenus(Control host, params FAMenuFlyout[] flyouts)
+    {
+        foreach (FAMenuFlyout flyout in flyouts)
+        {
+            CopyPasteMenuHelper.AddMenus(flyout, host);
+            TemplateMenuHelper.AddMenus(flyout, host);
+        }
+    }
+}

--- a/src/Beutl/Views/Editors/EditorMenuHelper.cs
+++ b/src/Beutl/Views/Editors/EditorMenuHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Editors;

--- a/src/Beutl/Views/Editors/ExpandTransitionHelper.cs
+++ b/src/Beutl/Views/Editors/ExpandTransitionHelper.cs
@@ -1,0 +1,34 @@
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls.Primitives;
+
+namespace Beutl.Views.Editors;
+
+public static class ExpandTransitionHelper
+{
+    public static readonly TimeSpan DefaultDuration = TimeSpan.FromMilliseconds(250);
+    public static readonly TimeSpan ListItemDuration = TimeSpan.FromMilliseconds(167);
+
+    public static IDisposable Attach(ToggleButton toggle, Visual content, TimeSpan? duration = null)
+    {
+        var transition = new CrossFade(duration ?? DefaultDuration);
+        CancellationTokenSource? cts = null;
+
+        return toggle.GetObservable(ToggleButton.IsCheckedProperty)
+            .Subscribe(async v =>
+            {
+                cts?.Cancel();
+                cts = new CancellationTokenSource();
+                CancellationToken token = cts.Token;
+
+                if (v == true)
+                {
+                    await transition.Start(null, content, token);
+                }
+                else
+                {
+                    await transition.Start(content, null, token);
+                }
+            });
+    }
+}

--- a/src/Beutl/Views/Editors/ExpandTransitionHelper.cs
+++ b/src/Beutl/Views/Editors/ExpandTransitionHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls.Primitives;
 

--- a/src/Beutl/Views/Editors/FallbackObjectViewHelper.cs
+++ b/src/Beutl/Views/Editors/FallbackObjectViewHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Beutl.Editor.Components.Views;
 

--- a/src/Beutl/Views/Editors/FallbackObjectViewHelper.cs
+++ b/src/Beutl/Views/Editors/FallbackObjectViewHelper.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Beutl.Editor.Components.Views;
+
+namespace Beutl.Views.Editors;
+
+public static class FallbackObjectViewHelper
+{
+    public static IDisposable Attach(Control host, Action<FallbackObjectView> addView)
+    {
+        return host.GetObservable(StyledElement.DataContextProperty)
+            .Select(x => x as IFallbackObjectViewModel)
+            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<IFallbackObjectViewModel?>(null))
+            .Switch()
+            .Where(v => v?.IsFallback.Value == true)
+            .Take(1)
+            .Subscribe(_ => addView(new FallbackObjectView()));
+    }
+}

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -1,12 +1,8 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Helpers;
-using Beutl.Editor.Components.Views;
 using Beutl.Engine;
 using Beutl.Graphics.Effects;
 using Beutl.Models;
@@ -19,52 +15,23 @@ namespace Beutl.Views.Editors;
 
 public partial class FilterEffectEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
     private bool _flyoutOpen;
 
     public FilterEffectEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(expandToggle, content);
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
 
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as FilterEffectEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<FilterEffectEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(
+            this,
+            (FAMenuFlyout)expandToggle.ContextFlyout!,
+            (FAMenuFlyout)ReferenceMenuButton.Flyout!);
     }
 
     private void Drop(object? sender, DragEventArgs e)
@@ -175,32 +142,7 @@ public partial class FilterEffectEditor : UserControl
                 selectVm.InitializeReferences(targets);
             }
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case TargetObjectInfo target:
-                        tcs.SetResult(target.Object);
-                        break;
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(KnownLibraryItemFormats.FilterEffect));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, KnownLibraryItemFormats.FilterEffect);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml.cs
@@ -199,7 +199,7 @@ public partial class FilterEffectEditor : UserControl
             pickerVm.Initialize(targets);
 
             var flyout = new TargetPickerFlyout(pickerVm);
-            flyout.ShowAt(this);
+            flyout.ShowAt(this, true);
 
             var tcs = new TaskCompletionSource<FilterEffect?>();
             flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
@@ -1,12 +1,8 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Beutl.Controls.PropertyEditors;
-using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Effects;
-using Beutl.Services;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
 
@@ -19,41 +15,11 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             nameof(ReorderHandle),
             o => o.ReorderHandle);
 
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
-
     public FilterEffectListItemEditor()
     {
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as FilterEffectEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<FilterEffectEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         this.GetObservable(DataContextProperty)
             .Select(x => x as FilterEffectEditorViewModel)
@@ -63,8 +29,7 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 
     public Control? ReorderHandle

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml.cs
@@ -28,7 +28,7 @@ public partial class FilterEffectListItemEditor : UserControl, IListItemEditor
             .CombineLatest(presenterEditor.GetObservable(PropertyEditor.ReorderHandleProperty))
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
 
-        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        reorderHandle.ContextFlyout = new FAMenuFlyout { Placement = PlacementMode.Pointer };
         EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -1,12 +1,8 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
-using Beutl.Editor.Components.Views;
-using Beutl.Language;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Services;
@@ -18,46 +14,15 @@ namespace Beutl.Views.Editors;
 
 public partial class GeometryEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
     private readonly ILogger _logger = Log.CreateLogger<GeometryEditor>();
-
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
 
     public GeometryEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as GeometryEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<GeometryEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
-
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)expandToggle.ContextFlyout!);
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);

--- a/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml.cs
+++ b/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml.cs
@@ -1,7 +1,5 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Interactivity;
@@ -13,29 +11,11 @@ namespace Beutl.Views.Editors;
 
 public partial class GraphModelNodeMemberView : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-
     public GraphModelNodeMemberView()
     {
         Resources["ViewModelToViewConverter"] = ViewModelToViewConverter.Instance;
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(expandToggle, content, ExpandTransitionHelper.ListItemDuration);
     }
 
     public void Remove_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
+++ b/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
@@ -1,0 +1,72 @@
+using Avalonia.Controls;
+using Beutl.Services;
+using Beutl.ViewModels.Dialogs;
+using Beutl.ViewModels.Editors;
+
+namespace Beutl.Views.Editors;
+
+public static class LibraryItemPickerHelper
+{
+    public static Task<object?> ShowAsync(
+        Control host,
+        SelectLibraryItemDialogViewModel selectVm,
+        string multipleTypeFormat)
+    {
+        var dialog = new LibraryItemPickerFlyout(selectVm);
+        dialog.ShowAt(host);
+        var tcs = new TaskCompletionSource<object?>();
+        dialog.Pinned += (_, item) => selectVm.Pin(item);
+        dialog.Unpinned += (_, item) => selectVm.Unpin(item);
+        dialog.Dismissed += (_, _) => tcs.SetResult(null);
+        dialog.Confirmed += (_, _) =>
+        {
+            switch (selectVm.SelectedItem.Value?.UserData)
+            {
+                case TargetObjectInfo target:
+                    tcs.SetResult(target.Object);
+                    break;
+                case SingleTypeLibraryItem single:
+                    tcs.SetResult(single.ImplementationType);
+                    break;
+                case MultipleTypeLibraryItem multi:
+                    tcs.SetResult(multi.Types.GetValueOrDefault(multipleTypeFormat));
+                    break;
+                default:
+                    tcs.SetResult(null);
+                    break;
+            }
+        };
+
+        return tcs.Task;
+    }
+
+    public static async Task<Type?> ShowTypeOnlyAsync(
+        Control host,
+        SelectLibraryItemDialogViewModel selectVm,
+        string multipleTypeFormat)
+    {
+        var dialog = new LibraryItemPickerFlyout(selectVm);
+        dialog.ShowAt(host);
+        var tcs = new TaskCompletionSource<Type?>();
+        dialog.Pinned += (_, item) => selectVm.Pin(item);
+        dialog.Unpinned += (_, item) => selectVm.Unpin(item);
+        dialog.Dismissed += (_, _) => tcs.SetResult(null);
+        dialog.Confirmed += (_, _) =>
+        {
+            switch (selectVm.SelectedItem.Value?.UserData)
+            {
+                case SingleTypeLibraryItem single:
+                    tcs.SetResult(single.ImplementationType);
+                    break;
+                case MultipleTypeLibraryItem multi:
+                    tcs.SetResult(multi.Types.GetValueOrDefault(multipleTypeFormat));
+                    break;
+                default:
+                    tcs.SetResult(null);
+                    break;
+            }
+        };
+
+        return await tcs.Task;
+    }
+}

--- a/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
+++ b/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
@@ -13,7 +13,7 @@ public static class LibraryItemPickerHelper
         string multipleTypeFormat)
     {
         var dialog = new LibraryItemPickerFlyout(selectVm);
-        dialog.ShowAt(host);
+        dialog.ShowAt(host, true);
         var tcs = new TaskCompletionSource<object?>();
         dialog.Pinned += (_, item) => selectVm.Pin(item);
         dialog.Unpinned += (_, item) => selectVm.Unpin(item);
@@ -46,7 +46,7 @@ public static class LibraryItemPickerHelper
         string multipleTypeFormat)
     {
         var dialog = new LibraryItemPickerFlyout(selectVm);
-        dialog.ShowAt(host);
+        dialog.ShowAt(host, true);
         var tcs = new TaskCompletionSource<Type?>();
         dialog.Pinned += (_, item) => selectVm.Pin(item);
         dialog.Unpinned += (_, item) => selectVm.Unpin(item);

--- a/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
+++ b/src/Beutl/Views/Editors/LibraryItemPickerHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Editors;

--- a/src/Beutl/Views/Editors/ListEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/ListEditor.axaml.cs
@@ -379,29 +379,7 @@ public partial class ListEditor : UserControl
             string format = propertyType.FullName!;
             var selectVm = new SelectLibraryItemDialogViewModel(format, propertyType);
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(format));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, format);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
@@ -1,6 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 
@@ -18,29 +16,10 @@ namespace Beutl.Views.Editors;
 
 public partial class PathFigureListItemEditor : UserControl, IListItemEditor
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts;
-
     public PathFigureListItemEditor()
     {
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content);
     }
 
     private void Tag_Click(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml.cs
@@ -1,35 +1,14 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 
 namespace Beutl.Views.Editors;
 
 public partial class PathOperationListItemEditor : UserControl, IListItemEditor
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-
     public PathOperationListItemEditor()
     {
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
     }
 
     public Control? ReorderHandle => reorderHandle;

--- a/src/Beutl/Views/Editors/PenEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PenEditor.axaml.cs
@@ -1,7 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
@@ -16,51 +13,14 @@ namespace Beutl.Views.Editors;
 
 public sealed partial class PenEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts1;
-    private CancellationTokenSource? _lastTransitionCts2;
-
     public PenEditor()
     {
         Resources["ViewModelToViewConverter"] = ViewModelToViewConverter.Instance;
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts1?.Cancel();
-                _lastTransitionCts1 = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts1.Token;
+        ExpandTransitionHelper.Attach(expandToggle, content);
+        ExpandTransitionHelper.Attach(expandMinorProps, minorProps);
 
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        expandMinorProps.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts2?.Cancel();
-                _lastTransitionCts2 = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts2.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, minorProps, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(minorProps, null, localToken);
-                }
-            });
-
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ExpandMenuButton.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)ExpandMenuButton.ContextFlyout!);
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
@@ -141,7 +141,7 @@ public sealed partial class PropertyEditorMenu : UserControl
                 args.Error = error;
             };
 
-            flyout.ShowAt(this);
+            flyout.ShowAt(this, true);
         }
     }
 

--- a/src/Beutl/Views/Editors/SceneEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/SceneEditor.axaml.cs
@@ -27,7 +27,7 @@ public partial class SceneEditor : UserControl
             pickerVm.Initialize(targets);
 
             var flyout = new TargetPickerFlyout(pickerVm);
-            flyout.ShowAt(this);
+            flyout.ShowAt(this, true);
 
             var tcs = new TaskCompletionSource<Scene?>();
             flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/TargetSelectionHelper.cs
+++ b/src/Beutl/Views/Editors/TargetSelectionHelper.cs
@@ -17,7 +17,7 @@ public static class TargetSelectionHelper
         pickerVm.Initialize(targets);
 
         var flyout = new TargetPickerFlyout(pickerVm);
-        flyout.ShowAt(host);
+        flyout.ShowAt(host, true);
 
         var tcs = new TaskCompletionSource<T?>();
         flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -35,7 +35,7 @@ public static class TemplateMenuHelper
                     NotificationService.ShowInformation(Strings.Templates, Strings.TemplateSaved);
                 }
             };
-            flyout.ShowAt(control);
+            flyout.ShowAt(control, true);
         };
 
         var applySubMenu = new MenuFlyoutSubItem { Text = Strings.ApplyTemplate };

--- a/src/Beutl/Views/Editors/TextureSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TextureSourceEditor.axaml.cs
@@ -1,13 +1,7 @@
-﻿using Avalonia;
-using Avalonia.Animation;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Beutl.Controls.PropertyEditors;
 using Beutl.Engine;
 using Beutl.Graphics;
-using Beutl.Graphics3D.Textures;
-using Beutl.Media.Source;
 using Beutl.Services;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dialogs;
@@ -19,31 +13,12 @@ namespace Beutl.Views.Editors;
 
 public partial class TextureSourceEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-
-    private CancellationTokenSource? _lastTransitionCts;
     private bool _flyoutOpen;
 
     public TextureSourceEditor()
     {
         InitializeComponent();
-
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(expandToggle, content);
     }
 
     private void Menu_Click(object? sender, RoutedEventArgs e)
@@ -116,32 +91,7 @@ public partial class TextureSourceEditor : UserControl
                 }
             }
 
-            var dialog = new LibraryItemPickerFlyout(selectVm);
-            dialog.ShowAt(this);
-            var tcs = new TaskCompletionSource<object?>();
-            dialog.Pinned += (_, item) => selectVm.Pin(item);
-            dialog.Unpinned += (_, item) => selectVm.Unpin(item);
-            dialog.Dismissed += (_, _) => tcs.SetResult(null);
-            dialog.Confirmed += (_, _) =>
-            {
-                switch (selectVm.SelectedItem.Value?.UserData)
-                {
-                    case TargetObjectInfo target:
-                        tcs.SetResult(target.Object);
-                        break;
-                    case SingleTypeLibraryItem single:
-                        tcs.SetResult(single.ImplementationType);
-                        break;
-                    case MultipleTypeLibraryItem multi:
-                        tcs.SetResult(multi.Types.GetValueOrDefault(KnownLibraryItemFormats.Drawable));
-                        break;
-                    default:
-                        tcs.SetResult(null);
-                        break;
-                }
-            };
-
-            return await tcs.Task;
+            return await LibraryItemPickerHelper.ShowAsync(this, selectVm, KnownLibraryItemFormats.Drawable);
         }
         finally
         {

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -23,7 +23,7 @@
                       Theme="{DynamicResource PropertyEditorMiniExpanderToggleButton}"
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
-                <ui:FAMenuFlyout>
+                <ui:FAMenuFlyout Placement="Pointer">
                     <ui:MenuFlyoutSubItem x:Name="ChangeTypeMenu"
                                           IconSource="New"
                                           Text="{x:Static lang:Strings.Change}" />

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -155,7 +155,7 @@ public partial class TransformEditor : UserControl
     {
         return s_flyout ??= new FAMenuFlyout()
         {
-            Placement = PlacementMode.BottomEdgeAlignedRight,
+            Placement = PlacementMode.Pointer,
             ItemsSource = CreateMenuItems((s, e) => s_handler?.Invoke(s, e))
         };
     }
@@ -223,7 +223,7 @@ public partial class TransformEditor : UserControl
         pickerVm.Initialize(targets);
 
         var flyout = new TargetPickerFlyout(pickerVm);
-        flyout.ShowAt(this);
+        flyout.ShowAt(this, true);
 
         var tcs = new TaskCompletionSource<Transform?>();
         flyout.Dismissed += (_, _) => tcs.TrySetResult(null);

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -1,12 +1,9 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Helpers;
-using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
 using Beutl.Models;
 using Beutl.Services;
@@ -17,56 +14,27 @@ namespace Beutl.Views.Editors;
 
 public partial class TransformEditor : UserControl
 {
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(250));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
-
     private static FAMenuFlyout? s_flyout;
     private static EventHandler<RoutedEventArgs>? s_handler;
 
     public TransformEditor()
     {
         InitializeComponent();
-        expandToggle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
+        ExpandTransitionHelper.Attach(expandToggle, content);
 
         ChangeTypeMenu.ItemsSource = CreateMenuItems(TransformTypeClicked);
         PresenterChangeTypeMenu.ItemsSource = CreateMenuItems(TransformTypeClicked);
 
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as TransformEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<TransformEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DragOverEvent, DragOver);
         AddHandler(DragDrop.DropEvent, Drop);
 
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)expandToggle.ContextFlyout!, this);
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)ReferenceMenuButton.Flyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(
+            this,
+            (FAMenuFlyout)expandToggle.ContextFlyout!,
+            (FAMenuFlyout)ReferenceMenuButton.Flyout!);
     }
 
     private void Drop(object? sender, DragEventArgs e)

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
@@ -1,13 +1,9 @@
 ﻿using Avalonia;
-using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Data.Converters;
 using Avalonia.Interactivity;
 using Beutl.Controls.PropertyEditors;
-using Beutl.Editor.Components.Views;
 using Beutl.Graphics.Transformation;
-using Beutl.Services;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
 
@@ -20,42 +16,12 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             nameof(ReorderHandle),
             o => o.ReorderHandle);
 
-    private static readonly CrossFade s_transition = new(TimeSpan.FromMilliseconds(167));
-    private CancellationTokenSource? _lastTransitionCts;
-    private FallbackObjectView? _fallbackObjectView;
-
     public TransformListItemEditor()
     {
         Resources["TransformTypeToIconConverter"] = TransformTypeToIconConverter.Instance;
         InitializeComponent();
-        reorderHandle.GetObservable(ToggleButton.IsCheckedProperty)
-            .Subscribe(async v =>
-            {
-                _lastTransitionCts?.Cancel();
-                _lastTransitionCts = new CancellationTokenSource();
-                CancellationToken localToken = _lastTransitionCts.Token;
-
-                if (v == true)
-                {
-                    await s_transition.Start(null, content, localToken);
-                }
-                else
-                {
-                    await s_transition.Start(content, null, localToken);
-                }
-            });
-
-        this.GetObservable(DataContextProperty)
-            .Select(x => x as TransformEditorViewModel)
-            .Select(x => x?.IsFallback.Select(_ => x) ?? Observable.ReturnThenNever<TransformEditorViewModel?>(null))
-            .Switch()
-            .Where(v => v?.IsFallback.Value == true)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                _fallbackObjectView = new FallbackObjectView();
-                content.Children.Add(_fallbackObjectView);
-            });
+        ExpandTransitionHelper.Attach(reorderHandle, content, ExpandTransitionHelper.ListItemDuration);
+        FallbackObjectViewHelper.Attach(this, view => content.Children.Add(view));
 
         this.GetObservable(DataContextProperty)
             .Select(x => x as TransformEditorViewModel)
@@ -65,8 +31,7 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
 
         reorderHandle.ContextFlyout = new FAMenuFlyout();
-        CopyPasteMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
-        TemplateMenuHelper.AddMenus((FAMenuFlyout)reorderHandle.ContextFlyout!, this);
+        EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 
     public Control? ReorderHandle

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml.cs
@@ -30,7 +30,7 @@ public partial class TransformListItemEditor : UserControl, IListItemEditor
             .CombineLatest(presenterEditor.GetObservable(PropertyEditor.ReorderHandleProperty))
             .Subscribe(t => UpdateReorderHandle(t.First, t.Second));
 
-        reorderHandle.ContextFlyout = new FAMenuFlyout();
+        reorderHandle.ContextFlyout = new FAMenuFlyout { Placement = PlacementMode.Pointer };
         EditorMenuHelper.AttachCopyPasteAndTemplateMenus(this, (FAMenuFlyout)reorderHandle.ContextFlyout);
     }
 


### PR DESCRIPTION
## Description
- Extract duplicated editor-view logic (expand transitions, fallback object views, copy-paste/template menu wiring, library item pickers, vector number attribute binding) into shared helpers under `src/Beutl/Views/Editors/` and `src/Beutl/ViewModels/Editors/`, cutting ~630 net lines across 30+ editors while making new editors easier to build.
- Standardize flyout positioning by passing `showAtPointer: true` to `Flyout.ShowAt` and setting `Placement="Pointer"` on context `FAMenuFlyout`s so menus anchor near the cursor consistently.

## Breaking changes
None

## Fixed issues
None