### PR TITLE
refactor: split EditViewModel into focused services

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -486,8 +486,7 @@ public sealed partial class TimelineTabView : UserControl
 
         if (template != null)
         {
-            if (viewModel.EditorContext.GetService(typeof(IElementAdder))
-                is IElementAdder adder
+            if (viewModel.EditorContext.GetService<IElementAdder>() is { } adder
                 && (template.BaseType == typeof(Element)
                     || template.BaseType.IsAssignableTo(typeof(EngineObject))))
             {

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -6,6 +6,7 @@ using Beutl.Media.Source;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
@@ -16,6 +17,7 @@ public sealed class BufferedPlayer : IPlayer
     private readonly ILogger _logger = Log.CreateLogger<BufferedPlayer>();
     private readonly ConcurrentQueue<IPlayer.Frame> _queue = new();
     private readonly EditViewModel _editViewModel;
+    private readonly IEditorClock _editorClock;
     private readonly FrameCacheManager _frameCacheManager;
     private readonly SceneRenderer _renderer;
     private readonly Scene _scene;
@@ -34,6 +36,7 @@ public sealed class BufferedPlayer : IPlayer
         _editViewModel = editViewModel;
         _frameCacheManager = editViewModel.FrameCacheManager.Value;
         _renderer = editViewModel.Renderer.Value;
+        _editorClock = editViewModel.GetRequiredService<IEditorClock>();
         _scene = scene;
         _isPlaying = isPlaying;
         _rate = rate;
@@ -47,7 +50,7 @@ public sealed class BufferedPlayer : IPlayer
 
     public void Start()
     {
-        int startFrame = (int)_editViewModel.CurrentTime.Value.ToFrameNumber(_rate);
+        int startFrame = (int)_editorClock.CurrentTime.Value.ToFrameNumber(_rate);
         int durationFrame = (int)Math.Ceiling(_scene.Duration.ToFrameNumber(_rate));
 
         RenderThread.Dispatcher.Dispatch(() =>

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -188,6 +188,9 @@ public static class AnimationEditTutorial
                         EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
                         if (editVm == null) return;
 
+                        var editorClock = editVm.GetService<IEditorClock>();
+                        if (editorClock == null) return;
+
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm.Scene);
                         if (element == null) return;
 
@@ -200,12 +203,12 @@ public static class AnimationEditTutorial
                         // Move playhead forward
                         if (animation.KeyFrames.Count >= 2)
                         {
-                            editVm.CurrentTime.Value = animation.KeyFrames[1].KeyTime + element.Start;
+                            editorClock.CurrentTime.Value = animation.KeyFrames[1].KeyTime + element.Start;
                             Dispatcher.UIThread.Post(() => TutorialService.Current.AdvanceStep());
                         }
                         else
                         {
-                            editVm.CurrentTime.Value = element.Start + TimeSpan.FromSeconds(2);
+                            editorClock.CurrentTime.Value = element.Start + TimeSpan.FromSeconds(2);
                             step4Subscription = TutorialHelpers.SubscribeToKeyFrameAdded(
                                 animation,
                                 2,
@@ -400,9 +403,10 @@ public static class AnimationEditTutorial
                     {
                         EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm?.Scene);
-                        if (editVm != null && element != null)
+                        var clock = editVm?.GetService<IEditorClock>();
+                        if (editVm != null && element != null && clock != null)
                         {
-                            editVm.CurrentTime.Value = element.Start;
+                            clock.CurrentTime.Value = element.Start;
                         }
                     },
                 },

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -15,6 +15,7 @@ using Beutl.ProjectSystem;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.Services.Tutorials;
 
@@ -47,10 +48,11 @@ public static class AnimationEditTutorial
                 if (!result) return false;
 
                 EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
-                if (editVm == null) return false;
+                var adder = editVm?.GetService<IElementAdder>();
+                if (adder == null) return false;
 
                 // 楕円要素を追加
-                editVm.AddElement(new ElementDescription(
+                adder.AddElement(new ElementDescription(
                     Start: TimeSpan.Zero,
                     Length: TimeSpan.FromSeconds(5),
                     Layer: 0,

--- a/src/Beutl/Services/Tutorials/TimelineBasicsTutorial.cs
+++ b/src/Beutl/Services/Tutorials/TimelineBasicsTutorial.cs
@@ -12,6 +12,7 @@ using Beutl.ProjectSystem;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.Services.Tutorials;
 
@@ -142,6 +143,9 @@ public static class TimelineBasicsTutorial
                         EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
                         if (editVm == null) return;
 
+                        var clock = editVm.GetService<IEditorClock>();
+                        if (clock == null) return;
+
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm.Scene);
                         EllipseShape? ellipseOp = TutorialHelpers.GetObject<EllipseShape>(element);
                         if (ellipseOp == null || element == null) return;
@@ -152,12 +156,12 @@ public static class TimelineBasicsTutorial
                         // すでにキーフレームが2つ以上ある場合は現在時間を変更し、次のステップに進む
                         if (animation.KeyFrames.Count >= 2)
                         {
-                            editVm.CurrentTime.Value = animation.KeyFrames[1].KeyTime + element.Start;
+                            clock.CurrentTime.Value = animation.KeyFrames[1].KeyTime + element.Start;
                             Dispatcher.UIThread.Post(() => TutorialService.Current.AdvanceStep());
                         }
                         else
                         {
-                            editVm.CurrentTime.Value = element.Start + TimeSpan.FromSeconds(2);
+                            clock.CurrentTime.Value = element.Start + TimeSpan.FromSeconds(2);
                             step4Subscription = TutorialHelpers.SubscribeToKeyFrameAdded(
                                 animation,
                                 2,

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -179,11 +179,12 @@ public static class TutorialHelpers
         Element? element,
         TimeSpan? additionalDuration = null)
     {
-        if (editVm == null || element == null) return;
+        var clock = editVm?.GetService<IEditorClock>();
+        if (editVm == null || element == null || clock == null) return;
 
         var duration = additionalDuration ?? TimeSpan.FromSeconds(1);
         editVm.Scene.Duration = element.Range.End + duration;
-        editVm.CurrentTime.Value = element.Start;
+        clock.CurrentTime.Value = element.Start;
         editVm.HistoryManager.Commit(CommandNames.ChangeSceneDuration);
     }
 

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -6,6 +6,7 @@ using Beutl.Graphics;
 using Beutl.Graphics.Transformation;
 using Beutl.ProjectSystem;
 using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.Services.Tutorials;
 
@@ -69,16 +70,16 @@ public static class TutorialHelpers
 
     public static IDisposable? SubscribeToElementSelection(EditViewModel? editVm, Action onSelected)
     {
-        if (editVm == null) return null;
+        if (editVm?.GetService<IEditorSelection>() is not { } editorSelection) return null;
 
         // Already selected?
-        if (editVm.SelectedObject.Value != null)
+        if (editorSelection.SelectedObject.Value != null)
         {
             Dispatcher.UIThread.Post(onSelected);
             return null;
         }
 
-        return editVm.SelectedObject.Where(obj => obj != null)
+        return editorSelection.SelectedObject.Where(obj => obj != null)
             .Take(1)
             .Subscribe(_ => Dispatcher.UIThread.Post(onSelected));
     }
@@ -244,9 +245,9 @@ public static class TutorialHelpers
 
     public static Drawable? GetDrawable(EditViewModel? editVm)
     {
-        if (editVm == null) return null;
+        if (editVm?.GetService<IEditorSelection>() is not { } editorSelection) return null;
 
-        Element? element = editVm.SelectedObject.Value as Element;
+        Element? element = editorSelection.SelectedObject.Value as Element;
         element ??= editVm.Scene.Children.FirstOrDefault(e =>
             e.Objects.OfType<Drawable>().Any());
 

--- a/src/Beutl/ViewModels/BufferStatusViewModel.cs
+++ b/src/Beutl/ViewModels/BufferStatusViewModel.cs
@@ -3,7 +3,7 @@
 using Avalonia.Threading;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Models;
-
+using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
@@ -17,13 +17,14 @@ public sealed class BufferStatusViewModel : IBufferStatus, IDisposable
     public BufferStatusViewModel(EditViewModel editViewModel)
     {
         _editViewModel = editViewModel;
+        var timelineOptionsProvider = editViewModel.GetRequiredService<ITimelineOptionsProvider>();
 
-        Start = StartTime.CombineLatest(editViewModel.Scale)
+        Start = StartTime.CombineLatest(timelineOptionsProvider.Scale)
             .Select(v => v.First.TimeToPixel(v.Second))
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        End = EndTime.CombineLatest(editViewModel.Scale)
+        End = EndTime.CombineLatest(timelineOptionsProvider.Scale)
             .Select(v => v.First.TimeToPixel(v.Second))
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/EditContext/EditorClockImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/EditorClockImpl.cs
@@ -1,0 +1,111 @@
+using System.ComponentModel;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+internal sealed class EditorClockImpl : IEditorClock, IDisposable
+{
+    private readonly Scene _scene;
+
+    public EditorClockImpl(Scene scene)
+    {
+        _scene = scene;
+        CurrentTime = new ReactivePropertySlim<TimeSpan>();
+        MaximumTime = new ReactivePropertySlim<TimeSpan>();
+
+        foreach (Element element in _scene.Children)
+        {
+            element.PropertyChanged += OnElementPropertyChanged;
+        }
+
+        _scene.Children.Attached += OnElementAttached;
+        _scene.Children.Detached += OnElementDetached;
+
+        CalculateMaximumTime();
+    }
+
+    public ReactivePropertySlim<TimeSpan> CurrentTime { get; }
+
+    public ReactivePropertySlim<TimeSpan> MaximumTime { get; }
+
+    IReactiveProperty<TimeSpan> IEditorClock.CurrentTime => CurrentTime;
+
+    IReadOnlyReactiveProperty<TimeSpan> IEditorClock.MaximumTime => MaximumTime;
+
+    private void OnElementAttached(Element obj)
+    {
+        obj.PropertyChanged += OnElementPropertyChanged;
+
+        if (MaximumTime.Value < obj.Range.End)
+        {
+            MaximumTime.Value = obj.Range.End;
+        }
+        else
+        {
+            CalculateMaximumTime();
+        }
+    }
+
+    private void OnElementDetached(Element obj)
+    {
+        obj.PropertyChanged -= OnElementPropertyChanged;
+
+        if (MaximumTime.Value < obj.Range.End)
+        {
+            MaximumTime.Value = obj.Range.End;
+        }
+        else
+        {
+            CalculateMaximumTime();
+        }
+    }
+
+    private void OnElementPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e is CorePropertyChangedEventArgs<TimeSpan> typedArgs)
+        {
+            bool startChanged = typedArgs.Property.Id == Element.StartProperty.Id;
+            bool lengthChanged = typedArgs.Property.Id == Element.LengthProperty.Id;
+
+            if (sender is Element element && (startChanged || lengthChanged))
+            {
+                // 変更前の値を取得
+                TimeRange oldRange = element.Range;
+                if (startChanged) oldRange = oldRange.WithStart(typedArgs.OldValue);
+                if (lengthChanged) oldRange = oldRange.WithDuration(typedArgs.OldValue);
+
+                if (MaximumTime.Value < element.Range.End)
+                {
+                    MaximumTime.Value = element.Range.End;
+                }
+                else if (MaximumTime.Value == oldRange.End)
+                {
+                    CalculateMaximumTime();
+                }
+            }
+        }
+    }
+
+    private void CalculateMaximumTime()
+    {
+        MaximumTime.Value = _scene.Children.Count > 0
+            ? _scene.Children.Max(i => i.Range.End)
+            : TimeSpan.Zero;
+    }
+
+    public void Dispose()
+    {
+        _scene.Children.Attached -= OnElementAttached;
+        _scene.Children.Detached -= OnElementDetached;
+
+        foreach (Element element in _scene.Children)
+        {
+            element.PropertyChanged -= OnElementPropertyChanged;
+        }
+
+        CurrentTime.Dispose();
+        MaximumTime.Dispose();
+    }
+}

--- a/src/Beutl/ViewModels/EditContext/EditorClockImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/EditorClockImpl.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 using Reactive.Bindings;

--- a/src/Beutl/ViewModels/EditContext/EditorSelectionImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/EditorSelectionImpl.cs
@@ -1,4 +1,4 @@
-using Beutl.Logging;
+﻿using Beutl.Logging;
 using Beutl.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;

--- a/src/Beutl/ViewModels/EditContext/EditorSelectionImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/EditorSelectionImpl.cs
@@ -1,0 +1,59 @@
+using Beutl.Logging;
+using Beutl.ProjectSystem;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
+
+namespace Beutl.ViewModels;
+
+internal sealed class EditorSelectionImpl : IEditorSelection, IDisposable
+{
+    private readonly ILogger _logger = Log.CreateLogger<EditorSelectionImpl>();
+    private readonly CompositeDisposable _disposables = [];
+
+    public EditorSelectionImpl()
+    {
+        SelectedObject = new ReactiveProperty<CoreObject?>()
+            .DisposeWith(_disposables);
+
+        SelectedObject.CombineWithPrevious()
+            .Subscribe(v =>
+            {
+                if (v.OldValue is IHierarchical oldHierarchical)
+                    oldHierarchical.DetachedFromHierarchy -= OnSelectedObjectDetachedFromHierarchy;
+
+                if (v.NewValue is IHierarchical newHierarchical)
+                    newHierarchical.DetachedFromHierarchy += OnSelectedObjectDetachedFromHierarchy;
+            })
+            .DisposeWith(_disposables);
+
+        SelectedLayerNumber = SelectedObject.Select(v =>
+                (v as Element)?.GetObservable(Element.ZIndexProperty).Select(i => (int?)i) ??
+                Observable.ReturnThenNever<int?>(null))
+            .Switch()
+            .ToReadOnlyReactivePropertySlim()
+            .AddTo(_disposables);
+    }
+
+    public ReactiveProperty<CoreObject?> SelectedObject { get; }
+
+    public ReadOnlyReactivePropertySlim<int?> SelectedLayerNumber { get; }
+
+    IReactiveProperty<CoreObject?> IEditorSelection.SelectedObject => SelectedObject;
+
+    IReadOnlyReactiveProperty<int?> IEditorSelection.SelectedLayerNumber => SelectedLayerNumber;
+
+    private void OnSelectedObjectDetachedFromHierarchy(object? sender, HierarchyAttachmentEventArgs e)
+    {
+        _logger.LogInformation("Selected object detached from hierarchy, clearing selection.");
+        SelectedObject.Value = null;
+    }
+
+    public void Dispose()
+    {
+        if (SelectedObject.Value is IHierarchical hierarchical)
+            hierarchical.DetachedFromHierarchy -= OnSelectedObjectDetachedFromHierarchy;
+
+        _disposables.Dispose();
+    }
+}

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -1,0 +1,309 @@
+using Beutl.Audio;
+using Beutl.Composition;
+using Beutl.Editor.Components.Helpers;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Transformation;
+using Beutl.Helpers;
+using Beutl.Language;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Beutl.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.ViewModels;
+
+internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
+{
+    private readonly ILogger _logger = Log.CreateLogger<ElementAdderImpl>();
+    private readonly EditViewModel _context = context;
+
+    public void AddElement(ElementDescription desc)
+    {
+        _logger.LogInformation("Adding new element with description: {Description}", desc);
+
+        Scene scene = _context.Scene;
+
+        Element CreateElement()
+        {
+            _logger.LogDebug("Creating new element with start: {Start}, length: {Length}, layer: {Layer}", desc.Start,
+                desc.Length, desc.Layer);
+            return new Element()
+            {
+                Start = desc.Start,
+                Length = desc.Length,
+                ZIndex = desc.Layer,
+                Uri = RandomFileNameGenerator.GenerateUri(scene.Uri!, Constants.ElementFileExtension)
+            };
+        }
+
+        void SetAccentColor(Element element, string str)
+        {
+            _logger.LogDebug("Setting accent color for element: {Element}, color string: {ColorString}", element, str);
+            element.AccentColor = ColorGenerator.GenerateColor(str);
+        }
+
+        void SetTransform(Drawable drawable)
+        {
+            if (!desc.Position.IsDefault)
+            {
+                _logger.LogDebug(
+                    "Setting transform for drawable: {Drawable}, position: {Position}",
+                    drawable, desc.Position);
+                Transform? transform = drawable.Transform.CurrentValue;
+                AddOrSetHelper.AddOrSet(
+                    ref transform,
+                    new TranslateTransform(desc.Position));
+                drawable.Transform.CurrentValue = transform;
+            }
+        }
+
+        T? TrySetDuration<T>(Element element, Func<T> init, Func<T, TimeSpan> getDuration)
+        {
+            try
+            {
+                var state = init();
+                element.Length = getDuration(state);
+                return state;
+            }
+            catch
+            {
+                return default;
+            }
+        }
+
+        TimelineTabViewModel? timeline = _context.FindToolTab<TimelineTabViewModel>();
+        using var compositeDisposable = new CompositeDisposable();
+
+        if (desc.FileName != null)
+        {
+            _logger.LogInformation("Adding element from file: {FileName}", desc.FileName);
+            (TimeRange Range, int ZIndex)? scrollPos = null;
+
+            Element CreateElementFor<TValue>(out TValue value)
+                where TValue : EngineObject, new()
+            {
+                Element element = CreateElement();
+                element.Name = Path.GetFileName(desc.FileName);
+                SetAccentColor(element, typeof(TValue).FullName!);
+
+                value = new TValue();
+                element.AddObject(value);
+                if (value is Drawable drawable)
+                {
+                    SetTransform(drawable);
+                }
+
+                return element;
+            }
+
+            if (MatchFileImage(desc.FileName))
+            {
+                _logger.LogDebug("File is an image.");
+                Element element = CreateElementFor<SourceImage>(out var t);
+                t.Source.CurrentValue = ImageSource.Open(desc.FileName);
+
+                CoreSerializer.StoreToUri(element, element.Uri!);
+                scene.AddChild(element);
+                scrollPos = (element.Range, element.ZIndex);
+            }
+            else if (MatchFileVideoOnly(desc.FileName))
+            {
+                _logger.LogDebug("File is a video.");
+                Element element1 = CreateElementFor<SourceVideo>(out var t1);
+                Element element2 = CreateElementFor<SourceSound>(out var t2);
+                element2.ZIndex++;
+                var video = VideoSource.Open(desc.FileName);
+                t1.Source.CurrentValue = video;
+                var videoResource = TrySetDuration(
+                    element1,
+                    () => video.ToResource(CompositionContext.Default),
+                    v => v.Duration);
+
+                var sound = SoundSource.Open(desc.FileName);
+                t2.Source.CurrentValue = sound;
+                var soundResource = TrySetDuration(
+                    element2,
+                    () => sound.ToResource(CompositionContext.Default),
+                    v => v.Duration);
+                // VideoSource.Resource, SoundSource.ResourceのMediaReaderは参照カウンターで管理され、Resource間で共有される
+                // すぐに解放してしまうとこのDuration設定時とレンダリング時の2回MediaReaderが生成されてしまう
+                // 作成 -> 参照カウントを引く -> 解放 -> レンダラ側で作成 のようになってしまう
+                // これを以下のようにさせる
+                // 作成 -> レンダラ側で参照カウントを追加 -> 以下のDisposeで参照カウントを引く -> 実体は解放されない
+                compositeDisposable.Add(Disposable.Create(() => RenderThread.Dispatcher.Dispatch(() =>
+                {
+                    videoResource?.Dispose();
+                    soundResource?.Dispose();
+                }, DispatchPriority.Low)));
+
+                CoreSerializer.StoreToUri(element1, element1.Uri!);
+                CoreSerializer.StoreToUri(element2, element2.Uri!);
+                scene.AddChild(element1);
+                scene.AddChild(element2);
+                // グループ化
+                scene.Groups.Add([element1.Id, element2.Id]);
+                scrollPos = (element1.Range, element1.ZIndex);
+            }
+            else if (MatchFileAudioOnly(desc.FileName))
+            {
+                _logger.LogDebug("File is an audio.");
+                Element element = CreateElementFor<SourceSound>(out var t);
+                var sound = SoundSource.Open(desc.FileName);
+                t.Source.CurrentValue = sound;
+                var soundResource = TrySetDuration(
+                    element,
+                    () => sound.ToResource(CompositionContext.Default),
+                    v => v.Duration);
+                compositeDisposable.Add(Disposable.Create(() =>
+                    RenderThread.Dispatcher.Dispatch(() => soundResource?.Dispose(), DispatchPriority.Low)));
+
+                CoreSerializer.StoreToUri(element, element.Uri!);
+                scene.AddChild(element);
+                scrollPos = (element.Range, element.ZIndex);
+            }
+
+            _context.HistoryManager.Commit(CommandNames.AddElement);
+
+            if (scrollPos.HasValue && timeline != null)
+            {
+                _logger.LogDebug("Scrolling to position: {ScrollPosition}", scrollPos.Value);
+                timeline?.ScrollTo.Execute(scrollPos.Value);
+            }
+        }
+        else
+        {
+            _logger.LogInformation("Adding new element without file.");
+            Element element = CreateElement();
+            if (desc.InitialObject != null)
+            {
+                element.Name = TypeDisplayHelpers.GetLocalizedName(desc.InitialObject);
+
+                element.AccentColor =
+                    ColorGenerator.GenerateColor(desc.InitialObject.FullName ?? desc.InitialObject.Name);
+                var engineObject = (EngineObject)Activator.CreateInstance(desc.InitialObject)!;
+                element.AddObject(engineObject);
+                if (engineObject is Drawable drawable)
+                {
+                    SetTransform(drawable);
+                }
+            }
+
+            CoreSerializer.StoreToUri(element, element.Uri!);
+            scene.AddChild(element);
+            _context.HistoryManager.Commit(CommandNames.AddElement);
+
+            timeline?.ScrollTo.Execute((element.Range, element.ZIndex));
+        }
+
+        _logger.LogInformation("Element added successfully.");
+    }
+
+    public void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer)
+    {
+        _logger.LogInformation("Adding element from template: {TemplateName}", template.Name.Value);
+
+        Scene scene = _context.Scene;
+
+        ICoreSerializable? instance = template.CreateInstance();
+        Element newElement;
+        if (instance is Element templateElement)
+        {
+            // ObjectRegenerator で ID を再生成
+            ObjectRegenerator.Regenerate(templateElement, out newElement);
+
+            newElement.Start = start;
+            newElement.ZIndex = layer;
+        }
+        else if (instance is EngineObject templateEngineObject)
+        {
+            ObjectRegenerator.Regenerate(
+                templateEngineObject, templateEngineObject.GetType(), out ICoreSerializable regenerated);
+            var newEngineObject = (EngineObject)regenerated;
+
+            newElement = new Element
+            {
+                Start = start,
+                Length = TimeSpan.FromSeconds(5),
+                ZIndex = layer,
+                Name = template.Name.Value,
+                AccentColor = ColorGenerator.GenerateColor(
+                    template.ActualType.FullName ?? template.ActualType.Name),
+            };
+            newElement.AddObject(newEngineObject);
+        }
+        else
+        {
+            _logger.LogWarning("Failed to create element from template.");
+            return;
+        }
+
+        newElement.Uri = RandomFileNameGenerator.GenerateUri(scene.Uri!, Constants.ElementFileExtension);
+
+        CoreSerializer.StoreToUri(newElement, newElement.Uri!);
+        scene.AddChild(newElement);
+        _context.HistoryManager.Commit(CommandNames.AddElementFromTemplate);
+
+        TimelineTabViewModel? timeline = _context.FindToolTab<TimelineTabViewModel>();
+        timeline?.ScrollTo.Execute((newElement.Range, newElement.ZIndex));
+
+        _logger.LogInformation("Element from template added successfully.");
+    }
+
+    private static bool MatchFileExtensions(string filePath, IEnumerable<string> extensions)
+    {
+        string ext = Path.GetExtension(filePath);
+        return extensions
+            .Select(x =>
+            {
+                int idx = x.LastIndexOf('.');
+                if (0 <= idx)
+                    return x.Substring(idx);
+                else
+                    return x;
+            })
+            .Contains(ext, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool MatchFileAudioOnly(string filePath)
+    {
+        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
+            .SelectMany(x => x.AudioExtensions())
+            .Distinct());
+    }
+
+    private static bool MatchFileVideoOnly(string filePath)
+    {
+        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
+            .SelectMany(x => x.VideoExtensions())
+            .Distinct());
+    }
+
+    private static bool MatchFileImage(string filePath)
+    {
+        string[] extensions =
+        [
+            "*.bmp",
+            "*.gif",
+            "*.ico",
+            "*.jpg",
+            "*.jpeg",
+            "*.png",
+            "*.wbmp",
+            "*.webp",
+            "*.pkm",
+            "*.ktx",
+            "*.astc",
+            "*.dng",
+            "*.heif",
+            "*.avif",
+        ];
+        return MatchFileExtensions(filePath, extensions);
+    }
+}

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -1,4 +1,4 @@
-using Beutl.Audio;
+﻿using Beutl.Audio;
 using Beutl.Composition;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.TimelineTab.ViewModels;

--- a/src/Beutl/ViewModels/EditContext/TimelineOptionsProviderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/TimelineOptionsProviderImpl.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Beutl.ProjectSystem;
 using Reactive.Bindings;
 

--- a/src/Beutl/ViewModels/EditContext/TimelineOptionsProviderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/TimelineOptionsProviderImpl.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+using Beutl.ProjectSystem;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+internal sealed class TimelineOptionsProviderImpl : ITimelineOptionsProvider, IDisposable
+{
+    public TimelineOptionsProviderImpl(Scene scene)
+    {
+        Scene = scene;
+        Options = new ReactiveProperty<TimelineOptions>(new TimelineOptions());
+        Scale = Options.Select(o => o.Scale);
+        Offset = Options.Select(o => o.Offset);
+    }
+
+    public Scene Scene { get; }
+
+    public ReactiveProperty<TimelineOptions> Options { get; }
+
+    public IObservable<float> Scale { get; }
+
+    public IObservable<Vector2> Offset { get; }
+
+    IReactiveProperty<TimelineOptions> ITimelineOptionsProvider.Options => Options;
+
+    public void Dispose()
+    {
+        Options.Dispose();
+    }
+}

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1,47 +1,35 @@
 ﻿using System.ComponentModel;
 using System.Numerics;
 using System.Text.Json.Nodes;
-using Beutl.Animation;
-using Beutl.Audio;
-using Beutl.Composition;
 using Beutl.Configuration;
 using Beutl.Editor;
-using Beutl.Editor.Components.GraphEditorTab.ViewModels;
-using Beutl.Editor.Components.Helpers;
-using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Observers;
 using Beutl.Editor.Operations;
-using Beutl.Engine;
-using Beutl.Graphics;
-using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Rendering.Cache;
-using Beutl.Graphics.Transformation;
-using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Media;
-using Beutl.Media.Decoding;
-using Beutl.Media.Source;
 using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
 using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
-using Beutl.Threading;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using Dispatcher = Avalonia.Threading.Dispatcher;
-using LibraryService = Beutl.Services.LibraryService;
 
 namespace Beutl.ViewModels;
 
-public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProvider,
-    ISupportAutoSaveEditorContext, IEditorClock, IEditorSelection, IElementAdder
+public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEditorContext
 {
     private readonly ILogger _logger = Log.CreateLogger<EditViewModel>();
     private readonly AutoSaveService _autoSaveService = new();
 
     private readonly CompositeDisposable _disposables = [];
+    private readonly TimelineOptionsProviderImpl _timelineOptionsProvider;
+    private readonly EditorClockImpl _editorClock;
+    private readonly EditorSelectionImpl _editorSelection;
+    private readonly ElementAdderImpl _elementAdder;
 
     public EditViewModel(Scene scene)
     {
@@ -49,13 +37,14 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
 
         Scene = scene;
         SceneId = scene.Id.ToString();
-        Scene.Children.Attached += OnElementAttached;
-        Scene.Children.Detached += OnElementDetached;
-        CurrentTime = new ReactivePropertySlim<TimeSpan>()
+
+        _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
             .DisposeWith(_disposables);
-        MaximumTime = new ReactivePropertySlim<TimeSpan>()
+        _editorClock = new EditorClockImpl(scene)
             .DisposeWith(_disposables);
-        CalculateMaximumTime();
+        _editorSelection = new EditorSelectionImpl()
+            .DisposeWith(_disposables);
+
         Renderer = scene.GetObservable(Scene.FrameSizeProperty).Select(_ => new SceneRenderer(Scene))
             .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
@@ -73,28 +62,6 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
             .DisposeWith(_disposables)!;
 
         config.PropertyChanged += OnEditorConfigPropertyChanged;
-
-        SelectedObject = new ReactiveProperty<CoreObject?>()
-            .DisposeWith(_disposables);
-
-        Scale = Options.Select(o => o.Scale);
-        Offset = Options.Select(o => o.Offset);
-        SelectedObject.CombineWithPrevious()
-            .Subscribe(v =>
-            {
-                if (v.OldValue is IHierarchical oldHierarchical)
-                    oldHierarchical.DetachedFromHierarchy -= OnSelectedObjectDetachedFromHierarchy;
-
-                if (v.NewValue is IHierarchical newHierarchical)
-                    newHierarchical.DetachedFromHierarchy += OnSelectedObjectDetachedFromHierarchy;
-            })
-            .DisposeWith(_disposables);
-
-        SelectedLayerNumber = SelectedObject.Select(v =>
-                (v as Element)?.GetObservable(Element.ZIndexProperty).Select(i => (int?)i) ??
-                Observable.ReturnThenNever<int?>(null))
-            .Switch()
-            .ToReadOnlyReactivePropertySlim();
 
         Player = new PlayerViewModel(this);
         Commands = new KnownCommandsImpl(scene, this);
@@ -116,6 +83,8 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         DockHost = new DockHostViewModel(SceneId, this)
             .DisposeWith(_disposables);
 
+        _elementAdder = new ElementAdderImpl(this);
+
         _autoSaveService.SaveError
             .Subscribe(_ =>
                 NotificationService.ShowError(string.Empty, MessageStrings.FileSaveException))
@@ -125,67 +94,6 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         RestoreState();
 
         _logger.LogInformation("Initialized EditViewModel for Scene ({SceneId}).", SceneId);
-    }
-
-    private void OnElementDetached(Element obj)
-    {
-        obj.PropertyChanged -= OnElementPropertyChanged;
-
-        if (MaximumTime.Value < obj.Range.End)
-        {
-            MaximumTime.Value = obj.Range.End;
-        }
-        else
-        {
-            CalculateMaximumTime();
-        }
-    }
-
-    private void OnElementAttached(Element obj)
-    {
-        obj.PropertyChanged += OnElementPropertyChanged;
-
-        if (MaximumTime.Value < obj.Range.End)
-        {
-            MaximumTime.Value = obj.Range.End;
-        }
-        else
-        {
-            CalculateMaximumTime();
-        }
-    }
-
-    private void CalculateMaximumTime()
-    {
-        MaximumTime.Value = Scene.Children.Count > 0
-            ? Scene.Children.Max(i => i.Range.End)
-            : TimeSpan.Zero;
-    }
-
-    private void OnElementPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e is CorePropertyChangedEventArgs<TimeSpan> typedArgs)
-        {
-            bool startChanged = typedArgs.Property.Id == Element.StartProperty.Id;
-            bool lengthChanged = typedArgs.Property.Id == Element.LengthProperty.Id;
-
-            if (sender is Element element && (startChanged || lengthChanged))
-            {
-                // 変更前の値を取得
-                TimeRange oldRange = element.Range;
-                if (startChanged) oldRange = oldRange.WithStart(typedArgs.OldValue);
-                if (lengthChanged) oldRange = oldRange.WithDuration(typedArgs.OldValue);
-
-                if (MaximumTime.Value < element.Range.End)
-                {
-                    MaximumTime.Value = element.Range.End;
-                }
-                else if (MaximumTime.Value == oldRange.End)
-                {
-                    CalculateMaximumTime();
-                }
-            }
-        }
     }
 
     private static FrameCacheOptions CreateFrameCacheOptions()
@@ -379,31 +287,25 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         return null;
     }
 
-    private void OnSelectedObjectDetachedFromHierarchy(object? sender, HierarchyAttachmentEventArgs e)
-    {
-        _logger.LogInformation("Selected object detached from hierarchy, clearing selection.");
-        SelectedObject.Value = null;
-    }
-
     // Telemetryで使う
     public string SceneId { get; }
 
     public Scene Scene { get; private set; }
 
-    public ReactivePropertySlim<TimeSpan> CurrentTime { get; }
+    public ReactivePropertySlim<TimeSpan> CurrentTime => _editorClock.CurrentTime;
 
     // Timelineの横幅をmax(MaximumTime, start+duration)で決める
-    public ReactivePropertySlim<TimeSpan> MaximumTime { get; }
+    public ReactivePropertySlim<TimeSpan> MaximumTime => _editorClock.MaximumTime;
 
     public ReadOnlyReactivePropertySlim<SceneRenderer> Renderer { get; }
 
     public ReadOnlyReactivePropertySlim<SceneComposer> Composer { get; }
 
-    public ReactiveProperty<CoreObject?> SelectedObject { get; }
+    public ReactiveProperty<CoreObject?> SelectedObject => _editorSelection.SelectedObject;
 
     public ReactivePropertySlim<bool> IsEnabled { get; } = new(true);
 
-    public ReadOnlyReactivePropertySlim<int?> SelectedLayerNumber { get; }
+    public ReadOnlyReactivePropertySlim<int?> SelectedLayerNumber => _editorSelection.SelectedLayerNumber;
 
     public PlayerViewModel Player { get; private set; }
 
@@ -419,45 +321,28 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
 
     public IKnownEditorCommands? Commands { get; private set; }
 
-    public IReactiveProperty<TimelineOptions> Options { get; } =
-        new ReactiveProperty<TimelineOptions>(new TimelineOptions());
+    public IReactiveProperty<TimelineOptions> Options => _timelineOptionsProvider.Options;
 
-    public IObservable<float> Scale { get; }
+    public IObservable<float> Scale => _timelineOptionsProvider.Scale;
 
-    public IObservable<Vector2> Offset { get; }
+    public IObservable<Vector2> Offset => _timelineOptionsProvider.Offset;
 
     IReactiveProperty<bool> IEditorContext.IsEnabled => IsEnabled;
-
-    IReactiveProperty<TimeSpan> IEditorClock.CurrentTime => CurrentTime;
-
-    IReadOnlyReactiveProperty<TimeSpan> IEditorClock.MaximumTime => MaximumTime;
-
-    IReactiveProperty<CoreObject?> IEditorSelection.SelectedObject => SelectedObject;
-
-    IReadOnlyReactiveProperty<int?> IEditorSelection.SelectedLayerNumber => SelectedLayerNumber;
 
     public DockHostViewModel DockHost { get; }
 
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
-        foreach (Element element in Scene.Children)
-        {
-            element.PropertyChanged -= OnElementPropertyChanged;
-        }
 
-        Scene.Children.Attached -= OnElementAttached;
-        Scene.Children.Detached -= OnElementDetached;
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
         SaveState();
+        SelectedObject.Value = null;
         await Player.DisposeAsync();
         _disposables.Dispose();
-        Options.Dispose();
         IsEnabled.Dispose();
         Player = null!;
         BufferStatus = null!;
-
-        SelectedObject.Value = null;
 
         Scene = null!;
         Commands = null!;
@@ -631,16 +516,16 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
             return HistoryManager;
 
         if (serviceType.IsAssignableTo(typeof(ITimelineOptionsProvider)))
-            return this;
+            return _timelineOptionsProvider;
 
         if (serviceType.IsAssignableTo(typeof(IEditorClock)))
-            return this;
+            return _editorClock;
 
         if (serviceType.IsAssignableTo(typeof(IEditorSelection)))
-            return this;
+            return _editorSelection;
 
         if (serviceType.IsAssignableTo(typeof(IElementAdder)))
-            return this;
+            return _elementAdder;
 
         if (serviceType == typeof(PlayerViewModel) || serviceType.IsAssignableTo(typeof(IPreviewPlayer)))
             return Player;
@@ -660,284 +545,10 @@ public sealed partial class EditViewModel : IEditorContext, ITimelineOptionsProv
         return null;
     }
 
-    public void AddElement(ElementDescription desc)
-    {
-        _logger.LogInformation("Adding new element with description: {Description}", desc);
-
-        Element CreateElement()
-        {
-            _logger.LogDebug("Creating new element with start: {Start}, length: {Length}, layer: {Layer}", desc.Start,
-                desc.Length, desc.Layer);
-            return new Element()
-            {
-                Start = desc.Start,
-                Length = desc.Length,
-                ZIndex = desc.Layer,
-                Uri = RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension)
-            };
-        }
-
-        void SetAccentColor(Element element, string str)
-        {
-            _logger.LogDebug("Setting accent color for element: {Element}, color string: {ColorString}", element, str);
-            element.AccentColor = ColorGenerator.GenerateColor(str);
-        }
-
-        void SetTransform(Drawable drawable)
-        {
-            if (!desc.Position.IsDefault)
-            {
-                _logger.LogDebug(
-                    "Setting transform for drawable: {Drawable}, position: {Position}",
-                    drawable, desc.Position);
-                Transform? transform = drawable.Transform.CurrentValue;
-                AddOrSetHelper.AddOrSet(
-                    ref transform,
-                    new TranslateTransform(desc.Position));
-                drawable.Transform.CurrentValue = transform;
-            }
-        }
-
-        T? TrySetDuration<T>(Element element, Func<T> init, Func<T, TimeSpan> getDuration)
-        {
-            try
-            {
-                var state = init();
-                element.Length = getDuration(state);
-                return state;
-            }
-            catch
-            {
-                return default;
-            }
-        }
-
-        TimelineTabViewModel? timeline = FindToolTab<TimelineTabViewModel>();
-        using var compositeDisposable = new CompositeDisposable();
-
-        if (desc.FileName != null)
-        {
-            _logger.LogInformation("Adding element from file: {FileName}", desc.FileName);
-            (TimeRange Range, int ZIndex)? scrollPos = null;
-
-            Element CreateElementFor<TValue>(out TValue value)
-                where TValue : EngineObject, new()
-            {
-                Element element = CreateElement();
-                element.Name = Path.GetFileName(desc.FileName);
-                SetAccentColor(element, typeof(TValue).FullName!);
-
-                value = new TValue();
-                element.AddObject(value);
-                if (value is Drawable drawable)
-                {
-                    SetTransform(drawable);
-                }
-
-                return element;
-            }
-
-            if (MatchFileImage(desc.FileName))
-            {
-                _logger.LogDebug("File is an image.");
-                Element element = CreateElementFor<SourceImage>(out var t);
-                t.Source.CurrentValue = ImageSource.Open(desc.FileName);
-
-                CoreSerializer.StoreToUri(element, element.Uri!);
-                Scene.AddChild(element);
-                scrollPos = (element.Range, element.ZIndex);
-            }
-            else if (MatchFileVideoOnly(desc.FileName))
-            {
-                _logger.LogDebug("File is a video.");
-                Element element1 = CreateElementFor<SourceVideo>(out var t1);
-                Element element2 = CreateElementFor<SourceSound>(out var t2);
-                element2.ZIndex++;
-                var video = VideoSource.Open(desc.FileName);
-                t1.Source.CurrentValue = video;
-                var videoResource = TrySetDuration(
-                    element1,
-                    () => video.ToResource(CompositionContext.Default),
-                    v => v.Duration);
-
-                var sound = SoundSource.Open(desc.FileName);
-                t2.Source.CurrentValue = sound;
-                var soundResource = TrySetDuration(
-                    element2,
-                    () => sound.ToResource(CompositionContext.Default),
-                    v => v.Duration);
-                // VideoSource.Resource, SoundSource.ResourceのMediaReaderは参照カウンターで管理され、Resource間で共有される
-                // すぐに解放してしまうとこのDuration設定時とレンダリング時の2回MediaReaderが生成されてしまう
-                // 作成 -> 参照カウントを引く -> 解放 -> レンダラ側で作成 のようになってしまう
-                // これを以下のようにさせる
-                // 作成 -> レンダラ側で参照カウントを追加 -> 以下のDisposeで参照カウントを引く -> 実体は解放されない
-                compositeDisposable.Add(Disposable.Create(() => RenderThread.Dispatcher.Dispatch(() =>
-                {
-                    videoResource?.Dispose();
-                    soundResource?.Dispose();
-                }, DispatchPriority.Low)));
-
-                CoreSerializer.StoreToUri(element1, element1.Uri!);
-                CoreSerializer.StoreToUri(element2, element2.Uri!);
-                Scene.AddChild(element1);
-                Scene.AddChild(element2);
-                // グループ化
-                Scene.Groups.Add([element1.Id, element2.Id]);
-                scrollPos = (element1.Range, element1.ZIndex);
-            }
-            else if (MatchFileAudioOnly(desc.FileName))
-            {
-                _logger.LogDebug("File is an audio.");
-                Element element = CreateElementFor<SourceSound>(out var t);
-                var sound = SoundSource.Open(desc.FileName);
-                t.Source.CurrentValue = sound;
-                var soundResource = TrySetDuration(
-                    element,
-                    () => sound.ToResource(CompositionContext.Default),
-                    v => v.Duration);
-                compositeDisposable.Add(Disposable.Create(() =>
-                    RenderThread.Dispatcher.Dispatch(() => soundResource?.Dispose(), DispatchPriority.Low)));
-
-                CoreSerializer.StoreToUri(element, element.Uri!);
-                Scene.AddChild(element);
-                scrollPos = (element.Range, element.ZIndex);
-            }
-
-            HistoryManager.Commit(CommandNames.AddElement);
-
-            if (scrollPos.HasValue && timeline != null)
-            {
-                _logger.LogDebug("Scrolling to position: {ScrollPosition}", scrollPos.Value);
-                timeline?.ScrollTo.Execute(scrollPos.Value);
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Adding new element without file.");
-            Element element = CreateElement();
-            if (desc.InitialObject != null)
-            {
-                element.Name = TypeDisplayHelpers.GetLocalizedName(desc.InitialObject);
-
-                element.AccentColor =
-                    ColorGenerator.GenerateColor(desc.InitialObject.FullName ?? desc.InitialObject.Name);
-                var engineObject = (EngineObject)Activator.CreateInstance(desc.InitialObject)!;
-                element.AddObject(engineObject);
-                if (engineObject is Drawable drawable)
-                {
-                    SetTransform(drawable);
-                }
-            }
-
-            CoreSerializer.StoreToUri(element, element.Uri!);
-            Scene.AddChild(element);
-            HistoryManager.Commit(CommandNames.AddElement);
-
-            timeline?.ScrollTo.Execute((element.Range, element.ZIndex));
-        }
-
-        _logger.LogInformation("Element added successfully.");
-    }
+    public void AddElement(ElementDescription desc) => _elementAdder.AddElement(desc);
 
     public void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer)
-    {
-        _logger.LogInformation("Adding element from template: {TemplateName}", template.Name.Value);
-
-        ICoreSerializable? instance = template.CreateInstance();
-        Element newElement;
-        if (instance is Element templateElement)
-        {
-            // ObjectRegenerator で ID を再生成
-            ObjectRegenerator.Regenerate(templateElement, out newElement);
-
-            newElement.Start = start;
-            newElement.ZIndex = layer;
-        }
-        else if (instance is EngineObject templateEngineObject)
-        {
-            ObjectRegenerator.Regenerate(
-                templateEngineObject, templateEngineObject.GetType(), out ICoreSerializable regenerated);
-            var newEngineObject = (EngineObject)regenerated;
-
-            newElement = new Element
-            {
-                Start = start,
-                Length = TimeSpan.FromSeconds(5),
-                ZIndex = layer,
-                Name = template.Name.Value,
-                AccentColor = ColorGenerator.GenerateColor(
-                    template.ActualType.FullName ?? template.ActualType.Name),
-            };
-            newElement.AddObject(newEngineObject);
-        }
-        else
-        {
-            _logger.LogWarning("Failed to create element from template.");
-            return;
-        }
-
-        newElement.Uri = RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension);
-
-        CoreSerializer.StoreToUri(newElement, newElement.Uri!);
-        Scene.AddChild(newElement);
-        HistoryManager.Commit(CommandNames.AddElementFromTemplate);
-
-        TimelineTabViewModel? timeline = FindToolTab<TimelineTabViewModel>();
-        timeline?.ScrollTo.Execute((newElement.Range, newElement.ZIndex));
-
-        _logger.LogInformation("Element from template added successfully.");
-    }
-
-    private static bool MatchFileExtensions(string filePath, IEnumerable<string> extensions)
-    {
-        string ext = Path.GetExtension(filePath);
-        return extensions
-            .Select(x =>
-            {
-                int idx = x.LastIndexOf('.');
-                if (0 <= idx)
-                    return x.Substring(idx);
-                else
-                    return x;
-            })
-            .Contains(ext, StringComparer.OrdinalIgnoreCase);
-    }
-
-    private static bool MatchFileAudioOnly(string filePath)
-    {
-        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
-            .SelectMany(x => x.AudioExtensions())
-            .Distinct());
-    }
-
-    private static bool MatchFileVideoOnly(string filePath)
-    {
-        return MatchFileExtensions(filePath, DecoderRegistry.EnumerateDecoder()
-            .SelectMany(x => x.VideoExtensions())
-            .Distinct());
-    }
-
-    private static bool MatchFileImage(string filePath)
-    {
-        string[] extensions =
-        [
-            "*.bmp",
-            "*.gif",
-            "*.ico",
-            "*.jpg",
-            "*.jpeg",
-            "*.png",
-            "*.wbmp",
-            "*.webp",
-            "*.pkm",
-            "*.ktx",
-            "*.astc",
-            "*.dng",
-            "*.heif",
-            "*.avif",
-        ];
-        return MatchFileExtensions(filePath, extensions);
-    }
+        => _elementAdder.AddElementFromTemplate(template, start, layer);
 
     private sealed class KnownCommandsImpl(Scene scene, EditViewModel viewModel) : IKnownEditorCommands
     {

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -321,12 +321,6 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public IKnownEditorCommands? Commands { get; private set; }
 
-    public IReactiveProperty<TimelineOptions> Options => _timelineOptionsProvider.Options;
-
-    public IObservable<float> Scale => _timelineOptionsProvider.Scale;
-
-    public IObservable<Vector2> Offset => _timelineOptionsProvider.Offset;
-
     IReactiveProperty<bool> IEditorContext.IsEnabled => IsEnabled;
 
     public DockHostViewModel DockHost { get; }
@@ -394,15 +388,15 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         var json = new JsonObject
         {
             ["selected-object"] = SelectedObject.Value?.Id,
-            ["max-layer-count"] = Options.Value.MaxLayerCount,
-            ["scale"] = Options.Value.Scale,
-            ["offset"] = new JsonObject { ["x"] = Options.Value.Offset.X, ["y"] = Options.Value.Offset.Y, },
+            ["max-layer-count"] = _timelineOptionsProvider.Options.Value.MaxLayerCount,
+            ["scale"] = _timelineOptionsProvider.Options.Value.Scale,
+            ["offset"] = new JsonObject { ["x"] = _timelineOptionsProvider.Options.Value.Offset.X, ["y"] = _timelineOptionsProvider.Options.Value.Offset.Y, },
             ["bpm-grid"] = new JsonObject
             {
-                ["bpm"] = Options.Value.BpmGrid.Bpm,
-                ["subdivisions"] = Options.Value.BpmGrid.Subdivisions,
-                ["offset"] = Options.Value.BpmGrid.Offset.ToString("c"),
-                ["is-enabled"] = Options.Value.BpmGrid.IsEnabled,
+                ["bpm"] = _timelineOptionsProvider.Options.Value.BpmGrid.Bpm,
+                ["subdivisions"] = _timelineOptionsProvider.Options.Value.BpmGrid.Subdivisions,
+                ["offset"] = _timelineOptionsProvider.Options.Value.BpmGrid.Offset.ToString("c"),
+                ["is-enabled"] = _timelineOptionsProvider.Options.Value.BpmGrid.IsEnabled,
             }
         };
 
@@ -487,7 +481,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
                 timelineOptions = timelineOptions with { BpmGrid = bpmGrid };
             }
 
-            Options.Value = timelineOptions;
+            _timelineOptionsProvider.Options.Value = timelineOptions;
 
             DockHost.ReadFromJson(jsonObject);
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -301,11 +301,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public ReadOnlyReactivePropertySlim<SceneComposer> Composer { get; }
 
-    public ReactiveProperty<CoreObject?> SelectedObject => _editorSelection.SelectedObject;
-
     public ReactivePropertySlim<bool> IsEnabled { get; } = new(true);
-
-    public ReadOnlyReactivePropertySlim<int?> SelectedLayerNumber => _editorSelection.SelectedLayerNumber;
 
     public PlayerViewModel Player { get; private set; }
 
@@ -331,7 +327,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
         SaveState();
-        SelectedObject.Value = null;
+        _editorSelection.SelectedObject.Value = null;
         await Player.DisposeAsync();
         _disposables.Dispose();
         IsEnabled.Dispose();
@@ -387,7 +383,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         string viewStateDir = ViewStateDirectory();
         var json = new JsonObject
         {
-            ["selected-object"] = SelectedObject.Value?.Id,
+            ["selected-object"] = _editorSelection.SelectedObject.Value?.Id,
             ["max-layer-count"] = _timelineOptionsProvider.Options.Value.MaxLayerCount,
             ["scale"] = _timelineOptionsProvider.Options.Value.Scale,
             ["offset"] = new JsonObject { ["x"] = _timelineOptionsProvider.Options.Value.Offset.X, ["y"] = _timelineOptionsProvider.Options.Value.Offset.Y, },
@@ -428,7 +424,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
                 if (id.HasValue)
                 {
                     var searcher = new ObjectSearcher(Scene, o => o is CoreObject obj && obj.Id == id.Value);
-                    SelectedObject.Value = searcher.Search() as CoreObject;
+                    _editorSelection.SelectedObject.Value = searcher.Search() as CoreObject;
                 }
             }
             catch (Exception ex)

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -545,11 +545,6 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         return null;
     }
 
-    public void AddElement(ElementDescription desc) => _elementAdder.AddElement(desc);
-
-    public void AddElementFromTemplate(ObjectTemplateItem template, TimeSpan start, int layer)
-        => _elementAdder.AddElementFromTemplate(template, start, layer);
-
     private sealed class KnownCommandsImpl(Scene scene, EditViewModel viewModel) : IKnownEditorCommands
     {
         public ValueTask<bool> OnSave()

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -292,11 +292,6 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public Scene Scene { get; private set; }
 
-    public ReactivePropertySlim<TimeSpan> CurrentTime => _editorClock.CurrentTime;
-
-    // Timelineの横幅をmax(MaximumTime, start+duration)で決める
-    public ReactivePropertySlim<TimeSpan> MaximumTime => _editorClock.MaximumTime;
-
     public ReadOnlyReactivePropertySlim<SceneRenderer> Renderer { get; }
 
     public ReadOnlyReactivePropertySlim<SceneComposer> Composer { get; }
@@ -398,7 +393,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         DockHost.WriteToJson(json);
 
-        json["current-time"] = JsonValue.Create(CurrentTime.Value);
+        json["current-time"] = JsonValue.Create(_editorClock.CurrentTime.Value);
 
         string name = Path.GetFileNameWithoutExtension(Scene.Uri!.LocalPath);
         json.JsonSave(Path.Combine(viewStateDir, $"{name}.config"));
@@ -484,7 +479,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             if (jsonObject.TryGetPropertyValueAsJsonValue("current-time", out string? currentTimeStr)
                 && TimeSpan.TryParse(currentTimeStr, out TimeSpan currentTime))
             {
-                CurrentTime.Value = currentTime;
+                _editorClock.CurrentTime.Value = currentTime;
             }
         }
         else

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -32,6 +32,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     private bool _skipKeyFrameIndexSubscription;
     private Element? _element;
     private EditViewModel? _editViewModel;
+    private IEditorClock? _clock;
     private IServiceProvider? _parentServices;
 
     protected BaseEditorViewModel(IPropertyAdapter property)
@@ -100,7 +101,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                         (float oldIndex, _) = t.OldValue;
                         (float newIndex, KeyFrames? keyframes) = t.NewValue;
 
-                        if (_editViewModel != null && keyframes is { Count: > 0 })
+                        if (_clock != null && keyframes is { Count: > 0 })
                         {
                             int newCeiled = (int)Math.Clamp(MathF.Ceiling(newIndex), 0, keyframes.Count - 1);
                             EditingKeyFrame.Value = keyframes[newCeiled];
@@ -110,7 +111,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                                 TimeSpan start = _element?.Start ?? default;
                                 TimeSpan keyTime = EditingKeyFrame.Value.KeyTime;
 
-                                _editViewModel.CurrentTime.Value = animation.UseGlobalClock ? keyTime : keyTime + start;
+                                _clock.CurrentTime.Value = animation.UseGlobalClock ? keyTime : keyTime + start;
                             }
                         }
                         else
@@ -212,15 +213,16 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
             _parentServices = serviceProvider;
             _element = serviceProvider.GetService<Element>();
             _editViewModel = serviceProvider.GetService<EditViewModel>();
+            _clock = serviceProvider.GetService<IEditorClock>();
 
-            if (_editViewModel != null)
+            if (_clock != null)
             {
                 _currentFrameRevoker?.Dispose();
                 _currentFrameRevoker = null;
 
                 if (PropertyAdapter is IAnimatablePropertyAdapter animatableProperty)
                 {
-                    _currentFrameRevoker = _editViewModel.CurrentTime
+                    _currentFrameRevoker = _clock.CurrentTime
                         .Do(_currentTime.OnNext)
                         .CombineLatest(animatableProperty.ObserveAnimation
                             .Select(x => (x as IKeyFrameAnimation)?.KeyFrames)
@@ -258,7 +260,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                 }
                 else
                 {
-                    _currentFrameRevoker = _editViewModel.CurrentTime
+                    _currentFrameRevoker = _clock.CurrentTime
                         .Subscribe(_currentTime.OnNext);
                 }
             }

--- a/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
@@ -7,6 +7,7 @@ using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
 using Beutl.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
@@ -99,7 +100,7 @@ public partial class MenuBarViewModel
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel)
             && viewModel.Scene is Scene scene
-            && viewModel.SelectedObject.Value is Element element)
+            && viewModel.GetService<IEditorSelection>()?.SelectedObject.Value is Element element)
         {
             scene.RemoveChild(element);
             viewModel.HistoryManager.Commit(CommandNames.RemoveElement);
@@ -111,7 +112,7 @@ public partial class MenuBarViewModel
         if (ClipboardHelper.GetClipboard() is IClipboard clipboard
             && TryGetSelectedEditViewModel(out EditViewModel? viewModel)
             && viewModel.Scene is Scene scene
-            && viewModel.SelectedObject.Value is Element element)
+            && viewModel.GetService<IEditorSelection>()?.SelectedObject.Value is Element element)
         {
             DataTransfer data = CreateElementDataObject(element);
 
@@ -125,7 +126,7 @@ public partial class MenuBarViewModel
     {
         if (ClipboardHelper.GetClipboard() is IClipboard clipboard
             && TryGetSelectedEditViewModel(out EditViewModel? viewModel)
-            && viewModel.SelectedObject.Value is Element element)
+            && viewModel.GetService<IEditorSelection>()?.SelectedObject.Value is Element element)
         {
             DataTransfer data = CreateElementDataObject(element);
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -34,6 +34,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<bool> _isEnabled;
     private readonly EditViewModel _editViewModel;
+    private readonly IEditorClock _editorClock;
     private IDisposable? _currentFrameSubscription;
     private CancellationTokenSource? _cts;
     private Size _maxFrameSize;
@@ -42,6 +43,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     public PlayerViewModel(EditViewModel editViewModel)
     {
         _editViewModel = editViewModel;
+        _editorClock = editViewModel.GetRequiredService<IEditorClock>();
         Scene = editViewModel.Scene;
         _isEnabled = editViewModel.IsEnabled;
         PlayPause = new AsyncReactiveCommand(_isEnabled.AsObservable())
@@ -62,7 +64,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .WithSubscribe(() =>
             {
                 int rate = GetFrameRate();
-                UpdateCurrentFrame(EditViewModel.CurrentTime.Value + TimeSpan.FromSeconds(1d / rate));
+                UpdateCurrentFrame(_editorClock.CurrentTime.Value + TimeSpan.FromSeconds(1d / rate));
             })
             .DisposeWith(_disposables);
 
@@ -70,7 +72,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .WithSubscribe(() =>
             {
                 int rate = GetFrameRate();
-                UpdateCurrentFrame(EditViewModel.CurrentTime.Value - TimeSpan.FromSeconds(1d / rate));
+                UpdateCurrentFrame(_editorClock.CurrentTime.Value - TimeSpan.FromSeconds(1d / rate));
             })
             .DisposeWith(_disposables);
 
@@ -80,10 +82,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 int rate = GetFrameRate();
                 var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
                 // 現在の時間がスタートと同じ場合、0に移動
-                EditViewModel.CurrentTime.Value =
-                    EditViewModel.CurrentTime.Value > endTime
+                _editorClock.CurrentTime.Value =
+                    _editorClock.CurrentTime.Value > endTime
                         ? endTime
-                        : EditViewModel.CurrentTime.Value > Scene.Start
+                        : _editorClock.CurrentTime.Value > Scene.Start
                             ? Scene.Start
                             : TimeSpan.Zero;
             })
@@ -94,10 +96,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             {
                 int rate = GetFrameRate();
                 var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
-                EditViewModel.CurrentTime.Value =
-                    EditViewModel.CurrentTime.Value < Scene.Start
+                _editorClock.CurrentTime.Value =
+                    _editorClock.CurrentTime.Value < Scene.Start
                         ? Scene.Start
-                        : EditViewModel.CurrentTime.Value < endTime
+                        : _editorClock.CurrentTime.Value < endTime
                             ? endTime
                             : Scene.Children.Count > 0
                                 ? Scene.Children.Max(i => i.Start + i.Length) - TimeSpan.FromSeconds(1d / rate)
@@ -116,12 +118,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             })
             .DisposeWith(_disposables);
 
-        CurrentFrame = EditViewModel.CurrentTime
+        CurrentFrame = _editorClock.CurrentTime
             .ToReactiveProperty()
             .DisposeWith(_disposables);
         _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
 
-        Duration = editViewModel.MaximumTime
+        Duration = _editorClock.MaximumTime
             .CombineLatest(Scene.GetObservable(Scene.DurationProperty), Scene.GetObservable(Scene.StartProperty),
                 CurrentFrame)
             .Select(i =>
@@ -200,7 +202,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         if (e is ElementEditedEventArgs elementEdited)
         {
-            TimeSpan time = EditViewModel.CurrentTime.Value;
+            TimeSpan time = _editorClock.CurrentTime.Value;
             if (!elementEdited.AffectedRange.Any(v => v.Contains(time)))
             {
                 return;
@@ -316,7 +318,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             int rate = GetFrameRate();
 
             TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
-            TimeSpan startTime = EditViewModel.CurrentTime.Value;
+            TimeSpan startTime = _editorClock.CurrentTime.Value;
             TimeSpan durationTime = Scene.Duration;
             int startFrame = (int)startTime.ToFrameNumber(rate);
             int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
@@ -366,7 +368,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
                             if (Scene != null)
                             {
-                                EditViewModel.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
+                                _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
                                 EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
                             }
                         }
@@ -473,7 +475,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         var composer = EditViewModel.Composer.Value;
         int sampleRate = composer.SampleRate;
-        TimeSpan cur = EditViewModel.CurrentTime.Value;
+        TimeSpan cur = _editorClock.CurrentTime.Value;
         var fmt = new WaveFormat(sampleRate, 32, 2);
         var source = new XAudioSource(audioContext);
         var primaryBuffer = new XAudioBuffer();
@@ -558,7 +560,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             audioContext.MakeCurrent();
 
             var composer = EditViewModel.Composer.Value;
-            TimeSpan cur = EditViewModel.CurrentTime.Value;
+            TimeSpan cur = _editorClock.CurrentTime.Value;
             uint[] buffers = audioContext.GenBuffers(2);
             uint source = audioContext.GenSource();
 
@@ -710,7 +712,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         return;
 
                     int rate = GetFrameRate();
-                    TimeSpan time = EditViewModel.CurrentTime.Value;
+                    TimeSpan time = _editorClock.CurrentTime.Value;
                     int frame = (int)Math.Round(time.ToFrameNumber(rate), MidpointRounding.AwayFromZero);
                     time = frame.ToTimeSpan(rate);
                     Ref<Bitmap>? bitmapRef;
@@ -778,7 +780,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         if (Scene == null) return;
 
-        if (EditViewModel.CurrentTime.Value != timeSpan)
+        if (_editorClock.CurrentTime.Value != timeSpan)
         {
             //int rate = Project.GetFrameRate();
             //timeSpan = timeSpan.FloorToRate(rate);
@@ -792,7 +794,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             //    timeSpan = TimeSpan.Zero;
             //}
 
-            EditViewModel.CurrentTime.Value = timeSpan;
+            _editorClock.CurrentTime.Value = timeSpan;
         }
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -17,6 +17,7 @@ using Beutl.Media.Source;
 using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 using Silk.NET.OpenAL;
@@ -650,7 +651,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void DrawBoundaries(Renderer renderer, SKCanvas canvas, Size canvasSize, bool recalculate = false)
     {
-        int? selected = EditViewModel.SelectedLayerNumber.Value;
+        var editorSelection = EditViewModel.GetRequiredService<IEditorSelection>();
+        int? selected = editorSelection.SelectedLayerNumber.Value;
         if (selected.HasValue)
         {
             var frameSize = new Size(renderer.FrameSize.Width, renderer.FrameSize.Height);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -35,6 +35,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private readonly ReactivePropertySlim<bool> _isEnabled;
     private readonly EditViewModel _editViewModel;
     private readonly IEditorClock _editorClock;
+    private readonly IEditorSelection _editorSelection;
     private IDisposable? _currentFrameSubscription;
     private CancellationTokenSource? _cts;
     private Size _maxFrameSize;
@@ -44,6 +45,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         _editViewModel = editViewModel;
         _editorClock = editViewModel.GetRequiredService<IEditorClock>();
+        _editorSelection = editViewModel.GetRequiredService<IEditorSelection>();
         Scene = editViewModel.Scene;
         _isEnabled = editViewModel.IsEnabled;
         PlayPause = new AsyncReactiveCommand(_isEnabled.AsObservable())
@@ -653,8 +655,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void DrawBoundaries(Renderer renderer, SKCanvas canvas, Size canvasSize, bool recalculate = false)
     {
-        var editorSelection = EditViewModel.GetRequiredService<IEditorSelection>();
-        int? selected = editorSelection.SelectedLayerNumber.Value;
+        int? selected = _editorSelection.SelectedLayerNumber.Value;
         if (selected.HasValue)
         {
             var frameSize = new Size(renderer.FrameSize.Width, renderer.FrameSize.Height);

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
@@ -64,9 +64,9 @@ public sealed partial class PropertyEditorMenu : UserControl
             {
                 EditExpression_Click(sender, e);
             }
-            else if (viewModel.HasAnimation.Value && viewModel.GetService<EditViewModel>() is { } editViewModel)
+            else if (viewModel.HasAnimation.Value && viewModel.GetService<IEditorClock>() is { } editorClock)
             {
-                TimeSpan keyTime = editViewModel.CurrentTime.Value;
+                TimeSpan keyTime = editorClock.CurrentTime.Value;
                 if (symbolIcon.IsFilled)
                 {
                     viewModel.RemoveKeyFrame(keyTime);

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -14,6 +14,7 @@ using Beutl.Services;
 using Beutl.ViewModels;
 using Beutl.Views.Dialogs;
 using FluentAvalonia.UI.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings.Extensions;
 
 namespace Beutl.Views;
@@ -112,7 +113,7 @@ public partial class MainView
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel)
             && viewModel.Scene is Scene scene
-            && viewModel.SelectedObject.Value is Element element)
+            && viewModel.GetService<IEditorSelection>()?.SelectedObject.Value is Element element)
         {
             string path = element.Uri!.LocalPath;
             string name = Path.GetFileName(path);

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -7,6 +7,7 @@ using Beutl.Graphics.Transformation;
 using Beutl.Helpers;
 using Beutl.ProjectSystem;
 using Beutl.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using AvaPoint = Avalonia.Point;
 
 namespace Beutl.Views;
@@ -82,6 +83,7 @@ public partial class PlayerView
                 return elements.Length == 0 ? 0 : elements.Max(v => v.ZIndex) + 1;
             }
 
+            var adder = editViewModel.GetRequiredService<IElementAdder>();
             if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
                 && TypeFormat.ToType(typeName) is { } type)
             {
@@ -89,14 +91,14 @@ public partial class PlayerView
 
                 int zindex = CalculateZIndex(scene);
 
-                editViewModel.AddElement(new ElementDescription(
+                adder.AddElement(new ElementDescription(
                     frame, TimeSpan.FromSeconds(5), zindex, InitialObject: type, Position: centeredPosition));
             }
             else if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } fileName)
             {
                 int zindex = CalculateZIndex(scene);
 
-                editViewModel.AddElement(new ElementDescription(
+                adder.AddElement(new ElementDescription(
                     frame, TimeSpan.FromSeconds(5), zindex, FileName: fileName, Position: centeredPosition));
 
                 e.Handled = true;

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -48,7 +48,8 @@ public partial class PlayerView
 
                 if (element != null)
                 {
-                    editViewModel.SelectedObject.Value = element;
+                    var editorSelection = editViewModel.GetService<IEditorSelection>();
+                    editorSelection?.SelectedObject.Value = element;
                 }
 
                 if (containsFe

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -24,6 +24,7 @@ using Beutl.Services;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using AvaImage = Avalonia.Controls.Image;
 using AvaPoint = Avalonia.Point;
@@ -347,7 +348,8 @@ public partial class PlayerView
 
                 if (Element != null)
                 {
-                    EditViewModel.SelectedObject.Value = Element;
+                    var editorSelection = EditViewModel.GetService<IEditorSelection>();
+                    editorSelection?.SelectedObject.Value = Element;
                 }
             }
 
@@ -1166,7 +1168,8 @@ public partial class PlayerView
             _camera = null;
 
             // 選択されているオブジェクトから探す
-            if (EditViewModel.SelectedObject.Value is Element element)
+            var editorSelection = EditViewModel.GetService<IEditorSelection>();
+            if (editorSelection?.SelectedObject.Value is Element element)
             {
                 var scene3DObj = element.Objects.OfType<Scene3D>().FirstOrDefault();
                 if (scene3DObj != null)

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -147,6 +147,10 @@ public partial class PlayerView
 
         public required PlayerViewModel ViewModel { get; init; }
 
+        public required IEditorClock Clock { get; init; }
+
+        public required IEditorSelection EditorSelection { get; init; }
+
         public EditViewModel EditViewModel => ViewModel.EditViewModel;
 
         public Drawable? Drawable { get; private set; }
@@ -186,7 +190,7 @@ public partial class PlayerView
                     }
                     else
                     {
-                        var res = transformGroup.ToResource(new CompositionContext(EditViewModel.CurrentTime.Value));
+                        var res = transformGroup.ToResource(new CompositionContext(Clock.CurrentTime.Value));
 
                         return (obj, res.Matrix);
                     }
@@ -198,7 +202,7 @@ public partial class PlayerView
         private KeyFrameState<float>? FindKeyFramePairOrNull(IProperty<float> property)
         {
             int rate = EditViewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-            TimeSpan globalkeyTime = EditViewModel.CurrentTime.Value;
+            TimeSpan globalkeyTime = Clock.CurrentTime.Value;
             TimeSpan localKeyTime = Element != null ? globalkeyTime - Element.Start : globalkeyTime;
 
             if (property.Animation is KeyFrameAnimation<float> animation)
@@ -331,7 +335,7 @@ public partial class PlayerView
             Drawable = RenderThread.Dispatcher.Invoke(() =>
             {
                 var compositor = EditViewModel.Renderer.Value.Compositor;
-                var compositionFrame = compositor.EvaluateGraphics(EditViewModel.CurrentTime.Value);
+                var compositionFrame = compositor.EvaluateGraphics(Clock.CurrentTime.Value);
                 return EditViewModel.Renderer.Value.HitTest(compositionFrame, new((float)_scaledStartPosition.X, (float)_scaledStartPosition.Y));
             });
 
@@ -339,7 +343,7 @@ public partial class PlayerView
             {
                 // TODO: DrawableGroup以下のDrawableを拾った場合の対応
                 int zindex = Drawable.ZIndex;
-                TimeSpan time = EditViewModel.CurrentTime.Value;
+                TimeSpan time = Clock.CurrentTime.Value;
 
                 Element = scene.Children.FirstOrDefault(v =>
                     v.ZIndex == zindex
@@ -348,8 +352,7 @@ public partial class PlayerView
 
                 if (Element != null)
                 {
-                    var editorSelection = EditViewModel.GetService<IEditorSelection>();
-                    editorSelection?.SelectedObject.Value = Element;
+                    EditorSelection.SelectedObject.Value = Element;
                 }
             }
 
@@ -607,16 +610,20 @@ public partial class PlayerView
 
         public required PlayerViewModel ViewModel { get; init; }
 
+        public required IEditorClock Clock { get; init; }
+
+        public required IEditorSelection EditorSelection { get; init; }
+
         public EditViewModel EditViewModel => ViewModel.EditViewModel;
 
-        private CompositionContext CompositionContext => field ??= new(EditViewModel.CurrentTime.Value);
+        private CompositionContext CompositionContext => field ??= new(Clock.CurrentTime.Value);
 
         private Control Image => View.image;
 
         private KeyFrameState<Vector3>? FindKeyFramePairOrNull(IProperty<Vector3> property)
         {
             int rate = EditViewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-            TimeSpan globalKeyTime = EditViewModel.CurrentTime.Value;
+            TimeSpan globalKeyTime = Clock.CurrentTime.Value;
             TimeSpan localKeyTime = _scene3D != null ? globalKeyTime - _scene3D.TimeRange.Start : globalKeyTime;
 
             if (property.Animation is KeyFrameAnimation<Vector3> animation)
@@ -1168,8 +1175,7 @@ public partial class PlayerView
             _camera = null;
 
             // 選択されているオブジェクトから探す
-            var editorSelection = EditViewModel.GetService<IEditorSelection>();
-            if (editorSelection?.SelectedObject.Value is Element element)
+            if (EditorSelection.SelectedObject.Value is Element element)
             {
                 var scene3DObj = element.Objects.OfType<Scene3D>().FirstOrDefault();
                 if (scene3DObj != null)
@@ -1189,7 +1195,7 @@ public partial class PlayerView
             var drawable = RenderThread.Dispatcher.Invoke(() =>
             {
                 var compositor = EditViewModel.Renderer.Value.Compositor;
-                var compositionFrame = compositor.EvaluateGraphics(EditViewModel.CurrentTime.Value);
+                var compositionFrame = compositor.EvaluateGraphics(Clock.CurrentTime.Value);
                 return EditViewModel.Renderer.Value.HitTest(compositionFrame, new((float)scaledPos.X, (float)scaledPos.Y));
             });
 
@@ -1314,7 +1320,13 @@ public partial class PlayerView
     {
         if (viewModel.IsMoveMode.Value)
         {
-            return new MouseControlMove { ViewModel = viewModel, View = this };
+            return new MouseControlMove
+            {
+                ViewModel = viewModel,
+                Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
+                EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
+                View = this
+            };
         }
         else if (viewModel.IsHandMode.Value)
         {
@@ -1322,7 +1334,13 @@ public partial class PlayerView
         }
         else if (viewModel.IsCameraMode.Value)
         {
-            return new MouseControl3DCamera { ViewModel = viewModel, View = this };
+            return new MouseControl3DCamera
+            {
+                ViewModel = viewModel,
+                Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
+                EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
+                View = this
+            };
         }
         else
         {


### PR DESCRIPTION
## Description
- Decompose EditViewModel by extracting dedicated implementation classes (EditorClockImpl, EditorSelectionImpl, ElementAdderImpl, TimelineOptionsProviderImpl) behind the existing IEditorClock, IEditorSelection, IElementAdder, and ITimelineOptionsProvider interfaces.
- Migrate callers (PlayerViewModel, BufferedPlayer, tutorial services, menu/timeline views, etc.) to consume these services directly instead of reaching into EditViewModel, shrinking EditViewModel by ~470 lines.
- Improves separation of concerns and testability by giving clock, selection, element creation, and timeline options their own owners.

## Breaking changes
None. EditViewModel no longer implements the extracted service interfaces, but it is an internal editor type and all in-repo consumers have been updated.

## Fixed issues
None.