### PR TITLE
feat: synchronize video playback to audio clock

### DIFF
--- a/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioSource.cs
+++ b/src/Beutl.Engine/Audio/Platforms/XAudio2/XAudioSource.cs
@@ -8,6 +8,8 @@ public sealed class XAudioSource(XAudioContext context) : IDisposable
 
     public int BuffersQueued => (int?)_sourceVoice?.State.BuffersQueued ?? -1;
 
+    public ulong SamplesPlayed => _sourceVoice?.State.SamplesPlayed ?? 0UL;
+
     public void Dispose()
     {
         _sourceVoice?.DestroyVoice();

--- a/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
@@ -50,7 +50,7 @@ public sealed class LoadInstalledExtensionTask : StartupTask
                                 item.Name);
                             Failures.Add((item, new InvalidOperationException(
                                 $"Dependency re-resolution failed for package '{item.Name}'.")));
-                            continue;
+                            return;
                         }
 
                         try

--- a/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
@@ -50,7 +50,7 @@ public sealed class LoadInstalledExtensionTask : StartupTask
                                 item.Name);
                             Failures.Add((item, new InvalidOperationException(
                                 $"Dependency re-resolution failed for package '{item.Name}'.")));
-                            return;
+                            continue;
                         }
 
                         try

--- a/src/Beutl/ViewModels/AudioPlaybackClock.cs
+++ b/src/Beutl/ViewModels/AudioPlaybackClock.cs
@@ -1,4 +1,4 @@
-namespace Beutl.ViewModels;
+﻿namespace Beutl.ViewModels;
 
 internal sealed class AudioPlaybackClock
 {

--- a/src/Beutl/ViewModels/AudioPlaybackClock.cs
+++ b/src/Beutl/ViewModels/AudioPlaybackClock.cs
@@ -1,0 +1,36 @@
+namespace Beutl.ViewModels;
+
+internal sealed class AudioPlaybackClock
+{
+    private readonly object _lock = new();
+    private TimeSpan _anchorAudioTime;
+    private long _anchorTimestamp;
+    private bool _running;
+
+    public void Anchor(TimeSpan audioTime)
+    {
+        lock (_lock)
+        {
+            _anchorAudioTime = audioTime;
+            _anchorTimestamp = Stopwatch.GetTimestamp();
+            _running = true;
+        }
+    }
+
+    public void Pause()
+    {
+        lock (_lock)
+        {
+            _running = false;
+        }
+    }
+
+    public TimeSpan? GetTime()
+    {
+        lock (_lock)
+        {
+            if (!_running) return null;
+            return _anchorAudioTime + Stopwatch.GetElapsedTime(_anchorTimestamp);
+        }
+    }
+}

--- a/src/Beutl/ViewModels/AudioPlaybackClock.cs
+++ b/src/Beutl/ViewModels/AudioPlaybackClock.cs
@@ -3,9 +3,17 @@ namespace Beutl.ViewModels;
 internal sealed class AudioPlaybackClock
 {
     private readonly object _lock = new();
+    private readonly TaskCompletionSource _started =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private TimeSpan _anchorAudioTime;
     private long _anchorTimestamp;
     private bool _running;
+
+    // 音声再生の準備が完了した（または失敗して終了した）ことを通知するタスク。
+    // これを待つことで、映像側のウォールクロック基準点を音声開始と揃えられる。
+    public Task StartedTask => _started.Task;
+
+    public void SignalStarted() => _started.TrySetResult();
 
     public void Anchor(TimeSpan audioTime)
     {
@@ -15,6 +23,7 @@ internal sealed class AudioPlaybackClock
             _anchorTimestamp = Stopwatch.GetTimestamp();
             _running = true;
         }
+        _started.TrySetResult();
     }
 
     public void Pause()
@@ -23,6 +32,7 @@ internal sealed class AudioPlaybackClock
         {
             _running = false;
         }
+        _started.TrySetResult();
     }
 
     public TimeSpan? GetTime()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -341,6 +341,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             var clock = new AudioPlaybackClock();
             var audioTask = PlayAudio(Scene, clock, startTime);
 
+            // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
+            // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
+            // 音声側が再生を開始（または音声なしと判明して終了）するまで待ってから
+            // ウォールクロックの基準点を取得する。
+            await clock.StartedTask;
+
             DateTime startDateTime = DateTime.UtcNow;
             var tcs = new TaskCompletionSource<bool>();
             int nextExpectedFrame = startFrame + 1;
@@ -487,6 +493,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         (y, x) = (x, y);
     }
 
+    // オーディオバックエンドが最初のサンプルを出力するまで短いポーリングで待機する。
+    // バックエンド起動レイテンシ分だけアンカーを遅らせることで、映像側のウォールクロック
+    // 基準点を実際の音声進行に揃える。タイムアウトは設けず、停止操作による
+    // cts.Cancel() でのみ抜ける (低速なバックエンドで 0 アンカーしないため)。
+    private static async Task WaitForFirstSampleAsync(
+        Func<bool> hasProgressed, bool hasAudio, CancellationToken token)
+    {
+        if (!hasAudio) return;
+        while (!token.IsCancellationRequested)
+        {
+            if (hasProgressed()) return;
+            await Task.Delay(1, token).ConfigureAwait(false);
+        }
+    }
+
     private async Task PlayWithXA2(XAudioContext audioContext, Scene scene,
         AudioPlaybackClock clock, TimeSpan startTime)
     {
@@ -543,7 +564,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             PrepareBuffer(secondaryBuffer);
 
             source.Play();
+            // Play() 直後は SamplesPlayed が 0 のままで、その時点でアンカーすると
+            // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
+            // 実際のサンプル出力が始まるのを観測してからアンカーする。
+            await WaitForFirstSampleAsync(() => source.SamplesPlayed > 0, hasAudio, cts.Token)
+                .ConfigureAwait(false);
             AnchorClock();
+            // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
+            clock.SignalStarted();
 
             await Task.Delay(1000, cts.Token).ConfigureAwait(false);
             AnchorClock();
@@ -637,7 +665,22 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             }
 
             audioContext.SourcePlay(source);
+            // SourcePlay() 直後は SampleOffset が 0 のままで、その時点でアンカーすると
+            // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
+            // 実際のサンプル出力が始まるのを観測してからアンカーする。
+            await WaitForFirstSampleAsync(
+                    () =>
+                    {
+                        audioContext.MakeCurrent();
+                        audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int offset);
+                        return offset > 0;
+                    },
+                    hasAudio,
+                    cts.Token)
+                .ConfigureAwait(false);
             AnchorClock();
+            // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
+            clock.SignalStarted();
 
             try
             {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -338,19 +338,30 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 _editViewModel.SceneId, rate, startFrame, durationFrame);
             playerImpl.Start();
 
-            var audioTask = PlayAudio(Scene);
+            var clock = new AudioPlaybackClock();
+            var audioTask = PlayAudio(Scene, clock, startTime);
 
             DateTime startDateTime = DateTime.UtcNow;
             var tcs = new TaskCompletionSource<bool>();
             int nextExpectedFrame = startFrame + 1;
             bool processing = false;
+
+            int ComputeExpectFrame()
+            {
+                TimeSpan elapsed = clock.GetTime() is { } audioTime
+                    ? audioTime - startTime
+                    : DateTime.UtcNow - startDateTime;
+                if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+                return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
+            }
+
             await using var timer = new Timer(_ =>
             {
                 if (processing) return;
                 processing = true;
                 try
                 {
-                    var expectFrame = (int)((DateTime.UtcNow - startDateTime).Ticks / tick.Ticks) + startFrame;
+                    var expectFrame = ComputeExpectFrame();
                     if (!IsPlaying.Value || expectFrame >= endFrame)
                     {
                         tcs.TrySetResult(true);
@@ -387,8 +398,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         // 期待していたフレームよりも前のフレームが来た場合
                     }
 
-                    playerImpl.Skipped(
-                        (int)((DateTime.UtcNow - startDateTime).Ticks / tick.Ticks) + startFrame + 1);
+                    playerImpl.Skipped(ComputeExpectFrame() + 1);
                 }
                 finally
                 {
@@ -424,21 +434,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         return rate;
     }
 
-    private async Task PlayAudio(Scene scene)
+    private async Task PlayAudio(Scene scene, AudioPlaybackClock clock, TimeSpan startTime)
     {
         try
         {
             if (OperatingSystem.IsWindows())
             {
                 using var audioContext = new XAudioContext();
-                await PlayWithXA2(audioContext, scene).ConfigureAwait(false);
+                await PlayWithXA2(audioContext, scene, clock, startTime).ConfigureAwait(false);
             }
             else
             {
                 await Task.Run(async () =>
                 {
                     using var audioContext = new AudioContext();
-                    await PlayWithOpenAL(audioContext, scene);
+                    await PlayWithOpenAL(audioContext, scene, clock, startTime);
                 });
             }
         }
@@ -448,6 +458,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 MessageStrings.AudioPlaybackException);
             _logger.LogError(ex, "An exception occurred during audio playback.");
             IsPlaying.Value = false;
+        }
+        finally
+        {
+            clock.Pause();
         }
     }
 
@@ -473,25 +487,41 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         (y, x) = (x, y);
     }
 
-    private async Task PlayWithXA2(XAudioContext audioContext, Scene scene)
+    private async Task PlayWithXA2(XAudioContext audioContext, Scene scene,
+        AudioPlaybackClock clock, TimeSpan startTime)
     {
         var composer = EditViewModel.Composer.Value;
         int sampleRate = composer.SampleRate;
-        TimeSpan cur = _editorClock.CurrentTime.Value;
+        TimeSpan cur = startTime;
         var fmt = new WaveFormat(sampleRate, 32, 2);
         var source = new XAudioSource(audioContext);
         var primaryBuffer = new XAudioBuffer();
         var secondaryBuffer = new XAudioBuffer();
+        bool hasAudio = false;
 
         void PrepareBuffer(XAudioBuffer buffer)
         {
             Pcm<Stereo32BitFloat>? pcm = FillAudioData(cur, composer);
             if (pcm != null)
             {
+                if (!hasAudio)
+                {
+                    sampleRate = pcm.SampleRate;
+                    fmt = new WaveFormat(sampleRate, 32, 2);
+                }
+
                 buffer.BufferData(pcm.DataSpan, fmt);
+                hasAudio = true;
             }
 
             source.QueueBuffer(buffer);
+        }
+
+        void AnchorClock()
+        {
+            if (!hasAudio) return;
+            double seconds = (double)source.SamplesPlayed / sampleRate;
+            clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
         }
 
         var cts = new CancellationTokenSource();
@@ -513,8 +543,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             PrepareBuffer(secondaryBuffer);
 
             source.Play();
+            AnchorClock();
 
             await Task.Delay(1000, cts.Token).ConfigureAwait(false);
+            AnchorClock();
 
             // primaryBufferが終了、secondaryが開始
 
@@ -534,6 +566,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 Swap(ref primaryBuffer, ref secondaryBuffer);
 
                 await Task.Delay(1000, cts.Token).ConfigureAwait(false);
+                AnchorClock();
             }
         }
         catch (OperationCanceledException)
@@ -550,7 +583,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
     }
 
-    private async Task PlayWithOpenAL(AudioContext audioContext, Scene scene)
+    private async Task PlayWithOpenAL(AudioContext audioContext, Scene scene,
+        AudioPlaybackClock clock, TimeSpan startTime)
     {
         var cts = new CancellationTokenSource();
         IDisposable revoker = IsPlaying.Where(v => !v)
@@ -562,25 +596,48 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             audioContext.MakeCurrent();
 
             var composer = EditViewModel.Composer.Value;
-            TimeSpan cur = _editorClock.CurrentTime.Value;
+            int sampleRate = composer.SampleRate;
+            TimeSpan cur = startTime;
             uint[] buffers = audioContext.GenBuffers(2);
             uint source = audioContext.GenSource();
+            long totalProcessedSamples = 0;
+            var queuedBufferSamples = new Queue<int>();
+            bool hasAudio = false;
+
+            void AnchorClock()
+            {
+                if (!hasAudio) return;
+                audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int sampleOffset);
+                long pos = totalProcessedSamples + sampleOffset;
+                double seconds = (double)pos / sampleRate;
+                clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
+            }
 
             foreach (uint buffer in buffers)
             {
                 using Pcm<Stereo32BitFloat>? pcmf = FillAudioData(cur, composer);
                 cur += s_second;
+                int fillSamples = 0;
                 if (pcmf != null)
                 {
                     using Pcm<Stereo16BitInteger> pcm = pcmf.Convert<Stereo16BitInteger>();
 
+                    if (!hasAudio)
+                    {
+                        sampleRate = pcm.SampleRate;
+                    }
+
                     audioContext.BufferData(buffer, BufferFormat.Stereo16, pcm.DataSpan, pcm.SampleRate);
+                    fillSamples = pcm.DataSpan.Length;
+                    hasAudio = true;
                 }
 
                 audioContext.SourceQueueBuffer(source, buffer);
+                queuedBufferSamples.Enqueue(fillSamples);
             }
 
             audioContext.SourcePlay(source);
+            AnchorClock();
 
             try
             {
@@ -593,14 +650,25 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         using Pcm<Stereo32BitFloat>? pcmf = FillAudioData(cur, composer);
                         cur += s_second;
                         uint buffer = audioContext.SourceUnqueueBuffer(source);
+                        int fillSamples = 0;
                         if (pcmf != null)
                         {
                             using Pcm<Stereo16BitInteger> pcm = pcmf.Convert<Stereo16BitInteger>();
 
+                            if (!hasAudio)
+                            {
+                                sampleRate = pcm.SampleRate;
+                            }
+
                             audioContext.BufferData(buffer, BufferFormat.Stereo16, pcm.DataSpan, pcm.SampleRate);
+                            fillSamples = pcm.DataSpan.Length;
+                            hasAudio = true;
                         }
 
                         audioContext.SourceQueueBuffer(source, buffer);
+
+                        totalProcessedSamples += queuedBufferSamples.Dequeue();
+                        queuedBufferSamples.Enqueue(fillSamples);
                         processed--;
                     }
 
@@ -609,6 +677,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         audioContext.SourcePlay(source);
                     }
 
+                    AnchorClock();
+
                     await Task.Delay(100, cts.Token).ConfigureAwait(false);
                     if (cur > scene.Duration)
                         break;
@@ -616,6 +686,15 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
                 while (audioContext.GetSourceState(source) == SourceState.Playing && IsPlaying.Value)
                 {
+                    audioContext.MakeCurrent();
+                    audioContext.GetSource(source, GetSourceInteger.BuffersProcessed, out int drainProcessed);
+                    while (drainProcessed > 0 && queuedBufferSamples.Count > 0)
+                    {
+                        audioContext.SourceUnqueueBuffer(source);
+                        totalProcessedSamples += queuedBufferSamples.Dequeue();
+                        drainProcessed--;
+                    }
+                    AnchorClock();
                     await Task.Delay(100, cts.Token).ConfigureAwait(false);
                 }
             }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -665,25 +665,29 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             }
 
             audioContext.SourcePlay(source);
-            // SourcePlay() 直後は SampleOffset が 0 のままで、その時点でアンカーすると
-            // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
-            // 実際のサンプル出力が始まるのを観測してからアンカーする。
-            await WaitForFirstSampleAsync(
-                    () =>
-                    {
-                        audioContext.MakeCurrent();
-                        audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int offset);
-                        return offset > 0;
-                    },
-                    hasAudio,
-                    cts.Token)
-                .ConfigureAwait(false);
-            AnchorClock();
-            // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
-            clock.SignalStarted();
 
             try
             {
+                // SourcePlay() 直後は SampleOffset が 0 のままで、その時点でアンカーすると
+                // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
+                // 実際のサンプル出力が始まるのを観測してからアンカーする。
+                await WaitForFirstSampleAsync(
+                        () =>
+                        {
+                            audioContext.MakeCurrent();
+                            audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int offset);
+                            return offset > 0;
+                        },
+                        hasAudio,
+                        cts.Token)
+                    .ConfigureAwait(false);
+                // await 後は別のプールスレッドで継続する可能性があり、
+                // OpenAL コンテキストはスレッド固有のため再バインドが必要。
+                audioContext.MakeCurrent();
+                AnchorClock();
+                // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
+                clock.SignalStarted();
+
                 while (IsPlaying.Value)
                 {
                     audioContext.MakeCurrent();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -350,7 +350,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             DateTime startDateTime = DateTime.UtcNow;
             var tcs = new TaskCompletionSource<bool>();
             int nextExpectedFrame = startFrame + 1;
-            bool processing = false;
+            int processing = 0;
 
             int ComputeExpectFrame()
             {
@@ -363,8 +363,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
             await using var timer = new Timer(_ =>
             {
-                if (processing) return;
-                processing = true;
+                if (Interlocked.Exchange(ref processing, 1) != 0) return;
                 try
                 {
                     var expectFrame = ComputeExpectFrame();
@@ -408,7 +407,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 }
                 finally
                 {
-                    processing = false;
+                    Interlocked.Exchange(ref processing, 0);
                 }
             }, null, tick, tick);
 
@@ -506,7 +505,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         {
             if (hasProgressed()) return true;
             if (Stopwatch.GetTimestamp() >= deadline) return false;
-            await Task.Delay(1, token).ConfigureAwait(false);
+            try
+            {
+                await Task.Delay(1, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
         }
         return false;
     }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -494,18 +494,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     }
 
     // オーディオバックエンドが最初のサンプルを出力するまで短いポーリングで待機する。
-    // バックエンド起動レイテンシ分だけアンカーを遅らせることで、映像側のウォールクロック
-    // 基準点を実際の音声進行に揃える。タイムアウトは設けず、停止操作による
-    // cts.Cancel() でのみ抜ける (低速なバックエンドで 0 アンカーしないため)。
-    private static async Task WaitForFirstSampleAsync(
+    // true を返した場合は実サンプルの観測に成功しており、呼び出し側は安全に AnchorClock できる。
+    // 期限内に進行が観測できなかった場合は false を返し、呼び出し側は音声クロックを諦めて
+    // 壁時計にフォールバックする (サスペンド/切断中のデバイスで無期限ハングするのを防ぐため)。
+    private static async Task<bool> WaitForFirstSampleAsync(
         Func<bool> hasProgressed, bool hasAudio, CancellationToken token)
     {
-        if (!hasAudio) return;
+        if (!hasAudio) return false;
+        long deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 2; // 2s
         while (!token.IsCancellationRequested)
         {
-            if (hasProgressed()) return;
+            if (hasProgressed()) return true;
+            if (Stopwatch.GetTimestamp() >= deadline) return false;
             await Task.Delay(1, token).ConfigureAwait(false);
         }
+        return false;
     }
 
     private async Task PlayWithXA2(XAudioContext audioContext, Scene scene,
@@ -519,6 +522,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         var primaryBuffer = new XAudioBuffer();
         var secondaryBuffer = new XAudioBuffer();
         bool hasAudio = false;
+        bool audioClockValid = false;
 
         void PrepareBuffer(XAudioBuffer buffer)
         {
@@ -540,7 +544,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         void AnchorClock()
         {
-            if (!hasAudio) return;
+            if (!hasAudio || !audioClockValid) return;
             double seconds = (double)source.SamplesPlayed / sampleRate;
             clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
         }
@@ -567,10 +571,19 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             // Play() 直後は SamplesPlayed が 0 のままで、その時点でアンカーすると
             // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
             // 実際のサンプル出力が始まるのを観測してからアンカーする。
-            await WaitForFirstSampleAsync(() => source.SamplesPlayed > 0, hasAudio, cts.Token)
+            // タイムアウトした場合はバックエンドがハングしている可能性が高いので、
+            // 音声クロックを諦めて壁時計にフォールバックする。
+            audioClockValid = await WaitForFirstSampleAsync(
+                    () => source.SamplesPlayed > 0, hasAudio, cts.Token)
                 .ConfigureAwait(false);
+            if (hasAudio && !audioClockValid)
+            {
+                _logger.LogWarning(
+                    "XAudio2 backend did not advance SamplesPlayed within the startup deadline; falling back to wall-clock timing.");
+            }
             AnchorClock();
-            // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
+            // 壁時計フォールバック時や音声なしの場合は AnchorClock が no-op のため、
+            // ここで明示的に StartedTask をシグナルする。
             clock.SignalStarted();
 
             await Task.Delay(1000, cts.Token).ConfigureAwait(false);
@@ -631,10 +644,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             long totalProcessedSamples = 0;
             var queuedBufferSamples = new Queue<int>();
             bool hasAudio = false;
+            bool audioClockValid = false;
 
             void AnchorClock()
             {
-                if (!hasAudio) return;
+                if (!hasAudio || !audioClockValid) return;
                 audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int sampleOffset);
                 long pos = totalProcessedSamples + sampleOffset;
                 double seconds = (double)pos / sampleRate;
@@ -671,7 +685,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 // SourcePlay() 直後は SampleOffset が 0 のままで、その時点でアンカーすると
                 // 映像がウォールクロックで先行し、後続の AnchorClock で巻き戻しが発生する。
                 // 実際のサンプル出力が始まるのを観測してからアンカーする。
-                await WaitForFirstSampleAsync(
+                // タイムアウトした場合はバックエンドがハングしている可能性が高いので、
+                // 音声クロックを諦めて壁時計にフォールバックする。
+                audioClockValid = await WaitForFirstSampleAsync(
                         () =>
                         {
                             audioContext.MakeCurrent();
@@ -684,8 +700,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 // await 後は別のプールスレッドで継続する可能性があり、
                 // OpenAL コンテキストはスレッド固有のため再バインドが必要。
                 audioContext.MakeCurrent();
+                if (hasAudio && !audioClockValid)
+                {
+                    _logger.LogWarning(
+                        "OpenAL backend did not advance SampleOffset within the startup deadline; falling back to wall-clock timing.");
+                }
                 AnchorClock();
-                // 音声なしの場合 AnchorClock は何もしないため、ここで明示的にシグナルする。
+                // 壁時計フォールバック時や音声なしの場合は AnchorClock が no-op のため、
+                // ここで明示的に StartedTask をシグナルする。
                 clock.SignalStarted();
 
                 while (IsPlaying.Value)


### PR DESCRIPTION
## Description
- Drive the video frame timer off the audio backend's actual sample position via a new `AudioPlaybackClock`, instead of a wall clock that drifted from what the user hears.
- Wait for the audio backend to report sample progress before anchoring the clock; if no progress is observed within 2 s (e.g. hung/suspended device), fall back to wall-clock timing so playback never hangs at start.

## Breaking changes
None

## Fixed issues
None