### PR TITLE
feat: Skip disabled elements in compositor and hit-testing

### DIFF
--- a/src/Beutl.ProjectSystem/SceneCompositor.cs
+++ b/src/Beutl.ProjectSystem/SceneCompositor.cs
@@ -160,7 +160,7 @@ public sealed class SceneCompositor : ICompositor
     {
         foreach (Element item in Scene.Children)
         {
-            if (item.Range.Contains(time))
+            if (item.IsEnabled && item.Range.Contains(time))
             {
                 currentElements.OrderedAdd(item, x => x.ZIndex);
             }
@@ -171,7 +171,7 @@ public sealed class SceneCompositor : ICompositor
     {
         foreach (Element item in Scene.Children)
         {
-            if (item.Range.Intersects(timeRange))
+            if (item.IsEnabled && item.Range.Intersects(timeRange))
             {
                 currentElements.OrderedAdd(item, x => x.ZIndex);
             }

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -42,7 +42,8 @@ public partial class PlayerView
                 int zindex = drawable.ZIndex;
 
                 Element? element = scene.Children.FirstOrDefault(v =>
-                    v.ZIndex == zindex
+                    v.IsEnabled
+                    && v.ZIndex == zindex
                     && v.Start <= frame
                     && frame < v.Range.End);
 

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -346,7 +346,8 @@ public partial class PlayerView
                 TimeSpan time = Clock.CurrentTime.Value;
 
                 Element = scene.Children.FirstOrDefault(v =>
-                    v.ZIndex == zindex
+                    v.IsEnabled
+                    && v.ZIndex == zindex
                     && v.Start <= time
                     && time < v.Range.End);
 

--- a/tests/Beutl.UnitTests/ProjectSystem/ElementTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ElementTests.cs
@@ -1,4 +1,4 @@
-using Beutl.ProjectSystem;
+﻿using Beutl.ProjectSystem;
 using NUnit.Framework.Legacy;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/ElementTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ElementTests.cs
@@ -1,0 +1,40 @@
+using Beutl.ProjectSystem;
+using NUnit.Framework.Legacy;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class ElementTests
+{
+    [Test]
+    public void IsEnabled_DefaultsToTrue()
+    {
+        var element = new Element();
+
+        ClassicAssert.IsTrue(element.IsEnabled);
+    }
+
+    [Test]
+    public void IsEnabled_ChangeRaisesEditedEvent()
+    {
+        var element = new Element();
+        int invocationCount = 0;
+        element.Edited += (_, _) => invocationCount++;
+
+        element.IsEnabled = false;
+
+        ClassicAssert.AreEqual(1, invocationCount);
+    }
+
+    [Test]
+    public void IsEnabled_SetSameValueDoesNotRaiseEdited()
+    {
+        var element = new Element { IsEnabled = true };
+        int invocationCount = 0;
+        element.Edited += (_, _) => invocationCount++;
+
+        element.IsEnabled = true;
+
+        ClassicAssert.AreEqual(0, invocationCount);
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneCompositorTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneCompositorTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Media;
 using Beutl.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneCompositorTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneCompositorTests.cs
@@ -1,0 +1,151 @@
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using NUnit.Framework.Legacy;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class SceneCompositorTests
+{
+    private static string GetTempPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"beutl_scene_compositor_{Guid.NewGuid():N}");
+    }
+
+    private static Scene CreateScene(string basePath)
+    {
+        Directory.CreateDirectory(basePath);
+        var scene = new Scene(100, 100, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(basePath, "test.scene"))
+        };
+        return scene;
+    }
+
+    private static Element CreateElement(string basePath, bool isEnabled, EngineObject obj)
+    {
+        var element = new Element
+        {
+            Start = TimeSpan.Zero,
+            Length = TimeSpan.FromSeconds(1),
+            IsEnabled = isEnabled,
+            Uri = new Uri(Path.Combine(basePath, $"{Guid.NewGuid():N}.layer"))
+        };
+        element.AddObject(obj);
+        return element;
+    }
+
+    [Test]
+    public void EvaluateGraphics_DisabledElement_IsExcluded()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element enabled = CreateElement(basePath, isEnabled: true, new TestGraphicsObject());
+            Element disabled = CreateElement(basePath, isEnabled: false, new TestGraphicsObject());
+            scene.Children.Add(enabled);
+            scene.Children.Add(disabled);
+            using var compositor = new SceneCompositor(scene);
+
+            CompositionFrame frame = compositor.EvaluateGraphics(TimeSpan.FromMilliseconds(500));
+
+            ClassicAssert.AreEqual(1, frame.Objects.Length);
+            ClassicAssert.AreSame(enabled.Objects[0], frame.Objects[0].GetOriginal());
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EvaluateAudio_DisabledElement_IsExcluded()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element enabled = CreateElement(basePath, isEnabled: true, new TestAudioObject());
+            Element disabled = CreateElement(basePath, isEnabled: false, new TestAudioObject());
+            scene.Children.Add(enabled);
+            scene.Children.Add(disabled);
+            using var compositor = new SceneCompositor(scene);
+
+            CompositionFrame frame = compositor.EvaluateAudio(
+                new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+
+            ClassicAssert.AreEqual(1, frame.Objects.Length);
+            ClassicAssert.AreSame(enabled.Objects[0], frame.Objects[0].GetOriginal());
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EvaluateGraphics_TogglingIsEnabled_UpdatesFrameContents()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element element = CreateElement(basePath, isEnabled: true, new TestGraphicsObject());
+            scene.Children.Add(element);
+            using var compositor = new SceneCompositor(scene);
+            var time = TimeSpan.FromMilliseconds(500);
+
+            ClassicAssert.AreEqual(1, compositor.EvaluateGraphics(time).Objects.Length);
+
+            element.IsEnabled = false;
+            ClassicAssert.AreEqual(0, compositor.EvaluateGraphics(time).Objects.Length);
+
+            element.IsEnabled = true;
+            ClassicAssert.AreEqual(1, compositor.EvaluateGraphics(time).Objects.Length);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EvaluateAudio_TogglingIsEnabled_UpdatesFrameContents()
+    {
+        // Graphics と Audio の両方が同じ SortLayers を経由するため、
+        // 有効/無効切り替え時に音声側も一貫してフィルタされることを確認する。
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element element = CreateElement(basePath, isEnabled: true, new TestAudioObject());
+            scene.Children.Add(element);
+            using var compositor = new SceneCompositor(scene);
+            var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+            ClassicAssert.AreEqual(1, compositor.EvaluateAudio(range).Objects.Length);
+
+            element.IsEnabled = false;
+            ClassicAssert.AreEqual(0, compositor.EvaluateAudio(range).Objects.Length);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Beutl.Engine.SuppressResourceClassGeneration]
+    private class TestGraphicsObject : EngineObject
+    {
+        public override CompositionTarget GetCompositionTarget() => CompositionTarget.Graphics;
+    }
+
+    [Beutl.Engine.SuppressResourceClassGeneration]
+    private class TestAudioObject : EngineObject
+    {
+        public override CompositionTarget GetCompositionTarget() => CompositionTarget.Audio;
+    }
+}


### PR DESCRIPTION
## Description

- Exclude elements whose `IsEnabled` is `false` from `SceneCompositor` graphics and audio evaluation, so disabling an element in the timeline now also mutes its audio and hides its graphics during playback.
- Skip disabled elements in `PlayerView` drag-drop and mouse hit-testing so users cannot accidentally select or drop onto elements that are not being rendered.
- Add unit tests covering `Element.IsEnabled` behavior and the compositor's filtering of disabled elements for both graphics and audio.

## Breaking changes

None

## Fixed issues

None