### PR TITLE
feat: Prevent MediaSource sharing between preview and encoder

### DIFF
--- a/src/Beutl.Engine/Composition/CompositionContext.cs
+++ b/src/Beutl.Engine/Composition/CompositionContext.cs
@@ -10,6 +10,8 @@ public class CompositionContext(TimeSpan time)
 
     public TimeSpan Time { get; set; } = time;
 
+    public bool DisableResourceShare { get; init; }
+
     public virtual T Get<T>(IProperty<T> property)
     {
         if (property == null)

--- a/src/Beutl.Engine/Graphics/FilterEffects/DelayAnimationEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DelayAnimationEffect.cs
@@ -29,7 +29,8 @@ public partial class DelayAnimationEffect : FilterEffect
         var childEffect = r.Effect.GetOriginal();
 
         context.CustomEffect(
-            (delay: r.Delay, globalTime: r.GlobalTime, childEffect, cache: r.DelayedResources),
+            (delay: r.Delay, globalTime: r.GlobalTime, childEffect, cache: r.DelayedResources,
+             disableResourceShare: r.DisableResourceShare),
             static (data, effectContext) =>
             {
                 int targetCount = effectContext.Targets.Count;
@@ -38,7 +39,10 @@ public partial class DelayAnimationEffect : FilterEffect
                 for (int i = data.cache.Count; i < targetCount; i++)
                 {
                     TimeSpan delayedTime = data.globalTime - TimeSpan.FromMilliseconds(data.delay * i);
-                    data.cache.Add(data.childEffect.ToResource(new CompositionContext(delayedTime)));
+                    data.cache.Add(data.childEffect.ToResource(new CompositionContext(delayedTime)
+                    {
+                        DisableResourceShare = data.disableResourceShare,
+                    }));
                 }
 
                 // 余分なキャッシュを縮小
@@ -55,7 +59,10 @@ public partial class DelayAnimationEffect : FilterEffect
 
                     // 既存Resourceを遅延時刻で更新
                     TimeSpan delayedTime = data.globalTime - TimeSpan.FromMilliseconds(data.delay * j);
-                    var delayedContext = new CompositionContext(delayedTime);
+                    var delayedContext = new CompositionContext(delayedTime)
+                    {
+                        DisableResourceShare = data.disableResourceShare,
+                    };
                     var updateOnly = false;
                     data.cache[j].Update(data.childEffect, delayedContext, ref updateOnly);
 
@@ -102,6 +109,7 @@ public partial class DelayAnimationEffect : FilterEffect
         private float _delay;
         private FilterEffect.Resource? _effect;
         private TimeSpan _globalTime;
+        private bool _disableResourceShare;
         private readonly List<FilterEffect.Resource> _delayedResources = [];
 
         public float Delay => _delay;
@@ -109,6 +117,8 @@ public partial class DelayAnimationEffect : FilterEffect
         public FilterEffect.Resource? Effect => _effect;
 
         public TimeSpan GlobalTime => _globalTime;
+
+        public bool DisableResourceShare => _disableResourceShare;
 
         public List<FilterEffect.Resource> DelayedResources => _delayedResources;
 
@@ -128,6 +138,7 @@ public partial class DelayAnimationEffect : FilterEffect
 
             TimeSpan oldTime = _globalTime;
             _globalTime = context.Time;
+            _disableResourceShare = context.DisableResourceShare;
             if (!updateOnly && oldTime != _globalTime)
             {
                 Version++;

--- a/src/Beutl.Engine/Graphics3D/Scene3D.cs
+++ b/src/Beutl.Engine/Graphics3D/Scene3D.cs
@@ -118,6 +118,8 @@ public partial class Scene3D : Drawable, IFlowOperator
 
         public TimeSpan Time { get; set; } = TimeSpan.Zero;
 
+        public bool DisableResourceShare { get; set; }
+
         public List<Light3D.Resource> Lights { get; set; } = [];
 
         public List<Object3D.Resource> Objects { get; set; } = [];
@@ -154,6 +156,8 @@ public partial class Scene3D : Drawable, IFlowOperator
                 Time = context.Time;
                 changed = true;
             }
+
+            DisableResourceShare = context.DisableResourceShare;
 
             // Consume lights and objects from flow
             using var consumedLights = new PooledList<Light3D.Resource>();

--- a/src/Beutl.Engine/Graphics3D/Scene3DRenderNode.cs
+++ b/src/Beutl.Engine/Graphics3D/Scene3DRenderNode.cs
@@ -80,7 +80,10 @@ internal sealed class Scene3DRenderNode(Scene3D.Resource scene) : RenderNode
 
         // Render
         renderer.Render(
-            new CompositionContext(scene.Time),
+            new CompositionContext(scene.Time)
+            {
+                DisableResourceShare = scene.DisableResourceShare,
+            },
             cameraResource,
             objectResources,
             lightResources,

--- a/src/Beutl.Engine/Media/Source/ImageSource.cs
+++ b/src/Beutl.Engine/Media/Source/ImageSource.cs
@@ -47,11 +47,19 @@ public sealed class ImageSource : MediaSource
             {
                 _counter?.Release();
                 _counter = null;
-                var localRef = Volatile.Read(ref imageSource._bitmapRef);
-                if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+
+                Counter<Bitmap>? shared = null;
+                if (!context.DisableResourceShare)
                 {
-                    _counter = counter;
-                    counter.AddRef();
+                    var localRef = Volatile.Read(ref imageSource._bitmapRef);
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                        shared = counter;
+                }
+
+                if (shared is not null)
+                {
+                    _counter = shared;
+                    shared.AddRef();
                 }
                 else
                 {
@@ -60,7 +68,13 @@ public sealed class ImageSource : MediaSource
                         using var stream = UriHelper.ResolveStream(imageSource.Uri);
                         var bitmap = Media.Bitmap.FromStream(stream);
                         _counter = new Counter<Bitmap>(bitmap, null);
-                        Volatile.Write(ref imageSource._bitmapRef, new(_counter));
+                        // DisableResourceShare 時は WeakReference を書き換えない。
+                        // 他 Renderer（プレビュー側）の共有カウンタを
+                        // エンコード専用カウンタで汚染してしまうため。
+                        if (!context.DisableResourceShare)
+                        {
+                            Volatile.Write(ref imageSource._bitmapRef, new(_counter));
+                        }
                     }
                     catch
                     {

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -104,11 +104,19 @@ public sealed class SoundSource : MediaSource
             {
                 _counter?.Release();
                 _counter = null;
-                var localRef = Volatile.Read(ref soundSource._mediaReaderRef);
-                if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+
+                Counter<MediaReader>? shared = null;
+                if (!context.DisableResourceShare)
                 {
-                    _counter = counter;
-                    counter.AddRef();
+                    var localRef = Volatile.Read(ref soundSource._mediaReaderRef);
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                        shared = counter;
+                }
+
+                if (shared is not null)
+                {
+                    _counter = shared;
+                    shared.AddRef();
                 }
                 else
                 {
@@ -116,7 +124,13 @@ public sealed class SoundSource : MediaSource
                     {
                         var reader = MediaReader.Open(soundSource.Uri.LocalPath, new(MediaMode.Audio));
                         _counter = new Counter<MediaReader>(reader, null);
-                        Volatile.Write(ref soundSource._mediaReaderRef, new WeakReference<Counter<MediaReader>>(_counter));
+                        // DisableResourceShare 時は WeakReference を書き換えない。
+                        // 他 Renderer（プレビュー側）の共有カウンタを
+                        // エンコード専用カウンタで汚染してしまうため。
+                        if (!context.DisableResourceShare)
+                        {
+                            Volatile.Write(ref soundSource._mediaReaderRef, new WeakReference<Counter<MediaReader>>(_counter));
+                        }
                     }
                     catch
                     {

--- a/src/Beutl.Engine/Media/Source/VideoSource.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSource.cs
@@ -78,11 +78,19 @@ public sealed class VideoSource : MediaSource
             {
                 _counter?.Release();
                 _counter = null;
-                var localRef = Volatile.Read(ref videoSource._mediaReaderRef);
-                if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+
+                Counter<MediaReader>? shared = null;
+                if (!context.DisableResourceShare)
                 {
-                    _counter = counter;
-                    counter.AddRef();
+                    var localRef = Volatile.Read(ref videoSource._mediaReaderRef);
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                        shared = counter;
+                }
+
+                if (shared is not null)
+                {
+                    _counter = shared;
+                    shared.AddRef();
                 }
                 else
                 {
@@ -90,7 +98,13 @@ public sealed class VideoSource : MediaSource
                     {
                         var reader = MediaReader.Open(videoSource.Uri.LocalPath, new(MediaMode.Video));
                         _counter = new Counter<MediaReader>(reader, null);
-                        Volatile.Write(ref videoSource._mediaReaderRef, new(_counter));
+                        // DisableResourceShare 時は WeakReference を書き換えない。
+                        // 他 Renderer（プレビュー側）の共有カウンタを
+                        // エンコード専用カウンタで汚染してしまうため。
+                        if (!context.DisableResourceShare)
+                        {
+                            Volatile.Write(ref videoSource._mediaReaderRef, new(_counter));
+                        }
                     }
                     catch
                     {

--- a/src/Beutl.NodeGraph/Composition/GraphSnapshot.cs
+++ b/src/Beutl.NodeGraph/Composition/GraphSnapshot.cs
@@ -165,7 +165,12 @@ public sealed class GraphSnapshot : IDisposable
             resource.ItemIndexMap = itemIndexMap;
             _resources[i] = resource;
 
-            _contexts[i] = new GraphCompositionContext(context.Time) { Resource = resource, Snapshot = this };
+            _contexts[i] = new GraphCompositionContext(context.Time)
+            {
+                Resource = resource,
+                Snapshot = this,
+                DisableResourceShare = context.DisableResourceShare,
+            };
         }
 
         return nodeToResourceIndex;

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
@@ -93,7 +93,8 @@ public sealed partial class SceneDrawable : Drawable
                 changed = true;
             }
 
-            if (_compositor?.Scene != ReferencedScene)
+            if (_compositor?.Scene != ReferencedScene
+                || _compositor?.DisableResourceShare != context.DisableResourceShare)
             {
                 _compositor?.Dispose();
                 _compositor = null;
@@ -101,7 +102,10 @@ public sealed partial class SceneDrawable : Drawable
 
             if (ReferencedScene != null && _compositor == null)
             {
-                _compositor = new SceneCompositor(ReferencedScene);
+                _compositor = new SceneCompositor(ReferencedScene)
+                {
+                    DisableResourceShare = context.DisableResourceShare,
+                };
             }
 
             if (ReferencedScene != null && !Enter(ReferencedScene))

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneSound.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneSound.cs
@@ -85,7 +85,8 @@ public sealed partial class SceneSound : Sound
 
         partial void PostUpdate(SceneSound obj, CompositionContext context)
         {
-            if (_compositor?.Scene != ReferencedScene)
+            if (_compositor?.Scene != ReferencedScene
+                || _compositor?.DisableResourceShare != context.DisableResourceShare)
             {
                 _compositor?.Dispose();
                 _compositor = null;
@@ -93,7 +94,10 @@ public sealed partial class SceneSound : Sound
 
             if (ReferencedScene != null && _compositor == null)
             {
-                _compositor = new SceneCompositor(ReferencedScene);
+                _compositor = new SceneCompositor(ReferencedScene)
+                {
+                    DisableResourceShare = context.DisableResourceShare,
+                };
             }
         }
 

--- a/src/Beutl.ProjectSystem/SceneComposer.cs
+++ b/src/Beutl.ProjectSystem/SceneComposer.cs
@@ -5,9 +5,14 @@ using Beutl.ProjectSystem;
 
 namespace Beutl;
 
-public sealed class SceneComposer(Scene scene) : Composer
+public sealed class SceneComposer : Composer
 {
-    private readonly SceneCompositor _compositor = new(scene);
+    private readonly SceneCompositor _compositor;
+
+    public SceneComposer(Scene scene, bool disableResourceShare = false)
+    {
+        _compositor = new SceneCompositor(scene) { DisableResourceShare = disableResourceShare };
+    }
 
     public SceneCompositor Compositor => _compositor;
 

--- a/src/Beutl.ProjectSystem/SceneCompositor.cs
+++ b/src/Beutl.ProjectSystem/SceneCompositor.cs
@@ -18,6 +18,8 @@ public sealed class SceneCompositor : ICompositor
 
     public Scene Scene { get; }
 
+    public bool DisableResourceShare { get; init; }
+
     private sealed class CompositorContext : CompositionContext, ISceneCompositionContext
     {
         private readonly SceneCompositor _compositor;
@@ -32,6 +34,7 @@ public sealed class SceneCompositor : ICompositor
             CurrentElements = currentElements;
             Target = target;
             Flow = flow;
+            DisableResourceShare = compositor.DisableResourceShare;
         }
 
         public IList<Element> CurrentElements { get; set; }

--- a/src/Beutl.ProjectSystem/SceneRenderer.cs
+++ b/src/Beutl.ProjectSystem/SceneRenderer.cs
@@ -3,9 +3,15 @@ using Beutl.ProjectSystem;
 
 namespace Beutl;
 
-public sealed class SceneRenderer(Scene scene) : Renderer(scene.FrameSize.Width, scene.FrameSize.Height)
+public sealed class SceneRenderer : Renderer
 {
-    private readonly SceneCompositor _compositor = new(scene);
+    private readonly SceneCompositor _compositor;
+
+    public SceneRenderer(Scene scene, bool disableResourceShare = false)
+        : base(scene.FrameSize.Width, scene.FrameSize.Height)
+    {
+        _compositor = new SceneCompositor(scene) { DisableResourceShare = disableResourceShare };
+    }
 
     public SceneCompositor Compositor => _compositor;
 

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -209,13 +209,13 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                 // エンコード前にEditViewModelのレンダラーキャッシュを削除してメモリ解放
                 ClearEditViewModelCaches();
 
-                // エンコード専用のRendererを作成（キャッシュ無効）
-                using var renderer = new SceneRenderer(Model);
+                // エンコード専用のRendererを作成（キャッシュ無効、リソース共有無効）
+                using var renderer = new SceneRenderer(Model, disableResourceShare: true);
                 renderer.CacheOptions = RenderCacheOptions.Disabled;
                 var frameProgress = new Subject<TimeSpan>();
                 using var frameProvider = new FrameProviderImpl(Model, videoSettings.FrameRate, renderer, frameProgress);
                 // サンプルプロバイダー作成
-                using var composer = new SceneComposer(Model) { SampleRate = audioSettings.SampleRate };
+                using var composer = new SceneComposer(Model, disableResourceShare: true) { SampleRate = audioSettings.SampleRate };
                 // var composer = _editViewModel.Composer.Value;
                 var sampleProgress = new Subject<TimeSpan>();
                 using var sampleProvider = new SampleProviderImpl(

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -1,0 +1,101 @@
+using Beutl.Composition;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics;
+
+[TestFixture]
+public class MediaSourceResourceShareTest
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        TestMediaHelper.RegisterTestDecoder();
+    }
+
+    [Test]
+    public void VideoSource_SharedByDefault_ReusesMediaReader()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(videoPath));
+
+        using var a = videoSource.ToResource(CompositionContext.Default);
+        using var b = videoSource.ToResource(CompositionContext.Default);
+
+        Assert.That(a.MediaReader, Is.Not.Null);
+        Assert.That(b.MediaReader, Is.Not.Null);
+        Assert.That(b.MediaReader, Is.SameAs(a.MediaReader),
+            "DisableResourceShare=false では同じ MediaReader を共有するはず");
+    }
+
+    [Test]
+    public void VideoSource_DisableResourceShare_YieldsIndependentMediaReader()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(videoPath));
+
+        var ctxPreview = CompositionContext.Default;
+        var ctxEncode = new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true };
+
+        using var preview = videoSource.ToResource(ctxPreview);
+        using var encode = (VideoSource.Resource)videoSource.ToResource(ctxEncode);
+
+        Assert.That(preview.MediaReader, Is.Not.Null);
+        Assert.That(encode.MediaReader, Is.Not.Null);
+        Assert.That(encode.MediaReader, Is.Not.SameAs(preview.MediaReader),
+            "DisableResourceShare=true では専用の MediaReader が割り当てられるはず");
+    }
+
+    [Test]
+    public void VideoSource_DisableResourceShare_DoesNotContaminateSharedCache()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(videoPath));
+
+        // エンコード側が先に Resource を生成しても、プレビュー側 (共有モード) は
+        // エンコード専用 MediaReader を掴まない
+        using var encode = (VideoSource.Resource)videoSource.ToResource(
+            new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
+        using var preview = videoSource.ToResource(CompositionContext.Default);
+
+        Assert.That(preview.MediaReader, Is.Not.SameAs(encode.MediaReader),
+            "エンコード専用 MediaReader がプレビュー側に漏れてはならない");
+    }
+
+    [Test]
+    public void ImageSource_SharedByDefault_ReusesBitmap()
+    {
+        var uri = TestMediaHelper.CreateTestImageUri(16, 16, Colors.Red);
+        var imageSource = new ImageSource();
+        imageSource.ReadFrom(uri);
+
+        using var a = imageSource.ToResource(CompositionContext.Default);
+        using var b = imageSource.ToResource(CompositionContext.Default);
+
+        Assert.That(a.Bitmap, Is.Not.Null);
+        Assert.That(b.Bitmap, Is.Not.Null);
+        Assert.That(b.Bitmap, Is.SameAs(a.Bitmap),
+            "DisableResourceShare=false では同じ Bitmap を共有するはず");
+    }
+
+    [Test]
+    public void ImageSource_DisableResourceShare_YieldsIndependentBitmap()
+    {
+        var uri = TestMediaHelper.CreateTestImageUri(16, 16, Colors.Red);
+        var imageSource = new ImageSource();
+        imageSource.ReadFrom(uri);
+
+        using var preview = imageSource.ToResource(CompositionContext.Default);
+        using var encode = imageSource.ToResource(
+            new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
+
+        Assert.That(preview.Bitmap, Is.Not.Null);
+        Assert.That(encode.Bitmap, Is.Not.Null);
+        Assert.That(encode.Bitmap, Is.Not.SameAs(preview.Bitmap),
+            "DisableResourceShare=true では専用の Bitmap が割り当てられるはず");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Media;
 using Beutl.Media.Source;
 using Beutl.UnitTests.Engine.Graphics.Rendering;

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -41,7 +41,7 @@ public class MediaSourceResourceShareTest
         var ctxEncode = new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true };
 
         using var preview = videoSource.ToResource(ctxPreview);
-        using var encode = (VideoSource.Resource)videoSource.ToResource(ctxEncode);
+        using var encode = videoSource.ToResource(ctxEncode);
 
         Assert.That(preview.MediaReader, Is.Not.Null);
         Assert.That(encode.MediaReader, Is.Not.Null);
@@ -58,12 +58,45 @@ public class MediaSourceResourceShareTest
 
         // エンコード側が先に Resource を生成しても、プレビュー側 (共有モード) は
         // エンコード専用 MediaReader を掴まない
-        using var encode = (VideoSource.Resource)videoSource.ToResource(
+        using var encode = videoSource.ToResource(
             new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
         using var preview = videoSource.ToResource(CompositionContext.Default);
 
         Assert.That(preview.MediaReader, Is.Not.SameAs(encode.MediaReader),
             "エンコード専用 MediaReader がプレビュー側に漏れてはならない");
+    }
+
+    [Test]
+    public void SoundSource_SharedByDefault_ReusesMediaReader()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(videoPath));
+
+        using var a = soundSource.ToResource(CompositionContext.Default);
+        using var b = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(a.MediaReader, Is.Not.Null);
+        Assert.That(b.MediaReader, Is.Not.Null);
+        Assert.That(b.MediaReader, Is.SameAs(a.MediaReader),
+            "DisableResourceShare=false では同じ MediaReader を共有するはず");
+    }
+
+    [Test]
+    public void SoundSource_DisableResourceShare_YieldsIndependentMediaReader()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(videoPath));
+
+        using var preview = soundSource.ToResource(CompositionContext.Default);
+        using var encode = soundSource.ToResource(
+            new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
+
+        Assert.That(preview.MediaReader, Is.Not.Null);
+        Assert.That(encode.MediaReader, Is.Not.Null);
+        Assert.That(encode.MediaReader, Is.Not.SameAs(preview.MediaReader),
+            "DisableResourceShare=true では専用の MediaReader が割り当てられるはず");
     }
 
     [Test]


### PR DESCRIPTION
## Description

- Add `CompositionContext.DisableResourceShare` (init-only) so a composition can opt out of the `WeakReference<Counter<T>>` cache used by `VideoSource` / `SoundSource` / `ImageSource`.
- When the flag is set, `MediaSource.Resource.Update()` neither reads from nor writes to the model-side cache, guaranteeing an isolated `MediaReader` / `Bitmap` for that resource.
- Wire the flag through `SceneCompositor`, `SceneRenderer`, and `SceneComposer`, propagate it to derived contexts (`GraphCompositionContext`, `DelayAnimationEffect`), and enable it in `OutputViewModel` for encoding so preview and export no longer compete over the same decoder state.

## Breaking changes

None. `SceneRenderer` / `SceneComposer` gain an optional `disableResourceShare` parameter that defaults to `false`, preserving existing call sites.

## Fixed issues

None.