### PR TITLE
fix: Add missing libraries to SDK and update namespace references

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -197,6 +197,7 @@ class Build : NukeBuild
                 ("Beutl.Threading", tfm),
                 ("Beutl.Utilities", tfm),
                 ("Beutl.NodeGraph", tfm),
+                ("Beutl.Editor", tfm),
             ];
 
             foreach (var (name, projectTfm) in projects)

--- a/sdk/Beutl.Extensibility.Sdk/Sdk/Sdk.targets
+++ b/sdk/Beutl.Extensibility.Sdk/Sdk/Sdk.targets
@@ -34,6 +34,7 @@
     <BeutlAutoReferenceExtensibility Condition="'$(BeutlAutoReferenceExtensibility)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceExtensibility>
     <BeutlAutoReferenceProjectSystem Condition="'$(BeutlAutoReferenceProjectSystem)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceProjectSystem>
     <BeutlAutoReferenceNodeGraph Condition="'$(BeutlAutoReferenceNodeGraph)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceNodeGraph>
+    <BeutlAutoReferenceEditor Condition="'$(BeutlAutoReferenceEditor)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceEditor>
     <BeutlAutoReferenceSourceGenerators Condition="'$(BeutlAutoReferenceSourceGenerators)' == ''">$(BeutlAutoReferenceAll)</BeutlAutoReferenceSourceGenerators>
   </PropertyGroup>
 
@@ -41,6 +42,7 @@
     <PackageReference Include="Beutl.Extensibility" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceExtensibility)' == 'true'" />
     <PackageReference Include="Beutl.ProjectSystem" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceProjectSystem)' == 'true'" />
     <PackageReference Include="Beutl.NodeGraph" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceNodeGraph)' == 'true'" />
+    <PackageReference Include="Beutl.Editor" Version="$(BeutlPackagesVersion)" ExcludeAssets="runtime;native" Condition="'$(BeutlAutoReferenceEditor)' == 'true'" />
     <PackageReference
       Include="Beutl.Engine.SourceGenerators"
       OutputItemType="Analyzer"
@@ -54,6 +56,7 @@
     <PackageReference Include="Beutl.Extensibility" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceExtensibility)' == 'true'" />
     <PackageReference Include="Beutl.ProjectSystem" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceProjectSystem)' == 'true'" />
     <PackageReference Include="Beutl.NodeGraph" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceNodeGraph)' == 'true'" />
+    <PackageReference Include="Beutl.Editor" Version="$(BeutlPackagesVersion)" Condition="'$(BeutlAutoReferenceEditor)' == 'true'" />
     <PackageReference
       Include="Beutl.Engine.SourceGenerators"
       OutputItemType="Analyzer"

--- a/src/Beutl.Api/Services/CoreLibraries.cs
+++ b/src/Beutl.Api/Services/CoreLibraries.cs
@@ -71,9 +71,9 @@ internal static class CoreLibraries
                             case "Beutl.Configuration":
                             case "Beutl.Controls":
                             case "Beutl.Core":
-                            case "Beutl.Embedding.FFmpeg":
+                            case "Beutl.Extensions.FFmpeg":
                             case "Beutl.Embedding.MediaFoundation" when OperatingSystem.IsWindows():
-                            case "Beutl.Embedding.AVFoundation" when OperatingSystem.IsMacOS():
+                            case "Beutl.Extensions.AVFoundation" when OperatingSystem.IsMacOS():
                             case "Beutl.Engine":
                             case "Beutl.Extensibility":
                             case "Beutl.Language":
@@ -84,6 +84,9 @@ internal static class CoreLibraries
                             case "Beutl.WaitingDialog":
                             case "Beutl.PackageTools.UI":
                             case "Beutl.ExceptionHandler":
+                            case "Beutl.Editor":
+                            case "Beutl.Editor.Components":
+                            case "Beutl.Engine.SourceGenerators":
                                 version = BeutlApplication.Version;
                                 break;
                             default:


### PR DESCRIPTION
## Description
- Include Beutl.Editor in the SDK auto-reference configuration so extension projects reference it alongside the other Beutl core libraries.
- Align CoreLibraries case labels with the current assembly names (Beutl.Embedding.FFmpeg / AVFoundation -> Beutl.Extensions.*) and register Beutl.Editor, Beutl.Editor.Components, and Beutl.Engine.SourceGenerators so their version resolves to the application version instead of falling through to the default branch.

## Breaking changes
None

## Fixed issues
- #1648