### PR TITLE
feat: Localize ReferencedScene property on SceneSound and SceneDrawable

### DIFF
--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -55,4 +55,7 @@
   <data name="SceneSound" xml:space="preserve">
     <value>シーン参照（音声）</value>
   </data>
+  <data name="SceneSound_ReferencedScene" xml:space="preserve">
+    <value>参照するシーン</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -60,4 +60,7 @@
   <data name="SceneSound" xml:space="preserve">
     <value>Scene Reference (Audio)</value>
   </data>
+  <data name="SceneSound_ReferencedScene" xml:space="preserve">
+    <value>Referenced Scene</value>
+  </data>
 </root>

--- a/src/Beutl.Language/GraphicsStrings.ja.resx
+++ b/src/Beutl.Language/GraphicsStrings.ja.resx
@@ -1351,6 +1351,9 @@
   <data name="SceneDrawable" xml:space="preserve">
     <value>シーン参照（動画）</value>
   </data>
+  <data name="SceneDrawable_ReferencedScene" xml:space="preserve">
+    <value>参照するシーン</value>
+  </data>
   <data name="FilterEffect" xml:space="preserve">
     <value>フィルターエフェクト</value>
   </data>

--- a/src/Beutl.Language/GraphicsStrings.resx
+++ b/src/Beutl.Language/GraphicsStrings.resx
@@ -1353,6 +1353,9 @@
   <data name="SceneDrawable" xml:space="preserve">
     <value>Scene Reference (Video)</value>
   </data>
+  <data name="SceneDrawable_ReferencedScene" xml:space="preserve">
+    <value>Referenced Scene</value>
+  </data>
   <data name="FilterEffect" xml:space="preserve">
     <value>Filter Effect</value>
   </data>

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneDrawable.cs
@@ -17,6 +17,7 @@ public sealed partial class SceneDrawable : Drawable
         ScanProperties<SceneDrawable>();
     }
 
+    [Display(Name = nameof(GraphicsStrings.SceneDrawable_ReferencedScene), ResourceType = typeof(GraphicsStrings))]
     public IProperty<Scene?> ReferencedScene { get; } = Property.Create<Scene?>();
 
     protected override Size MeasureCore(Size availableSize, Drawable.Resource resource)

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneSound.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneSound.cs
@@ -18,6 +18,7 @@ public sealed partial class SceneSound : Sound
         ScanProperties<SceneSound>();
     }
 
+    [Display(Name = nameof(AudioStrings.SceneSound_ReferencedScene), ResourceType = typeof(AudioStrings))]
     public IProperty<Scene?> ReferencedScene { get; } = Property.Create<Scene?>();
 
     public override void Compose(AudioContext context, Sound.Resource resource)


### PR DESCRIPTION
## Description
- Add localized display name for the `ReferencedScene` property on `SceneSound` and `SceneDrawable` so it appears with a proper label in the property editor instead of the raw identifier.
- Introduce `SceneSound_ReferencedScene` in `AudioStrings` and `SceneDrawable_ReferencedScene` in `GraphicsStrings`, each with English and Japanese translations.

## Breaking changes
None

## Fixed issues
None