### PR TITLE
feat: Add waveform shapes and frequency scales to visualizer

### DIFF
--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Engine;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Engine;
@@ -32,11 +32,16 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
     [Range(2, 2048)]
     public IProperty<int> TimeColumns { get; } = Property.Create(256);
 
+    [Display(Name = nameof(GraphicsStrings.AudioVisualizer_FrequencyScale), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<FrequencyScale> FrequencyScale { get; } = Property.Create(AudioVisualizers.FrequencyScale.Logarithmic);
+
     public new partial class Resource
     {
         private float[] _fftReal = [];
         private float[] _fftImag = [];
         private float[] _fftMagnitudes = [];
+        private int[] _rowBinLo = [];
+        private int[] _rowBinHi = [];
         private SKPaint? _paint;
 
         protected override (TimeSpan Start, TimeSpan Duration) ComputeSampleWindow(TimeSpan currentTime)
@@ -66,11 +71,11 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
             float width = (float)bounds.Width;
             float height = (float)bounds.Height;
             float colWidth = width / columns;
-            float binHeight = height / bins;
             float reference = fftSize * 0.5f;
             float gain = Math.Max(0f, Gain);
             // FloorDb は Range(-200, 0) だが、0 に設定されると (0 - floorDb) が 0 除算になるため -0.001 以下にクランプする
             float floorDb = MathF.Min(FloorDb, -0.001f);
+            FrequencyScale freqScale = FrequencyScale;
 
             if (_fftReal.Length < fftSize) _fftReal = new float[fftSize];
             if (_fftImag.Length < fftSize) _fftImag = new float[fftSize];
@@ -82,13 +87,44 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
             ReadOnlySpan<float> samples = CachedSampleSpan;
             int sampleCount = samples.Length;
 
-            // Fill の最高強度 (normalized=1) に対応するペイントを bounds 全体で 1 回構築。
-            // 各セルでは opacity のみ変化させるので、SKPaint の Color の A チャンネルを毎回書き換える。
+            // 高強度 (normalized=1) 相当の Fill を 1 度構築し、各セルは Alpha のみ書き換える。
             _paint ??= new SKPaint();
             new BrushConstructor(bounds, Fill, BlendMode.SrcOver).ConfigurePaint(_paint);
             _paint.Style = SKPaintStyle.Fill;
             SKColor baseColor = _paint.Color;
             byte baseAlpha = baseColor.Alpha;
+
+            // 周波数軸スケール用に「bin の取得関数」を決定する。
+            // y=0 が最高周波数、y=height が最低周波数として配置。
+            float fMax = CachedSampleRate * 0.5f;
+            float fMin = MathF.Max(20f, fMax / bins);
+            double melMin = freqScale == FrequencyScale.Mel ? 2595.0 * Math.Log10(1 + fMin / 700.0) : 0;
+            double melMax = freqScale == FrequencyScale.Mel ? 2595.0 * Math.Log10(1 + fMax / 700.0) : 0;
+
+            int pixelRows = Math.Max(1, (int)MathF.Ceiling(height));
+            float rowHeight = height / pixelRows;
+
+            // 各行がカバーする FFT bin 範囲 [lo, hi) を事前計算。
+            // pixelRows < bins の場合でも bin の取りこぼしが発生しないよう bin 範囲全体を描画時に max 集約する。
+            if (_rowBinLo.Length < pixelRows) _rowBinLo = new int[pixelRows];
+            if (_rowBinHi.Length < pixelRows) _rowBinHi = new int[pixelRows];
+            for (int row = 0; row < pixelRows; row++)
+            {
+                // row=0 が最高周波数。下端は t_low (低周波)、上端は t_high (高周波)。
+                double tLow = 1.0 - (row + 1) / (double)pixelRows;
+                double tHigh = 1.0 - row / (double)pixelRows;
+                if (tLow < 0) tLow = 0;
+                if (tHigh > 1) tHigh = 1;
+                double f1 = FreqForT(tLow, freqScale, fMin, fMax, melMin, melMax);
+                double f2 = FreqForT(tHigh, freqScale, fMin, fMax, melMin, melMax);
+                int bLo = (int)Math.Floor(f1 / fMax * bins);
+                int bHi = (int)Math.Ceiling(f2 / fMax * bins);
+                if (bLo < 0) bLo = 0;
+                if (bHi > bins) bHi = bins;
+                if (bHi <= bLo) bHi = Math.Min(bLo + 1, bins);
+                _rowBinLo[row] = bLo;
+                _rowBinHi[row] = bHi;
+            }
 
             for (int col = 0; col < columns; col++)
             {
@@ -102,11 +138,22 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
                 Fft.Magnitudes(real, imag, mags);
 
                 float colX = (float)bounds.X + col * colWidth;
-                float drawColWidth = Math.Max(1f, colWidth + 0.5f);
+                float drawColWidth = MathF.Max(1f, colWidth + 0.5f);
 
-                for (int bin = 0; bin < bins; bin++)
+                for (int row = 0; row < pixelRows; row++)
                 {
-                    float db = Fft.MagnitudeToDb(mags[bin] * gain, reference);
+                    int bLo = _rowBinLo[row];
+                    int bHi = _rowBinHi[row];
+
+                    // bin 範囲内の最大マグニチュードで代表させる（ピーク可視化優先）
+                    float peak = 0f;
+                    for (int b = bLo; b < bHi; b++)
+                    {
+                        float m = mags[b];
+                        if (m > peak) peak = m;
+                    }
+
+                    float db = Fft.MagnitudeToDb(peak * gain, reference);
                     float normalized = (db - floorDb) / (0f - floorDb);
                     normalized = Math.Clamp(normalized, 0f, 1f);
                     if (normalized <= 0f) continue;
@@ -115,13 +162,20 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
                     if (alpha == 0) continue;
                     _paint.Color = baseColor.WithAlpha(alpha);
 
-                    // 高い周波数を上側に配置
-                    float y = (float)bounds.Y + height - (bin + 1) * binHeight;
+                    float y = (float)bounds.Y + row * rowHeight;
                     canvas.Canvas.DrawRect(
-                        new SKRect(colX, y, colX + drawColWidth, y + Math.Max(1f, binHeight + 0.5f)),
+                        new SKRect(colX, y, colX + drawColWidth, y + MathF.Max(1f, rowHeight + 0.5f)),
                         _paint);
                 }
             }
         }
+
+        private static double FreqForT(double t, FrequencyScale scale, float fMin, float fMax, double melMin, double melMax)
+            => scale switch
+            {
+                FrequencyScale.Logarithmic => fMin * Math.Pow(fMax / fMin, t),
+                FrequencyScale.Mel => 700.0 * (Math.Pow(10, (melMin + (melMax - melMin) * t) / 2595.0) - 1),
+                _ => t * fMax,
+            };
     }
 }

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrogramDrawable.cs
@@ -14,6 +14,18 @@ public sealed partial class AudioSpectrogramDrawable : AudioVisualizerDrawable
     public AudioSpectrogramDrawable()
     {
         ScanProperties<AudioSpectrogramDrawable>();
+
+        // 編集頻度順に並べ替え: Source → Fill → 信号調整(Gain/FloorDb) → 時間/周波数設定 → 解像度 → サイズ
+        MoveProperty(Source, 0);
+        MoveProperty(Fill, 1);
+        MoveProperty(Gain, 2);
+        MoveProperty(FloorDb, 3);
+        MoveProperty(WindowSeconds, 4);
+        MoveProperty(FrequencyScale, 5);
+        MoveProperty(TimeColumns, 6);
+        MoveProperty(FftSize, 7);
+        MoveProperty(Width, 8);
+        MoveProperty(Height, 9);
     }
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_WindowSeconds), ResourceType = typeof(GraphicsStrings))]

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrumDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrumDrawable.cs
@@ -13,6 +13,19 @@ public sealed partial class AudioSpectrumDrawable : AudioVisualizerDrawable
     {
         ScanProperties<AudioSpectrumDrawable>();
         Shape.CurrentValue = new BarSpectrumShape();
+
+        // 編集頻度順に並べ替え: Source → 見た目(Shape/Fill) → 信号調整(Gain/FloorDb) → 応答(Smoothing) → 周波数設定(Scale/BarCount) → 解像度(FftSize) → サイズ
+        MoveProperty(Source, 0);
+        MoveProperty(Shape, 1);
+        MoveProperty(Fill, 2);
+        MoveProperty(Gain, 3);
+        MoveProperty(FloorDb, 4);
+        MoveProperty(Smoothing, 5);
+        MoveProperty(FrequencyScale, 6);
+        MoveProperty(BarCount, 7);
+        MoveProperty(FftSize, 8);
+        MoveProperty(Width, 9);
+        MoveProperty(Height, 10);
     }
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_Shape), ResourceType = typeof(GraphicsStrings))]

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrumDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioSpectrumDrawable.cs
@@ -26,8 +26,8 @@ public sealed partial class AudioSpectrumDrawable : AudioVisualizerDrawable
     [Range(64, 16384)]
     public IProperty<int> FftSize { get; } = Property.Create(1024);
 
-    [Display(Name = nameof(GraphicsStrings.AudioVisualizer_LogarithmicFrequency), ResourceType = typeof(GraphicsStrings))]
-    public IProperty<bool> LogarithmicFrequency { get; } = Property.Create(true);
+    [Display(Name = nameof(GraphicsStrings.AudioVisualizer_FrequencyScale), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<FrequencyScale> FrequencyScale { get; } = Property.Create(AudioVisualizers.FrequencyScale.Logarithmic);
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_FloorDb), ResourceType = typeof(GraphicsStrings))]
     [Range(-200f, 0f)]
@@ -90,7 +90,7 @@ public sealed partial class AudioSpectrumDrawable : AudioVisualizerDrawable
             float floorDb = MathF.Min(FloorDb, -0.001f);
 
             int barCount = Math.Min(Math.Max(1, BarCount), bins);
-            bool logarithmic = LogarithmicFrequency;
+            FrequencyScale freqScale = FrequencyScale;
 
             if (_smoothedMagnitudes.Length < barCount)
             {
@@ -106,22 +106,37 @@ public sealed partial class AudioSpectrumDrawable : AudioVisualizerDrawable
 
             float fMax = CachedSampleRate * 0.5f;
             float fMin = Math.Max(20f, fMax / bins);
+            double melMin = freqScale == FrequencyScale.Mel ? 2595.0 * Math.Log10(1 + fMin / 700.0) : 0;
+            double melMax = freqScale == FrequencyScale.Mel ? 2595.0 * Math.Log10(1 + fMax / 700.0) : 0;
 
             for (int i = 0; i < barCount; i++)
             {
                 int binLow;
                 int binHigh;
-                if (logarithmic)
+                switch (freqScale)
                 {
-                    double freqLow = fMin * Math.Pow(fMax / fMin, (double)i / barCount);
-                    double freqHigh = fMin * Math.Pow(fMax / fMin, (double)(i + 1) / barCount);
-                    binLow = (int)Math.Floor(freqLow / fMax * bins);
-                    binHigh = (int)Math.Ceiling(freqHigh / fMax * bins);
-                }
-                else
-                {
-                    binLow = i * bins / barCount;
-                    binHigh = (i + 1) * bins / barCount;
+                    case FrequencyScale.Logarithmic:
+                        {
+                            double freqLow = fMin * Math.Pow(fMax / fMin, (double)i / barCount);
+                            double freqHigh = fMin * Math.Pow(fMax / fMin, (double)(i + 1) / barCount);
+                            binLow = (int)Math.Floor(freqLow / fMax * bins);
+                            binHigh = (int)Math.Ceiling(freqHigh / fMax * bins);
+                            break;
+                        }
+                    case FrequencyScale.Mel:
+                        {
+                            double m1 = melMin + (melMax - melMin) * i / barCount;
+                            double m2 = melMin + (melMax - melMin) * (i + 1) / barCount;
+                            double f1 = 700.0 * (Math.Pow(10, m1 / 2595.0) - 1);
+                            double f2 = 700.0 * (Math.Pow(10, m2 / 2595.0) - 1);
+                            binLow = (int)Math.Floor(f1 / fMax * bins);
+                            binHigh = (int)Math.Ceiling(f2 / fMax * bins);
+                            break;
+                        }
+                    default:
+                        binLow = i * bins / barCount;
+                        binHigh = (i + 1) * bins / barCount;
+                        break;
                 }
 
                 if (binHigh <= binLow) binHigh = binLow + 1;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Beutl.Audio;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;
@@ -7,23 +7,17 @@ using Beutl.Media;
 
 namespace Beutl.Graphics.AudioVisualizers;
 
-public enum WaveformStyle
-{
-    MinMaxBar,
-    Line,
-    FilledMirror
-}
-
 [Display(Name = nameof(GraphicsStrings.AudioWaveform), ResourceType = typeof(GraphicsStrings))]
 public sealed partial class AudioWaveformDrawable : AudioVisualizerDrawable
 {
     public AudioWaveformDrawable()
     {
         ScanProperties<AudioWaveformDrawable>();
+        Shape.CurrentValue = new MinMaxBarWaveformShape();
     }
 
-    [Display(Name = nameof(GraphicsStrings.AudioVisualizer_WaveformStyle), ResourceType = typeof(GraphicsStrings))]
-    public IProperty<WaveformStyle> Style { get; } = Property.Create(WaveformStyle.MinMaxBar);
+    [Display(Name = nameof(GraphicsStrings.AudioVisualizer_Shape), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<WaveformShape?> Shape { get; } = Property.Create<WaveformShape?>();
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_BarCount), ResourceType = typeof(GraphicsStrings))]
     [Range(1, 10000)]
@@ -47,6 +41,8 @@ public sealed partial class AudioWaveformDrawable : AudioVisualizerDrawable
         protected override void RenderForeground(ImmediateCanvas canvas, Rect bounds)
         {
             if (CachedSampleLength == 0 || Fill is null) return;
+            WaveformShape.Resource? shape = Shape;
+            if (shape is null) return;
 
             int barCount = Math.Max(1, BarCount);
             if (_minBuf.Length < barCount) _minBuf = new float[barCount];
@@ -55,71 +51,8 @@ public sealed partial class AudioWaveformDrawable : AudioVisualizerDrawable
             Span<float> maxBuf = _maxBuf.AsSpan(0, barCount);
             SoundSamplingHelper.DownsampleMinMax(CachedSampleSpan, minBuf, maxBuf);
 
-            float width = (float)bounds.Width;
-            float height = (float)bounds.Height;
-            float centerY = height * 0.5f;
             float gain = Math.Max(0f, Gain);
-            float slotWidth = width / barCount;
-            float barWidth = Math.Max(1f, slotWidth - 0.5f);
-
-            switch (Style)
-            {
-                case WaveformStyle.MinMaxBar:
-                    for (int i = 0; i < barCount; i++)
-                    {
-                        float min = Math.Clamp(minBuf[i] * gain, -1f, 1f);
-                        float max = Math.Clamp(maxBuf[i] * gain, -1f, 1f);
-                        float topY = centerY - max * centerY;
-                        float bottomY = centerY - min * centerY;
-                        float barHeight = Math.Max(1f, bottomY - topY);
-                        float x = i * slotWidth;
-                        canvas.DrawRectangle(new Rect(x, topY, barWidth, barHeight), Fill, null);
-                    }
-                    break;
-
-                case WaveformStyle.Line:
-                    {
-                        // (min + max) / 2 は対称振動で相殺して中心線に潰れるため、
-                        // max(|min|, |max|) をピークエンベロープとして上側にラインを引く。
-                        const float lineThickness = 1.5f;
-                        float halfThick = lineThickness * 0.5f;
-                        float? prevY = null;
-                        for (int i = 0; i < barCount; i++)
-                        {
-                            float peak = MathF.Max(MathF.Abs(minBuf[i]), MathF.Abs(maxBuf[i]));
-                            float value = Math.Clamp(peak * gain, 0f, 1f);
-                            float y = centerY - value * centerY;
-                            float x = i * slotWidth;
-
-                            canvas.DrawRectangle(new Rect(x, y - halfThick, barWidth, lineThickness), Fill, null);
-
-                            if (prevY.HasValue)
-                            {
-                                float minY = Math.Min(prevY.Value, y);
-                                float maxY = Math.Max(prevY.Value, y);
-                                if (maxY - minY > lineThickness)
-                                {
-                                    canvas.DrawRectangle(new Rect(x - halfThick, minY, lineThickness, maxY - minY), Fill, null);
-                                }
-                            }
-                            prevY = y;
-                        }
-                        break;
-                    }
-
-                case WaveformStyle.FilledMirror:
-                    for (int i = 0; i < barCount; i++)
-                    {
-                        float abs = Math.Max(Math.Abs(minBuf[i]), Math.Abs(maxBuf[i]));
-                        float magnitude = Math.Clamp(abs * gain, 0f, 1f);
-                        float halfHeight = magnitude * centerY;
-                        float topY = centerY - halfHeight;
-                        float barHeight = Math.Max(1f, halfHeight * 2f);
-                        float x = i * slotWidth;
-                        canvas.DrawRectangle(new Rect(x, topY, barWidth, barHeight), Fill, null);
-                    }
-                    break;
-            }
+            shape.Render(canvas, bounds, minBuf, maxBuf, gain, Fill);
         }
     }
 }

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Audio;
 using Beutl.Engine;
 using Beutl.Graphics.Rendering;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
@@ -35,7 +35,7 @@ public sealed partial class AudioWaveformDrawable : AudioVisualizerDrawable
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_WindowSeconds), ResourceType = typeof(GraphicsStrings))]
     [Range(0.01f, 3600f)]
-    public IProperty<float> WindowSeconds { get; } = Property.CreateAnimatable(4f);
+    public IProperty<float> WindowSeconds { get; } = Property.CreateAnimatable(0.1f);
 
     public new partial class Resource
     {

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/AudioWaveformDrawable.cs
@@ -14,6 +14,16 @@ public sealed partial class AudioWaveformDrawable : AudioVisualizerDrawable
     {
         ScanProperties<AudioWaveformDrawable>();
         Shape.CurrentValue = new MinMaxBarWaveformShape();
+
+        // 編集頻度順に並べ替え: Source → 見た目(Shape/Fill) → 信号調整(Gain) → 時間/解像度(WindowSeconds/BarCount) → サイズ(Width/Height)
+        MoveProperty(Source, 0);
+        MoveProperty(Shape, 1);
+        MoveProperty(Fill, 2);
+        MoveProperty(Gain, 3);
+        MoveProperty(WindowSeconds, 4);
+        MoveProperty(BarCount, 5);
+        MoveProperty(Width, 6);
+        MoveProperty(Height, 7);
     }
 
     [Display(Name = nameof(GraphicsStrings.AudioVisualizer_Shape), ResourceType = typeof(GraphicsStrings))]

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/BlockWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/BlockWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/BlockWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/BlockWaveformShape.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_Block), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class BlockWaveformShape : WaveformShape
+{
+    public BlockWaveformShape()
+    {
+        ScanProperties<BlockWaveformShape>();
+    }
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_BlockCount), ResourceType = typeof(GraphicsStrings))]
+    [Range(1, 128)]
+    public IProperty<int> BlockCount { get; } = Property.Create(16);
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_BlockGap), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 50f)]
+    public IProperty<float> BlockGap { get; } = Property.CreateAnimatable(1f);
+
+    // 0 にすると slotWidth から自動決定
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_BarWidth), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 10000f)]
+    public IProperty<float> BarWidth { get; } = Property.CreateAnimatable(0f);
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_Mirrored), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<bool> Mirrored { get; } = Property.Create(false);
+
+    public new partial class Resource
+    {
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount == 0) return;
+
+            int blockCount = Math.Max(1, BlockCount);
+            float blockGap = MathF.Max(0f, BlockGap);
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float slotWidth = width / barCount;
+            float requested = BarWidth;
+            float barWidth = requested > 0f ? MathF.Max(0.5f, requested) : MathF.Max(1f, slotWidth - 0.5f);
+            float offsetX = (slotWidth - barWidth) * 0.5f;
+            bool mirrored = Mirrored;
+
+            if (mirrored)
+            {
+                // 中央から上下対称に点灯。blockCount は片側ブロック数。
+                float centerY = (float)bounds.Y + height * 0.5f;
+                float halfHeight = height * 0.5f;
+                float blockHeight = MathF.Max(0.5f, (halfHeight - blockGap * (blockCount - 1)) / blockCount);
+                for (int i = 0; i < barCount; i++)
+                {
+                    float peak = MathF.Max(MathF.Abs(mins[i]), MathF.Abs(maxs[i]));
+                    float magnitude = Math.Clamp(peak * gain, 0f, 1f);
+                    int lit = (int)MathF.Round(magnitude * blockCount);
+                    if (lit <= 0) continue;
+                    float x = (float)bounds.X + i * slotWidth + offsetX;
+                    for (int b = 0; b < lit; b++)
+                    {
+                        float topY = centerY - (b + 1) * blockHeight - b * blockGap;
+                        canvas.DrawRectangle(new Rect(x, topY, barWidth, blockHeight), fill, null);
+                        float botY = centerY + b * (blockHeight + blockGap);
+                        canvas.DrawRectangle(new Rect(x, botY, barWidth, blockHeight), fill, null);
+                    }
+                }
+            }
+            else
+            {
+                // 下から上に点灯。
+                float blockHeight = MathF.Max(0.5f, (height - blockGap * (blockCount - 1)) / blockCount);
+                float baseY = (float)bounds.Y + height;
+                for (int i = 0; i < barCount; i++)
+                {
+                    float peak = MathF.Max(MathF.Abs(mins[i]), MathF.Abs(maxs[i]));
+                    float magnitude = Math.Clamp(peak * gain, 0f, 1f);
+                    int lit = (int)MathF.Round(magnitude * blockCount);
+                    if (lit <= 0) continue;
+                    float x = (float)bounds.X + i * slotWidth + offsetX;
+                    for (int b = 0; b < lit; b++)
+                    {
+                        float topY = baseY - (b + 1) * blockHeight - b * blockGap;
+                        canvas.DrawRectangle(new Rect(x, topY, barWidth, blockHeight), fill, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/DotsWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/DotsWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/DotsWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/DotsWaveformShape.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+public enum DotsWaveformMode
+{
+    MinMax,
+    Center,
+}
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_Dots), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class DotsWaveformShape : WaveformShape
+{
+    public DotsWaveformShape()
+    {
+        ScanProperties<DotsWaveformShape>();
+    }
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_DotRadius), ResourceType = typeof(GraphicsStrings))]
+    [Range(0.5f, 100f)]
+    public IProperty<float> DotRadius { get; } = Property.CreateAnimatable(2f);
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_DotMode), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<DotsWaveformMode> Mode { get; } = Property.Create(DotsWaveformMode.MinMax);
+
+    public new partial class Resource
+    {
+        private SKPath? _path;
+        private SKPaint? _paint;
+
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount == 0) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float halfHeight = height * 0.5f;
+            float centerY = (float)bounds.Y + halfHeight;
+            float slotWidth = width / barCount;
+            float dotRadius = MathF.Max(0.5f, DotRadius);
+            bool minmax = Mode == DotsWaveformMode.MinMax;
+
+            _paint ??= new SKPaint();
+            new BrushConstructor(bounds, fill, BlendMode.SrcOver).ConfigurePaint(_paint);
+            _paint.Style = SKPaintStyle.Fill;
+            _paint.IsAntialias = true;
+            _path ??= new SKPath();
+            _path.Reset();
+
+            for (int i = 0; i < barCount; i++)
+            {
+                float cx = (float)bounds.X + i * slotWidth + slotWidth * 0.5f;
+                if (minmax)
+                {
+                    float max = Math.Clamp(maxs[i] * gain, -1f, 1f);
+                    float min = Math.Clamp(mins[i] * gain, -1f, 1f);
+                    _path.AddCircle(cx, centerY - max * halfHeight, dotRadius);
+                    _path.AddCircle(cx, centerY - min * halfHeight, dotRadius);
+                }
+                else
+                {
+                    float center = (mins[i] + maxs[i]) * 0.5f;
+                    float v = Math.Clamp(center * gain, -1f, 1f);
+                    _path.AddCircle(cx, centerY - v * halfHeight, dotRadius);
+                }
+            }
+
+            canvas.Canvas.DrawPath(_path, _paint);
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _path?.Dispose();
+                _paint?.Dispose();
+            }
+            _path = null;
+            _paint = null;
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FilledEnvelopeWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FilledEnvelopeWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FilledEnvelopeWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FilledEnvelopeWaveformShape.cs
@@ -1,0 +1,119 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_FilledEnvelope), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class FilledEnvelopeWaveformShape : WaveformShape
+{
+    public FilledEnvelopeWaveformShape()
+    {
+        ScanProperties<FilledEnvelopeWaveformShape>();
+    }
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_Smoothness), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 100f)]
+    public IProperty<float> Smoothness { get; } = Property.CreateAnimatable(0f);
+
+    // true なら max(|min|, |max|) の ±絶対値 を用いて完全上下対称の形状になる
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_Symmetric), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<bool> Symmetric { get; } = Property.Create(false);
+
+    public new partial class Resource
+    {
+        private SKPath? _path;
+        private SKPaint? _paint;
+        private float _lastCornerRadius = -1f;
+        private SKPathEffect? _cornerEffect;
+
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount < 2) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float halfHeight = height * 0.5f;
+            float centerY = (float)bounds.Y + halfHeight;
+            float slotWidth = width / barCount;
+            float smoothness = Math.Clamp(Smoothness / 100f, 0f, 1f);
+            float cornerRadius = smoothness * slotWidth * 2f;
+            bool symmetric = Symmetric;
+
+            _paint ??= new SKPaint();
+            new BrushConstructor(bounds, fill, BlendMode.SrcOver).ConfigurePaint(_paint);
+            _paint.Style = SKPaintStyle.Fill;
+            if (_lastCornerRadius != cornerRadius)
+            {
+                _cornerEffect?.Dispose();
+                _cornerEffect = cornerRadius > 0.01f ? SKPathEffect.CreateCorner(cornerRadius) : null;
+                _lastCornerRadius = cornerRadius;
+            }
+            _paint.PathEffect = _cornerEffect;
+
+            _path ??= new SKPath();
+            _path.Reset();
+
+            // 上側 (max or abs) を左→右
+            for (int i = 0; i < barCount; i++)
+            {
+                float v;
+                if (symmetric)
+                {
+                    v = MathF.Max(MathF.Abs(mins[i]), MathF.Abs(maxs[i]));
+                    v = Math.Clamp(v * gain, 0f, 1f);
+                }
+                else
+                {
+                    v = Math.Clamp(maxs[i] * gain, -1f, 1f);
+                }
+                float x = (float)bounds.X + i * slotWidth + slotWidth * 0.5f;
+                float y = centerY - v * halfHeight;
+                if (i == 0) _path.MoveTo(x, y);
+                else _path.LineTo(x, y);
+            }
+            // 下側 (min or -abs) を右→左
+            for (int i = barCount - 1; i >= 0; i--)
+            {
+                float v;
+                if (symmetric)
+                {
+                    float peak = MathF.Max(MathF.Abs(mins[i]), MathF.Abs(maxs[i]));
+                    v = -Math.Clamp(peak * gain, 0f, 1f);
+                }
+                else
+                {
+                    v = Math.Clamp(mins[i] * gain, -1f, 1f);
+                }
+                float x = (float)bounds.X + i * slotWidth + slotWidth * 0.5f;
+                float y = centerY - v * halfHeight;
+                _path.LineTo(x, y);
+            }
+            _path.Close();
+
+            canvas.Canvas.DrawPath(_path, _paint);
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _path?.Dispose();
+                _paint?.Dispose();
+                _cornerEffect?.Dispose();
+            }
+            _path = null;
+            _paint = null;
+            _cornerEffect = null;
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FilledMirrorWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FilledMirrorWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FilledMirrorWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FilledMirrorWaveformShape.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_FilledMirror), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class FilledMirrorWaveformShape : WaveformShape
+{
+    public FilledMirrorWaveformShape()
+    {
+        ScanProperties<FilledMirrorWaveformShape>();
+    }
+
+    // 0 にすると slotWidth から自動決定
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_BarWidth), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 10000f)]
+    public IProperty<float> BarWidth { get; } = Property.CreateAnimatable(0f);
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_CornerRadius), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<CornerRadius> CornerRadius { get; } =
+        Property.CreateAnimatable<CornerRadius>(new CornerRadius(0f));
+
+    public new partial class Resource
+    {
+        private SKPaint? _paint;
+        private SKPath? _path;
+
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount == 0) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float halfHeight = height * 0.5f;
+            float centerY = (float)bounds.Y + halfHeight;
+            float slotWidth = width / barCount;
+            float requested = BarWidth;
+            float barWidth = requested > 0f ? MathF.Max(0.5f, requested) : MathF.Max(1f, slotWidth - 0.5f);
+            float offsetX = (slotWidth - barWidth) * 0.5f;
+
+            CornerRadius cr = CornerRadius;
+            bool round = !cr.IsEmpty;
+
+            if (round)
+            {
+                _paint ??= new SKPaint();
+                new BrushConstructor(bounds, fill, BlendMode.SrcOver).ConfigurePaint(_paint);
+                _paint.Style = SKPaintStyle.Fill;
+                _path ??= new SKPath();
+                _path.Reset();
+            }
+
+            for (int i = 0; i < barCount; i++)
+            {
+                float abs = MathF.Max(MathF.Abs(mins[i]), MathF.Abs(maxs[i]));
+                float magnitude = Math.Clamp(abs * gain, 0f, 1f);
+                float halfBarHeight = MathF.Max(0.5f, magnitude * halfHeight);
+                float topY = centerY - halfBarHeight;
+                float barHeight = halfBarHeight * 2f;
+                float x = (float)bounds.X + i * slotWidth + offsetX;
+
+                if (round)
+                {
+                    float maxRadius = MathF.Min(barWidth, barHeight) * 0.5f;
+                    float tl = MathF.Min(cr.TopLeft, maxRadius);
+                    float tr = MathF.Min(cr.TopRight, maxRadius);
+                    float br = MathF.Min(cr.BottomRight, maxRadius);
+                    float bl = MathF.Min(cr.BottomLeft, maxRadius);
+
+                    var rect = new SKRect(x, topY, x + barWidth, topY + barHeight);
+                    var radii = new SKPoint[4]
+                    {
+                        new SKPoint(tl, tl),
+                        new SKPoint(tr, tr),
+                        new SKPoint(br, br),
+                        new SKPoint(bl, bl),
+                    };
+                    using var roundRect = new SKRoundRect();
+                    roundRect.SetRectRadii(rect, radii);
+                    _path!.AddRoundRect(roundRect);
+                }
+                else
+                {
+                    canvas.DrawRectangle(new Rect(x, topY, barWidth, barHeight), fill, null);
+                }
+            }
+
+            if (round)
+            {
+                canvas.Canvas.DrawPath(_path!, _paint!);
+            }
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _paint?.Dispose();
+                _path?.Dispose();
+            }
+            _paint = null;
+            _path = null;
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FrequencyScale.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FrequencyScale.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Graphics.AudioVisualizers;
+﻿namespace Beutl.Graphics.AudioVisualizers;
 
 public enum FrequencyScale
 {

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/FrequencyScale.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/FrequencyScale.cs
@@ -1,0 +1,8 @@
+namespace Beutl.Graphics.AudioVisualizers;
+
+public enum FrequencyScale
+{
+    Linear,
+    Logarithmic,
+    Mel,
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/LineWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/LineWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/LineWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/LineWaveformShape.cs
@@ -1,0 +1,112 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_Line), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class LineWaveformShape : WaveformShape
+{
+    public LineWaveformShape()
+    {
+        ScanProperties<LineWaveformShape>();
+    }
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_Thickness), ResourceType = typeof(GraphicsStrings))]
+    [Range(0.5f, 50f)]
+    public IProperty<float> Thickness { get; } = Property.CreateAnimatable(1.5f);
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_Smoothness), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 100f)]
+    public IProperty<float> Smoothness { get; } = Property.CreateAnimatable(0f);
+
+    [Display(Name = nameof(GraphicsStrings.WaveformShape_Mirrored), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<bool> Mirrored { get; } = Property.Create(false);
+
+    public new partial class Resource
+    {
+        private SKPath? _path;
+        private SKPaint? _paint;
+        private float _lastCornerRadius = -1f;
+        private SKPathEffect? _cornerEffect;
+
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount < 2) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float halfHeight = height * 0.5f;
+            float centerY = (float)bounds.Y + halfHeight;
+            float slotWidth = width / barCount;
+            float thickness = MathF.Max(0.5f, Thickness);
+            float smoothness = Math.Clamp(Smoothness / 100f, 0f, 1f);
+            float cornerRadius = smoothness * slotWidth * 2f;
+            bool mirrored = Mirrored;
+
+            _paint ??= new SKPaint();
+            new BrushConstructor(bounds, fill, BlendMode.SrcOver).ConfigurePaint(_paint);
+            _paint.Style = SKPaintStyle.Stroke;
+            _paint.StrokeCap = SKStrokeCap.Round;
+            _paint.StrokeJoin = SKStrokeJoin.Round;
+            _paint.StrokeWidth = thickness;
+            if (_lastCornerRadius != cornerRadius)
+            {
+                _cornerEffect?.Dispose();
+                _cornerEffect = cornerRadius > 0.01f ? SKPathEffect.CreateCorner(cornerRadius) : null;
+                _lastCornerRadius = cornerRadius;
+            }
+            _paint.PathEffect = _cornerEffect;
+
+            _path ??= new SKPath();
+            _path.Reset();
+
+            // 上側包絡線 (max)
+            for (int i = 0; i < barCount; i++)
+            {
+                float max = Math.Clamp(maxs[i] * gain, -1f, 1f);
+                float x = (float)bounds.X + i * slotWidth + slotWidth * 0.5f;
+                float y = centerY - max * halfHeight;
+                if (i == 0) _path.MoveTo(x, y);
+                else _path.LineTo(x, y);
+            }
+
+            if (mirrored)
+            {
+                // 下側包絡線 (min) を独立したサブパスで追加
+                for (int i = 0; i < barCount; i++)
+                {
+                    float min = Math.Clamp(mins[i] * gain, -1f, 1f);
+                    float x = (float)bounds.X + i * slotWidth + slotWidth * 0.5f;
+                    float y = centerY - min * halfHeight;
+                    if (i == 0) _path.MoveTo(x, y);
+                    else _path.LineTo(x, y);
+                }
+            }
+
+            canvas.Canvas.DrawPath(_path, _paint);
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _path?.Dispose();
+                _paint?.Dispose();
+                _cornerEffect?.Dispose();
+            }
+            _path = null;
+            _paint = null;
+            _cornerEffect = null;
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/MinMaxBarWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/MinMaxBarWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/MinMaxBarWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/MinMaxBarWaveformShape.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_MinMaxBar), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class MinMaxBarWaveformShape : WaveformShape
+{
+    public MinMaxBarWaveformShape()
+    {
+        ScanProperties<MinMaxBarWaveformShape>();
+    }
+
+    // 0 にすると slotWidth から自動決定（従来の WaveformStyle.MinMaxBar と同じ挙動）。
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_BarWidth), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 10000f)]
+    public IProperty<float> BarWidth { get; } = Property.CreateAnimatable(0f);
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_CornerRadius), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<CornerRadius> CornerRadius { get; } =
+        Property.CreateAnimatable<CornerRadius>(new CornerRadius(0f));
+
+    public new partial class Resource
+    {
+        private SKPaint? _paint;
+        private SKPath? _path;
+
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount == 0) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float centerY = (float)bounds.Y + height * 0.5f;
+            float halfHeight = height * 0.5f;
+            float slotWidth = width / barCount;
+            float requested = BarWidth;
+            float barWidth = requested > 0f ? MathF.Max(0.5f, requested) : MathF.Max(1f, slotWidth - 0.5f);
+            float offsetX = (slotWidth - barWidth) * 0.5f;
+
+            CornerRadius cr = CornerRadius;
+            bool round = !cr.IsEmpty;
+
+            if (round)
+            {
+                _paint ??= new SKPaint();
+                new BrushConstructor(bounds, fill, BlendMode.SrcOver).ConfigurePaint(_paint);
+                _paint.Style = SKPaintStyle.Fill;
+                _path ??= new SKPath();
+                _path.Reset();
+            }
+
+            for (int i = 0; i < barCount; i++)
+            {
+                float min = Math.Clamp(mins[i] * gain, -1f, 1f);
+                float max = Math.Clamp(maxs[i] * gain, -1f, 1f);
+                float topY = centerY - max * halfHeight;
+                float bottomY = centerY - min * halfHeight;
+                float barHeight = MathF.Max(1f, bottomY - topY);
+                float x = (float)bounds.X + i * slotWidth + offsetX;
+
+                if (round)
+                {
+                    float maxRadius = MathF.Min(barWidth, barHeight) * 0.5f;
+                    float tl = MathF.Min(cr.TopLeft, maxRadius);
+                    float tr = MathF.Min(cr.TopRight, maxRadius);
+                    float br = MathF.Min(cr.BottomRight, maxRadius);
+                    float bl = MathF.Min(cr.BottomLeft, maxRadius);
+
+                    var rect = new SKRect(x, topY, x + barWidth, topY + barHeight);
+                    var radii = new SKPoint[4]
+                    {
+                        new SKPoint(tl, tl),
+                        new SKPoint(tr, tr),
+                        new SKPoint(br, br),
+                        new SKPoint(bl, bl),
+                    };
+                    using var roundRect = new SKRoundRect();
+                    roundRect.SetRectRadii(rect, radii);
+                    _path!.AddRoundRect(roundRect);
+                }
+                else
+                {
+                    canvas.DrawRectangle(new Rect(x, topY, barWidth, barHeight), fill, null);
+                }
+            }
+
+            if (round)
+            {
+                canvas.Canvas.DrawPath(_path!, _paint!);
+            }
+        }
+
+        partial void PostDispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _paint?.Dispose();
+                _path?.Dispose();
+            }
+            _paint = null;
+            _path = null;
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/RadialWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/RadialWaveformShape.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/RadialWaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/RadialWaveformShape.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Engine;
+using Beutl.Language;
+using Beutl.Media;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+[Display(Name = nameof(GraphicsStrings.WaveformShape_Radial), ResourceType = typeof(GraphicsStrings))]
+public sealed partial class RadialWaveformShape : WaveformShape
+{
+    public RadialWaveformShape()
+    {
+        ScanProperties<RadialWaveformShape>();
+    }
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_InnerRadius), ResourceType = typeof(GraphicsStrings))]
+    [Range(0f, 10000f)]
+    public IProperty<float> InnerRadius { get; } = Property.CreateAnimatable(40f);
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_StartAngle), ResourceType = typeof(GraphicsStrings))]
+    public IProperty<float> StartAngle { get; } = Property.CreateAnimatable(-90f);
+
+    [Display(Name = nameof(GraphicsStrings.SpectrumShape_BarWidth), ResourceType = typeof(GraphicsStrings))]
+    [Range(0.5f, 100f)]
+    public IProperty<float> BarWidth { get; } = Property.CreateAnimatable(4f);
+
+    public new partial class Resource
+    {
+        internal override void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill)
+        {
+            int barCount = mins.Length;
+            if (barCount == 0) return;
+
+            float width = (float)bounds.Width;
+            float height = (float)bounds.Height;
+            float cx = (float)bounds.X + width * 0.5f;
+            float cy = (float)bounds.Y + height * 0.5f;
+            float outerRadius = MathF.Min(width, height) * 0.5f;
+            float innerRadius = MathF.Min(InnerRadius, outerRadius - 1f);
+            if (innerRadius < 0f) innerRadius = 0f;
+            float maxOut = outerRadius - innerRadius;
+            float maxIn = innerRadius;
+            if (maxOut <= 0f && maxIn <= 0f) return;
+
+            float barWidth = MathF.Max(0.5f, BarWidth);
+            float startAngleDeg = StartAngle;
+            float angleStep = 360f / barCount;
+            float half = barWidth * 0.5f;
+
+            for (int i = 0; i < barCount; i++)
+            {
+                float max = Math.Clamp(maxs[i] * gain, -1f, 1f);
+                float min = Math.Clamp(mins[i] * gain, -1f, 1f);
+                float outLen = MathF.Max(0f, max) * maxOut;
+                float inLen = MathF.Max(0f, -min) * maxIn;
+                if (outLen <= 0.5f && inLen <= 0.5f) continue;
+
+                float angleDeg = startAngleDeg + angleStep * i;
+                float angleRad = angleDeg * MathF.PI / 180f;
+                float translateX = cx + innerRadius * MathF.Cos(angleRad);
+                float translateY = cy + innerRadius * MathF.Sin(angleRad);
+
+                Matrix transform = Matrix.CreateRotation(angleRad) * Matrix.CreateTranslation(translateX, translateY);
+                using (canvas.PushTransform(transform))
+                {
+                    if (outLen > 0.5f)
+                    {
+                        canvas.DrawRectangle(new Rect(0f, -half, outLen, barWidth), fill, null);
+                    }
+                    if (inLen > 0.5f)
+                    {
+                        canvas.DrawRectangle(new Rect(-inLen, -half, inLen, barWidth), fill, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/WaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/WaveformShape.cs
@@ -1,4 +1,4 @@
-using Beutl.Engine;
+﻿using Beutl.Engine;
 using Beutl.Media;
 
 namespace Beutl.Graphics.AudioVisualizers;

--- a/src/Beutl.Engine/Graphics/AudioVisualizers/WaveformShape.cs
+++ b/src/Beutl.Engine/Graphics/AudioVisualizers/WaveformShape.cs
@@ -1,0 +1,27 @@
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.Graphics.AudioVisualizers;
+
+public abstract partial class WaveformShape : EngineObject
+{
+    public WaveformShape()
+    {
+        ScanProperties<WaveformShape>();
+    }
+
+    public abstract partial class Resource
+    {
+        /// <summary>
+        /// 波形を描画する。mins / maxs は各スロットの最小値・最大値（-1..1、gain 未適用）。
+        /// Shape 実装側で gain の適用と -1..1 へのクランプを行う。
+        /// </summary>
+        internal abstract void Render(
+            ImmediateCanvas canvas,
+            Rect bounds,
+            ReadOnlySpan<float> mins,
+            ReadOnlySpan<float> maxs,
+            float gain,
+            Brush.Resource fill);
+    }
+}

--- a/src/Beutl.Language/GraphicsStrings.ja.resx
+++ b/src/Beutl.Language/GraphicsStrings.ja.resx
@@ -1378,8 +1378,8 @@
   <data name="AudioVisualizer_FftSize" xml:space="preserve">
     <value>FFTサイズ</value>
   </data>
-  <data name="AudioVisualizer_LogarithmicFrequency" xml:space="preserve">
-    <value>対数周波数軸</value>
+  <data name="AudioVisualizer_FrequencyScale" xml:space="preserve">
+    <value>周波数軸</value>
   </data>
   <data name="AudioVisualizer_FloorDb" xml:space="preserve">
     <value>下限（dB）</value>

--- a/src/Beutl.Language/GraphicsStrings.ja.resx
+++ b/src/Beutl.Language/GraphicsStrings.ja.resx
@@ -1369,9 +1369,6 @@
   <data name="AudioSpectrogram" xml:space="preserve">
     <value>スペクトログラム</value>
   </data>
-  <data name="AudioVisualizer_WaveformStyle" xml:space="preserve">
-    <value>波形スタイル</value>
-  </data>
   <data name="AudioVisualizer_BarCount" xml:space="preserve">
     <value>バー数</value>
   </data>
@@ -1434,5 +1431,8 @@
   </data>
   <data name="SpectrumShape_Direction" xml:space="preserve">
     <value>方向</value>
+  </data>
+  <data name="WaveformShape_MinMaxBar" xml:space="preserve">
+    <value>最小最大バー</value>
   </data>
 </root>

--- a/src/Beutl.Language/GraphicsStrings.ja.resx
+++ b/src/Beutl.Language/GraphicsStrings.ja.resx
@@ -1435,4 +1435,40 @@
   <data name="WaveformShape_MinMaxBar" xml:space="preserve">
     <value>最小最大バー</value>
   </data>
+  <data name="WaveformShape_Line" xml:space="preserve">
+    <value>折れ線</value>
+  </data>
+  <data name="WaveformShape_FilledMirror" xml:space="preserve">
+    <value>上下対称塗り</value>
+  </data>
+  <data name="WaveformShape_FilledEnvelope" xml:space="preserve">
+    <value>包絡線塗り</value>
+  </data>
+  <data name="WaveformShape_Block" xml:space="preserve">
+    <value>ブロック</value>
+  </data>
+  <data name="WaveformShape_Dots" xml:space="preserve">
+    <value>ドット</value>
+  </data>
+  <data name="WaveformShape_Radial" xml:space="preserve">
+    <value>放射状</value>
+  </data>
+  <data name="WaveformShape_BlockCount" xml:space="preserve">
+    <value>ブロック数</value>
+  </data>
+  <data name="WaveformShape_BlockGap" xml:space="preserve">
+    <value>ブロック間隔</value>
+  </data>
+  <data name="WaveformShape_Mirrored" xml:space="preserve">
+    <value>上下対称</value>
+  </data>
+  <data name="WaveformShape_Symmetric" xml:space="preserve">
+    <value>振幅対称</value>
+  </data>
+  <data name="WaveformShape_DotRadius" xml:space="preserve">
+    <value>ドット半径</value>
+  </data>
+  <data name="WaveformShape_DotMode" xml:space="preserve">
+    <value>ドット配置</value>
+  </data>
 </root>

--- a/src/Beutl.Language/GraphicsStrings.resx
+++ b/src/Beutl.Language/GraphicsStrings.resx
@@ -1371,9 +1371,6 @@
   <data name="AudioSpectrogram" xml:space="preserve">
     <value>Audio Spectrogram</value>
   </data>
-  <data name="AudioVisualizer_WaveformStyle" xml:space="preserve">
-    <value>Waveform Style</value>
-  </data>
   <data name="AudioVisualizer_BarCount" xml:space="preserve">
     <value>Bar Count</value>
   </data>
@@ -1436,5 +1433,8 @@
   </data>
   <data name="SpectrumShape_Direction" xml:space="preserve">
     <value>Direction</value>
+  </data>
+  <data name="WaveformShape_MinMaxBar" xml:space="preserve">
+    <value>MinMax Bar</value>
   </data>
 </root>

--- a/src/Beutl.Language/GraphicsStrings.resx
+++ b/src/Beutl.Language/GraphicsStrings.resx
@@ -1437,4 +1437,40 @@
   <data name="WaveformShape_MinMaxBar" xml:space="preserve">
     <value>MinMax Bar</value>
   </data>
+  <data name="WaveformShape_Line" xml:space="preserve">
+    <value>Line</value>
+  </data>
+  <data name="WaveformShape_FilledMirror" xml:space="preserve">
+    <value>Filled Mirror</value>
+  </data>
+  <data name="WaveformShape_FilledEnvelope" xml:space="preserve">
+    <value>Filled Envelope</value>
+  </data>
+  <data name="WaveformShape_Block" xml:space="preserve">
+    <value>Block</value>
+  </data>
+  <data name="WaveformShape_Dots" xml:space="preserve">
+    <value>Dots</value>
+  </data>
+  <data name="WaveformShape_Radial" xml:space="preserve">
+    <value>Radial</value>
+  </data>
+  <data name="WaveformShape_BlockCount" xml:space="preserve">
+    <value>Block Count</value>
+  </data>
+  <data name="WaveformShape_BlockGap" xml:space="preserve">
+    <value>Block Gap</value>
+  </data>
+  <data name="WaveformShape_Mirrored" xml:space="preserve">
+    <value>Mirrored</value>
+  </data>
+  <data name="WaveformShape_Symmetric" xml:space="preserve">
+    <value>Symmetric</value>
+  </data>
+  <data name="WaveformShape_DotRadius" xml:space="preserve">
+    <value>Dot Radius</value>
+  </data>
+  <data name="WaveformShape_DotMode" xml:space="preserve">
+    <value>Dot Mode</value>
+  </data>
 </root>

--- a/src/Beutl.Language/GraphicsStrings.resx
+++ b/src/Beutl.Language/GraphicsStrings.resx
@@ -1380,8 +1380,8 @@
   <data name="AudioVisualizer_FftSize" xml:space="preserve">
     <value>FFT Size</value>
   </data>
-  <data name="AudioVisualizer_LogarithmicFrequency" xml:space="preserve">
-    <value>Logarithmic Frequency</value>
+  <data name="AudioVisualizer_FrequencyScale" xml:space="preserve">
+    <value>Frequency Scale</value>
   </data>
   <data name="AudioVisualizer_FloorDb" xml:space="preserve">
     <value>Floor (dB)</value>

--- a/tests/Beutl.UnitTests/Engine/Graphics/AudioVisualizerDrawableTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/AudioVisualizerDrawableTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Graphics;
 using Beutl.Graphics.AudioVisualizers;
 using Beutl.Graphics.Rendering;

--- a/tests/Beutl.UnitTests/Engine/Graphics/AudioVisualizerDrawableTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/AudioVisualizerDrawableTests.cs
@@ -1,4 +1,4 @@
-﻿using Beutl.Composition;
+using Beutl.Composition;
 using Beutl.Graphics;
 using Beutl.Graphics.AudioVisualizers;
 using Beutl.Graphics.Rendering;
@@ -29,6 +29,14 @@ public class AudioVisualizerDrawableTests
         Fill = { CurrentValue = new SolidColorBrush(Colors.White) }
     };
 
+    private static void RenderOnce(Drawable drawable)
+    {
+        using var resource = drawable.ToResource(CompositionContext.Default);
+        using var container = new ContainerRenderNode();
+        using var context = new GraphicsContext2D(container, new PixelSize(400, 200));
+        drawable.Render(context, resource);
+    }
+
     [Test]
     public void Waveform_NoSource_HasEmptyCache()
     {
@@ -44,35 +52,64 @@ public class AudioVisualizerDrawableTests
     public void Waveform_Render_NoSource_DoesNotThrow()
     {
         var drawable = CreateWaveform();
-        using var resource = (AudioWaveformDrawable.Resource)drawable.ToResource(CompositionContext.Default);
-
-        using var container = new ContainerRenderNode();
-        using var context = new GraphicsContext2D(container, new PixelSize(400, 200));
-
-        Assert.DoesNotThrow(() => drawable.Render(context, resource));
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
     }
 
     [Test]
     public void Spectrum_Render_NoSource_DoesNotThrow()
     {
         var drawable = CreateSpectrum();
-        using var resource = (AudioSpectrumDrawable.Resource)drawable.ToResource(CompositionContext.Default);
-
-        using var container = new ContainerRenderNode();
-        using var context = new GraphicsContext2D(container, new PixelSize(400, 200));
-
-        Assert.DoesNotThrow(() => drawable.Render(context, resource));
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
     }
 
     [Test]
     public void Spectrogram_Render_NoSource_DoesNotThrow()
     {
         var drawable = CreateSpectrogram();
-        using var resource = (AudioSpectrogramDrawable.Resource)drawable.ToResource(CompositionContext.Default);
-
-        using var container = new ContainerRenderNode();
-        using var context = new GraphicsContext2D(container, new PixelSize(400, 200));
-
-        Assert.DoesNotThrow(() => drawable.Render(context, resource));
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
     }
+
+    [TestCaseSource(nameof(WaveformShapeCases))]
+    public void Waveform_WithEachShape_DoesNotThrow(Func<WaveformShape> factory)
+    {
+        var drawable = CreateWaveform();
+        drawable.Shape.CurrentValue = factory();
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
+    }
+
+    public static IEnumerable<Func<WaveformShape>> WaveformShapeCases() =>
+    [
+        () => new MinMaxBarWaveformShape(),
+        () => new LineWaveformShape(),
+        () => new LineWaveformShape { Mirrored = { CurrentValue = true } },
+        () => new FilledMirrorWaveformShape(),
+        () => new FilledEnvelopeWaveformShape(),
+        () => new FilledEnvelopeWaveformShape { Symmetric = { CurrentValue = true } },
+        () => new BlockWaveformShape(),
+        () => new BlockWaveformShape { Mirrored = { CurrentValue = true } },
+        () => new DotsWaveformShape(),
+        () => new DotsWaveformShape { Mode = { CurrentValue = DotsWaveformMode.Center } },
+        () => new RadialWaveformShape(),
+    ];
+
+    [TestCase(FrequencyScale.Linear)]
+    [TestCase(FrequencyScale.Logarithmic)]
+    [TestCase(FrequencyScale.Mel)]
+    public void Spectrum_FrequencyScale_DoesNotThrow(FrequencyScale scale)
+    {
+        var drawable = CreateSpectrum();
+        drawable.FrequencyScale.CurrentValue = scale;
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
+    }
+
+    [TestCase(FrequencyScale.Linear)]
+    [TestCase(FrequencyScale.Logarithmic)]
+    [TestCase(FrequencyScale.Mel)]
+    public void Spectrogram_FrequencyScale_DoesNotThrow(FrequencyScale scale)
+    {
+        var drawable = CreateSpectrogram();
+        drawable.FrequencyScale.CurrentValue = scale;
+        Assert.DoesNotThrow(() => RenderOnce(drawable));
+    }
+
 }


### PR DESCRIPTION
## Description

- Introduce a pluggable `WaveformShape` abstraction for `AudioWaveformDrawable` so waveform rendering can be swapped between styles instead of being hard-coded.
- Ship seven waveform shapes (MinMaxBar, Line, FilledMirror, FilledEnvelope, Block, Dots, Radial) to give creators more expressive audio visuals out of the box.
- Replace the boolean `LogarithmicFrequency` option on the spectrum/spectrogram with a `FrequencyScale` enum (Linear/Logarithmic/Mel) and aggregate FFT bins accordingly for more accurate frequency mapping.
- Improve editor usability by reordering properties, defaulting the waveform window to 0.1s, expanding unit tests, and adding UTF-8 BOM to new source files.

## Breaking changes

- `AudioSpectrumDrawable`/`AudioSpectrogramDrawable`: the `LogarithmicFrequency` boolean property and the `AudioVisualizer_LogarithmicFrequency` localization key are removed. Use the new `FrequencyScale` property and `AudioVisualizer_FrequencyScale` key instead (`FrequencyScale.Logarithmic` reproduces the previous behavior).
- `AudioWaveformDrawable`: the previous `WaveformStyle` property and `AudioVisualizer_WaveformStyle` localization key are removed. Configure the new `Shape` property with a `WaveformShape` plugin (e.g. `MinMaxBarWaveformShape`) instead.
- The default waveform window length is now `0.1s`; projects relying on the prior default should set the value explicitly.

## Fixed issues

None