### PR TITLE
feat: Add Hold easing for step interpolation

### DIFF
--- a/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
@@ -67,6 +67,7 @@ public sealed class LibraryTabViewModel : IDisposable, IToolContext
         new SineEaseInOut(),
         new SineEaseOut(),
         new LinearEasing(),
+        new HoldEasing(),
     ];
 
     public List<LibraryItemViewModel> LibraryItems { get; }

--- a/src/Beutl.Engine/Animation/Easings/HoldEasing.cs
+++ b/src/Beutl.Engine/Animation/Easings/HoldEasing.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Animation.Easings;
+﻿namespace Beutl.Animation.Easings;
 
 public sealed class HoldEasing : Easing
 {

--- a/src/Beutl.Engine/Animation/Easings/HoldEasing.cs
+++ b/src/Beutl.Engine/Animation/Easings/HoldEasing.cs
@@ -1,0 +1,9 @@
+namespace Beutl.Animation.Easings;
+
+public sealed class HoldEasing : Easing
+{
+    public override float Ease(float progress)
+    {
+        return progress < 1f ? 0f : 1f;
+    }
+}

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -240,6 +240,9 @@
   <data name="Easing" xml:space="preserve">
     <value>イージング</value>
   </data>
+  <data name="Hold" xml:space="preserve">
+    <value>ホールド</value>
+  </data>
   <data name="ElementProperty" xml:space="preserve">
     <value>要素プロパティ</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -245,6 +245,9 @@
   <data name="Easing" xml:space="preserve">
     <value>Easing</value>
   </data>
+  <data name="Hold" xml:space="preserve">
+    <value>Hold</value>
+  </data>
   <data name="ElementProperty" xml:space="preserve">
     <value>Element Property</value>
   </data>

--- a/tests/Beutl.UnitTests/Engine/Animation/HoldEasingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/HoldEasingTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation.Easings;
+﻿using Beutl.Animation.Easings;
 
 namespace Beutl.UnitTests.Engine.Animation;
 

--- a/tests/Beutl.UnitTests/Engine/Animation/HoldEasingTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/HoldEasingTests.cs
@@ -1,0 +1,32 @@
+using Beutl.Animation.Easings;
+
+namespace Beutl.UnitTests.Engine.Animation;
+
+public class HoldEasingTests
+{
+    [Test]
+    public void Ease_BeforeEnd_ReturnsZero()
+    {
+        var easing = new HoldEasing();
+
+        Assert.That(easing.Ease(0f), Is.EqualTo(0f));
+        Assert.That(easing.Ease(0.5f), Is.EqualTo(0f));
+        Assert.That(easing.Ease(0.999f), Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void Ease_AtEnd_ReturnsOne()
+    {
+        var easing = new HoldEasing();
+
+        Assert.That(easing.Ease(1f), Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void Ease_BeyondEnd_ReturnsOne()
+    {
+        var easing = new HoldEasing();
+
+        Assert.That(easing.Ease(1.5f), Is.EqualTo(1f));
+    }
+}


### PR DESCRIPTION
## Description
- Adds `HoldEasing`, a step easing that returns 0 until progress reaches 1 and then returns 1, enabling discrete/stepped animation transitions.
- Registers the new easing in the Library tab and adds the localized `Hold` string (en/ja) so users can pick it from the UI.
- Adds unit tests covering progress before, at, and beyond the end of the curve.

## Breaking changes
None

## Fixed issues
None