### PR TITLE
feat: Add Shift/Alt modifiers to number scrub for coarse/fine adjustment

### DIFF
--- a/src/Beutl.Controls/Helpers/NumberEditorHelper.cs
+++ b/src/Beutl.Controls/Helpers/NumberEditorHelper.cs
@@ -30,6 +30,18 @@ public static class NumberEditorHelper
         return move * GetScrubModifierCoefficient(modifiers);
     }
 
+    // 整数型 TValue では小数移動量が CreateTruncating で 0 に切り捨てられ、
+    // fine modifier (係数 0.1) ではドラッグがほぼ反応しなくなる。
+    // ここでフレーム間の小数残差を accumulator に持ち越し、整数化できた分のみ返す。
+    public static TValue ConsumeScrubAccumulator<TValue>(ref double accumulator, double scaledMove)
+        where TValue : INumber<TValue>
+    {
+        accumulator += scaledMove;
+        TValue truncated = TValue.CreateTruncating(accumulator);
+        accumulator -= double.CreateTruncating(truncated);
+        return truncated;
+    }
+
     public static TValue AddPreservingScale<TValue>(TValue original, TValue delta)
         where TValue : INumber<TValue>
     {

--- a/src/Beutl.Controls/Helpers/NumberEditorHelper.cs
+++ b/src/Beutl.Controls/Helpers/NumberEditorHelper.cs
@@ -1,9 +1,35 @@
 ﻿using System.Numerics;
 
+using Avalonia.Input;
+
 namespace Beutl;
 
 public static class NumberEditorHelper
 {
+    public static double GetScrubModifierCoefficient(KeyModifiers modifiers)
+    {
+        bool shift = modifiers.HasFlag(KeyModifiers.Shift);
+        bool fine = modifiers.HasFlag(KeyModifiers.Alt) || modifiers.HasFlag(KeyModifiers.Meta);
+        if (shift && fine)
+        {
+            return 1.0;
+        }
+        if (shift)
+        {
+            return 10.0;
+        }
+        if (fine)
+        {
+            return 0.1;
+        }
+        return 1.0;
+    }
+
+    public static double ApplyScrubModifier(double move, KeyModifiers modifiers)
+    {
+        return move * GetScrubModifierCoefficient(modifiers);
+    }
+
     public static TValue AddPreservingScale<TValue>(TValue original, TValue delta)
         where TValue : INumber<TValue>
     {

--- a/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
@@ -107,7 +107,8 @@ public class NumberEditor<TValue> : StringEditor
 
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
-            TValue delta = TValue.CreateTruncating(move.X) * SmallChange;
+            double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
+            TValue delta = TValue.CreateTruncating(scaledX) * SmallChange;
             TValue oldValue = Value;
             TValue newValue = NumberEditorHelper.AddPreservingScale(oldValue, delta);
             if (newValue != oldValue)

--- a/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
@@ -42,6 +42,7 @@ public class NumberEditor<TValue> : StringEditor
     private readonly CompositeDisposable _disposables = [];
     private bool _headerPressed;
     private Point _headerDragStart;
+    private double _scrubAccumulator;
     private TextBlock _headerText;
 
     public NumberEditor()
@@ -108,7 +109,7 @@ public class NumberEditor<TValue> : StringEditor
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
             double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
-            TValue delta = TValue.CreateTruncating(scaledX) * SmallChange;
+            TValue delta = NumberEditorHelper.ConsumeScrubAccumulator<TValue>(ref _scrubAccumulator, scaledX) * SmallChange;
             TValue oldValue = Value;
             TValue newValue = NumberEditorHelper.AddPreservingScale(oldValue, delta);
             if (newValue != oldValue)
@@ -147,6 +148,7 @@ public class NumberEditor<TValue> : StringEditor
         {
             _oldValue = Value;
             _headerDragStart = pointerPoint.Position;
+            _scrubAccumulator = 0;
             PointerLockHelper.Pressed(_headerText, _headerDragStart);
             _headerPressed = true;
             e.Handled = true;

--- a/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
@@ -71,7 +71,8 @@ public class RationalEditor : StringEditor
 
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
-            var delta = new Rational((int)move.X, 1);
+            double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
+            var delta = new Rational((int)scaledX, 1);
             Rational oldValue = Value;
             Rational newValue = Value + delta;
             if (newValue != oldValue)

--- a/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
@@ -24,6 +24,7 @@ public class RationalEditor : StringEditor
     private readonly CompositeDisposable _disposables = [];
     private bool _headerPressed;
     private Point _headerDragStart;
+    private double _scrubAccumulator;
     private TextBlock _headerText;
 
     public RationalEditor()
@@ -72,7 +73,8 @@ public class RationalEditor : StringEditor
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
             double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
-            var delta = new Rational((int)scaledX, 1);
+            int truncated = NumberEditorHelper.ConsumeScrubAccumulator<int>(ref _scrubAccumulator, scaledX);
+            var delta = new Rational(truncated, 1);
             Rational oldValue = Value;
             Rational newValue = Value + delta;
             if (newValue != oldValue)
@@ -111,6 +113,7 @@ public class RationalEditor : StringEditor
         {
             _oldValue = Value;
             _headerDragStart = pointerPoint.Position;
+            _scrubAccumulator = 0;
             PointerLockHelper.Pressed(_headerText, _headerDragStart);
             _headerPressed = true;
             e.Handled = true;

--- a/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
@@ -40,6 +40,7 @@ public class Vector2Editor<TElement> : Vector2Editor
     private TextBlock _headerText;
     private Point _headerDragStart;
     private bool _headerPressed;
+    private double _scrubAccumulator;
 
     public Vector2Editor()
     {
@@ -148,7 +149,7 @@ public class Vector2Editor<TElement> : Vector2Editor
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(headerText, point, ref _headerDragStart);
             double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
-            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
+            TElement delta = NumberEditorHelper.ConsumeScrubAccumulator<TElement>(ref _scrubAccumulator, scaledX) * SmallChange;
 
             var newValues = (FirstValue, SecondValue);
             var oldValues = (FirstValue, SecondValue);
@@ -209,6 +210,7 @@ public class Vector2Editor<TElement> : Vector2Editor
                 _oldFirstValue = FirstValue;
                 _oldSecondValue = SecondValue;
                 _headerDragStart = pointerPoint.Position;
+                _scrubAccumulator = 0;
                 PointerLockHelper.Pressed(headerText, _headerDragStart);
                 _headerPressed = true;
                 e.Handled = true;

--- a/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
@@ -147,7 +147,8 @@ public class Vector2Editor<TElement> : Vector2Editor
 
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(headerText, point, ref _headerDragStart);
-            TElement delta = TElement.CreateTruncating(move.X) * SmallChange;
+            double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
+            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
 
             var newValues = (FirstValue, SecondValue);
             var oldValues = (FirstValue, SecondValue);

--- a/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
@@ -174,7 +174,8 @@ public class Vector3Editor<TElement> : Vector3Editor
 
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(headerText, point, ref _headerDragStart);
-            TElement delta = TElement.CreateTruncating(move.X) * SmallChange;
+            double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
+            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
 
             var newValues = (FirstValue, SecondValue, ThirdValue);
             var oldValues = (FirstValue, SecondValue, ThirdValue);

--- a/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
@@ -48,6 +48,7 @@ public class Vector3Editor<TElement> : Vector3Editor
     private TextBlock _headerText;
     private Point _headerDragStart;
     private bool _headerPressed;
+    private double _scrubAccumulator;
 
     public Vector3Editor()
     {
@@ -175,7 +176,7 @@ public class Vector3Editor<TElement> : Vector3Editor
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(headerText, point, ref _headerDragStart);
             double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
-            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
+            TElement delta = NumberEditorHelper.ConsumeScrubAccumulator<TElement>(ref _scrubAccumulator, scaledX) * SmallChange;
 
             var newValues = (FirstValue, SecondValue, ThirdValue);
             var oldValues = (FirstValue, SecondValue, ThirdValue);
@@ -242,6 +243,7 @@ public class Vector3Editor<TElement> : Vector3Editor
                 _oldSecondValue = SecondValue;
                 _oldThirdValue = ThirdValue;
                 _headerDragStart = pointerPoint.Position;
+                _scrubAccumulator = 0;
                 PointerLockHelper.Pressed(headerText, _headerDragStart);
                 _headerPressed = true;
                 e.Handled = true;

--- a/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
@@ -201,7 +201,8 @@ public class Vector4Editor<TElement> : Vector4Editor
 
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
-            TElement delta = TElement.CreateTruncating(move.X) * SmallChange;
+            double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
+            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
 
             var newValues = (
                 NumberEditorHelper.AddPreservingScale(FirstValue, delta),

--- a/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
@@ -67,6 +67,7 @@ public class Vector4Editor<TElement> : Vector4Editor
     private TextBlock _headerText;
     private Point _headerDragStart;
     private bool _headerPressed;
+    private double _scrubAccumulator;
 
     public Vector4Editor()
     {
@@ -202,7 +203,7 @@ public class Vector4Editor<TElement> : Vector4Editor
             // ポインタロック + デルタ取得
             Point move = PointerLockHelper.Moved(_headerText, point, ref _headerDragStart);
             double scaledX = NumberEditorHelper.ApplyScrubModifier(move.X, e.KeyModifiers);
-            TElement delta = TElement.CreateTruncating(scaledX) * SmallChange;
+            TElement delta = NumberEditorHelper.ConsumeScrubAccumulator<TElement>(ref _scrubAccumulator, scaledX) * SmallChange;
 
             var newValues = (
                 NumberEditorHelper.AddPreservingScale(FirstValue, delta),
@@ -250,6 +251,7 @@ public class Vector4Editor<TElement> : Vector4Editor
             _oldFirstValue = FirstValue;
             _oldSecondValue = SecondValue;
             _headerDragStart = pointerPoint.Position;
+            _scrubAccumulator = 0;
             PointerLockHelper.Pressed(_headerText, _headerDragStart);
             _headerPressed = true;
             e.Handled = true;


### PR DESCRIPTION
## Description

- Adds keyboard modifier support to numeric drag-scrub on `NumberEditor`, `RationalEditor`, `Vector2Editor`, `Vector3Editor`, and `Vector4Editor` so users can adjust precision on the fly.
- Holding `Shift` multiplies the scrub delta by 10 for coarse adjustment, while `Alt` (or `Meta` on macOS) divides it by 10 for fine adjustment; pressing both restores the default 1x step.
- Centralizes the modifier-to-coefficient mapping in `NumberEditorHelper` (`GetScrubModifierCoefficient` / `ApplyScrubModifier`) so every editor scales `move.X` consistently before computing the value delta.

## Breaking changes

None

## Fixed issues

None