### PR TITLE
feat: Add platform export presets for YouTube, X, Instagram, TikTok, Discord

### DIFF
--- a/src/Beutl.Controls/Behaviors/OutputPickerItemBehavior.cs
+++ b/src/Beutl.Controls/Behaviors/OutputPickerItemBehavior.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Avalonia.Xaml.Interactivity;
+using Beutl.Controls.PropertyEditors;
+
+namespace Beutl.Controls.Behaviors;
+
+public class OutputPickerItemBehavior : Behavior<ToggleButton>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.Click += OnClick;
+        }
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.Click -= OnClick;
+        }
+    }
+
+    private void OnClick(object sender, RoutedEventArgs e)
+    {
+        var parent = AssociatedObject?.FindAncestorOfType<OutputPickerFlyoutPresenter>();
+        if (parent != null && AssociatedObject is { DataContext: PinnableOutputItem item })
+        {
+            parent.UpdatePinState(item, AssociatedObject.IsChecked == true);
+        }
+    }
+}

--- a/src/Beutl.Controls/Behaviors/OutputPickerItemMoreButtonBehavior.cs
+++ b/src/Beutl.Controls/Behaviors/OutputPickerItemMoreButtonBehavior.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Avalonia.Xaml.Interactivity;
+using Beutl.Controls.PropertyEditors;
+
+namespace Beutl.Controls.Behaviors;
+
+public class OutputPickerItemMoreButtonBehavior : Behavior<Button>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.Click += OnClick;
+        }
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.Click -= OnClick;
+        }
+    }
+
+    private void OnClick(object sender, RoutedEventArgs e)
+    {
+        var parent = AssociatedObject?.FindAncestorOfType<OutputPickerFlyoutPresenter>();
+        if (parent != null && AssociatedObject is { DataContext: PinnableOutputItem item })
+        {
+            parent.RequestMoreMenu(item, AssociatedObject);
+        }
+    }
+}

--- a/src/Beutl.Controls/PropertyEditors/OutputPickerFlyoutPresenter.cs
+++ b/src/Beutl.Controls/PropertyEditors/OutputPickerFlyoutPresenter.cs
@@ -1,0 +1,287 @@
+﻿#nullable enable
+
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Beutl.Reactive;
+using Reactive.Bindings;
+
+namespace Beutl.Controls.PropertyEditors;
+
+public sealed class PinnableOutputItem(
+    string displayName,
+    bool isPinned,
+    object userData,
+    string? description = null) : IEquatable<PinnableOutputItem?>
+{
+    public string DisplayName { get; } = displayName;
+
+    public bool IsPinned { get; } = isPinned;
+
+    public object UserData { get; } = userData;
+
+    public string? Description { get; } = description;
+
+    public bool Equals(PinnableOutputItem? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return DisplayName == other.DisplayName && IsPinned == other.IsPinned && Equals(UserData, other.UserData);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || obj is PinnableOutputItem other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(IsPinned, UserData);
+    }
+}
+
+public class OutputPickerFlyoutPresenter : DraggablePickerFlyoutPresenter
+{
+    public static readonly StyledProperty<ReactiveCollection<PinnableOutputItem>?> ProfileItemsProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, ReactiveCollection<PinnableOutputItem>?>(nameof(ProfileItems));
+
+    public static readonly StyledProperty<ReactiveCollection<PinnableOutputItem>?> PresetItemsProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, ReactiveCollection<PinnableOutputItem>?>(nameof(PresetItems));
+
+    public static readonly StyledProperty<PinnableOutputItem?> SelectedProfileProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, PinnableOutputItem?>(nameof(SelectedProfile));
+
+    public static readonly StyledProperty<PinnableOutputItem?> SelectedPresetProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, PinnableOutputItem?>(nameof(SelectedPreset));
+
+    public static readonly StyledProperty<bool> ShowPresetsProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, bool>(nameof(ShowPresets));
+
+    public static readonly StyledProperty<bool> ShowSearchBoxProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, bool>(nameof(ShowSearchBox));
+
+    public static readonly StyledProperty<string?> SearchTextProperty =
+        AvaloniaProperty.Register<OutputPickerFlyoutPresenter, string?>(nameof(SearchText));
+
+    private const string SearchBoxPseudoClass = ":search-box";
+    private const string ShowPresetsPseudoClass = ":show-presets";
+
+    private readonly CompositeDisposable _keyboardDisposables = [];
+    private TextBox? _searchTextBox;
+    private ListBox? _profileListBox;
+    private ListBox? _presetListBox;
+    private ToggleButton? _profilesTabButton;
+    private ToggleButton? _presetsTabButton;
+
+    public event Action<PinnableOutputItem>? Pinned;
+
+    public event Action<PinnableOutputItem>? Unpinned;
+
+    public event Action<PinnableOutputItem, Control>? MoreMenuRequested;
+
+    public ReactiveCollection<PinnableOutputItem>? ProfileItems
+    {
+        get => GetValue(ProfileItemsProperty);
+        set => SetValue(ProfileItemsProperty, value);
+    }
+
+    public ReactiveCollection<PinnableOutputItem>? PresetItems
+    {
+        get => GetValue(PresetItemsProperty);
+        set => SetValue(PresetItemsProperty, value);
+    }
+
+    public PinnableOutputItem? SelectedProfile
+    {
+        get => GetValue(SelectedProfileProperty);
+        set => SetValue(SelectedProfileProperty, value);
+    }
+
+    public PinnableOutputItem? SelectedPreset
+    {
+        get => GetValue(SelectedPresetProperty);
+        set => SetValue(SelectedPresetProperty, value);
+    }
+
+    public bool ShowPresets
+    {
+        get => GetValue(ShowPresetsProperty);
+        set => SetValue(ShowPresetsProperty, value);
+    }
+
+    public bool ShowSearchBox
+    {
+        get => GetValue(ShowSearchBoxProperty);
+        set => SetValue(ShowSearchBoxProperty, value);
+    }
+
+    public string? SearchText
+    {
+        get => GetValue(SearchTextProperty);
+        set => SetValue(SearchTextProperty, value);
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        _keyboardDisposables.Clear();
+        base.OnApplyTemplate(e);
+
+        _searchTextBox = e.NameScope.Find<TextBox>("SearchTextBox");
+        _profileListBox = e.NameScope.Find<ListBox>("PART_ProfileListBox");
+        _presetListBox = e.NameScope.Find<ListBox>("PART_PresetListBox");
+        _profilesTabButton = e.NameScope.Find<ToggleButton>("ProfilesTabButton");
+        _presetsTabButton = e.NameScope.Find<ToggleButton>("PresetsTabButton");
+
+        if (_profileListBox != null) _profileListBox.Focusable = true;
+        if (_presetListBox != null) _presetListBox.Focusable = true;
+
+        _profilesTabButton?.AddDisposableHandler(Button.ClickEvent, OnProfilesTabClick)
+            .DisposeWith(_keyboardDisposables);
+        _presetsTabButton?.AddDisposableHandler(Button.ClickEvent, OnPresetsTabClick)
+            .DisposeWith(_keyboardDisposables);
+
+        this.AddDisposableHandler(KeyDownEvent, OnPresenterKeyDown, RoutingStrategies.Tunnel)
+            .DisposeWith(_keyboardDisposables);
+
+        _searchTextBox?.AddDisposableHandler(KeyDownEvent, OnSearchBoxKeyDown)
+            .DisposeWith(_keyboardDisposables);
+
+        _profileListBox?.AddDisposableHandler(KeyDownEvent, OnListBoxKeyDown, RoutingStrategies.Tunnel)
+            .DisposeWith(_keyboardDisposables);
+
+        _presetListBox?.AddDisposableHandler(KeyDownEvent, OnListBoxKeyDown, RoutingStrategies.Tunnel)
+            .DisposeWith(_keyboardDisposables);
+    }
+
+    private void OnPresenterKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e is { Key: Key.F, KeyModifiers: KeyModifiers.Control or KeyModifiers.Meta })
+        {
+            ShowSearchBox = true;
+            e.Handled = true;
+            _searchTextBox?.Focus();
+            return;
+        }
+
+        if (e is { Key: Key.Tab, KeyModifiers: KeyModifiers.None or KeyModifiers.Shift })
+        {
+            ShowPresets = !ShowPresets;
+            e.Handled = true;
+            FocusListBox();
+        }
+    }
+
+    private void OnListBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (sender is not ListBox listBox) return;
+
+        switch (e.Key)
+        {
+            case Key.Up:
+                listBox.SelectedIndex = listBox.SelectedIndex <= 0
+                    ? 0
+                    : listBox.SelectedIndex - 1;
+                ScrollSelectedIntoView(listBox);
+                e.Handled = true;
+                break;
+            case Key.Down:
+                listBox.SelectedIndex = listBox.SelectedIndex >= listBox.ItemCount - 1
+                    ? listBox.ItemCount - 1
+                    : listBox.SelectedIndex + 1;
+                ScrollSelectedIntoView(listBox);
+                e.Handled = true;
+                break;
+        }
+
+        FocusListBox();
+    }
+
+    private static void ScrollSelectedIntoView(ListBox listBox)
+    {
+        if (listBox.SelectedItem is { } item)
+        {
+            listBox.ScrollIntoView(item);
+        }
+    }
+
+    private void OnProfilesTabClick(object? sender, RoutedEventArgs e)
+    {
+        ShowPresets = false;
+    }
+
+    private void OnPresetsTabClick(object? sender, RoutedEventArgs e)
+    {
+        ShowPresets = true;
+    }
+
+    private void OnSearchBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Down:
+                FocusListBox();
+                e.Handled = true;
+                break;
+            case Key.Escape:
+                ShowSearchBox = false;
+                FocusListBox();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    public void FocusInitialElement()
+    {
+        Dispatcher.UIThread.Post(FocusListBox, DispatcherPriority.Input);
+    }
+
+    private void FocusListBox()
+    {
+        var target = GetCurrentListBox();
+        if (target is null) return;
+        if (target.SelectedIndex < 0 && target.ItemCount > 0)
+            target.SelectedIndex = 0;
+
+        target.Focus();
+    }
+
+    private ListBox? GetCurrentListBox() => ShowPresets ? _presetListBox : _profileListBox;
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == ShowSearchBoxProperty)
+        {
+            PseudoClasses.Set(SearchBoxPseudoClass, ShowSearchBox);
+            if (ShowSearchBox)
+            {
+                _searchTextBox?.Focus();
+            }
+        }
+        else if (change.Property == ShowPresetsProperty)
+        {
+            PseudoClasses.Set(ShowPresetsPseudoClass, ShowPresets);
+        }
+    }
+
+    internal void UpdatePinState(PinnableOutputItem item, bool isPinned)
+    {
+        if (isPinned)
+        {
+            Pinned?.Invoke(item);
+        }
+        else
+        {
+            Unpinned?.Invoke(item);
+        }
+    }
+
+    internal void RequestMoreMenu(PinnableOutputItem item, Control anchor)
+    {
+        MoreMenuRequested?.Invoke(item, anchor);
+    }
+}

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -56,6 +56,7 @@
                 <ResourceInclude Source="/Styling/PropertyEditors/BrushEditorFlyoutPresenter.axaml" />
                 <ResourceInclude Source="/Styling/PropertyEditors/GradientStopsSlider.axaml" />
                 <ResourceInclude Source="/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml" />
+                <ResourceInclude Source="/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml" />
                 <ResourceInclude Source="/Styling/PropertyEditors/FontFamilyPickerFlyoutPresenter.axaml" />
                 <ResourceInclude Source="/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml" />
                 <ResourceInclude Source="/Styling/PropertyEditors/ReferenceEditor.axaml" />

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -1,0 +1,339 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:behaviors="using:Beutl.Controls.Behaviors"
+                    xmlns:int="using:Avalonia.Xaml.Interactivity"
+                    xmlns:lang="using:Beutl.Language"
+                    xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                    x:CompileBindings="True">
+    <ControlTheme x:Key="OutputPicker_ToggleButton"
+                  BasedOn="{StaticResource TransparentToggleButton}"
+                  TargetType="ToggleButton">
+        <Setter Property="Padding" Value="6,5,6,6" />
+        <Setter Property="CornerRadius" Value="8" />
+    </ControlTheme>
+
+    <ControlTheme x:Key="OutputPicker_MoreButton"
+                  BasedOn="{StaticResource TransparentButton}"
+                  TargetType="Button">
+        <Setter Property="Padding" Value="6,5,6,6" />
+        <Setter Property="CornerRadius" Value="8" />
+    </ControlTheme>
+
+    <ControlTheme x:Key="OutputPicker_ListBoxItem" TargetType="ListBoxItem">
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="Background" Value="{DynamicResource ListViewItemBackground}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
+        <Setter Property="Padding" Value="16,0,8,0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="MinWidth" Value="{DynamicResource ListViewItemMinWidth}" />
+        <Setter Property="MinHeight" Value="{DynamicResource ListViewItemMinHeight}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="Root"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+
+                    <Grid ColumnDefinitions="*,4,Auto,Auto">
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          Margin="2"
+                                          Padding="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}" />
+
+                        <ToggleButton Name="PinButton"
+                                      Grid.Column="2"
+                                      Margin="0,0,2,0"
+                                      IsChecked="{Binding $self.((local:PinnableOutputItem)DataContext).IsPinned, FallbackValue=False}"
+                                      IsVisible="False"
+                                      Theme="{StaticResource OutputPicker_ToggleButton}">
+                            <int:Interaction.Behaviors>
+                                <behaviors:OutputPickerItemBehavior />
+                            </int:Interaction.Behaviors>
+                            <ui:SymbolIcon Symbol="Pin" />
+                        </ToggleButton>
+
+                        <Button Name="MoreItemButton"
+                                Grid.Column="3"
+                                Margin="0,0,4,0"
+                                IsVisible="False"
+                                Theme="{StaticResource OutputPicker_MoreButton}">
+                            <int:Interaction.Behaviors>
+                                <behaviors:OutputPickerItemMoreButtonBehavior />
+                            </int:Interaction.Behaviors>
+                            <ui:SymbolIcon Symbol="MoreVertical" />
+                        </Button>
+
+                        <Rectangle Name="SelectionIndicator"
+                                   Width="3"
+                                   Height="16"
+                                   Margin="2,0,0,0"
+                                   HorizontalAlignment="Left"
+                                   VerticalAlignment="Center"
+                                   Fill="{DynamicResource AccentFillColorDefaultBrush}"
+                                   IsVisible="False"
+                                   RadiusX="2"
+                                   RadiusY="2"
+                                   RenderTransform="scaleY(0)"
+                                   UseLayoutRounding="False">
+                            <Rectangle.Transitions>
+                                <Transitions>
+                                    <TransformOperationsTransition Easing="0,0 0,1"
+                                                                   Property="RenderTransform"
+                                                                   Duration="00:00:00.167" />
+                                </Transitions>
+                            </Rectangle.Transitions>
+                        </Rectangle>
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover /template/ ToggleButton#PinButton">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
+        <Style Selector="^ /template/ ToggleButton#PinButton:checked">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
+        <Style Selector="^:pointerover /template/ Button#MoreItemButton">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ Border#Root">
+                <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundPointerOver}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ Border#Root">
+                <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPressed}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundPressed}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:selected">
+            <Style Selector="^ /template/ Border#Root">
+                <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelected}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelected}" />
+            </Style>
+            <Style Selector="^ /template/ Rectangle#SelectionIndicator">
+                <Setter Property="IsVisible" Value="True" />
+                <Setter Property="RenderTransform" Value="scaleY(1)" />
+            </Style>
+            <Style Selector="^:not(:focus) /template/ Border#Root">
+                <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelected}" />
+            </Style>
+            <Style Selector="^:not(:focus) /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelected}" />
+            </Style>
+
+
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ Border#Root">
+                    <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelectedPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ Rectangle#SelectionIndicator">
+                    <Setter Property="Fill" Value="{DynamicResource ListViewItemSelectionIndicatorPointerOverBrush}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ Border#Root">
+                    <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelectedPressed}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPressed}" />
+                </Style>
+                <Style Selector="^ /template/ Rectangle#SelectionIndicator">
+                    <Setter Property="Fill" Value="{DynamicResource ListViewItemSelectionIndicatorPressedBrush}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:disabled /template/ Rectangle#SelectionIndicator">
+                <Setter Property="Fill" Value="{DynamicResource ListViewItemSelectionIndicatorDisabledBrush}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="{x:Type local:OutputPickerFlyoutPresenter}" TargetType="local:OutputPickerFlyoutPresenter">
+        <Setter Property="Width" Value="240" />
+        <Setter Property="ShowHideButtons" Value="True" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Background" Value="{DynamicResource FlyoutPresenterBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderThemeBrush}" />
+        <Setter Property="BorderThickness" Value="{StaticResource FlyoutBorderThemeThickness}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Padding="{DynamicResource FlyoutBorderThemePadding}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Grid RowDefinitions="Auto,Auto,Auto">
+                        <Grid Name="DragArea"
+                              Height="40"
+                              VerticalAlignment="Top"
+                              Background="Transparent"
+                              ColumnDefinitions="*,Auto">
+                            <WrapPanel Name="TabLayout" Margin="4,4,0,4">
+                                <ToggleButton Name="ShowSearchBoxButton" IsChecked="{TemplateBinding ShowSearchBox, Mode=TwoWay}">
+                                    <ui:SymbolIcon Symbol="Find" />
+                                </ToggleButton>
+                                <ToggleButton Name="ProfilesTabButton"
+                                              IsChecked="{Binding !$parent[local:OutputPickerFlyoutPresenter].ShowPresets, Mode=OneWay}"
+                                              ToolTip.Tip="{x:Static lang:Strings.Profiles}">
+                                    <ui:SymbolIcon Symbol="Document" />
+                                </ToggleButton>
+                                <ToggleButton Name="PresetsTabButton"
+                                              IsChecked="{Binding $parent[local:OutputPickerFlyoutPresenter].ShowPresets, Mode=OneWay}"
+                                              ToolTip.Tip="{x:Static lang:Strings.Presets}">
+                                    <ui:SymbolIcon Symbol="Bookmark" />
+                                </ToggleButton>
+                            </WrapPanel>
+
+                            <Button Name="CloseButton"
+                                    Grid.Column="1"
+                                    Width="32"
+                                    Height="32"
+                                    Margin="4"
+                                    Padding="0"
+                                    HorizontalAlignment="Right"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    Theme="{StaticResource TransparentButton}">
+                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                            </Button>
+                        </Grid>
+
+                        <Border Grid.Row="2"
+                                BorderBrush="{DynamicResource PickerFlyoutPresenterDivider}"
+                                BorderThickness="0,1,0,0">
+
+                            <Panel Name="AcceptDismissContainer"
+                                   Height="{DynamicResource PickerAcceptDismissRegionHeight}"
+                                   IsVisible="False">
+                                <Grid ColumnDefinitions="*,*">
+                                    <Button Name="AcceptButton"
+                                            Margin="4,4,2,4"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Stretch"
+                                            Theme="{StaticResource FlyoutAcceptDismiss}">
+                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                    </Button>
+                                    <Button Name="DismissButton"
+                                            Grid.Column="1"
+                                            Margin="2,4,4,4"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Stretch"
+                                            Theme="{StaticResource FlyoutAcceptDismiss}">
+                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                    </Button>
+                                </Grid>
+
+                            </Panel>
+                        </Border>
+
+                        <StackPanel Grid.Row="1">
+                            <TextBox x:Name="SearchTextBox"
+                                     Margin="4,0,4,4"
+                                     Classes="clearButton"
+                                     IsVisible="False"
+                                     Text="{TemplateBinding SearchText, Mode=TwoWay}"
+                                     Watermark="{x:Static lang:Strings.Search}" />
+
+                            <ListBox x:Name="PART_ProfileListBox"
+                                     Height="250"
+                                     Margin="4,4,4,0"
+                                     ItemContainerTheme="{StaticResource OutputPicker_ListBoxItem}"
+                                     ItemsSource="{TemplateBinding ProfileItems}"
+                                     SelectedItem="{Binding $parent[local:OutputPickerFlyoutPresenter].SelectedProfile, Mode=TwoWay}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="local:PinnableOutputItem">
+                                        <TextBlock VerticalAlignment="Center"
+                                                   Text="{Binding DisplayName}"
+                                                   ToolTip.Tip="{Binding Description}" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <ListBox x:Name="PART_PresetListBox"
+                                     Height="250"
+                                     Margin="4,4,4,0"
+                                     IsVisible="False"
+                                     ItemContainerTheme="{StaticResource OutputPicker_ListBoxItem}"
+                                     ItemsSource="{TemplateBinding PresetItems}"
+                                     SelectedItem="{Binding $parent[local:OutputPickerFlyoutPresenter].SelectedPreset, Mode=TwoWay}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="local:PinnableOutputItem">
+                                        <TextBlock VerticalAlignment="Center"
+                                                   Text="{Binding DisplayName}"
+                                                   ToolTip.Tip="{Binding Description}" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:acceptdismiss /template/ Panel#AcceptDismissContainer">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+        <Style Selector="^:acceptdismiss /template/ Button#CloseButton">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+
+        <Style Selector="^:search-box /template/ TextBox#SearchTextBox">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
+        <!-- プリセットタブ表示時: プロファイルリスト非表示、プリセットリスト表示 -->
+        <Style Selector="^:show-presets /template/ ListBox#PART_ProfileListBox">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <Style Selector="^:show-presets /template/ ListBox#PART_PresetListBox">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
+        <Style Selector="^ /template/ WrapPanel#TabLayout">
+            <Style Selector="^ > ToggleButton">
+                <Setter Property="Width" Value="32" />
+                <Setter Property="Height" Value="32" />
+                <Setter Property="Margin" Value="0,0,4,0" />
+                <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
+
+                <Style Selector="^ > ui|FontIcon">
+                    <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
+                </Style>
+            </Style>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -976,4 +976,25 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="EnterTemplateName" xml:space="preserve">
     <value>テンプレート名を入力</value>
   </data>
+  <data name="Preset_YouTube_1080p60" xml:space="preserve">
+    <value>YouTube 1080p 60fps</value>
+  </data>
+  <data name="Preset_YouTube_4K60" xml:space="preserve">
+    <value>YouTube 4K 60fps</value>
+  </data>
+  <data name="Preset_Twitter_1080p" xml:space="preserve">
+    <value>Twitter (X) 1080p (最長 2:20)</value>
+  </data>
+  <data name="Preset_Instagram_Reels" xml:space="preserve">
+    <value>Instagram リール 9:16 (最長 90 秒)</value>
+  </data>
+  <data name="Preset_Instagram_Feed" xml:space="preserve">
+    <value>Instagram フィード 1:1</value>
+  </data>
+  <data name="Preset_TikTok" xml:space="preserve">
+    <value>TikTok 縦動画 9:16</value>
+  </data>
+  <data name="Preset_Discord_8MB" xml:space="preserve">
+    <value>Discord 8MB 制限 (約 10 分)</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -995,6 +995,6 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
     <value>TikTok 縦動画 9:16</value>
   </data>
   <data name="Preset_Discord_8MB" xml:space="preserve">
-    <value>Discord 8MB 制限 (約 10 分)</value>
+    <value>Discord 8MB 制限 (約 1 分)</value>
   </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -982,4 +982,25 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="EnterTemplateName" xml:space="preserve">
     <value>Enter template name</value>
   </data>
+  <data name="Preset_YouTube_1080p60" xml:space="preserve">
+    <value>YouTube 1080p 60fps</value>
+  </data>
+  <data name="Preset_YouTube_4K60" xml:space="preserve">
+    <value>YouTube 4K 60fps</value>
+  </data>
+  <data name="Preset_Twitter_1080p" xml:space="preserve">
+    <value>Twitter (X) 1080p (max 2:20)</value>
+  </data>
+  <data name="Preset_Instagram_Reels" xml:space="preserve">
+    <value>Instagram Reels 9:16 (max 90s)</value>
+  </data>
+  <data name="Preset_Instagram_Feed" xml:space="preserve">
+    <value>Instagram Feed 1:1</value>
+  </data>
+  <data name="Preset_TikTok" xml:space="preserve">
+    <value>TikTok 9:16</value>
+  </data>
+  <data name="Preset_Discord_8MB" xml:space="preserve">
+    <value>Discord 8MB (~10 min)</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1001,6 +1001,6 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
     <value>TikTok 9:16</value>
   </data>
   <data name="Preset_Discord_8MB" xml:space="preserve">
-    <value>Discord 8MB (~10 min)</value>
+    <value>Discord 8MB (~1 min)</value>
   </data>
 </root>

--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -184,6 +184,10 @@ public sealed class OutputPresetService
             {
                 CreateDefaultPresets();
             }
+            else
+            {
+                AddPlatformPresets();
+            }
         }
     }
 
@@ -433,6 +437,11 @@ public sealed class OutputPresetService
         string level,
         int audioSampleRate = 48000)
     {
+        if (_items.Any(i => i.Name.Value == name))
+        {
+            return;
+        }
+
         CodecRecord videoCodec = VideoCodecChoicesProvider.GetChoices()
             .Cast<CodecRecord>()
             .FirstOrDefault(i => i.Name == "libx264") ?? CodecRecord.Default;

--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -3,7 +3,9 @@ using System.Text.Json.Nodes;
 using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.FFmpegIpc;
 using Beutl.Helpers;
+using Beutl.Language;
 using Beutl.Logging;
+using Beutl.Media;
 using Beutl.Serialization;
 using Beutl.Services.PrimitiveImpls;
 using Microsoft.Extensions.Logging;
@@ -334,5 +336,149 @@ public sealed class OutputPresetService
                 ["AudioSettings"] = CoreSerializer.SerializeToJsonObject(aud)
             },
             "HLG"));
+
+        AddPlatformPresets();
+    }
+
+    private void AddPlatformPresets()
+    {
+        AddH264Preset(
+            Strings.Preset_YouTube_1080p60,
+            new PixelSize(1920, 1080),
+            new Rational(60, 1),
+            videoBitrate: 12_000_000,
+            audioBitrate: 192_000,
+            preset: "slow",
+            crf: "20",
+            profile: "high",
+            level: "4.2");
+
+        AddH264Preset(
+            Strings.Preset_YouTube_4K60,
+            new PixelSize(3840, 2160),
+            new Rational(60, 1),
+            videoBitrate: 45_000_000,
+            audioBitrate: 192_000,
+            preset: "slow",
+            crf: "20",
+            profile: "high",
+            level: "5.1");
+
+        AddH264Preset(
+            Strings.Preset_Twitter_1080p,
+            new PixelSize(1920, 1080),
+            new Rational(30, 1),
+            videoBitrate: 25_000_000,
+            audioBitrate: 128_000,
+            preset: "medium",
+            crf: "21",
+            profile: "high",
+            level: "4.0");
+
+        AddH264Preset(
+            Strings.Preset_Instagram_Reels,
+            new PixelSize(1080, 1920),
+            new Rational(30, 1),
+            videoBitrate: 5_000_000,
+            audioBitrate: 128_000,
+            preset: "medium",
+            crf: "23",
+            profile: "high",
+            level: "4.0");
+
+        AddH264Preset(
+            Strings.Preset_Instagram_Feed,
+            new PixelSize(1080, 1080),
+            new Rational(30, 1),
+            videoBitrate: 3_500_000,
+            audioBitrate: 128_000,
+            preset: "medium",
+            crf: "23",
+            profile: "high",
+            level: "4.0");
+
+        AddH264Preset(
+            Strings.Preset_TikTok,
+            new PixelSize(1080, 1920),
+            new Rational(30, 1),
+            videoBitrate: 6_000_000,
+            audioBitrate: 128_000,
+            preset: "medium",
+            crf: "23",
+            profile: "high",
+            level: "4.0");
+
+        AddH264Preset(
+            Strings.Preset_Discord_8MB,
+            new PixelSize(720, 480),
+            new Rational(30, 1),
+            videoBitrate: 800_000,
+            audioBitrate: 64_000,
+            preset: "medium",
+            crf: "30",
+            profile: "main",
+            level: "3.1",
+            audioSampleRate: 44100);
+    }
+
+    private void AddH264Preset(
+        string name,
+        PixelSize destinationSize,
+        Rational frameRate,
+        int videoBitrate,
+        int audioBitrate,
+        string preset,
+        string crf,
+        string profile,
+        string level,
+        int audioSampleRate = 48000)
+    {
+        CodecRecord videoCodec = VideoCodecChoicesProvider.GetChoices()
+            .Cast<CodecRecord>()
+            .FirstOrDefault(i => i.Name == "libx264") ?? CodecRecord.Default;
+        CodecRecord audioCodec = AudioCodecChoicesProvider.GetChoices()
+            .Cast<CodecRecord>()
+            .FirstOrDefault(i => i.Name == "aac") ?? CodecRecord.Default;
+
+        if (videoCodec == CodecRecord.Default || audioCodec == CodecRecord.Default)
+        {
+            return;
+        }
+
+        var vid = new FFmpegVideoEncoderSettings
+        {
+            Format = FFPixelFormat.YUV420P,
+            Bitrate = videoBitrate,
+            KeyframeRate = (int)Math.Round((double)frameRate.Numerator / Math.Max(1, frameRate.Denominator) * 2),
+            Codec = videoCodec,
+            SourceSize = destinationSize,
+            DestinationSize = destinationSize,
+            FrameRate = frameRate
+        };
+        vid.Options.Clear();
+        vid.Options.AddRange(
+        [
+            new AdditionalOption("preset", preset),
+            new AdditionalOption("crf", crf),
+            new AdditionalOption("profile", profile),
+            new AdditionalOption("level", level),
+        ]);
+
+        var aud = new FFmpegAudioEncoderSettings
+        {
+            Bitrate = audioBitrate,
+            SampleRate = audioSampleRate,
+            Codec = audioCodec
+        };
+
+        _items.Add(new OutputPresetItem(
+            SceneOutputExtension.Instance,
+            new JsonObject
+            {
+                ["SelectedEncoder"] = TypeFormat.ToString(typeof(FFmpegControlledEncodingExtension)),
+                ["VideoSettings"] = CoreSerializer.SerializeToJsonObject(vid),
+                ["AudioSettings"] = CoreSerializer.SerializeToJsonObject(aud)
+            },
+            name));
     }
 }

--- a/src/Beutl/ViewModels/Tools/OutputPickerViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputPickerViewModel.cs
@@ -1,0 +1,199 @@
+﻿using System.Collections.Specialized;
+using System.Reactive.Linq;
+using System.Text.Json;
+using Beutl.Collections;
+using Beutl.Configuration;
+using Beutl.Controls.PropertyEditors;
+using Beutl.Services;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
+
+namespace Beutl.ViewModels.Tools;
+
+public sealed class OutputPickerViewModel : IDisposable
+{
+    private const string PinnedProfilesKey = "OutputPicker.PinnedProfiles";
+    private const string PinnedPresetsKey = "OutputPicker.PinnedPresets";
+
+    private readonly ICoreList<OutputProfileItem> _profileSource;
+    private readonly ICoreList<OutputPresetItem> _presetSource;
+    private readonly HashSet<string> _pinnedProfiles;
+    private readonly HashSet<string> _pinnedPresets;
+    private readonly IDisposable _searchSubscription;
+
+    public OutputPickerViewModel(
+        ICoreList<OutputProfileItem> profileSource,
+        ICoreList<OutputPresetItem> presetSource)
+    {
+        _profileSource = profileSource;
+        _presetSource = presetSource;
+
+        _pinnedProfiles = LoadPinned(PinnedProfilesKey);
+        _pinnedPresets = LoadPinned(PinnedPresetsKey);
+
+        _profileSource.CollectionChanged += OnProfileSourceChanged;
+        _presetSource.CollectionChanged += OnPresetSourceChanged;
+
+        _searchSubscription = SearchText
+            .Skip(1)
+            .Throttle(TimeSpan.FromMilliseconds(100))
+            .ObserveOnUIDispatcher()
+            .Subscribe(_ =>
+            {
+                RebuildProfiles();
+                RebuildPresets();
+            });
+
+        RebuildProfiles();
+        RebuildPresets();
+    }
+
+    public ReactiveCollection<PinnableOutputItem> ProfileItems { get; } = [];
+
+    public ReactiveCollection<PinnableOutputItem> PresetItems { get; } = [];
+
+    public ReactiveProperty<PinnableOutputItem?> SelectedProfile { get; } = new();
+
+    public ReactiveProperty<PinnableOutputItem?> SelectedPreset { get; } = new();
+
+    public ReactiveProperty<bool> ShowPresets { get; } = new(true);
+
+    public ReactiveProperty<string?> SearchText { get; } = new();
+
+    public void SetInitialSelection(OutputProfileItem? currentProfile)
+    {
+        if (currentProfile == null) return;
+        SelectedProfile.Value = ProfileItems.FirstOrDefault(i => ReferenceEquals(i.UserData, currentProfile));
+    }
+
+    public void Pin(PinnableOutputItem item)
+    {
+        switch (item.UserData)
+        {
+            case OutputProfileItem profile:
+                _pinnedProfiles.Add(profile.Context.Name.Value);
+                Save(PinnedProfilesKey, _pinnedProfiles);
+                RebuildProfiles();
+                break;
+            case OutputPresetItem preset:
+                _pinnedPresets.Add(preset.Name.Value);
+                Save(PinnedPresetsKey, _pinnedPresets);
+                RebuildPresets();
+                break;
+        }
+    }
+
+    public void Unpin(PinnableOutputItem item)
+    {
+        switch (item.UserData)
+        {
+            case OutputProfileItem profile:
+                _pinnedProfiles.Remove(profile.Context.Name.Value);
+                Save(PinnedProfilesKey, _pinnedProfiles);
+                RebuildProfiles();
+                break;
+            case OutputPresetItem preset:
+                _pinnedPresets.Remove(preset.Name.Value);
+                Save(PinnedPresetsKey, _pinnedPresets);
+                RebuildPresets();
+                break;
+        }
+    }
+
+    public void Dispose()
+    {
+        _profileSource.CollectionChanged -= OnProfileSourceChanged;
+        _presetSource.CollectionChanged -= OnPresetSourceChanged;
+        _searchSubscription.Dispose();
+    }
+
+    private void OnProfileSourceChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildProfiles();
+
+    private void OnPresetSourceChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildPresets();
+
+    private void RebuildProfiles()
+    {
+        var selected = SelectedProfile.Value?.UserData;
+        ProfileItems.ClearOnScheduler();
+
+        IEnumerable<PinnableOutputItem> items = _profileSource
+            .Select(p => new PinnableOutputItem(
+                p.Context.Name.Value,
+                _pinnedProfiles.Contains(p.Context.Name.Value),
+                p));
+
+        items = ApplyFilterAndSort(items);
+
+        foreach (var item in items)
+        {
+            ProfileItems.Add(item);
+            if (selected != null && ReferenceEquals(item.UserData, selected))
+            {
+                SelectedProfile.Value = item;
+            }
+        }
+    }
+
+    private void RebuildPresets()
+    {
+        var selected = SelectedPreset.Value?.UserData;
+        PresetItems.ClearOnScheduler();
+
+        IEnumerable<PinnableOutputItem> items = _presetSource
+            .Select(p => new PinnableOutputItem(
+                p.Name.Value,
+                _pinnedPresets.Contains(p.Name.Value),
+                p));
+
+        items = ApplyFilterAndSort(items);
+
+        foreach (var item in items)
+        {
+            PresetItems.Add(item);
+            if (selected != null && ReferenceEquals(item.UserData, selected))
+            {
+                SelectedPreset.Value = item;
+            }
+        }
+    }
+
+    private IEnumerable<PinnableOutputItem> ApplyFilterAndSort(IEnumerable<PinnableOutputItem> items)
+    {
+        if (!string.IsNullOrWhiteSpace(SearchText.Value))
+        {
+            string[] segments = SearchText.Value.Split(' ')
+                .Select(s => s.Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToArray();
+
+            items = items.Where(item =>
+                segments.All(s => item.DisplayName.Contains(s, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return items
+            .OrderByDescending(i => i.IsPinned)
+            .ThenBy(i => i.DisplayName, StringComparer.CurrentCultureIgnoreCase);
+    }
+
+    private static HashSet<string> LoadPinned(string key)
+    {
+        try
+        {
+            string json = Preferences.Default.Get(key, "[]");
+            string[]? names = JsonSerializer.Deserialize<string[]>(json);
+            return names == null
+                ? new HashSet<string>(StringComparer.Ordinal)
+                : new HashSet<string>(names, StringComparer.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    private static void Save(string key, HashSet<string> set)
+    {
+        string json = JsonSerializer.Serialize(set.ToArray());
+        Preferences.Default.Set(key, json);
+    }
+}

--- a/src/Beutl/Views/Tools/OutputPickerFlyout.cs
+++ b/src/Beutl/Views/Tools/OutputPickerFlyout.cs
@@ -1,0 +1,109 @@
+﻿using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Beutl.Controls.PropertyEditors;
+using Beutl.ViewModels.Tools;
+using FluentAvalonia.Core;
+using FluentAvalonia.UI.Controls.Primitives;
+
+namespace Beutl.Views.Tools;
+
+public sealed class OutputPickerFlyout(OutputPickerViewModel viewModel) : PickerFlyoutBase
+{
+    public event TypedEventHandler<OutputPickerFlyout, EventArgs>? Confirmed;
+
+    public event TypedEventHandler<OutputPickerFlyout, EventArgs>? Dismissed;
+
+    public event TypedEventHandler<OutputPickerFlyout, PinnableOutputItem>? Pinned;
+
+    public event TypedEventHandler<OutputPickerFlyout, PinnableOutputItem>? Unpinned;
+
+    public event TypedEventHandler<OutputPickerFlyout, MoreMenuRequestedArgs>? MoreMenuRequested;
+
+    public OutputPickerViewModel ViewModel { get; } = viewModel;
+
+    protected override Control CreatePresenter()
+    {
+        var pfp = new OutputPickerFlyoutPresenter();
+        pfp.CloseClicked += OnFlyoutDismissed;
+        pfp.Confirmed += OnFlyoutConfirmed;
+        pfp.Dismissed += OnFlyoutDismissed;
+        pfp.Pinned += item =>
+        {
+            ViewModel.Pin(item);
+            Pinned?.Invoke(this, item);
+        };
+        pfp.Unpinned += item =>
+        {
+            ViewModel.Unpin(item);
+            Unpinned?.Invoke(this, item);
+        };
+        pfp.MoreMenuRequested += (item, anchor) =>
+            MoreMenuRequested?.Invoke(this, new MoreMenuRequestedArgs(item, anchor));
+
+        pfp.ProfileItems = ViewModel.ProfileItems;
+        pfp.PresetItems = ViewModel.PresetItems;
+        pfp.ShowPresets = ViewModel.ShowPresets.Value;
+
+        pfp.GetObservable(OutputPickerFlyoutPresenter.SelectedProfileProperty)
+            .Subscribe(v => ViewModel.SelectedProfile.Value = v);
+        pfp.GetObservable(OutputPickerFlyoutPresenter.SelectedPresetProperty)
+            .Subscribe(v => ViewModel.SelectedPreset.Value = v);
+        pfp.GetObservable(OutputPickerFlyoutPresenter.SearchTextProperty)
+            .Subscribe(v => ViewModel.SearchText.Value = v);
+        pfp.GetObservable(OutputPickerFlyoutPresenter.ShowPresetsProperty)
+            .Subscribe(v => ViewModel.ShowPresets.Value = v);
+
+        pfp.KeyDown += (_, e) =>
+        {
+            switch (e.Key)
+            {
+                case Key.Enter:
+                    OnConfirmed();
+                    break;
+                case Key.Escape:
+                    Dismissed?.Invoke(this, EventArgs.Empty);
+                    Hide();
+                    break;
+            }
+        };
+        return pfp;
+    }
+
+    protected override void OnOpened()
+    {
+        base.OnOpened();
+        if (Popup.Child is OutputPickerFlyoutPresenter pfp)
+        {
+            pfp.FocusInitialElement();
+        }
+    }
+
+    private void OnFlyoutDismissed(DraggablePickerFlyoutPresenter sender, object args)
+    {
+        Dismissed?.Invoke(this, EventArgs.Empty);
+        Hide();
+    }
+
+    private void OnFlyoutConfirmed(DraggablePickerFlyoutPresenter sender, object args)
+    {
+        OnConfirmed();
+    }
+
+    protected override void OnConfirmed()
+    {
+        Confirmed?.Invoke(this, EventArgs.Empty);
+        Hide();
+    }
+
+    protected override void OnOpening(CancelEventArgs args)
+    {
+        base.OnOpening(args);
+        Popup.IsLightDismissEnabled = false;
+    }
+
+    protected override bool ShouldShowConfirmationButtons() => true;
+}
+
+public sealed record MoreMenuRequestedArgs(PinnableOutputItem Item, Control Anchor);

--- a/src/Beutl/Views/Tools/OutputTab.axaml
+++ b/src/Beutl/Views/Tools/OutputTab.axaml
@@ -1,11 +1,9 @@
 <UserControl x:Class="Beutl.Views.Tools.OutputTab"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:Beutl.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:services="using:Beutl.Services"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModels="using:Beutl.ViewModels.Tools"
              Name="Root"
@@ -14,97 +12,6 @@
              x:CompileBindings="True"
              x:DataType="viewModels:OutputTabViewModel"
              mc:Ignorable="d">
-    <UserControl.Resources>
-        <DataTemplate x:Key="OutputProfilesItemTemplate" x:DataType="services:OutputProfileItem">
-            <ComboBoxItem>
-                <ComboBoxItem.IsSelected>
-                    <MultiBinding Converter="{x:Static converters:EqualAllConverter.Instance}" Mode="OneWay">
-                        <Binding FallbackValue="{x:Null}"
-                                 Mode="OneWay"
-                                 Path="#Root.((viewModels:OutputTabViewModel)DataContext).SelectedItem.Value" />
-                        <Binding Path="." />
-                    </MultiBinding>
-                </ComboBoxItem.IsSelected>
-                <ComboBoxItem.Styles>
-                    <Style Selector="ComboBoxItem Button#ItemMoreButton">
-                        <Setter Property="Opacity" Value="0" />
-                    </Style>
-                    <Style Selector="ComboBoxItem:pointerover Button#ItemMoreButton">
-                        <Setter Property="Opacity" Value="1" />
-                    </Style>
-                </ComboBoxItem.Styles>
-                <Interaction.Behaviors>
-                    <EventTriggerBehavior EventName="Tapped">
-                        <CallMethodAction MethodName="OnProfileItemClick" TargetObject="Root" />
-                    </EventTriggerBehavior>
-                </Interaction.Behaviors>
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock VerticalAlignment="Center" Text="{Binding Context.Name.Value}" />
-                    <Button Name="ItemMoreButton"
-                            Grid.Column="1"
-                            Margin="0,0,-6,0"
-                            Padding="4"
-                            Theme="{StaticResource TransparentButton}">
-                        <Button.Flyout>
-                            <ui:FAMenuFlyout>
-                                <ui:MenuFlyoutItem Click="OnRemoveClick"
-                                                   CommandParameter="{Binding}"
-                                                   IconSource="Delete"
-                                                   Text="{x:Static lang:Strings.Remove}" />
-                                <ui:MenuFlyoutItem Click="OnRenameClick"
-                                                   CommandParameter="{Binding}"
-                                                   Tag="{Binding #ItemMoreButton}"
-                                                   Text="{x:Static lang:Strings.Rename}" />
-                                <ui:MenuFlyoutItem Click="OnConvertPresetClick"
-                                                   CommandParameter="{Binding}"
-                                                   Text="{x:Static lang:Strings.Convert_to_preset}" />
-                            </ui:FAMenuFlyout>
-                        </Button.Flyout>
-                        <ui:SymbolIcon Symbol="MoreVertical" />
-                    </Button>
-                </Grid>
-            </ComboBoxItem>
-        </DataTemplate>
-        <DataTemplate x:Key="OutputPresetsItemTemplate" x:DataType="services:OutputPresetItem">
-            <ComboBoxItem IsSelected="False">
-                <ComboBoxItem.Styles>
-                    <Style Selector="ComboBoxItem Button#ItemMoreButton">
-                        <Setter Property="Opacity" Value="0" />
-                    </Style>
-                    <Style Selector="ComboBoxItem:pointerover Button#ItemMoreButton">
-                        <Setter Property="Opacity" Value="1" />
-                    </Style>
-                </ComboBoxItem.Styles>
-                <Interaction.Behaviors>
-                    <EventTriggerBehavior EventName="Tapped">
-                        <CallMethodAction MethodName="OnPresetItemClick" TargetObject="Root" />
-                    </EventTriggerBehavior>
-                </Interaction.Behaviors>
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock VerticalAlignment="Center" Text="{Binding Name.Value}" />
-                    <Button Name="ItemMoreButton"
-                            Grid.Column="1"
-                            Margin="0,0,-6,0"
-                            Padding="4"
-                            Theme="{StaticResource TransparentButton}">
-                        <Button.Flyout>
-                            <ui:FAMenuFlyout>
-                                <ui:MenuFlyoutItem Click="OnRemoveClick"
-                                                   CommandParameter="{Binding}"
-                                                   IconSource="Delete"
-                                                   Text="{x:Static lang:Strings.Remove}" />
-                                <ui:MenuFlyoutItem Click="OnRenameClick"
-                                                   CommandParameter="{Binding}"
-                                                   Tag="{Binding #ItemMoreButton}"
-                                                   Text="{x:Static lang:Strings.Rename}" />
-                            </ui:FAMenuFlyout>
-                        </Button.Flyout>
-                        <ui:SymbolIcon Symbol="MoreVertical" />
-                    </Button>
-                </Grid>
-            </ComboBoxItem>
-        </DataTemplate>
-    </UserControl.Resources>
     <ScrollViewer>
         <StackPanel>
             <Grid Margin="4" ColumnDefinitions="*,4,Auto,4,Auto">
@@ -113,33 +20,6 @@
                                 Click="OnProfilesButtonClick">
                     <TextBlock Text="{Binding SelectedItem.Value.Context.Name.Value}" />
                 </DropDownButton>
-                <Popup Name="ProfilesPopup"
-                       MinWidth="{Binding #ProfilesButton.Bounds.Width}"
-                       InheritsTransform="True"
-                       IsLightDismissEnabled="True"
-                       PlacementTarget="ProfilesButton"
-                       WindowManagerAddShadowHint="False">
-                    <Border Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                            HorizontalAlignment="Stretch"
-                            Background="{DynamicResource ComboBoxDropDownBackground}"
-                            BackgroundSizing="InnerBorderEdge"
-                            BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                            BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                            CornerRadius="{DynamicResource OverlayCornerRadius}">
-                        <ScrollViewer>
-                            <StackPanel Margin="{DynamicResource ComboBoxDropdownContentMargin}">
-                                <TextBlock Margin="4"
-                                           Text="{x:Static lang:Strings.Profiles}"
-                                           Theme="{StaticResource CaptionTextBlockStyle}" />
-                                <ItemsControl ItemTemplate="{StaticResource OutputProfilesItemTemplate}" ItemsSource="{Binding Items}" />
-                                <TextBlock Margin="4"
-                                           Text="{x:Static lang:Strings.Presets}"
-                                           Theme="{StaticResource CaptionTextBlockStyle}" />
-                                <ItemsControl ItemTemplate="{StaticResource OutputPresetsItemTemplate}" ItemsSource="{Binding PresetItems}" />
-                            </StackPanel>
-                        </ScrollViewer>
-                    </Border>
-                </Popup>
 
                 <Button Grid.Column="2"
                         Padding="8"

--- a/src/Beutl/Views/Tools/OutputTab.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputTab.axaml.cs
@@ -1,13 +1,15 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.LogicalTree;
 using Beutl.Controls;
+using Beutl.Controls.PropertyEditors;
 using Beutl.Services;
 using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Tools;
+using FluentAvalonia.UI.Controls;
 using AddOutputProfileDialog = Beutl.Views.Dialogs.AddOutputProfileDialog;
 
 namespace Beutl.Views.Tools;
@@ -15,6 +17,7 @@ namespace Beutl.Views.Tools;
 public partial class OutputTab : UserControl
 {
     private readonly IDataTemplate _sharedDataTemplate = new _DataTemplate();
+    private OutputPickerFlyout? _activeFlyout;
 
     public OutputTab()
     {
@@ -45,16 +48,10 @@ public partial class OutputTab : UserControl
     private void OnRemoveClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not OutputTabViewModel viewModel) return;
-        switch (sender)
+        if (sender is ICommandSource { CommandParameter: OutputProfileItem item })
         {
-            case ICommandSource { CommandParameter: OutputProfileItem item }:
-                viewModel.RemoveItem(item);
-                viewModel.Save();
-                break;
-            case ICommandSource { CommandParameter: OutputPresetItem presetItem }:
-                OutputPresetService.Instance.Items.Remove(presetItem);
-                OutputPresetService.Instance.SaveItems();
-                break;
+            viewModel.RemoveItem(item);
+            viewModel.Save();
         }
     }
 
@@ -69,28 +66,15 @@ public partial class OutputTab : UserControl
     private void OnRenameClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not OutputTabViewModel viewModel) return;
-        OutputProfileItem? item = (sender as ICommandSource)?.CommandParameter as OutputProfileItem;
-        OutputPresetItem? presetItem = (sender as ICommandSource)?.CommandParameter as OutputPresetItem;
-        if (item == null && presetItem == null) return;
-        var target = (sender as Control)?.Tag as Control ?? MoreButton;
+        if ((sender as ICommandSource)?.CommandParameter is not OutputProfileItem item) return;
 
-        var flyout = new RenameFlyout { Text = item?.Context.Name.Value ?? presetItem?.Name.Value };
-
+        var flyout = new RenameFlyout { Text = item.Context.Name.Value };
         flyout.Confirmed += (_, text) =>
         {
-            if (item != null)
-            {
-                item.Context.Name.Value = text ?? "";
-                viewModel.Save();
-            }
-            else if (presetItem != null)
-            {
-                presetItem.Name.Value = text ?? "";
-                OutputPresetService.Instance.SaveItems();
-            }
+            item.Context.Name.Value = text ?? "";
+            viewModel.Save();
         };
-
-        flyout.ShowAt(target);
+        flyout.ShowAt(MoreButton);
     }
 
     private sealed class _DataTemplate : IDataTemplate
@@ -125,28 +109,133 @@ public partial class OutputTab : UserControl
 
     private void OnProfilesButtonClick(object? sender, RoutedEventArgs e)
     {
-        ProfilesPopup.IsOpen = !ProfilesPopup.IsOpen;
-    }
-
-    public void OnProfileItemClick(object? sender, TappedEventArgs e)
-    {
-        if ((e.Source as StyledElement)?.GetSelfAndLogicalAncestors().Any(i => i is Button) == true) return;
-        if (e.Source is not StyledElement { DataContext: OutputProfileItem item }) return;
         if (DataContext is not OutputTabViewModel viewModel) return;
 
-        viewModel.SelectedItem.Value = item;
-        ProfilesPopup.IsOpen = false;
+        var pickerVm = new OutputPickerViewModel(viewModel.Items, viewModel.PresetItems);
+        pickerVm.SetInitialSelection(viewModel.SelectedItem.Value);
+
+        var flyout = new OutputPickerFlyout(pickerVm);
+        _activeFlyout = flyout;
+        flyout.Confirmed += OnPickerConfirmed;
+        flyout.Dismissed += OnPickerDismissed;
+        flyout.MoreMenuRequested += OnPickerMoreMenuRequested;
+        flyout.Closed += (_, _) =>
+        {
+            flyout.Confirmed -= OnPickerConfirmed;
+            flyout.Dismissed -= OnPickerDismissed;
+            flyout.MoreMenuRequested -= OnPickerMoreMenuRequested;
+            pickerVm.Dispose();
+            if (ReferenceEquals(_activeFlyout, flyout)) _activeFlyout = null;
+        };
+
+        flyout.ShowAt(ProfilesButton, true);
     }
 
-    public void OnPresetItemClick(object? sender, TappedEventArgs e)
+    private void OnPickerConfirmed(OutputPickerFlyout sender, EventArgs e)
     {
-        if ((e.Source as StyledElement)?.GetSelfAndLogicalAncestors().Any(i => i is Button) == true) return;
-        if (e.Source is not StyledElement { DataContext: OutputPresetItem item }) return;
         if (DataContext is not OutputTabViewModel viewModel) return;
 
-        if (viewModel.SelectedItem.Value?.Context is ISupportOutputPreset supportPreset)
-            item.Apply(supportPreset);
+        if (sender.ViewModel.ShowPresets.Value)
+        {
+            if (sender.ViewModel.SelectedPreset.Value?.UserData is OutputPresetItem preset
+                && viewModel.SelectedItem.Value?.Context is ISupportOutputPreset supportPreset
+                && preset.Extension.GetType() == ((IOutputContext)supportPreset).Extension.GetType())
+            {
+                preset.Apply(supportPreset);
+            }
+        }
+        else
+        {
+            if (sender.ViewModel.SelectedProfile.Value?.UserData is OutputProfileItem profile)
+            {
+                viewModel.SelectedItem.Value = profile;
+            }
+        }
+    }
 
-        ProfilesPopup.IsOpen = false;
+    private void OnPickerDismissed(OutputPickerFlyout sender, EventArgs e)
+    {
+    }
+
+    private void OnPickerMoreMenuRequested(OutputPickerFlyout sender, MoreMenuRequestedArgs args)
+    {
+        if (DataContext is not OutputTabViewModel viewModel) return;
+
+        var menu = new FAMenuFlyout();
+
+        switch (args.Item.UserData)
+        {
+            case OutputProfileItem profile:
+                {
+                    var removeItem = new MenuFlyoutItem
+                    {
+                        Text = Language.Strings.Remove,
+                        IconSource = new SymbolIconSource { Symbol = Symbol.Delete }
+                    };
+                    removeItem.Click += (_, _) =>
+                    {
+                        viewModel.RemoveItem(profile);
+                        viewModel.Save();
+                    };
+                    menu.Items.Add(removeItem);
+
+                    var renameItem = new MenuFlyoutItem { Text = Language.Strings.Rename };
+                    renameItem.Click += (_, _) => ShowRenameFlyout(profile, args.Anchor);
+                    menu.Items.Add(renameItem);
+
+                    var convertItem = new MenuFlyoutItem { Text = Language.Strings.Convert_to_preset };
+                    convertItem.Click += (_, _) =>
+                    {
+                        OutputPresetService.Instance.AddItem(profile.Context, $"{profile.Context.Name.Value} (Preset)");
+                        OutputPresetService.Instance.SaveItems();
+                    };
+                    menu.Items.Add(convertItem);
+                    break;
+                }
+            case OutputPresetItem preset:
+                {
+                    var removeItem = new MenuFlyoutItem
+                    {
+                        Text = Language.Strings.Remove,
+                        IconSource = new SymbolIconSource { Symbol = Symbol.Delete }
+                    };
+                    removeItem.Click += (_, _) =>
+                    {
+                        OutputPresetService.Instance.Items.Remove(preset);
+                        OutputPresetService.Instance.SaveItems();
+                    };
+                    menu.Items.Add(removeItem);
+
+                    var renameItem = new MenuFlyoutItem { Text = Language.Strings.Rename };
+                    renameItem.Click += (_, _) => ShowRenameFlyout(preset, args.Anchor);
+                    menu.Items.Add(renameItem);
+                    break;
+                }
+        }
+
+        menu.ShowAt(args.Anchor);
+    }
+
+    private void ShowRenameFlyout(object target, Control anchor)
+    {
+        if (DataContext is not OutputTabViewModel viewModel) return;
+
+        var profile = target as OutputProfileItem;
+        var preset = target as OutputPresetItem;
+        var flyout = new RenameFlyout { Text = profile?.Context.Name.Value ?? preset?.Name.Value };
+        flyout.Confirmed += (_, text) =>
+        {
+            if (profile != null)
+            {
+                profile.Context.Name.Value = text ?? "";
+                viewModel.Save();
+            }
+            else if (preset != null)
+            {
+                preset.Name.Value = text ?? "";
+                OutputPresetService.Instance.SaveItems();
+            }
+        };
+        flyout.ShowAt(anchor);
     }
 }


### PR DESCRIPTION
## Description

### Platform export presets

- Add seven H.264/AAC output presets tuned for popular delivery targets so users can export to common platforms without manually tuning bitrate, resolution, or codec options.
- Cover YouTube 1080p60 / 4K60, X (Twitter) 1080p, Instagram Reels (9:16) and Feed (1:1), TikTok (9:16), and a Discord 8 MB free-tier preset.
- Introduce a shared `AddH264Preset` helper in `OutputPresetService` and add localized preset display names (en/ja) under `Beutl.Language`.

### Output picker UI redesign

- Replace the simple `DropDownButton` + `Popup` in the Output tool tab with a 240 px draggable flyout modeled on `LibraryItemPicker`, so the growing list of platform presets stays browsable.
- Profiles and presets are split into separate tabs (presets shown by default), with a search box (Ctrl+F or the find toggle), keyboard navigation (↑↓ / Enter / Esc / Tab), and per-row pin and more menu buttons.
- Pinned profiles and presets are persisted to `Preferences` (`OutputPicker.PinnedProfiles` / `OutputPicker.PinnedPresets`) and float to the top of each list, making favorite platform presets one click away.
- New components: `OutputPickerFlyoutPresenter` (+ theme), `OutputPickerFlyout`, `OutputPickerViewModel`, and the supporting pin/more behaviors.

## Breaking changes

None

## Fixed issues

None