### PR TITLE
feat: Add audio Compressor effect

### DIFF
--- a/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;

--- a/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Language;
+
+namespace Beutl.Audio.Effects;
+
+[Display(Name = nameof(AudioStrings.CompressorEffect), ResourceType = typeof(AudioStrings))]
+public sealed partial class CompressorEffect : AudioEffect
+{
+    public CompressorEffect()
+    {
+        ScanProperties<CompressorEffect>();
+    }
+
+    [Range(-60f, 0f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Threshold), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(-20f);
+
+    [Range(1f, 20f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Ratio), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Ratio { get; } = Property.CreateAnimatable(4f);
+
+    [Range(0.1f, 500f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Attack), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Attack { get; } = Property.CreateAnimatable(10f);
+
+    [Range(1f, 5000f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Release), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Release { get; } = Property.CreateAnimatable(100f);
+
+    [Range(0f, 24f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Knee), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Knee { get; } = Property.CreateAnimatable(6f);
+
+    [Range(-24f, 24f)]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(0f);
+
+    public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
+    {
+        var compressorNode = context.AddNode(new CompressorNode
+        {
+            Threshold = Threshold,
+            Ratio = Ratio,
+            Attack = Attack,
+            Release = Release,
+            Knee = Knee,
+            MakeupGain = MakeupGain
+        });
+
+        context.Connect(inputNode, compressorNode);
+        return compressorNode;
+    }
+}

--- a/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
@@ -17,33 +17,39 @@ public sealed partial class CompressorEffect : AudioEffect
     }
 
     [Range(MinThresholdDb, MaxThresholdDb)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_Threshold), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Threshold), Description = nameof(AudioStrings.CompressorEffect_Threshold_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
     public IProperty<float> Threshold { get; } = Property.CreateAnimatable(DefaultThresholdDb);
 
     [Range(MinRatio, MaxRatio)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_Ratio), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Ratio), Description = nameof(AudioStrings.CompressorEffect_Ratio_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(1, 0.1)]
     public IProperty<float> Ratio { get; } = Property.CreateAnimatable(DefaultRatio);
 
     [Range(MinAttackMs, MaxAttackMs)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_Attack), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Attack), Description = nameof(AudioStrings.CompressorEffect_Attack_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
     public IProperty<float> Attack { get; } = Property.CreateAnimatable(DefaultAttackMs);
 
     [Range(MinReleaseMs, MaxReleaseMs)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_Release), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Release), Description = nameof(AudioStrings.CompressorEffect_Release_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(100, 10)]
     public IProperty<float> Release { get; } = Property.CreateAnimatable(DefaultReleaseMs);
 
     [Range(MinKneeDb, MaxKneeDb)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_Knee), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_Knee), Description = nameof(AudioStrings.CompressorEffect_Knee_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(1, 0.1)]
     public IProperty<float> Knee { get; } = Property.CreateAnimatable(DefaultKneeDb);
 
     [Range(MinMakeupGainDb, MaxMakeupGainDb)]
-    [Display(Name = nameof(AudioStrings.CompressorEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.CompressorEffect_MakeupGain), Description = nameof(AudioStrings.CompressorEffect_MakeupGain_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(1, 0.1)]
     public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(DefaultMakeupGainDb);
 
     public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)

--- a/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorEffect.cs
@@ -4,6 +4,8 @@ using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 using Beutl.Language;
 
+using static Beutl.Audio.Effects.CompressorParameters;
+
 namespace Beutl.Audio.Effects;
 
 [Display(Name = nameof(AudioStrings.CompressorEffect), ResourceType = typeof(AudioStrings))]
@@ -14,35 +16,35 @@ public sealed partial class CompressorEffect : AudioEffect
         ScanProperties<CompressorEffect>();
     }
 
-    [Range(-60f, 0f)]
+    [Range(MinThresholdDb, MaxThresholdDb)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_Threshold), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(-20f);
+    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(DefaultThresholdDb);
 
-    [Range(1f, 20f)]
+    [Range(MinRatio, MaxRatio)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_Ratio), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Ratio { get; } = Property.CreateAnimatable(4f);
+    public IProperty<float> Ratio { get; } = Property.CreateAnimatable(DefaultRatio);
 
-    [Range(0.1f, 500f)]
+    [Range(MinAttackMs, MaxAttackMs)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_Attack), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Attack { get; } = Property.CreateAnimatable(10f);
+    public IProperty<float> Attack { get; } = Property.CreateAnimatable(DefaultAttackMs);
 
-    [Range(1f, 5000f)]
+    [Range(MinReleaseMs, MaxReleaseMs)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_Release), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Release { get; } = Property.CreateAnimatable(100f);
+    public IProperty<float> Release { get; } = Property.CreateAnimatable(DefaultReleaseMs);
 
-    [Range(0f, 24f)]
+    [Range(MinKneeDb, MaxKneeDb)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_Knee), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Knee { get; } = Property.CreateAnimatable(6f);
+    public IProperty<float> Knee { get; } = Property.CreateAnimatable(DefaultKneeDb);
 
-    [Range(-24f, 24f)]
+    [Range(MinMakeupGainDb, MaxMakeupGainDb)]
     [Display(Name = nameof(AudioStrings.CompressorEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(0f);
+    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(DefaultMakeupGainDb);
 
     public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
     {

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,0 +1,31 @@
+﻿namespace Beutl.Audio.Effects;
+
+// Single source of truth for the compressor's parameter ranges and defaults. CompressorEffect
+// references these in its [Range] / Property.CreateAnimatable declarations and CompressorNode
+// references the same values when clamping per-sample animated inputs, so the two cannot drift.
+internal static class CompressorParameters
+{
+    public const float MinThresholdDb = -60f;
+    public const float MaxThresholdDb = 0f;
+    public const float DefaultThresholdDb = -20f;
+
+    public const float MinRatio = 1f;
+    public const float MaxRatio = 20f;
+    public const float DefaultRatio = 4f;
+
+    public const float MinAttackMs = 0.1f;
+    public const float MaxAttackMs = 500f;
+    public const float DefaultAttackMs = 10f;
+
+    public const float MinReleaseMs = 1f;
+    public const float MaxReleaseMs = 5000f;
+    public const float DefaultReleaseMs = 100f;
+
+    public const float MinKneeDb = 0f;
+    public const float MaxKneeDb = 24f;
+    public const float DefaultKneeDb = 6f;
+
+    public const float MinMakeupGainDb = -24f;
+    public const float MaxMakeupGainDb = 24f;
+    public const float DefaultMakeupGainDb = 0f;
+}

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -41,6 +41,13 @@ internal static class CompressorParameters
     // call site — neither `using static CompressorParameters;` nor `[Range(MinX, MaxX)]` triggers
     // type initialization. The module initializer sidesteps that and guarantees the asserts
     // below execute on every Debug-build run (production builds elide Debug.Assert anyway).
+    //
+    // CA2255 warns against [ModuleInitializer] in libraries because a library author cannot control
+    // initialization order relative to the host. That concern does not apply here: Validate only
+    // runs Debug.Assert checks over compile-time constants, has no ordering dependency, and produces
+    // no observable side effect. The suppression is kept method-local (rather than a project-wide
+    // NoWarn) so any future, less-benign [ModuleInitializer] elsewhere in the engine still warns.
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
     [ModuleInitializer]
     internal static void Validate()
     {
@@ -51,6 +58,7 @@ internal static class CompressorParameters
         AssertRange(MinKneeDb, DefaultKneeDb, MaxKneeDb, "Knee");
         AssertRange(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb, "MakeupGain");
     }
+#pragma warning restore CA2255
 
     private static void AssertRange(float min, float def, float max, string name)
     {

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Beutl.Audio.Effects;
 
@@ -34,17 +35,21 @@ internal static class CompressorParameters
     public const float MaxMakeupGainDb = 24f;
     public const float DefaultMakeupGainDb = 0f;
 
-    static CompressorParameters()
+    // [ModuleInitializer] runs once at module load regardless of whether any non-const member
+    // is touched. A static constructor on this class would NOT run, because every consumer
+    // references our `const float` fields, and the C# compiler inlines const literals at the
+    // call site — neither `using static CompressorParameters;` nor `[Range(MinX, MaxX)]` triggers
+    // type initialization. The module initializer sidesteps that and guarantees the asserts
+    // below execute on every Debug-build run (production builds elide Debug.Assert anyway).
+    [ModuleInitializer]
+    internal static void Validate()
     {
-        // Run once at module load so an inconsistent Min/Default/Max edit is caught immediately
-        // in debug builds rather than producing subtle audio glitches at runtime.
         AssertRange(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb, "Threshold");
         AssertRange(MinRatio, DefaultRatio, MaxRatio, "Ratio");
         AssertRange(MinAttackMs, DefaultAttackMs, MaxAttackMs, "Attack");
         AssertRange(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs, "Release");
         AssertRange(MinKneeDb, DefaultKneeDb, MaxKneeDb, "Knee");
         AssertRange(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb, "MakeupGain");
-        Debug.Assert(MinRatio >= 1f, "MinRatio must stay >= 1f or the slope formula amplifies.");
     }
 
     private static void AssertRange(float min, float def, float max, string name)

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,11 +1,13 @@
-﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
-
 namespace Beutl.Audio.Effects;
 
 // Single source of truth for the compressor's parameter ranges and defaults. CompressorEffect
 // references these in its [Range] / Property.CreateAnimatable declarations and CompressorNode
 // references the same values when clamping per-sample animated inputs, so the two cannot drift.
+//
+// The Min/Default/Max consistency of every entry below is asserted by
+// CompressorEffectTests.CompressorParameters_RangeIsConsistent — a plain unit test, not a runtime
+// hook — so a future edit that puts a default outside its range fails CI with a named test rather
+// than a load-time Debug.Assert.
 internal static class CompressorParameters
 {
     public const float MinThresholdDb = -60f;
@@ -34,35 +36,4 @@ internal static class CompressorParameters
     public const float MinMakeupGainDb = -24f;
     public const float MaxMakeupGainDb = 24f;
     public const float DefaultMakeupGainDb = 0f;
-
-    // [ModuleInitializer] runs once at module load regardless of whether any non-const member
-    // is touched. A static constructor on this class would NOT run, because every consumer
-    // references our `const float` fields, and the C# compiler inlines const literals at the
-    // call site — neither `using static CompressorParameters;` nor `[Range(MinX, MaxX)]` triggers
-    // type initialization. The module initializer sidesteps that and guarantees the asserts
-    // below execute on every Debug-build run (production builds elide Debug.Assert anyway).
-    //
-    // CA2255 warns against [ModuleInitializer] in libraries because a library author cannot control
-    // initialization order relative to the host. That concern does not apply here: Validate only
-    // runs Debug.Assert checks over compile-time constants, has no ordering dependency, and produces
-    // no observable side effect. The suppression is kept method-local (rather than a project-wide
-    // NoWarn) so any future, less-benign [ModuleInitializer] elsewhere in the engine still warns.
-#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
-    [ModuleInitializer]
-    internal static void Validate()
-    {
-        AssertRange(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb, "Threshold");
-        AssertRange(MinRatio, DefaultRatio, MaxRatio, "Ratio");
-        AssertRange(MinAttackMs, DefaultAttackMs, MaxAttackMs, "Attack");
-        AssertRange(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs, "Release");
-        AssertRange(MinKneeDb, DefaultKneeDb, MaxKneeDb, "Knee");
-        AssertRange(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb, "MakeupGain");
-    }
-#pragma warning restore CA2255
-
-    private static void AssertRange(float min, float def, float max, string name)
-    {
-        Debug.Assert(min < max, $"{name}: Min ({min}) must be strictly less than Max ({max}).");
-        Debug.Assert(min <= def && def <= max, $"{name}: Default ({def}) must lie in [{min}, {max}].");
-    }
 }

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,4 +1,6 @@
-﻿namespace Beutl.Audio.Effects;
+﻿using System.Diagnostics;
+
+namespace Beutl.Audio.Effects;
 
 // Single source of truth for the compressor's parameter ranges and defaults. CompressorEffect
 // references these in its [Range] / Property.CreateAnimatable declarations and CompressorNode
@@ -9,6 +11,9 @@ internal static class CompressorParameters
     public const float MaxThresholdDb = 0f;
     public const float DefaultThresholdDb = -20f;
 
+    // MinRatio must stay >= 1f. The slope formula `1 - 1/Ratio` becomes negative below 1, which
+    // would amplify above-threshold signals instead of compressing them; CompressorNode.Sanitize
+    // relies on this invariant to make the slope safe without an additional guard.
     public const float MinRatio = 1f;
     public const float MaxRatio = 20f;
     public const float DefaultRatio = 4f;
@@ -28,4 +33,23 @@ internal static class CompressorParameters
     public const float MinMakeupGainDb = -24f;
     public const float MaxMakeupGainDb = 24f;
     public const float DefaultMakeupGainDb = 0f;
+
+    static CompressorParameters()
+    {
+        // Run once at module load so an inconsistent Min/Default/Max edit is caught immediately
+        // in debug builds rather than producing subtle audio glitches at runtime.
+        AssertRange(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb, "Threshold");
+        AssertRange(MinRatio, DefaultRatio, MaxRatio, "Ratio");
+        AssertRange(MinAttackMs, DefaultAttackMs, MaxAttackMs, "Attack");
+        AssertRange(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs, "Release");
+        AssertRange(MinKneeDb, DefaultKneeDb, MaxKneeDb, "Knee");
+        AssertRange(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb, "MakeupGain");
+        Debug.Assert(MinRatio >= 1f, "MinRatio must stay >= 1f or the slope formula amplifies.");
+    }
+
+    private static void AssertRange(float min, float def, float max, string name)
+    {
+        Debug.Assert(min < max, $"{name}: Min ({min}) must be strictly less than Max ({max}).");
+        Debug.Assert(min <= def && def <= max, $"{name}: Default ({def}) must lie in [{min}, {max}].");
+    }
 }

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Audio.Effects;
+﻿namespace Beutl.Audio.Effects;
 
 // Single source of truth for the compressor's parameter ranges and defaults. CompressorEffect
 // references these in its [Range] / Property.CreateAnimatable declarations and CompressorNode

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -9,7 +9,7 @@ public sealed class CompressorNode : AudioNode
 
     private float _envelopeDb = MinDb;
     private int _lastSampleRate;
-    private TimeSpan? _lastTimeRangeStart;
+    private TimeSpan? _lastTimeRangeEnd;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -36,18 +36,21 @@ public sealed class CompressorNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        if (!_lastTimeRangeStart.HasValue || _lastTimeRangeStart.Value > context.TimeRange.Start)
+        // Reset whenever the chunk does not continue directly from the previous one, because the
+        // node instance is cached across Compose() calls and stale envelope state would otherwise
+        // bleed into the first samples after a seek or stop/restart.
+        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
             Reset();
         }
-        _lastTimeRangeStart = context.TimeRange.Start + context.TimeRange.Duration;
+        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
-        bool hasAnimation = Threshold.IsAnimatable ||
-                            Ratio.IsAnimatable ||
-                            Attack.IsAnimatable ||
-                            Release.IsAnimatable ||
-                            Knee.IsAnimatable ||
-                            MakeupGain.IsAnimatable;
+        bool hasAnimation = Threshold.Animation != null ||
+                            Ratio.Animation != null ||
+                            Attack.Animation != null ||
+                            Release.Animation != null ||
+                            Knee.Animation != null ||
+                            MakeupGain.Animation != null;
 
         if (!hasAnimation)
         {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -1,0 +1,203 @@
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.Audio.Graph.Nodes;
+
+public sealed class CompressorNode : AudioNode
+{
+    private const float MinDb = -100f;
+
+    private float _envelopeDb = MinDb;
+    private int _lastSampleRate;
+    private TimeSpan? _lastTimeRangeStart;
+
+    public required IProperty<float> Threshold { get; init; }
+
+    public required IProperty<float> Ratio { get; init; }
+
+    public required IProperty<float> Attack { get; init; }
+
+    public required IProperty<float> Release { get; init; }
+
+    public required IProperty<float> Knee { get; init; }
+
+    public required IProperty<float> MakeupGain { get; init; }
+
+    public override AudioBuffer Process(AudioProcessContext context)
+    {
+        if (Inputs.Count != 1)
+            throw new InvalidOperationException("Compressor node requires exactly one input.");
+
+        var input = Inputs[0].Process(context);
+
+        if (_lastSampleRate != context.SampleRate)
+        {
+            Reset();
+            _lastSampleRate = context.SampleRate;
+        }
+
+        if (!_lastTimeRangeStart.HasValue || _lastTimeRangeStart.Value > context.TimeRange.Start)
+        {
+            Reset();
+        }
+        _lastTimeRangeStart = context.TimeRange.Start + context.TimeRange.Duration;
+
+        bool hasAnimation = Threshold.IsAnimatable ||
+                            Ratio.IsAnimatable ||
+                            Attack.IsAnimatable ||
+                            Release.IsAnimatable ||
+                            Knee.IsAnimatable ||
+                            MakeupGain.IsAnimatable;
+
+        if (!hasAnimation)
+        {
+            return ProcessStatic(input, context);
+        }
+
+        return ProcessAnimated(input, context);
+    }
+
+    private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+
+        float threshold = Threshold.CurrentValue;
+        float ratio = MathF.Max(1f, Ratio.CurrentValue);
+        float attackMs = MathF.Max(0.01f, Attack.CurrentValue);
+        float releaseMs = MathF.Max(0.01f, Release.CurrentValue);
+        float knee = MathF.Max(0f, Knee.CurrentValue);
+        float makeupGain = MakeupGain.CurrentValue;
+
+        float attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
+        float releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
+        float slope = 1f - 1f / ratio;
+        float makeupLinear = AudioMath.ConvertDbToLinear(makeupGain);
+
+        int channels = input.ChannelCount;
+        for (int i = 0; i < input.SampleCount; i++)
+        {
+            float peak = 0f;
+            for (int ch = 0; ch < channels; ch++)
+            {
+                float a = MathF.Abs(input.GetChannelData(ch)[i]);
+                if (a > peak) peak = a;
+            }
+
+            float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
+            float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
+            _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
+
+            float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
+            float gainLinear = AudioMath.ConvertDbToLinear(-gainReductionDb) * makeupLinear;
+
+            for (int ch = 0; ch < channels; ch++)
+            {
+                output.GetChannelData(ch)[i] = input.GetChannelData(ch)[i] * gainLinear;
+            }
+        }
+
+        return output;
+    }
+
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+
+        const int maxChunkSize = 1024;
+        int bufferSize = Math.Min(maxChunkSize, input.SampleCount);
+        Span<float> thresholds = stackalloc float[bufferSize];
+        Span<float> ratios = stackalloc float[bufferSize];
+        Span<float> attacks = stackalloc float[bufferSize];
+        Span<float> releases = stackalloc float[bufferSize];
+        Span<float> knees = stackalloc float[bufferSize];
+        Span<float> makeups = stackalloc float[bufferSize];
+
+        int channels = input.ChannelCount;
+        int processed = 0;
+        while (processed < input.SampleCount)
+        {
+            int chunkSize = Math.Min(bufferSize, input.SampleCount - processed);
+
+            var chunkStart = context.GetTimeForSample(processed);
+            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+            context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Ratio, chunkRange, context.SampleRate, ratios[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Attack, chunkRange, context.SampleRate, attacks[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Knee, chunkRange, context.SampleRate, knees[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
+
+            for (int i = 0; i < chunkSize; i++)
+            {
+                int idx = processed + i;
+                float peak = 0f;
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    float a = MathF.Abs(input.GetChannelData(ch)[idx]);
+                    if (a > peak) peak = a;
+                }
+
+                float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
+
+                float threshold = thresholds[i];
+                float ratio = MathF.Max(1f, ratios[i]);
+                float attackMs = MathF.Max(0.01f, attacks[i]);
+                float releaseMs = MathF.Max(0.01f, releases[i]);
+                float knee = MathF.Max(0f, knees[i]);
+                float makeupDb = makeups[i];
+
+                float attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
+                float releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
+                float slope = 1f - 1f / ratio;
+
+                float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
+                _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
+
+                float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
+                float gainLinear = AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
+
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    output.GetChannelData(ch)[idx] = input.GetChannelData(ch)[idx] * gainLinear;
+                }
+            }
+
+            processed += chunkSize;
+        }
+
+        return output;
+    }
+
+    private static float ComputeCoeff(float timeMs, int sampleRate)
+    {
+        return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
+    }
+
+    private static float ComputeGainReductionDb(float envelopeDb, float thresholdDb, float kneeDb, float slope)
+    {
+        if (kneeDb > 0f)
+        {
+            float halfKnee = kneeDb * 0.5f;
+            float diff = envelopeDb - thresholdDb;
+            if (diff <= -halfKnee)
+            {
+                return 0f;
+            }
+            if (diff < halfKnee)
+            {
+                float x = diff + halfKnee;
+                return slope * x * x / (2f * kneeDb);
+            }
+            return slope * diff;
+        }
+
+        return envelopeDb > thresholdDb ? slope * (envelopeDb - thresholdDb) : 0f;
+    }
+
+    public void Reset()
+    {
+        _envelopeDb = MinDb;
+    }
+}

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -1,4 +1,4 @@
-using Beutl.Engine;
+﻿using Beutl.Engine;
 using Beutl.Media;
 
 namespace Beutl.Audio.Graph.Nodes;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -70,10 +70,11 @@ public sealed class CompressorNode : AudioNode
         // Expression-backed properties are intentionally not checked here: AnimationSampler does
         // not currently evaluate expressions per-sample, so treating HasExpression as live would
         // route to ProcessAnimated and read the same CurrentValue every iteration — strictly
-        // worse than ProcessStatic, which reads it once. Aligned with EqualizerEffect's matching
-        // FIXME: once AnimationSampler evaluates expressions per-sample, this guard must also
-        // treat HasExpression as live or expression-backed parameters will be silently frozen
-        // at their graph-build-time value.
+        // worse than ProcessStatic, which reads it once. The same root cause is documented at
+        // EqualizerEffect.IsNeutral (build-time band elision), where the FIXME notes that once
+        // AnimationSampler evaluates expressions per-sample, both that guard and this one must
+        // be updated to treat HasExpression as live; otherwise expression-backed parameters
+        // will be silently frozen at their graph-build-time value.
         bool hasAnimation = Threshold.Animation != null ||
                             Ratio.Animation != null ||
                             Attack.Animation != null ||
@@ -109,9 +110,10 @@ public sealed class CompressorNode : AudioNode
                 if (a > peak) peak = a;
             }
 
-            // peak == 0 (digital silence) and peak == NaN both fail `peak > 0f`, so inputDb
-            // collapses to MinDb here; downstream RecoverEnvelopeIfNonFinite / SanitizeOutput
-            // handle the NaN case if it slipped through arithmetic above.
+            // peak == 0 (digital silence) collapses inputDb to MinDb here. The local `peak` is
+            // always finite because the abs/max loop above stays at 0 when MathF.Abs(NaN) > 0
+            // is false; any non-finite envelope state arriving from elsewhere is recovered by
+            // RecoverEnvelopeIfNonFinite below.
             float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
             float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
             _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
@@ -347,13 +349,27 @@ public sealed class CompressorNode : AudioNode
 
     // Internal so tests can drive an explicit reset, but not part of the public API: external
     // callers must not zero the envelope mid-buffer (it would produce an audible click).
-    // Reset is also the natural "new render session" boundary (sample-rate change, seek), so we
-    // clear the diagnostic latches here. Otherwise, once a non-finite event fired in an earlier
-    // session, the operator would never see another warning for the entire node lifetime — even
-    // after fixing the offending keyframe and re-rendering.
+    // Reset() corresponds to a "new render session" boundary (sample-rate change, seek), and
+    // unifies two concerns:
+    //   - DSP state (the envelope follower) — see ResetEnvelope
+    //   - Diagnostic latches (one-shot warnings) — see ResetDiagnostics
+    // They are atomic in production callers because every session boundary is also a fresh
+    // diagnostic window: we want operators to see warnings re-fire after fixing a bad keyframe
+    // and re-rendering. Splitting them into named helpers makes the dual responsibility legible
+    // at the call site instead of buried in this comment.
     internal void Reset()
     {
+        ResetEnvelope();
+        ResetDiagnostics();
+    }
+
+    private void ResetEnvelope()
+    {
         _envelopeDb = MinDb;
+    }
+
+    private void ResetDiagnostics()
+    {
         _loggedNonFiniteEnvelope = false;
         _loggedNonFiniteSample = false;
         _loggedNonFiniteParameters.Clear();

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -353,10 +353,10 @@ public sealed class CompressorNode : AudioNode
     // unifies two concerns:
     //   - DSP state (the envelope follower) — see ResetEnvelope
     //   - Diagnostic latches (one-shot warnings) — see ResetDiagnostics
-    // They are atomic in production callers because every session boundary is also a fresh
-    // diagnostic window: we want operators to see warnings re-fire after fixing a bad keyframe
-    // and re-rendering. Splitting them into named helpers makes the dual responsibility legible
-    // at the call site instead of buried in this comment.
+    // They are always invoked together in production callers because every session boundary is
+    // also a fresh diagnostic window: we want operators to see warnings re-fire after fixing a
+    // bad keyframe and re-rendering. Splitting them into named helpers makes the dual
+    // responsibility legible at the call site instead of buried in this comment.
     internal void Reset()
     {
         ResetEnvelope();

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -52,9 +52,10 @@ public sealed class CompressorNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        // Reset whenever the chunk does not continue directly from the previous one, because the
-        // node instance is cached across Compose() calls and stale envelope state would otherwise
-        // bleed into the first samples after a seek or stop/restart.
+        // Reset on the very first call (no prior end recorded) and whenever the new chunk does
+        // not start exactly where the previous one ended. The node instance is cached across
+        // Compose() calls, so without this guard stale envelope state would bleed into the first
+        // samples after a seek or stop/restart.
         if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
             Reset();
@@ -66,6 +67,13 @@ public sealed class CompressorNode : AudioNode
             return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
         }
 
+        // Expression-backed properties are intentionally not checked here: AnimationSampler does
+        // not currently evaluate expressions per-sample, so treating HasExpression as live would
+        // route to ProcessAnimated and read the same CurrentValue every iteration — strictly
+        // worse than ProcessStatic, which reads it once. Aligned with EqualizerEffect's matching
+        // FIXME: once AnimationSampler evaluates expressions per-sample, this guard must also
+        // treat HasExpression as live or expression-backed parameters will be silently frozen
+        // at their graph-build-time value.
         bool hasAnimation = Threshold.Animation != null ||
                             Ratio.Animation != null ||
                             Attack.Animation != null ||
@@ -90,7 +98,6 @@ public sealed class CompressorNode : AudioNode
         float attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
         float releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
         float slope = 1f - 1f / p.Ratio;
-        float makeupLinear = AudioMath.ConvertDbToLinear(p.MakeupGain);
 
         int channels = input.ChannelCount;
         for (int i = 0; i < input.SampleCount; i++)
@@ -102,13 +109,16 @@ public sealed class CompressorNode : AudioNode
                 if (a > peak) peak = a;
             }
 
+            // peak == 0 (digital silence) and peak == NaN both fail `peak > 0f`, so inputDb
+            // collapses to MinDb here; downstream RecoverEnvelopeIfNonFinite / SanitizeOutput
+            // handle the NaN case if it slipped through arithmetic above.
             float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
             float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
             _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
             RecoverEnvelopeIfNonFinite();
 
             float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
-            float gainLinear = AudioMath.ConvertDbToLinear(-gainReductionDb) * makeupLinear;
+            float gainLinear = ComputeGainLinear(gainReductionDb, p.MakeupGain);
 
             for (int ch = 0; ch < channels; ch++)
             {
@@ -196,7 +206,7 @@ public sealed class CompressorNode : AudioNode
                 RecoverEnvelopeIfNonFinite();
 
                 float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
-                float gainLinear = AudioMath.ConvertDbToLinear(p.MakeupGain - gainReductionDb);
+                float gainLinear = ComputeGainLinear(gainReductionDb, p.MakeupGain);
 
                 for (int ch = 0; ch < channels; ch++)
                 {
@@ -286,11 +296,31 @@ public sealed class CompressorNode : AudioNode
         return 0f;
     }
 
+    // Combined linear gain factor: the dB-domain reduction is subtracted and the makeup gain is
+    // added before a single dB→linear conversion. Both ProcessStatic and ProcessAnimated share
+    // this helper so the static and animated paths cannot drift out of agreement (they used to
+    // apply makeup as a pre-computed `makeupLinear` multiplier vs. an in-formula addition, which
+    // is mathematically equivalent but a future refactor of one branch could silently break the
+    // other).
+    private static float ComputeGainLinear(float gainReductionDb, float makeupDb)
+    {
+        return AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
+    }
+
+    // Standard one-pole IIR smoothing coefficient for a 1/e settling time of `timeMs` at the
+    // given sample rate: y[n] = x[n] + coeff * (y[n-1] - x[n]) reaches (1 - 1/e) ≈ 63% of a step
+    // change after exactly `timeMs` milliseconds. Operates in dB-domain on `_envelopeDb` because
+    // dB-domain peak smoothing better matches how the human ear perceives compression action.
     private static float ComputeCoeff(float timeMs, int sampleRate)
     {
         return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
     }
 
+    // Soft-knee gain computer (Reece/Giannoulis formulation): when `kneeDb > 0`, the gain
+    // reduction curve transitions smoothly from "no compression" to the full `slope * diff`
+    // line over a `kneeDb`-wide region centred on the threshold, via a quadratic that is
+    // C¹-continuous at both knee boundaries. With `kneeDb == 0` this collapses to the standard
+    // hard-knee formula.
     private static float ComputeGainReductionDb(float envelopeDb, float thresholdDb, float kneeDb, float slope)
     {
         if (kneeDb > 0f)
@@ -303,6 +333,9 @@ public sealed class CompressorNode : AudioNode
             }
             if (diff < halfKnee)
             {
+                // Quadratic interpolation across the knee: at diff = -halfKnee returns 0, at
+                // diff = +halfKnee returns slope * halfKnee, with matching derivatives at both
+                // ends (= 0 below, = slope above) so the overall curve is smooth.
                 float x = diff + halfKnee;
                 return slope * x * x / (2f * kneeDb);
             }
@@ -314,9 +347,16 @@ public sealed class CompressorNode : AudioNode
 
     // Internal so tests can drive an explicit reset, but not part of the public API: external
     // callers must not zero the envelope mid-buffer (it would produce an audible click).
+    // Reset is also the natural "new render session" boundary (sample-rate change, seek), so we
+    // clear the diagnostic latches here. Otherwise, once a non-finite event fired in an earlier
+    // session, the operator would never see another warning for the entire node lifetime — even
+    // after fixing the offending keyframe and re-rendering.
     internal void Reset()
     {
         _envelopeDb = MinDb;
+        _loggedNonFiniteEnvelope = false;
+        _loggedNonFiniteSample = false;
+        _loggedNonFiniteParameters.Clear();
     }
 
     private struct EffectiveParameters

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -1,15 +1,32 @@
 ﻿using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.Media;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class CompressorNode : AudioNode
 {
+    private static readonly ILogger s_logger = Log.CreateLogger<CompressorNode>();
+
     private const float MinDb = -100f;
+
+    // Lower bounds match the [Range] attributes declared on CompressorEffect. Keeping them in sync
+    // avoids silent clamping when animation values overshoot the declared range.
+    private const float MinAttackMs = 0.1f;
+    private const float MinReleaseMs = 1f;
+    private const float MinRatio = 1f;
+    private const float MinKneeDb = 0f;
 
     private float _envelopeDb = MinDb;
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
+
+    // Latched per node instance so the warning only fires once per non-finite event class, even
+    // when the corruption persists across thousands of samples.
+    private bool _loggedNonFiniteEnvelope;
+    private bool _loggedNonFiniteSample;
+    private bool _loggedNonFiniteParameter;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -26,7 +43,8 @@ public sealed class CompressorNode : AudioNode
     public override AudioBuffer Process(AudioProcessContext context)
     {
         if (Inputs.Count != 1)
-            throw new InvalidOperationException("Compressor node requires exactly one input.");
+            throw new InvalidOperationException(
+                $"Compressor node requires exactly one input but got {Inputs.Count}.");
 
         var input = Inputs[0].Process(context);
 
@@ -64,12 +82,12 @@ public sealed class CompressorNode : AudioNode
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        float threshold = Threshold.CurrentValue;
-        float ratio = MathF.Max(1f, Ratio.CurrentValue);
-        float attackMs = MathF.Max(0.01f, Attack.CurrentValue);
-        float releaseMs = MathF.Max(0.01f, Release.CurrentValue);
-        float knee = MathF.Max(0f, Knee.CurrentValue);
-        float makeupGain = MakeupGain.CurrentValue;
+        float threshold = SafeParameter(Threshold.CurrentValue, Threshold.DefaultValue, nameof(Threshold));
+        float ratio = MathF.Max(MinRatio, SafeParameter(Ratio.CurrentValue, Ratio.DefaultValue, nameof(Ratio)));
+        float attackMs = MathF.Max(MinAttackMs, SafeParameter(Attack.CurrentValue, Attack.DefaultValue, nameof(Attack)));
+        float releaseMs = MathF.Max(MinReleaseMs, SafeParameter(Release.CurrentValue, Release.DefaultValue, nameof(Release)));
+        float knee = MathF.Max(MinKneeDb, SafeParameter(Knee.CurrentValue, Knee.DefaultValue, nameof(Knee)));
+        float makeupGain = SafeParameter(MakeupGain.CurrentValue, MakeupGain.DefaultValue, nameof(MakeupGain));
 
         float attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
         float releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
@@ -89,13 +107,15 @@ public sealed class CompressorNode : AudioNode
             float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
             float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
             _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
+            RecoverEnvelopeIfNonFinite();
 
             float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
             float gainLinear = AudioMath.ConvertDbToLinear(-gainReductionDb) * makeupLinear;
 
             for (int ch = 0; ch < channels; ch++)
             {
-                output.GetChannelData(ch)[i] = input.GetChannelData(ch)[i] * gainLinear;
+                float sample = input.GetChannelData(ch)[i] * gainLinear;
+                output.GetChannelData(ch)[i] = SanitizeOutput(sample);
             }
         }
 
@@ -115,8 +135,27 @@ public sealed class CompressorNode : AudioNode
         Span<float> knees = stackalloc float[bufferSize];
         Span<float> makeups = stackalloc float[bufferSize];
 
+        // Final fallbacks used when an animated parameter samples to NaN/Infinity (e.g. malformed
+        // KeyFrame). Without this guard, a single non-finite animated value would propagate into
+        // the gain calculation and cause the output sanitizer to silently zero out every sample.
+        float thresholdFallback = SafeParameter(Threshold.CurrentValue, Threshold.DefaultValue, nameof(Threshold));
+        float ratioFallback = MathF.Max(MinRatio, SafeParameter(Ratio.CurrentValue, Ratio.DefaultValue, nameof(Ratio)));
+        float attackFallback = MathF.Max(MinAttackMs, SafeParameter(Attack.CurrentValue, Attack.DefaultValue, nameof(Attack)));
+        float releaseFallback = MathF.Max(MinReleaseMs, SafeParameter(Release.CurrentValue, Release.DefaultValue, nameof(Release)));
+        float kneeFallback = MathF.Max(MinKneeDb, SafeParameter(Knee.CurrentValue, Knee.DefaultValue, nameof(Knee)));
+        float makeupFallback = SafeParameter(MakeupGain.CurrentValue, MakeupGain.DefaultValue, nameof(MakeupGain));
+
         int channels = input.ChannelCount;
         int processed = 0;
+
+        // lastAttackMs/lastReleaseMs are seeded with NaN so the first comparison is always
+        // unequal and the coefficients get computed on the very first sample. After that, Exp
+        // is only called when the animated ms value actually changes.
+        float lastAttackMs = float.NaN;
+        float lastReleaseMs = float.NaN;
+        float attackCoeff = 0f;
+        float releaseCoeff = 0f;
+
         while (processed < input.SampleCount)
         {
             int chunkSize = Math.Min(bufferSize, input.SampleCount - processed);
@@ -144,26 +183,36 @@ public sealed class CompressorNode : AudioNode
 
                 float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
 
-                float threshold = thresholds[i];
-                float ratio = MathF.Max(1f, ratios[i]);
-                float attackMs = MathF.Max(0.01f, attacks[i]);
-                float releaseMs = MathF.Max(0.01f, releases[i]);
-                float knee = MathF.Max(0f, knees[i]);
-                float makeupDb = makeups[i];
+                float threshold = SafeParameter(thresholds[i], thresholdFallback, nameof(Threshold));
+                float ratio = MathF.Max(MinRatio, SafeParameter(ratios[i], ratioFallback, nameof(Ratio)));
+                float attackMs = MathF.Max(MinAttackMs, SafeParameter(attacks[i], attackFallback, nameof(Attack)));
+                float releaseMs = MathF.Max(MinReleaseMs, SafeParameter(releases[i], releaseFallback, nameof(Release)));
+                float knee = MathF.Max(MinKneeDb, SafeParameter(knees[i], kneeFallback, nameof(Knee)));
+                float makeupDb = SafeParameter(makeups[i], makeupFallback, nameof(MakeupGain));
 
-                float attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
-                float releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
+                if (attackMs != lastAttackMs)
+                {
+                    attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
+                    lastAttackMs = attackMs;
+                }
+                if (releaseMs != lastReleaseMs)
+                {
+                    releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
+                    lastReleaseMs = releaseMs;
+                }
                 float slope = 1f - 1f / ratio;
 
                 float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
                 _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
+                RecoverEnvelopeIfNonFinite();
 
                 float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
                 float gainLinear = AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
 
                 for (int ch = 0; ch < channels; ch++)
                 {
-                    output.GetChannelData(ch)[idx] = input.GetChannelData(ch)[idx] * gainLinear;
+                    float sample = input.GetChannelData(ch)[idx] * gainLinear;
+                    output.GetChannelData(ch)[idx] = SanitizeOutput(sample);
                 }
             }
 
@@ -171,6 +220,45 @@ public sealed class CompressorNode : AudioNode
         }
 
         return output;
+    }
+
+    // Without this guard, a single non-finite envelope sample would permanently poison the state
+    // until the next Reset(). The first occurrence is logged; subsequent ones are suppressed so
+    // the audio thread is not spammed.
+    private void RecoverEnvelopeIfNonFinite()
+    {
+        if (float.IsFinite(_envelopeDb)) return;
+        _envelopeDb = MinDb;
+        if (_loggedNonFiniteEnvelope) return;
+        s_logger.LogWarning(
+            "Compressor envelope became non-finite (input sample produced inf/NaN); resetting to {MinDb} dB. Further occurrences will be suppressed.",
+            MinDb);
+        _loggedNonFiniteEnvelope = true;
+    }
+
+    private float SafeParameter(float value, float fallback, string paramName)
+    {
+        if (float.IsFinite(value)) return value;
+        if (!_loggedNonFiniteParameter)
+        {
+            s_logger.LogWarning(
+                "Compressor parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences will be suppressed.",
+                paramName, fallback);
+            _loggedNonFiniteParameter = true;
+        }
+        return fallback;
+    }
+
+    private float SanitizeOutput(float sample)
+    {
+        if (float.IsFinite(sample)) return sample;
+        if (!_loggedNonFiniteSample)
+        {
+            s_logger.LogWarning(
+                "Compressor produced a non-finite output sample; replacing with 0 to protect downstream nodes. Further occurrences will be suppressed.");
+            _loggedNonFiniteSample = true;
+        }
+        return 0f;
     }
 
     private static float ComputeCoeff(float timeMs, int sampleRate)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -33,6 +33,17 @@ public sealed class CompressorNode : AudioNode
     // Per-parameter so a non-finite sample on one parameter (e.g. Attack) does not silently
     // suppress diagnostics for an unrelated parameter (e.g. Threshold) later in the stream.
     private readonly HashSet<string> _loggedNonFiniteParameters = new();
+    // Same once-per-parameter latch for the distinct "finite but out-of-[Range]" case (e.g. an
+    // animation drives Attack to 1e9 ms). Kept separate from _loggedNonFiniteParameters so a
+    // non-finite warning and a clamp warning for the same parameter are not conflated.
+    private readonly HashSet<string> _loggedClampedParameters = new();
+
+    // Test-only counters (observed via InternalsVisibleTo) recording how many warnings were
+    // actually emitted — the only externally visible consequence of the one-shot latches. They let
+    // the latch re-arm semantics (preserved across a seek, re-armed on a sample-rate change or
+    // Reset) be asserted without wiring a logger sink to the static logger.
+    internal int NonFiniteSampleWarnings;
+    internal int ClampWarnings;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -116,32 +127,60 @@ public sealed class CompressorNode : AudioNode
         float slope = 1f - 1f / p.Ratio;
 
         int channels = input.ChannelCount;
+        int sampleCount = input.SampleCount;
         var (inputChannels, outputChannels) = MapChannels(input, output);
-        for (int i = 0; i < input.SampleCount; i++)
+
+        // The cached Memory handles are loop-invariant for the whole call, so materialize the
+        // channel spans ONCE for the dominant mono/stereo case and index those — this removes the
+        // per-sample Memory<float>.Span getter (called 3x/sample/channel) that the >2-channel
+        // fallback still pays. Span<float>[] is impossible (Span is a ref struct), hence the
+        // explicit locals.
+        if (channels <= 2)
         {
-            float peak = 0f;
-            for (int ch = 0; ch < channels; ch++)
+            Span<float> in0 = inputChannels[0].Span;
+            Span<float> out0 = outputChannels[0].Span;
+            Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+            Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
+            for (int i = 0; i < sampleCount; i++)
             {
-                float a = MathF.Abs(inputChannels[ch].Span[i]);
-                if (a > peak) peak = a;
+                float s0 = in0[i];
+                float peak = MathF.Abs(s0);
+                float s1 = 0f;
+                if (channels == 2)
+                {
+                    s1 = in1[i];
+                    float a1 = MathF.Abs(s1);
+                    if (a1 > peak) peak = a1;
+                }
+
+                float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                out0[i] = SanitizeOutput(s0 * gainLinear);
+                if (channels == 2)
+                {
+                    out1[i] = SanitizeOutput(s1 * gainLinear);
+                }
             }
-
-            // peak == 0 (digital silence) collapses inputDb to MinDb here. The local `peak` is
-            // always finite because the abs/max loop above stays at 0 when MathF.Abs(NaN) > 0
-            // is false; any non-finite envelope state arriving from elsewhere is recovered by
-            // RecoverEnvelopeIfNonFinite below.
-            float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
-            float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
-            _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
-            RecoverEnvelopeIfNonFinite();
-
-            float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
-            float gainLinear = ComputeGainLinear(gainReductionDb, p.MakeupGain);
-
-            for (int ch = 0; ch < channels; ch++)
+        }
+        else
+        {
+            for (int i = 0; i < sampleCount; i++)
             {
-                float sample = inputChannels[ch].Span[i] * gainLinear;
-                outputChannels[ch].Span[i] = SanitizeOutput(sample);
+                float peak = 0f;
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    float a = MathF.Abs(inputChannels[ch].Span[i]);
+                    if (a > peak) peak = a;
+                }
+
+                float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    float sample = inputChannels[ch].Span[i] * gainLinear;
+                    outputChannels[ch].Span[i] = SanitizeOutput(sample);
+                }
             }
         }
 
@@ -167,7 +206,18 @@ public sealed class CompressorNode : AudioNode
         EffectiveParameters fallback = ReadStaticParameters();
 
         int channels = input.ChannelCount;
+        int sampleCount = input.SampleCount;
         var (inputChannels, outputChannels) = MapChannels(input, output);
+
+        // Materialize the channel spans once for the whole call (the cached Memory handles are
+        // stable across the chunk loop), matching ProcessStatic so the per-sample Memory.Span
+        // getter is removed for the dominant mono/stereo case. The >2-channel path keeps the
+        // Memory indexing, where the getter cost is negligible beside the per-sample sampling.
+        Span<float> in0 = channels <= 2 ? inputChannels[0].Span : default;
+        Span<float> out0 = channels <= 2 ? outputChannels[0].Span : default;
+        Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+        Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
         int processed = 0;
 
         // lastAttackMs/lastReleaseMs are seeded with NaN so the first comparison is always
@@ -178,9 +228,9 @@ public sealed class CompressorNode : AudioNode
         float attackCoeff = 0f;
         float releaseCoeff = 0f;
 
-        while (processed < input.SampleCount)
+        while (processed < sampleCount)
         {
-            int chunkSize = Math.Min(bufferSize, input.SampleCount - processed);
+            int chunkSize = Math.Min(bufferSize, sampleCount - processed);
 
             var chunkStart = context.GetTimeForSample(processed);
             var chunkEnd = context.GetTimeForSample(processed + chunkSize);
@@ -196,14 +246,6 @@ public sealed class CompressorNode : AudioNode
             for (int i = 0; i < chunkSize; i++)
             {
                 int idx = processed + i;
-                float peak = 0f;
-                for (int ch = 0; ch < channels; ch++)
-                {
-                    float a = MathF.Abs(inputChannels[ch].Span[idx]);
-                    if (a > peak) peak = a;
-                }
-
-                float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
 
                 EffectiveParameters p = SanitizeAnimated(
                     thresholds[i], ratios[i], attacks[i], releases[i], knees[i], makeups[i], fallback);
@@ -220,17 +262,42 @@ public sealed class CompressorNode : AudioNode
                 }
                 float slope = 1f - 1f / p.Ratio;
 
-                float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
-                _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
-                RecoverEnvelopeIfNonFinite();
-
-                float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
-                float gainLinear = ComputeGainLinear(gainReductionDb, p.MakeupGain);
-
-                for (int ch = 0; ch < channels; ch++)
+                if (channels <= 2)
                 {
-                    float sample = inputChannels[ch].Span[idx] * gainLinear;
-                    outputChannels[ch].Span[idx] = SanitizeOutput(sample);
+                    float s0 = in0[idx];
+                    float peak = MathF.Abs(s0);
+                    float s1 = 0f;
+                    if (channels == 2)
+                    {
+                        s1 = in1[idx];
+                        float a1 = MathF.Abs(s1);
+                        if (a1 > peak) peak = a1;
+                    }
+
+                    float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                    out0[idx] = SanitizeOutput(s0 * gainLinear);
+                    if (channels == 2)
+                    {
+                        out1[idx] = SanitizeOutput(s1 * gainLinear);
+                    }
+                }
+                else
+                {
+                    float peak = 0f;
+                    for (int ch = 0; ch < channels; ch++)
+                    {
+                        float a = MathF.Abs(inputChannels[ch].Span[idx]);
+                        if (a > peak) peak = a;
+                    }
+
+                    float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                    for (int ch = 0; ch < channels; ch++)
+                    {
+                        float sample = inputChannels[ch].Span[idx] * gainLinear;
+                        outputChannels[ch].Span[idx] = SanitizeOutput(sample);
+                    }
                 }
             }
 
@@ -292,10 +359,25 @@ public sealed class CompressorNode : AudioNode
     // Substitute fallback for NaN/Infinity, then clamp to the parameter's declared [Range].
     // The clamp is what guards against an animated value silently bypassing the [Range] declaration
     // on CompressorEffect — without it, e.g. an animated Attack of 1e9 ms would freeze the
-    // envelope without any diagnostic.
+    // envelope. A finite-but-out-of-range value is a real authoring error (a malformed keyframe, a
+    // units mistake, an easing overshoot) distinct from the non-finite case SafeParameter handles,
+    // so it gets its own once-per-parameter warning: the clamp keeps the DSP safe, but without this
+    // breadcrumb the misconfiguration would be indistinguishable from correct in-range automation.
     private float Sanitize(float value, float fallback, float min, float max, string paramName)
     {
-        return Math.Clamp(SafeParameter(value, fallback, paramName), min, max);
+        float safe = SafeParameter(value, fallback, paramName);
+        float clamped = Math.Clamp(safe, min, max);
+        // Only finite values reach here as `safe != clamped` (a non-finite input was already
+        // replaced with the in-range fallback, so it clamps to itself). Latch once per parameter to
+        // keep the audio thread quiet; re-armed only by ResetDiagnostics (sample-rate change / Reset).
+        if (clamped != safe && _loggedClampedParameters.Add(paramName))
+        {
+            ClampWarnings++;
+            s_logger.LogWarning(
+                "Compressor parameter '{Param}' value {Value} is outside its valid range [{Min}, {Max}]; clamping to {Clamped}. Further out-of-range occurrences for this parameter will be suppressed.",
+                paramName, safe, min, max, clamped);
+        }
+        return clamped;
     }
 
     // Without this guard, a single non-finite envelope sample would permanently poison the state
@@ -329,11 +411,35 @@ public sealed class CompressorNode : AudioNode
         if (float.IsFinite(sample)) return sample;
         if (!_loggedNonFiniteSample)
         {
+            NonFiniteSampleWarnings++;
+            // With every parameter clamped and the envelope independently recovered, the computed
+            // gain cannot itself overflow — so a non-finite sample here almost always means an
+            // upstream node emitted NaN/Infinity. We zero it to protect downstream nodes and point
+            // the breadcrumb at the likely culprit rather than implying the compressor produced it.
             s_logger.LogWarning(
-                "Compressor produced a non-finite output sample; replacing with 0 to protect downstream nodes. Further occurrences will be suppressed.");
+                "Compressor encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.");
             _loggedNonFiniteSample = true;
         }
         return 0f;
+    }
+
+    // Advances the envelope follower by one sample's peak and returns the linear gain to apply.
+    // Shared by ProcessStatic and ProcessAnimated so the envelope/gain math cannot drift between
+    // the two paths: they already shared ComputeGainReductionDb/ComputeGainLinear, and this also
+    // unifies the inputDb derivation and the one-pole envelope update that were previously
+    // duplicated inline in both loops.
+    private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, float slope)
+    {
+        // peak == 0 (digital silence) collapses inputDb to MinDb. The caller's abs/max keeps `peak`
+        // finite (MathF.Abs(NaN) > 0 is false, so a stray NaN never raises peak); any non-finite
+        // envelope state arriving from elsewhere is recovered by RecoverEnvelopeIfNonFinite below.
+        float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
+        float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
+        _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
+        RecoverEnvelopeIfNonFinite();
+
+        float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
+        return ComputeGainLinear(gainReductionDb, p.MakeupGain);
     }
 
     // Combined linear gain factor: the dB-domain reduction is subtracted and the makeup gain is
@@ -413,6 +519,7 @@ public sealed class CompressorNode : AudioNode
         _loggedNonFiniteEnvelope = false;
         _loggedNonFiniteSample = false;
         _loggedNonFiniteParameters.Clear();
+        _loggedClampedParameters.Clear();
     }
 
     protected override void Dispose(bool disposing)
@@ -428,13 +535,15 @@ public sealed class CompressorNode : AudioNode
         base.Dispose(disposing);
     }
 
-    private struct EffectiveParameters
+    // readonly + init-only: every instance is built via object initializer and thereafter only read
+    // (it is even passed `in` to NextGain/SanitizeAnimated), so immutability is the real intent.
+    private readonly struct EffectiveParameters
     {
-        public float Threshold;
-        public float Ratio;
-        public float Attack;
-        public float Release;
-        public float Knee;
-        public float MakeupGain;
+        public float Threshold { get; init; }
+        public float Ratio { get; init; }
+        public float Attack { get; init; }
+        public float Release { get; init; }
+        public float Knee { get; init; }
+        public float MakeupGain { get; init; }
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -1,7 +1,10 @@
-﻿using Beutl.Engine;
+﻿using Beutl.Audio.Effects;
+using Beutl.Engine;
 using Beutl.Logging;
 using Beutl.Media;
 using Microsoft.Extensions.Logging;
+
+using static Beutl.Audio.Effects.CompressorParameters;
 
 namespace Beutl.Audio.Graph.Nodes;
 
@@ -11,13 +14,6 @@ public sealed class CompressorNode : AudioNode
 
     private const float MinDb = -100f;
 
-    // Lower bounds match the [Range] attributes declared on CompressorEffect. Keeping them in sync
-    // avoids silent clamping when animation values overshoot the declared range.
-    private const float MinAttackMs = 0.1f;
-    private const float MinReleaseMs = 1f;
-    private const float MinRatio = 1f;
-    private const float MinKneeDb = 0f;
-
     private float _envelopeDb = MinDb;
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
@@ -26,7 +22,9 @@ public sealed class CompressorNode : AudioNode
     // when the corruption persists across thousands of samples.
     private bool _loggedNonFiniteEnvelope;
     private bool _loggedNonFiniteSample;
-    private bool _loggedNonFiniteParameter;
+    // Per-parameter so a non-finite sample on one parameter (e.g. Attack) does not silently
+    // suppress diagnostics for an unrelated parameter (e.g. Threshold) later in the stream.
+    private readonly HashSet<string> _loggedNonFiniteParameters = new();
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -63,6 +61,11 @@ public sealed class CompressorNode : AudioNode
         }
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
+        if (input.SampleCount == 0)
+        {
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+        }
+
         bool hasAnimation = Threshold.Animation != null ||
                             Ratio.Animation != null ||
                             Attack.Animation != null ||
@@ -82,17 +85,12 @@ public sealed class CompressorNode : AudioNode
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        float threshold = SafeParameter(Threshold.CurrentValue, Threshold.DefaultValue, nameof(Threshold));
-        float ratio = MathF.Max(MinRatio, SafeParameter(Ratio.CurrentValue, Ratio.DefaultValue, nameof(Ratio)));
-        float attackMs = MathF.Max(MinAttackMs, SafeParameter(Attack.CurrentValue, Attack.DefaultValue, nameof(Attack)));
-        float releaseMs = MathF.Max(MinReleaseMs, SafeParameter(Release.CurrentValue, Release.DefaultValue, nameof(Release)));
-        float knee = MathF.Max(MinKneeDb, SafeParameter(Knee.CurrentValue, Knee.DefaultValue, nameof(Knee)));
-        float makeupGain = SafeParameter(MakeupGain.CurrentValue, MakeupGain.DefaultValue, nameof(MakeupGain));
+        EffectiveParameters p = ReadStaticParameters();
 
-        float attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
-        float releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
-        float slope = 1f - 1f / ratio;
-        float makeupLinear = AudioMath.ConvertDbToLinear(makeupGain);
+        float attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+        float releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+        float slope = 1f - 1f / p.Ratio;
+        float makeupLinear = AudioMath.ConvertDbToLinear(p.MakeupGain);
 
         int channels = input.ChannelCount;
         for (int i = 0; i < input.SampleCount; i++)
@@ -109,7 +107,7 @@ public sealed class CompressorNode : AudioNode
             _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
             RecoverEnvelopeIfNonFinite();
 
-            float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
+            float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
             float gainLinear = AudioMath.ConvertDbToLinear(-gainReductionDb) * makeupLinear;
 
             for (int ch = 0; ch < channels; ch++)
@@ -138,12 +136,7 @@ public sealed class CompressorNode : AudioNode
         // Final fallbacks used when an animated parameter samples to NaN/Infinity (e.g. malformed
         // KeyFrame). Without this guard, a single non-finite animated value would propagate into
         // the gain calculation and cause the output sanitizer to silently zero out every sample.
-        float thresholdFallback = SafeParameter(Threshold.CurrentValue, Threshold.DefaultValue, nameof(Threshold));
-        float ratioFallback = MathF.Max(MinRatio, SafeParameter(Ratio.CurrentValue, Ratio.DefaultValue, nameof(Ratio)));
-        float attackFallback = MathF.Max(MinAttackMs, SafeParameter(Attack.CurrentValue, Attack.DefaultValue, nameof(Attack)));
-        float releaseFallback = MathF.Max(MinReleaseMs, SafeParameter(Release.CurrentValue, Release.DefaultValue, nameof(Release)));
-        float kneeFallback = MathF.Max(MinKneeDb, SafeParameter(Knee.CurrentValue, Knee.DefaultValue, nameof(Knee)));
-        float makeupFallback = SafeParameter(MakeupGain.CurrentValue, MakeupGain.DefaultValue, nameof(MakeupGain));
+        EffectiveParameters fallback = ReadStaticParameters();
 
         int channels = input.ChannelCount;
         int processed = 0;
@@ -183,31 +176,27 @@ public sealed class CompressorNode : AudioNode
 
                 float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
 
-                float threshold = SafeParameter(thresholds[i], thresholdFallback, nameof(Threshold));
-                float ratio = MathF.Max(MinRatio, SafeParameter(ratios[i], ratioFallback, nameof(Ratio)));
-                float attackMs = MathF.Max(MinAttackMs, SafeParameter(attacks[i], attackFallback, nameof(Attack)));
-                float releaseMs = MathF.Max(MinReleaseMs, SafeParameter(releases[i], releaseFallback, nameof(Release)));
-                float knee = MathF.Max(MinKneeDb, SafeParameter(knees[i], kneeFallback, nameof(Knee)));
-                float makeupDb = SafeParameter(makeups[i], makeupFallback, nameof(MakeupGain));
+                EffectiveParameters p = SanitizeAnimated(
+                    thresholds[i], ratios[i], attacks[i], releases[i], knees[i], makeups[i], fallback);
 
-                if (attackMs != lastAttackMs)
+                if (p.Attack != lastAttackMs)
                 {
-                    attackCoeff = ComputeCoeff(attackMs, context.SampleRate);
-                    lastAttackMs = attackMs;
+                    attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+                    lastAttackMs = p.Attack;
                 }
-                if (releaseMs != lastReleaseMs)
+                if (p.Release != lastReleaseMs)
                 {
-                    releaseCoeff = ComputeCoeff(releaseMs, context.SampleRate);
-                    lastReleaseMs = releaseMs;
+                    releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+                    lastReleaseMs = p.Release;
                 }
-                float slope = 1f - 1f / ratio;
+                float slope = 1f - 1f / p.Ratio;
 
                 float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
                 _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
                 RecoverEnvelopeIfNonFinite();
 
-                float gainReductionDb = ComputeGainReductionDb(_envelopeDb, threshold, knee, slope);
-                float gainLinear = AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
+                float gainReductionDb = ComputeGainReductionDb(_envelopeDb, p.Threshold, p.Knee, slope);
+                float gainLinear = AudioMath.ConvertDbToLinear(p.MakeupGain - gainReductionDb);
 
                 for (int ch = 0; ch < channels; ch++)
                 {
@@ -220,6 +209,43 @@ public sealed class CompressorNode : AudioNode
         }
 
         return output;
+    }
+
+    private EffectiveParameters ReadStaticParameters()
+    {
+        return new EffectiveParameters
+        {
+            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Ratio = Sanitize(Ratio.CurrentValue, Ratio.DefaultValue, MinRatio, MaxRatio, nameof(Ratio)),
+            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Knee = Sanitize(Knee.CurrentValue, Knee.DefaultValue, MinKneeDb, MaxKneeDb, nameof(Knee)),
+            MakeupGain = Sanitize(MakeupGain.CurrentValue, MakeupGain.DefaultValue, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
+        };
+    }
+
+    private EffectiveParameters SanitizeAnimated(
+        float threshold, float ratio, float attack, float release, float knee, float makeup,
+        in EffectiveParameters fallback)
+    {
+        return new EffectiveParameters
+        {
+            Threshold = Sanitize(threshold, fallback.Threshold, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Ratio = Sanitize(ratio, fallback.Ratio, MinRatio, MaxRatio, nameof(Ratio)),
+            Attack = Sanitize(attack, fallback.Attack, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Release = Sanitize(release, fallback.Release, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Knee = Sanitize(knee, fallback.Knee, MinKneeDb, MaxKneeDb, nameof(Knee)),
+            MakeupGain = Sanitize(makeup, fallback.MakeupGain, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
+        };
+    }
+
+    // Substitute fallback for NaN/Infinity, then clamp to the parameter's declared [Range].
+    // The clamp is what guards against an animated value silently bypassing the [Range] declaration
+    // on CompressorEffect — without it, e.g. an animated Attack of 1e9 ms would freeze the
+    // envelope without any diagnostic.
+    private float Sanitize(float value, float fallback, float min, float max, string paramName)
+    {
+        return Math.Clamp(SafeParameter(value, fallback, paramName), min, max);
     }
 
     // Without this guard, a single non-finite envelope sample would permanently poison the state
@@ -239,12 +265,11 @@ public sealed class CompressorNode : AudioNode
     private float SafeParameter(float value, float fallback, string paramName)
     {
         if (float.IsFinite(value)) return value;
-        if (!_loggedNonFiniteParameter)
+        if (_loggedNonFiniteParameters.Add(paramName))
         {
             s_logger.LogWarning(
-                "Compressor parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences will be suppressed.",
+                "Compressor parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
                 paramName, fallback);
-            _loggedNonFiniteParameter = true;
         }
         return fallback;
     }
@@ -287,8 +312,20 @@ public sealed class CompressorNode : AudioNode
         return envelopeDb > thresholdDb ? slope * (envelopeDb - thresholdDb) : 0f;
     }
 
-    public void Reset()
+    // Internal so tests can drive an explicit reset, but not part of the public API: external
+    // callers must not zero the envelope mid-buffer (it would produce an audible click).
+    internal void Reset()
     {
         _envelopeDb = MinDb;
+    }
+
+    private struct EffectiveParameters
+    {
+        public float Threshold;
+        public float Ratio;
+        public float Attack;
+        public float Release;
+        public float Knee;
+        public float MakeupGain;
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -18,6 +18,14 @@ public sealed class CompressorNode : AudioNode
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
 
+    // Per-channel handles into the current input/output buffers, cached so the per-sample hot loops
+    // avoid GetChannelData's disposed/bounds checks and re-slicing on every access. Span<float>[]
+    // cannot be used (Span is a ref struct), so we hold Memory<float> and materialize the span per
+    // channel. The backing arrays are reused across Process() calls and only reallocated when the
+    // channel count changes, mirroring EqualizerNode's channel-keyed filter cache.
+    private Memory<float>[]? _inputChannelCache;
+    private Memory<float>[]? _outputChannelCache;
+
     // Latched per node instance so the warning only fires once per non-finite event class, even
     // when the corruption persists across thousands of samples.
     private bool _loggedNonFiniteEnvelope;
@@ -46,19 +54,26 @@ public sealed class CompressorNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
+        // A sample-rate change is a genuine reconfiguration (coefficients must be recomputed for
+        // the new rate), so treat it as a full session boundary: reset both the envelope and the
+        // one-shot diagnostic latches.
         if (_lastSampleRate != context.SampleRate)
         {
             Reset();
             _lastSampleRate = context.SampleRate;
         }
 
-        // Reset on the very first call (no prior end recorded) and whenever the new chunk does
-        // not start exactly where the previous one ended. The node instance is cached across
-        // Compose() calls, so without this guard stale envelope state would bleed into the first
-        // samples after a seek or stop/restart.
+        // Reset the envelope on the very first call (no prior end recorded) and whenever the new
+        // chunk does not start exactly where the previous one ended. The node instance is cached
+        // across Compose() calls, so without this guard stale envelope state would bleed into the
+        // first samples after a seek or stop/restart. Only the DSP state is reset here, NOT the
+        // diagnostic latches: a stuttering scrubber produces many discontinuities within a single
+        // session, and re-arming the one-shot warnings on every one of them would let a persistent
+        // non-finite condition re-log once per Process call. Diagnostics re-arm only on a
+        // sample-rate change or an explicit Reset() (e.g. a deliberate re-render).
         if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
-            Reset();
+            ResetEnvelope();
         }
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
@@ -101,12 +116,13 @@ public sealed class CompressorNode : AudioNode
         float slope = 1f - 1f / p.Ratio;
 
         int channels = input.ChannelCount;
+        var (inputChannels, outputChannels) = MapChannels(input, output);
         for (int i = 0; i < input.SampleCount; i++)
         {
             float peak = 0f;
             for (int ch = 0; ch < channels; ch++)
             {
-                float a = MathF.Abs(input.GetChannelData(ch)[i]);
+                float a = MathF.Abs(inputChannels[ch].Span[i]);
                 if (a > peak) peak = a;
             }
 
@@ -124,8 +140,8 @@ public sealed class CompressorNode : AudioNode
 
             for (int ch = 0; ch < channels; ch++)
             {
-                float sample = input.GetChannelData(ch)[i] * gainLinear;
-                output.GetChannelData(ch)[i] = SanitizeOutput(sample);
+                float sample = inputChannels[ch].Span[i] * gainLinear;
+                outputChannels[ch].Span[i] = SanitizeOutput(sample);
             }
         }
 
@@ -151,6 +167,7 @@ public sealed class CompressorNode : AudioNode
         EffectiveParameters fallback = ReadStaticParameters();
 
         int channels = input.ChannelCount;
+        var (inputChannels, outputChannels) = MapChannels(input, output);
         int processed = 0;
 
         // lastAttackMs/lastReleaseMs are seeded with NaN so the first comparison is always
@@ -182,7 +199,7 @@ public sealed class CompressorNode : AudioNode
                 float peak = 0f;
                 for (int ch = 0; ch < channels; ch++)
                 {
-                    float a = MathF.Abs(input.GetChannelData(ch)[idx]);
+                    float a = MathF.Abs(inputChannels[ch].Span[idx]);
                     if (a > peak) peak = a;
                 }
 
@@ -212,8 +229,8 @@ public sealed class CompressorNode : AudioNode
 
                 for (int ch = 0; ch < channels; ch++)
                 {
-                    float sample = input.GetChannelData(ch)[idx] * gainLinear;
-                    output.GetChannelData(ch)[idx] = SanitizeOutput(sample);
+                    float sample = inputChannels[ch].Span[idx] * gainLinear;
+                    outputChannels[ch].Span[idx] = SanitizeOutput(sample);
                 }
             }
 
@@ -221,6 +238,27 @@ public sealed class CompressorNode : AudioNode
         }
 
         return output;
+    }
+
+    // Caches per-channel Memory handles for the current input/output buffers, reusing the backing
+    // arrays across calls (only reallocated on a channel-count change). The hot loops then index
+    // the cached handles instead of calling GetChannelData per sample. See the field comment.
+    private (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
+    {
+        int channels = input.ChannelCount;
+        if (_inputChannelCache is null || _inputChannelCache.Length != channels)
+        {
+            _inputChannelCache = new Memory<float>[channels];
+            _outputChannelCache = new Memory<float>[channels];
+        }
+
+        for (int ch = 0; ch < channels; ch++)
+        {
+            _inputChannelCache[ch] = input.GetChannelMemory(ch);
+            _outputChannelCache![ch] = output.GetChannelMemory(ch);
+        }
+
+        return (_inputChannelCache, _outputChannelCache!);
     }
 
     private EffectiveParameters ReadStaticParameters()
@@ -347,17 +385,19 @@ public sealed class CompressorNode : AudioNode
         return envelopeDb > thresholdDb ? slope * (envelopeDb - thresholdDb) : 0f;
     }
 
-    // Internal so tests can drive an explicit reset, but not part of the public API: external
-    // callers must not zero the envelope mid-buffer (it would produce an audible click).
-    // Reset() corresponds to a "new render session" boundary (sample-rate change, seek), and
-    // unifies two concerns:
-    //   - DSP state (the envelope follower) — see ResetEnvelope
-    //   - Diagnostic latches (one-shot warnings) — see ResetDiagnostics
-    // They are always invoked together in production callers because every session boundary is
-    // also a fresh diagnostic window: we want operators to see warnings re-fire after fixing a
-    // bad keyframe and re-rendering. Splitting them into named helpers makes the dual
-    // responsibility legible at the call site instead of buried in this comment.
-    internal void Reset()
+    /// <summary>
+    /// Resets the compressor to a clean "new render session" state: zeroes the envelope follower
+    /// and re-arms the one-shot non-finite diagnostic warnings.
+    /// </summary>
+    /// <remarks>
+    /// Do not call this mid-buffer during continuous playback — zeroing the envelope there produces
+    /// an audible click. <see cref="Reset"/> is for genuine session boundaries (a deliberate
+    /// re-render, or an explicit stop/seek driven by an orchestrator). <see cref="Process"/> already
+    /// resets the envelope automatically on a sample-rate change or a time-range discontinuity, so
+    /// routine seeking does not require an external call. Public to match the sibling stateful nodes
+    /// <c>EqualizerNode</c> and <c>DelayNode</c>, which expose <c>Reset()</c> for the same purpose.
+    /// </remarks>
+    public void Reset()
     {
         ResetEnvelope();
         ResetDiagnostics();
@@ -373,6 +413,19 @@ public sealed class CompressorNode : AudioNode
         _loggedNonFiniteEnvelope = false;
         _loggedNonFiniteSample = false;
         _loggedNonFiniteParameters.Clear();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Drop the cached handles so we do not keep the last processed buffers' pooled memory
+            // referenced after disposal. They are re-filled at the start of the next Process() call.
+            _inputChannelCache = null;
+            _outputChannelCache = null;
+        }
+
+        base.Dispose(disposing);
     }
 
     private struct EffectiveParameters

--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -82,4 +82,25 @@
   <data name="Equalizer_Gain" xml:space="preserve">
     <value>ゲイン</value>
   </data>
+  <data name="CompressorEffect" xml:space="preserve">
+    <value>コンプレッサー</value>
+  </data>
+  <data name="CompressorEffect_Threshold" xml:space="preserve">
+    <value>スレッショルド (dB)</value>
+  </data>
+  <data name="CompressorEffect_Ratio" xml:space="preserve">
+    <value>レシオ</value>
+  </data>
+  <data name="CompressorEffect_Attack" xml:space="preserve">
+    <value>アタック (ms)</value>
+  </data>
+  <data name="CompressorEffect_Release" xml:space="preserve">
+    <value>リリース (ms)</value>
+  </data>
+  <data name="CompressorEffect_Knee" xml:space="preserve">
+    <value>ニー (dB)</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain" xml:space="preserve">
+    <value>メイクアップゲイン (dB)</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -103,4 +103,22 @@
   <data name="CompressorEffect_MakeupGain" xml:space="preserve">
     <value>メイクアップゲイン (dB)</value>
   </data>
+  <data name="CompressorEffect_Threshold_Description" xml:space="preserve">
+    <value>圧縮を開始するレベル。これを超えた信号が圧縮されます。</value>
+  </data>
+  <data name="CompressorEffect_Ratio_Description" xml:space="preserve">
+    <value>スレッショルドを超えた信号の圧縮比。値が大きいほど強く圧縮されます。</value>
+  </data>
+  <data name="CompressorEffect_Attack_Description" xml:space="preserve">
+    <value>信号がスレッショルドを超えてから圧縮が効き始めるまでの時間。</value>
+  </data>
+  <data name="CompressorEffect_Release_Description" xml:space="preserve">
+    <value>信号がスレッショルドを下回ってから圧縮が解除されるまでの時間。</value>
+  </data>
+  <data name="CompressorEffect_Knee_Description" xml:space="preserve">
+    <value>スレッショルド付近で圧縮へ移行する滑らかさ。0 でハードニー、大きいほど滑らかになります。</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
+    <value>圧縮で下がった出力レベルを補正するゲイン。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -87,4 +87,25 @@
   <data name="Equalizer_Gain" xml:space="preserve">
     <value>Gain</value>
   </data>
+  <data name="CompressorEffect" xml:space="preserve">
+    <value>Compressor</value>
+  </data>
+  <data name="CompressorEffect_Threshold" xml:space="preserve">
+    <value>Threshold (dB)</value>
+  </data>
+  <data name="CompressorEffect_Ratio" xml:space="preserve">
+    <value>Ratio</value>
+  </data>
+  <data name="CompressorEffect_Attack" xml:space="preserve">
+    <value>Attack (ms)</value>
+  </data>
+  <data name="CompressorEffect_Release" xml:space="preserve">
+    <value>Release (ms)</value>
+  </data>
+  <data name="CompressorEffect_Knee" xml:space="preserve">
+    <value>Knee (dB)</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain" xml:space="preserve">
+    <value>Makeup Gain (dB)</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -108,4 +108,22 @@
   <data name="CompressorEffect_MakeupGain" xml:space="preserve">
     <value>Makeup Gain (dB)</value>
   </data>
+  <data name="CompressorEffect_Threshold_Description" xml:space="preserve">
+    <value>The level above which the signal is compressed.</value>
+  </data>
+  <data name="CompressorEffect_Ratio_Description" xml:space="preserve">
+    <value>The amount of compression applied above the threshold. Higher values compress more strongly.</value>
+  </data>
+  <data name="CompressorEffect_Attack_Description" xml:space="preserve">
+    <value>How quickly compression engages after the signal crosses the threshold.</value>
+  </data>
+  <data name="CompressorEffect_Release_Description" xml:space="preserve">
+    <value>How quickly compression releases after the signal falls below the threshold.</value>
+  </data>
+  <data name="CompressorEffect_Knee_Description" xml:space="preserve">
+    <value>How gradually compression engages around the threshold. 0 is a hard knee; larger values are smoother.</value>
+  </data>
+  <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
+    <value>Gain applied after compression to compensate for the reduced level.</value>
+  </data>
 </root>

--- a/src/Beutl/Services/LibraryRegistrar.cs
+++ b/src/Beutl/Services/LibraryRegistrar.cs
@@ -210,6 +210,7 @@ public static class LibraryRegistrar
             .RegisterGroup(AudioStrings.AudioEffect, g => g
                 .AddAudioEffect<DelayEffect>(AudioStrings.DelayEffect)
                 .AddAudioEffect<EqualizerEffect>(AudioStrings.Equalizer)
+                .AddAudioEffect<CompressorEffect>(AudioStrings.CompressorEffect)
             );
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
@@ -6,8 +6,11 @@ using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 
+using static Beutl.Audio.Effects.CompressorParameters;
+
 namespace Beutl.UnitTests.Engine.Audio;
 
+[TestFixture]
 public class CompressorEffectTests
 {
     private sealed class StubInputNode : AudioNode
@@ -78,6 +81,40 @@ public class CompressorEffectTests
         Assert.That(effect.Release.CurrentValue, Is.EqualTo(100f));
         Assert.That(effect.Knee.CurrentValue, Is.EqualTo(6f));
         Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ScanProperties_RegistersNamesAndRangeValidatorsForEveryProperty()
+    {
+        // ScanProperties<CompressorEffect>() runs in the constructor and is expected to (a) name
+        // each IProperty<float> after its CLR member and (b) attach the [Range] validator so
+        // out-of-range assignments are coerced at the engine layer — not just visually constrained
+        // in the UI. A validator-absent property would silently accept any value. We assert the
+        // name and exercise the coercion (clamp) at both bounds for every property.
+        var effect = new CompressorEffect();
+
+        AssertNameAndRange(effect.Threshold, nameof(effect.Threshold), MinThresholdDb, MaxThresholdDb);
+        AssertNameAndRange(effect.Ratio, nameof(effect.Ratio), MinRatio, MaxRatio);
+        AssertNameAndRange(effect.Attack, nameof(effect.Attack), MinAttackMs, MaxAttackMs);
+        AssertNameAndRange(effect.Release, nameof(effect.Release), MinReleaseMs, MaxReleaseMs);
+        AssertNameAndRange(effect.Knee, nameof(effect.Knee), MinKneeDb, MaxKneeDb);
+        AssertNameAndRange(effect.MakeupGain, nameof(effect.MakeupGain), MinMakeupGainDb, MaxMakeupGainDb);
+    }
+
+    private static void AssertNameAndRange(IProperty<float> property, string expectedName, float min, float max)
+    {
+        Assert.That(property.Name, Is.EqualTo(expectedName),
+            $"ScanProperties must name the property '{expectedName}'.");
+
+        // Above-max assignment must clamp down to max (proves the [Range] validator is wired).
+        property.CurrentValue = max + 1000f;
+        Assert.That(property.CurrentValue, Is.EqualTo(max),
+            $"{expectedName}: a value above the max must be coerced to {max}; validator appears unwired.");
+
+        // Below-min assignment must clamp up to min.
+        property.CurrentValue = min - 1000f;
+        Assert.That(property.CurrentValue, Is.EqualTo(min),
+            $"{expectedName}: a value below the min must be coerced to {min}; validator appears unwired.");
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
@@ -1,0 +1,80 @@
+﻿using Beutl.Audio;
+using Beutl.Audio.Effects;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+public class CompressorEffectTests
+{
+    private sealed class StubInputNode : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            return new AudioBuffer(context.SampleRate, 2, 0);
+        }
+    }
+
+    [Test]
+    public void CreateNode_WiresEveryPropertyToMatchingNodeSlot()
+    {
+        // Each IProperty<float> on the effect must be forwarded by reference to the corresponding
+        // slot on CompressorNode. Reference equality (not just value equality) is critical because
+        // the node reads CurrentValue and Animation through these references at process time —
+        // copying the value would freeze it. A swap of any two properties (Threshold↔Ratio, etc.)
+        // would silently corrupt the compressor without this test.
+        var effect = new CompressorEffect();
+        using var context = new AudioContext(48000, 2);
+        var inputNode = context.AddNode(new StubInputNode());
+
+        var node = effect.CreateNode(context, inputNode);
+
+        Assert.That(node, Is.InstanceOf<CompressorNode>());
+        var compressor = (CompressorNode)node;
+
+        Assert.That(compressor.Threshold, Is.SameAs(effect.Threshold));
+        Assert.That(compressor.Ratio, Is.SameAs(effect.Ratio));
+        Assert.That(compressor.Attack, Is.SameAs(effect.Attack));
+        Assert.That(compressor.Release, Is.SameAs(effect.Release));
+        Assert.That(compressor.Knee, Is.SameAs(effect.Knee));
+        Assert.That(compressor.MakeupGain, Is.SameAs(effect.MakeupGain));
+    }
+
+    [Test]
+    public void CreateNode_ConnectsInputAheadOfCompressor()
+    {
+        // The contract is "audio flows input → compressor". Connect must run with arguments in
+        // that order so the compressor's Inputs collection contains the upstream node, not the
+        // other way around (which would route the compressor's own output into the input node
+        // and produce silence at best, an infinite loop at worst).
+        var effect = new CompressorEffect();
+        using var context = new AudioContext(48000, 2);
+        var inputNode = context.AddNode(new StubInputNode());
+
+        var node = effect.CreateNode(context, inputNode);
+
+        Assert.That(node.Inputs, Has.Count.EqualTo(1));
+        Assert.That(node.Inputs[0], Is.SameAs(inputNode));
+        // The returned node is the compressor itself, not the input — downstream effects need to
+        // chain off the compressor.
+        Assert.That(node, Is.Not.SameAs(inputNode));
+    }
+
+    [Test]
+    public void CreateNode_DefaultPropertyValuesMatchCompressorParameters()
+    {
+        // The CompressorEffect's default values are sourced from CompressorParameters. If any
+        // default drifted (e.g. the file was edited but not the [Range]), the effect would still
+        // load but operators would see unexpected starting parameters. This guards against that
+        // drift by asserting each property's CurrentValue is the documented default.
+        var effect = new CompressorEffect();
+
+        Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(-20f));
+        Assert.That(effect.Ratio.CurrentValue, Is.EqualTo(4f));
+        Assert.That(effect.Attack.CurrentValue, Is.EqualTo(10f));
+        Assert.That(effect.Release.CurrentValue, Is.EqualTo(100f));
+        Assert.That(effect.Knee.CurrentValue, Is.EqualTo(6f));
+        Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(0f));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Audio;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using Beutl.Audio;
 using Beutl.Audio.Effects;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
@@ -76,5 +78,24 @@ public class CompressorEffectTests
         Assert.That(effect.Release.CurrentValue, Is.EqualTo(100f));
         Assert.That(effect.Knee.CurrentValue, Is.EqualTo(6f));
         Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void CompressorParameters_Validate_IsAnnotatedAsModuleInitializer()
+    {
+        // CompressorParameters.Validate is the only execution path for the Min/Default/Max
+        // consistency asserts. Because every consumer references const fields (which the C#
+        // compiler inlines), no `ldsfld` against CompressorParameters is ever emitted, so a
+        // plain static constructor would not run. The class instead relies on
+        // [ModuleInitializer] to invoke Validate at module load. If a future refactor removes
+        // the attribute or renames the method without updating the contract, the asserts
+        // become silent dead code. This reflection check fails fast if either invariant breaks.
+        var method = typeof(CompressorParameters).GetMethod(
+            "Validate",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.That(method, Is.Not.Null,
+            "CompressorParameters.Validate must exist; it is the only carrier of the [ModuleInitializer] attribute.");
+        Assert.That(method!.GetCustomAttribute<ModuleInitializerAttribute>(), Is.Not.Null,
+            "CompressorParameters.Validate must be annotated [ModuleInitializer] so the Min/Default/Max asserts run at module load. Without it, the asserts become unreachable.");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using Beutl.Audio;
+﻿using Beutl.Audio;
 using Beutl.Audio.Effects;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
@@ -117,22 +115,25 @@ public class CompressorEffectTests
             $"{expectedName}: a value below the min must be coerced to {min}; validator appears unwired.");
     }
 
-    [Test]
-    public void CompressorParameters_Validate_IsAnnotatedAsModuleInitializer()
+    private static IEnumerable<TestCaseData> ParameterRanges()
     {
-        // CompressorParameters.Validate is the only execution path for the Min/Default/Max
-        // consistency asserts. Because every consumer references const fields (which the C#
-        // compiler inlines), no `ldsfld` against CompressorParameters is ever emitted, so a
-        // plain static constructor would not run. The class instead relies on
-        // [ModuleInitializer] to invoke Validate at module load. If a future refactor removes
-        // the attribute or renames the method without updating the contract, the asserts
-        // become silent dead code. This reflection check fails fast if either invariant breaks.
-        var method = typeof(CompressorParameters).GetMethod(
-            "Validate",
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.That(method, Is.Not.Null,
-            "CompressorParameters.Validate must exist; it is the only carrier of the [ModuleInitializer] attribute.");
-        Assert.That(method!.GetCustomAttribute<ModuleInitializerAttribute>(), Is.Not.Null,
-            "CompressorParameters.Validate must be annotated [ModuleInitializer] so the Min/Default/Max asserts run at module load. Without it, the asserts become unreachable.");
+        yield return new TestCaseData(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb).SetName("Threshold");
+        yield return new TestCaseData(MinRatio, DefaultRatio, MaxRatio).SetName("Ratio");
+        yield return new TestCaseData(MinAttackMs, DefaultAttackMs, MaxAttackMs).SetName("Attack");
+        yield return new TestCaseData(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs).SetName("Release");
+        yield return new TestCaseData(MinKneeDb, DefaultKneeDb, MaxKneeDb).SetName("Knee");
+        yield return new TestCaseData(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb).SetName("MakeupGain");
+    }
+
+    [TestCaseSource(nameof(ParameterRanges))]
+    public void CompressorParameters_RangeIsConsistent(float min, float def, float max)
+    {
+        // CompressorParameters is the single source of truth shared between CompressorEffect's
+        // [Range] declarations and CompressorNode's per-sample clamps. These asserts catch an edit
+        // that puts a default outside its range, or inverts a min/max, at CI time with a named
+        // failing case — the role formerly served by a [ModuleInitializer] + Debug.Assert, which
+        // was invisible in Release builds and ran on every Debug host load for no benefit.
+        Assert.That(min, Is.LessThan(max), "Min must be strictly less than Max.");
+        Assert.That(def, Is.InRange(min, max), "Default must lie within [Min, Max].");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -1,0 +1,157 @@
+using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+public class CompressorNodeTests
+{
+    private const int SampleRate = 48000;
+
+    private sealed class StubSourceNode : AudioNode
+    {
+        public required AudioBuffer Buffer { get; init; }
+
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            var copy = new AudioBuffer(Buffer.SampleRate, Buffer.ChannelCount, Buffer.SampleCount);
+            Buffer.CopyTo(copy);
+            return copy;
+        }
+    }
+
+    private static AudioBuffer CreateSineBuffer(float amplitude, float frequencyHz, int sampleCount, int channels = 2)
+    {
+        var buffer = new AudioBuffer(SampleRate, channels, sampleCount);
+        for (int ch = 0; ch < channels; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                data[i] = amplitude * MathF.Sin(2f * MathF.PI * frequencyHz * i / SampleRate);
+            }
+        }
+        return buffer;
+    }
+
+    private static float PeakDb(AudioBuffer buffer, int startSample)
+    {
+        float peak = 0f;
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = startSample; i < buffer.SampleCount; i++)
+            {
+                float a = MathF.Abs(data[i]);
+                if (a > peak) peak = a;
+            }
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    [Test]
+    public void Process_BelowThreshold_LeavesSignalUnchanged()
+    {
+        // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should pass through.
+        const int sampleCount = SampleRate / 2;
+        var input = CreateSineBuffer(0.05f, 1000f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(10f),
+            Release = Property.CreateAnimatable(100f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(source);
+
+        var ctx = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)),
+            SampleRate,
+            new AnimationSampler(),
+            null);
+
+        var output = node.Process(ctx);
+
+        float inputPeakDb = PeakDb(input, 0);
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+
+        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(0.5f));
+    }
+
+    [Test]
+    public void Process_AboveThreshold_AppliesExpectedGainReduction()
+    {
+        // Steady 0.9 amplitude (~-0.92 dB) sine, threshold -20 dB, ratio 4:1, hard knee.
+        // Steady-state gain reduction ≈ (-0.92 - -20) * (1 - 1/4) ≈ 14.3 dB.
+        const int sampleCount = SampleRate;
+        var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(source);
+
+        var ctx = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)),
+            SampleRate,
+            new AnimationSampler(),
+            null);
+
+        var output = node.Process(ctx);
+
+        // After the attack settles, the signal should sit around -15 dB.
+        float steadyStartSample = SampleRate / 2;
+        float outputPeakDb = PeakDb(output, (int)steadyStartSample);
+
+        Assert.That(outputPeakDb, Is.LessThan(-12f));
+        Assert.That(outputPeakDb, Is.GreaterThan(-18f));
+    }
+
+    [Test]
+    public void Process_MakeupGain_RaisesOutputAboveReducedLevel()
+    {
+        const int sampleCount = SampleRate;
+        var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(6f)
+        };
+        node.AddInput(source);
+
+        var ctx = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)),
+            SampleRate,
+            new AnimationSampler(),
+            null);
+
+        var output = node.Process(ctx);
+
+        float steadyStartSample = SampleRate / 2;
+        float outputPeakDb = PeakDb(output, (int)steadyStartSample);
+
+        // 6 dB makeup applied to ~-15 dB → ~-9 dB.
+        Assert.That(outputPeakDb, Is.LessThan(-6f));
+        Assert.That(outputPeakDb, Is.GreaterThan(-12f));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -769,4 +769,228 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1));
         Assert.Throws<InvalidOperationException>(() => node.Process(ctx));
     }
+
+    [Test]
+    public void Process_ZeroLengthInput_Static_ReturnsEmptyBuffer()
+    {
+        // A zero-length chunk (silent gap, end-of-stream tail) must not divide by zero, allocate
+        // a stackalloc[0] for animation buffers, or otherwise misbehave. The static path is
+        // exercised because no parameters are animated.
+        using var input = new AudioBuffer(SampleRate, 2, 0);
+        var node = CreateNode();
+        node.AddInput(new StubSourceNode { Buffer = input });
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.Zero);
+
+        using var output = node.Process(ctx);
+
+        Assert.That(output.SampleCount, Is.EqualTo(0));
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
+        Assert.That(output.SampleRate, Is.EqualTo(SampleRate));
+    }
+
+    [Test]
+    public void Process_ZeroLengthInput_Animated_ReturnsEmptyBuffer()
+    {
+        // Same as above but on the animated path: a stackalloc[0] would otherwise be allocated
+        // and the chunk loop must handle SampleCount == 0 cleanly.
+        using var input = new AudioBuffer(SampleRate, 2, 0);
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -10f, KeyTime = TimeSpan.FromSeconds(1.0) });
+        var thresholdProperty = Property.CreateAnimatable(-20f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.Zero);
+        using var output = node.Process(ctx);
+
+        Assert.That(output.SampleCount, Is.EqualTo(0));
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Process_AnimatedMakeupGain_AppliesPerSampleGain()
+    {
+        // Sweep MakeupGain from 0 dB (start) to +12 dB (end) over a steady loud signal. The
+        // tail of the buffer must measure ~12 dB louder than the head — proving that the
+        // animated `makeupDb - gainReductionDb` path actually mixes the per-sample makeup value
+        // into the output (and that the sign is correct).
+        const int sampleCount = SampleRate; // 1 s buffer
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var makeupAnim = new KeyFrameAnimation<float>();
+        makeupAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 0f, KeyTime = TimeSpan.Zero });
+        makeupAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 12f, KeyTime = TimeSpan.FromSeconds(1.0) });
+        var makeupProperty = Property.CreateAnimatable(0f);
+        makeupProperty.Animation = makeupAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = makeupProperty
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+        using var output = node.Process(ctx);
+
+        // Compare a steady-state window early in the buffer (makeup ≈ 0 dB) against one near
+        // the end (makeup ≈ +12 dB). Both are after the attack ramp so envelope state is steady.
+        int probeWidth = SampleRate / 100; // 10 ms
+        float earlyPeakDb = PeakDbInWindow(output, SampleRate / 4, probeWidth);
+        float latePeakDb = PeakDbInWindow(output, sampleCount - probeWidth, probeWidth);
+
+        float observedRise = latePeakDb - earlyPeakDb;
+        // 12 dB nominal; tolerance allows for ~3 dB of drift due to envelope ripple and the
+        // 25%→100% sweep range covering 9 dB rather than the full 12 dB.
+        Assert.That(observedRise, Is.GreaterThan(6f),
+            $"Animated MakeupGain should raise output level (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB, rise≈{observedRise:F2} dB)");
+        Assert.That(observedRise, Is.LessThan(15f),
+            $"Animated MakeupGain rise is implausibly large (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_AnimatedRatio_BelowOne_ClampsToPassthrough()
+    {
+        // The animated path's clamp must mirror the static path: an animated ratio of 0.5
+        // would otherwise produce slope = 1 - 1/0.5 = -1 which AMPLIFIES above the threshold.
+        // After clamping to MinRatio=1, slope = 0 → passthrough.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var ratioAnim = new KeyFrameAnimation<float>();
+        ratioAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 0.5f, KeyTime = TimeSpan.Zero });
+        ratioAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 0.5f, KeyTime = TimeSpan.FromSeconds(0.25) });
+        var ratioProperty = Property.CreateAnimatable(0.5f);
+        ratioProperty.Animation = ratioAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = ratioProperty,
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+        float inputPeakDb = PeakDb(input, 0);
+        // After clamp, output must NOT exceed input peak (no amplification).
+        Assert.That(outputPeakDb, Is.LessThanOrEqualTo(inputPeakDb + 0.1f),
+            $"Animated ratio<1 must clamp to passthrough; output {outputPeakDb:F2} dB exceeded input {inputPeakDb:F2} dB");
+        // And it must roughly equal the input (no compression either).
+        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(0.5f));
+    }
+
+    [Test]
+    public void Process_AnimatedAttack_AboveMaxClampsAndKeepsEnvelopeMoving()
+    {
+        // An animated Attack of 1e9 ms would collapse the coefficient to exactly 1.0, freezing
+        // the envelope so it never tracks the input — and therefore never crosses the threshold
+        // and never compresses. After clamping to MaxAttackMs the coefficient is < 1.0 so the
+        // envelope advances. We use a deep threshold (-50 dB) so the slow envelope reaches it
+        // within a 1 s buffer; the visible output reduction is then proof the clamp engaged.
+        const int sampleCount = SampleRate;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var attackAnim = new KeyFrameAnimation<float>();
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.Zero });
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.FromSeconds(1.0) });
+        var attackProperty = Property.CreateAnimatable(1e9f);
+        attackProperty.Animation = attackAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-50f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = attackProperty,
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+        using var output = node.Process(ctx);
+
+        // Probe in the last 50 ms window so the clamped 500 ms attack has had ~2 time constants
+        // to bring the envelope above -50 dB and trigger compression.
+        int probeWidth = SampleRate / 20;
+        float steadyPeakDb = PeakDbInWindow(output, sampleCount - probeWidth, probeWidth);
+        // Without clamping: envelope frozen at -100 dB → no compression → output ≈ input (-0.92 dB).
+        // With clamping: envelope advances, crosses -50 dB threshold, triggers heavy reduction.
+        Assert.That(steadyPeakDb, Is.LessThan(-10f),
+            $"Animated Attack overshoot must be clamped so the envelope can still track; got {steadyPeakDb:F2} dB");
+    }
+
+    [Test]
+    public void Process_MultipleAnimatedNonFiniteParameters_AllFallBackIndependently()
+    {
+        // Two animated parameters simultaneously produce NaN. With a single shared latch, only
+        // one parameter would log and the second's fallback could be skipped if the latch were
+        // also gating the substitution; the per-parameter HashSet ensures both still substitute
+        // their fallbacks. Observable: output is not muted (would be -100 dB if NaN propagated).
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var attackAnim = new KeyFrameAnimation<float>();
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
+        var attackProperty = Property.CreateAnimatable(5f);
+        attackProperty.Animation = attackAnim;
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
+        var thresholdProperty = Property.CreateAnimatable(-20f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = attackProperty,
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.GreaterThan(-25f),
+            $"Both NaN parameters must fall back so output remains audible; got {steadyPeakDb:F2} dB");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
 using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
@@ -23,16 +24,26 @@ public class CompressorNodeTests
         }
     }
 
-    private static AudioBuffer CreateSineBuffer(float amplitude, float frequencyHz, int sampleCount, int channels = 2)
+    private static AudioBuffer CreateSineBuffer(float amplitude, float frequencyHz, int sampleCount, int channels = 2, int sampleRate = SampleRate)
     {
-        var buffer = new AudioBuffer(SampleRate, channels, sampleCount);
+        var buffer = new AudioBuffer(sampleRate, channels, sampleCount);
         for (int ch = 0; ch < channels; ch++)
         {
             var data = buffer.GetChannelData(ch);
             for (int i = 0; i < sampleCount; i++)
             {
-                data[i] = amplitude * MathF.Sin(2f * MathF.PI * frequencyHz * i / SampleRate);
+                data[i] = amplitude * MathF.Sin(2f * MathF.PI * frequencyHz * i / sampleRate);
             }
+        }
+        return buffer;
+    }
+
+    private static AudioBuffer CreateConstantBuffer(float amplitude, int sampleCount, int channels = 2)
+    {
+        var buffer = new AudioBuffer(SampleRate, channels, sampleCount);
+        for (int ch = 0; ch < channels; ch++)
+        {
+            buffer.GetChannelData(ch).Fill(amplitude);
         }
         return buffer;
     }
@@ -52,106 +63,710 @@ public class CompressorNodeTests
         return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
     }
 
+    private static float ChannelPeakDb(AudioBuffer buffer, int channel, int startSample)
+    {
+        float peak = 0f;
+        var data = buffer.GetChannelData(channel);
+        for (int i = startSample; i < buffer.SampleCount; i++)
+        {
+            float a = MathF.Abs(data[i]);
+            if (a > peak) peak = a;
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static float PeakDbInWindow(AudioBuffer buffer, int startSample, int width)
+    {
+        int end = Math.Min(buffer.SampleCount, startSample + width);
+        float peak = 0f;
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = startSample; i < end; i++)
+            {
+                float a = MathF.Abs(data[i]);
+                if (a > peak) peak = a;
+            }
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static CompressorNode CreateNode(
+        float threshold = -20f,
+        float ratio = 4f,
+        float attack = 5f,
+        float release = 50f,
+        float knee = 0f,
+        float makeup = 0f)
+    {
+        return new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(threshold),
+            Ratio = Property.CreateAnimatable(ratio),
+            Attack = Property.CreateAnimatable(attack),
+            Release = Property.CreateAnimatable(release),
+            Knee = Property.CreateAnimatable(knee),
+            MakeupGain = Property.CreateAnimatable(makeup)
+        };
+    }
+
+    private static AudioProcessContext CreateContext(TimeSpan start, TimeSpan duration, int sampleRate = SampleRate)
+    {
+        return new AudioProcessContext(
+            new TimeRange(start, duration),
+            sampleRate,
+            new AnimationSampler(),
+            null);
+    }
+
     [Test]
     public void Process_BelowThreshold_LeavesSignalUnchanged()
     {
-        // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should pass through.
+        // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should be a
+        // bit-identical pass-through. We verify per-sample equality (not just peak) so that any
+        // unexpected residual gain reduction is caught immediately.
         const int sampleCount = SampleRate / 2;
-        var input = CreateSineBuffer(0.05f, 1000f, sampleCount);
+        using var input = CreateSineBuffer(0.05f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
 
-        var node = new CompressorNode
-        {
-            Threshold = Property.CreateAnimatable(-20f),
-            Ratio = Property.CreateAnimatable(4f),
-            Attack = Property.CreateAnimatable(10f),
-            Release = Property.CreateAnimatable(100f),
-            Knee = Property.CreateAnimatable(0f),
-            MakeupGain = Property.CreateAnimatable(0f)
-        };
+        var node = CreateNode();
         node.AddInput(source);
 
-        var ctx = new AudioProcessContext(
-            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)),
-            SampleRate,
-            new AnimationSampler(),
-            null);
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5));
 
-        var output = node.Process(ctx);
+        using var output = node.Process(ctx);
 
-        float inputPeakDb = PeakDb(input, 0);
-        float outputPeakDb = PeakDb(output, sampleCount / 2);
-
-        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(0.5f));
+        for (int ch = 0; ch < input.ChannelCount; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(outData[i], Is.EqualTo(inData[i]).Within(1e-5f));
+            }
+        }
     }
 
     [Test]
     public void Process_AboveThreshold_AppliesExpectedGainReduction()
     {
-        // Steady 0.9 amplitude (~-0.92 dB) sine, threshold -20 dB, ratio 4:1, hard knee.
-        // Steady-state gain reduction ≈ (-0.92 - -20) * (1 - 1/4) ≈ 14.3 dB.
+        // Sine well above the threshold: the per-sample peak detector dips at every zero crossing
+        // so the steady-state reduction is somewhat below the textbook ratio formula. Tolerance
+        // is loose enough to absorb that envelope ripple but tight enough to catch a slope sign
+        // flip or a missing makeup application.
         const int sampleCount = SampleRate;
-        var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
 
-        var node = new CompressorNode
-        {
-            Threshold = Property.CreateAnimatable(-20f),
-            Ratio = Property.CreateAnimatable(4f),
-            Attack = Property.CreateAnimatable(5f),
-            Release = Property.CreateAnimatable(50f),
-            Knee = Property.CreateAnimatable(0f),
-            MakeupGain = Property.CreateAnimatable(0f)
-        };
+        var node = CreateNode();
         node.AddInput(source);
 
-        var ctx = new AudioProcessContext(
-            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)),
-            SampleRate,
-            new AnimationSampler(),
-            null);
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
 
-        var output = node.Process(ctx);
+        using var output = node.Process(ctx);
 
-        // After the attack settles, the signal should sit around -15 dB.
         float steadyStartSample = SampleRate / 2;
         float outputPeakDb = PeakDb(output, (int)steadyStartSample);
 
-        Assert.That(outputPeakDb, Is.LessThan(-12f));
-        Assert.That(outputPeakDb, Is.GreaterThan(-18f));
+        Assert.That(outputPeakDb, Is.EqualTo(-13.5f).Within(1.5f));
     }
 
     [Test]
     public void Process_MakeupGain_RaisesOutputAboveReducedLevel()
     {
         const int sampleCount = SampleRate;
-        var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
+
+        var node = CreateNode(makeup: 6f);
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+
+        using var output = node.Process(ctx);
+
+        float steadyStartSample = SampleRate / 2;
+        float outputPeakDb = PeakDb(output, (int)steadyStartSample);
+
+        // Makeup gain should add directly on top of the compressed level.
+        Assert.That(outputPeakDb, Is.EqualTo(-7.5f).Within(1.5f));
+    }
+
+    [Test]
+    public void Process_RatioOne_PassesSignalThroughUnchanged()
+    {
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = CreateNode(ratio: 1f);
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+
+        using var output = node.Process(ctx);
+
+        for (int ch = 0; ch < input.ChannelCount; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(outData[i], Is.EqualTo(inData[i]).Within(1e-6f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_RatioBelowOne_ClampsToPassthrough()
+    {
+        // Animation/programmatic assignment can push ratio below 1; the node must clamp it to 1
+        // (passthrough) rather than amplify above the threshold.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = CreateNode(ratio: 0.5f);
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+
+        using var output = node.Process(ctx);
+
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+        float inputPeakDb = PeakDb(input, 0);
+        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(0.5f));
+    }
+
+    [Test]
+    public void Process_LinkedStereo_AppliesSameGainToBothChannels()
+    {
+        // L = 0.9 sine drives compression; R = 0.05 sine sits below the threshold and would not
+        // compress on its own. Linked-stereo behaviour applies the L-derived gain reduction to R
+        // as well, so R's output should be R_input_peak attenuated by the same amount as L.
+        const int sampleCount = SampleRate;
+        using var input = new AudioBuffer(SampleRate, 2, sampleCount);
+        float leftInputPeakDb = 20f * MathF.Log10(0.9f);
+        float rightInputPeakDb = 20f * MathF.Log10(0.05f);
+        var lData = input.GetChannelData(0);
+        var rData = input.GetChannelData(1);
+        for (int i = 0; i < sampleCount; i++)
+        {
+            float t = 2f * MathF.PI * 1000f * i / SampleRate;
+            lData[i] = 0.9f * MathF.Sin(t);
+            rData[i] = 0.05f * MathF.Sin(t);
+        }
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = CreateNode();
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+
+        using var output = node.Process(ctx);
+
+        int steadyStart = SampleRate / 2;
+        float leftPeakDb = ChannelPeakDb(output, 0, steadyStart);
+        float rightPeakDb = ChannelPeakDb(output, 1, steadyStart);
+
+        // L should be compressed to ~-13.5 dB (same as the steady-state test above).
+        Assert.That(leftPeakDb, Is.EqualTo(-13.5f).Within(1.5f),
+            "Sanity check: this test relies on L being compressed; if this fails the linked-gain expectation below is moot.");
+
+        // The L-channel gain reduction (positive dB number) inferred from the measurement is
+        // applied to the R channel by linked-stereo design, so R should land at the same dB
+        // distance below its input peak.
+        float leftGainReductionDb = leftInputPeakDb - leftPeakDb;
+        float expectedRightDb = rightInputPeakDb - leftGainReductionDb;
+        Assert.That(rightPeakDb, Is.EqualTo(expectedRightDb).Within(1.5f));
+    }
+
+    [Test]
+    public void Process_EnvelopeStateContinuesAcrossChunks()
+    {
+        // A node warmed up by a previous loud chunk must NOT reset its envelope when the next
+        // chunk continues directly in time. We verify this by comparing the first sample of the
+        // second chunk against a fresh node processing the same loud input from scratch:
+        // the warmed-up node is already in compression so its first sample is quieter, while
+        // the fresh node still has to ramp through the attack phase.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        var ctx2 = CreateContext(chunkDuration, chunkDuration);
+
+        var nodeContinuing = CreateNode(release: 1000f);
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeContinuing.AddInput(new StubSourceNode { Buffer = warmupInput });
+        using var warmup = nodeContinuing.Process(ctx1);
+        nodeContinuing.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeContinuing.AddInput(new StubSourceNode { Buffer = followInput });
+        using var followOutput = nodeContinuing.Process(ctx2);
+
+        var nodeFresh = CreateNode(release: 1000f);
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new StubSourceNode { Buffer = freshInput });
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        float continuingFirst = MathF.Abs(followOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(continuingFirst, Is.LessThan(freshFirst));
+    }
+
+    [Test]
+    public void Process_NonContiguousTimeRange_ResetsEnvelope()
+    {
+        // First chunk drives compression; the second chunk starts at a non-contiguous time and
+        // must therefore reset the envelope so it begins fresh from MinDb.
+        const int chunkSamples = SampleRate / 10;
+        using var loud = CreateConstantBuffer(0.9f, chunkSamples);
+
+        var node = CreateNode(release: 1000f);
+        node.AddInput(new StubSourceNode { Buffer = loud });
+        var ctx1 = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var firstOutput = node.Process(ctx1);
+
+        node.ClearInputs();
+        using var loud2 = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = loud2 });
+        // Start time jumps forward (seek), breaking contiguity.
+        var ctxSeek = CreateContext(TimeSpan.FromSeconds(5.0), TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var seekedOutput = node.Process(ctxSeek);
+
+        var nodeFresh = CreateNode(release: 1000f);
+        using var loud3 = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new StubSourceNode { Buffer = loud3 });
+        using var freshOutput = nodeFresh.Process(
+            CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate)));
+
+        // After a seek-style discontinuity, the envelope was reset, so the first sample should
+        // match a fresh node's first sample (within float tolerance).
+        float seekedFirst = MathF.Abs(seekedOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(seekedFirst, Is.EqualTo(freshFirst).Within(1e-4f));
+    }
+
+    [Test]
+    public void Process_SampleRateChange_ResetsEnvelope()
+    {
+        const int chunkSamples = SampleRate / 10;
+        using var loud = CreateConstantBuffer(0.9f, chunkSamples);
+
+        var node = CreateNode(release: 1000f);
+        node.AddInput(new StubSourceNode { Buffer = loud });
+        var ctx48 = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var firstOutput = node.Process(ctx48);
+
+        node.ClearInputs();
+        const int altSampleRate = 44100;
+        using var loud44 = CreateSineBuffer(0.9f, 1000f, altSampleRate / 10, 2, altSampleRate);
+        node.AddInput(new StubSourceNode { Buffer = loud44 });
+        // Time continues but sample rate changed → must reset envelope (and recompute coefficients
+        // for the new rate).
+        var ctx44 = new AudioProcessContext(
+            new TimeRange(TimeSpan.FromSeconds(chunkSamples / (double)SampleRate), TimeSpan.FromSeconds(0.1)),
+            altSampleRate,
+            new AnimationSampler(),
+            null);
+        using var secondOutput = node.Process(ctx44);
+
+        // After a sample-rate switch the envelope is reset, so the first sample must match a
+        // fresh node running at the new rate.
+        var nodeFresh = CreateNode(release: 1000f);
+        using var freshInput = CreateSineBuffer(0.9f, 1000f, altSampleRate / 10, 2, altSampleRate);
+        nodeFresh.AddInput(new StubSourceNode { Buffer = freshInput });
+        var ctxFresh = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(0.1)),
+            altSampleRate,
+            new AnimationSampler(),
+            null);
+        using var freshOutput = nodeFresh.Process(ctxFresh);
+
+        float secondFirst = MathF.Abs(secondOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(secondFirst, Is.EqualTo(freshFirst).Within(1e-4f));
+    }
+
+    [Test]
+    public void Reset_ClearsEnvelopeState()
+    {
+        // Process one chunk to drive the envelope into compression, then Reset() and process the
+        // next chunk at a *contiguous* time. Without Reset(), the time-range check would NOT
+        // trigger an automatic reset, so any difference from a fresh node must come from the
+        // explicit Reset() call.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        var ctx2 = CreateContext(chunkDuration, chunkDuration);
+
+        var node = CreateNode(release: 1000f);
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = warmupInput });
+        using var firstOutput = node.Process(ctx1);
+
+        node.Reset();
+        node.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = followInput });
+        using var afterResetOutput = node.Process(ctx2);
+
+        var nodeFresh = CreateNode(release: 1000f);
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new StubSourceNode { Buffer = freshInput });
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        Assert.That(
+            MathF.Abs(afterResetOutput.GetChannelData(0)[0]),
+            Is.EqualTo(MathF.Abs(freshOutput.GetChannelData(0)[0])).Within(1e-4f));
+    }
+
+    [Test]
+    public void Process_AnimatedThreshold_EngagesAnimatedPath()
+    {
+        // Threshold animates from -10 dB (no compression for 0.05 input) at t=0 to -40 dB
+        // (heavy compression for 0.05 input) at t=0.5s. The output should be louder near t=0
+        // and quieter near t=0.5s, proving the animated path is exercised.
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateConstantBuffer(0.05f, sampleCount);
+        var source = new StubSourceNode { Buffer = input };
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -10f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.FromSeconds(0.5) });
+
+        var thresholdProperty = Property.CreateAnimatable(-10f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(8f),
+            Attack = Property.CreateAnimatable(1f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5));
+
+        using var output = node.Process(ctx);
+
+        int lastQuarterStart = sampleCount * 3 / 4;
+        float earlyPeakDb = PeakDb(output, 0);
+        float latePeakDb = PeakDb(output, lastQuarterStart);
+
+        // Early threshold sits above the input (no compression); late threshold sits below it
+        // (compression engages). The late portion must therefore be measurably quieter.
+        Assert.That(latePeakDb, Is.LessThan(earlyPeakDb - 2f),
+            $"Animated threshold should attenuate the late portion (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_InfinityInputSamples_RecoversAndDoesNotLeakNonFiniteOutput()
+    {
+        // First few samples on every channel are +Infinity, which (after MathF.Abs and Log10)
+        // produces inputDb = +Infinity, polluting the envelope state. Subsequent samples are a
+        // normal sine wave. The self-recovery clamp must reset the envelope and the output
+        // sanitizer must ensure no NaN/Infinity sample escapes downstream.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        for (int ch = 0; ch < input.ChannelCount; ch++)
+        {
+            var data = input.GetChannelData(ch);
+            data[0] = float.PositiveInfinity;
+            data[1] = float.PositiveInfinity;
+        }
+
+        var source = new StubSourceNode { Buffer = input };
+        var node = CreateNode();
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        // No sample anywhere in the output may be NaN or Infinity.
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        // The steady-state region recovered to a sensible compressed level.
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.GreaterThan(-30f));
+        Assert.That(steadyPeakDb, Is.LessThan(0f));
+    }
+
+    [Test]
+    public void Process_NaNInputSamples_ProducesFiniteOutput()
+    {
+        // A NaN input sample multiplied by any gain stays NaN. The output sanitizer must
+        // replace it with 0 so downstream consumers receive only finite samples.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+        input.GetChannelData(0)[0] = float.NaN;
+        input.GetChannelData(1)[0] = float.NaN;
+
+        var source = new StubSourceNode { Buffer = input };
+        var node = CreateNode();
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        Assert.That(output.GetChannelData(0)[0], Is.EqualTo(0f));
+        Assert.That(output.GetChannelData(1)[0], Is.EqualTo(0f));
+        // Subsequent samples remain finite.
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 1; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True);
+            }
+        }
+    }
+
+    [Test]
+    public void Process_SoftKnee_ProducesSmoothTransitionAroundThreshold()
+    {
+        // Soft knee starts attenuating before the input crosses the threshold; hard knee does
+        // not. We feed a sine right at the threshold and verify that soft-knee output is lower
+        // than hard-knee output, confirming the quadratic in-knee region engages.
+        const int sampleCount = SampleRate / 2;
+        // 0.1 amplitude → exactly -20 dB peak, matching the threshold.
+        using var input = CreateSineBuffer(0.1f, 1000f, sampleCount);
+
+        var hardKneeNode = CreateNode(threshold: -20f, ratio: 4f, knee: 0f);
+        hardKneeNode.AddInput(new StubSourceNode { Buffer = input });
+        using var hardOutput = hardKneeNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        var softKneeNode = CreateNode(threshold: -20f, ratio: 4f, knee: 12f);
+        softKneeNode.AddInput(new StubSourceNode { Buffer = input });
+        using var softOutput = softKneeNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        int steadyStart = sampleCount / 2;
+        float hardPeakDb = PeakDb(hardOutput, steadyStart);
+        float softPeakDb = PeakDb(softOutput, steadyStart);
+
+        // Soft knee already engages before the input crosses the threshold, so its output peak
+        // should be measurably lower than the hard-knee output.
+        Assert.That(softPeakDb, Is.LessThan(hardPeakDb - 0.3f),
+            $"Soft knee should attenuate near threshold (hard≈{hardPeakDb:F2} dB, soft≈{softPeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_MonoBuffer_ProducesExpectedGainReduction()
+    {
+        // The implementation iterates over the channel count; a single-channel buffer must work
+        // with no off-by-one and reach the same compression level as the stereo case.
+        const int sampleCount = SampleRate;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount, channels: 1);
+        var source = new StubSourceNode { Buffer = input };
+
+        var node = CreateNode();
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+        using var output = node.Process(ctx);
+
+        Assert.That(output.ChannelCount, Is.EqualTo(1));
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.EqualTo(-13.5f).Within(1.5f));
+    }
+
+    [Test]
+    public void Process_NoInputs_Throws()
+    {
+        var node = CreateNode();
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1));
+        Assert.Throws<InvalidOperationException>(() => node.Process(ctx));
+    }
+
+    [Test]
+    public void Process_AnimatedAttackRelease_ExercisesCoefficientCache()
+    {
+        // Animate Attack from 1 ms (fast) to 200 ms (slow) over the buffer. Every new ms value
+        // invalidates the per-sample coefficient cache (`attackMs != lastAttackMs`), so
+        // ComputeCoeff is recomputed repeatedly. To verify the recomputed coefficients actually
+        // affect behaviour, we feed a step input (silence → loud) that arrives late in the
+        // buffer when the slow attack value is in effect. Right after the step the envelope
+        // hasn't clamped yet, so the transient peak must be louder than the eventually-settled
+        // tail. With attack stuck at 1 ms throughout, the transient would clamp instantly and
+        // this difference would not appear.
+        const int sampleCount = SampleRate; // 1 s buffer
+        int stepAt = SampleRate * 4 / 10;   // 400 ms in: animated attack ≈ 80 ms
+        using var input = new AudioBuffer(SampleRate, 2, sampleCount);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = input.GetChannelData(ch);
+            for (int i = stepAt; i < sampleCount; i++)
+            {
+                data[i] = 0.9f * MathF.Sin(2f * MathF.PI * 1000f * i / SampleRate);
+            }
+        }
+
+        var attackAnim = new KeyFrameAnimation<float>();
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1f, KeyTime = TimeSpan.Zero });
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 200f, KeyTime = TimeSpan.FromSeconds(1.0) });
+        var attackProperty = Property.CreateAnimatable(1f);
+        attackProperty.Animation = attackAnim;
 
         var node = new CompressorNode
         {
             Threshold = Property.CreateAnimatable(-20f),
             Ratio = Property.CreateAnimatable(4f),
+            Attack = attackProperty,
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+        using var output = node.Process(ctx);
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True);
+            }
+        }
+
+        int probeWidth = SampleRate / 200;          // 5 ms
+        float transientPeakDb = PeakDbInWindow(output, stepAt, probeWidth);
+        float settledPeakDb = PeakDbInWindow(output, sampleCount - probeWidth, probeWidth);
+
+        Assert.That(transientPeakDb, Is.GreaterThan(settledPeakDb + 1.0f),
+            $"Slow attack should leave a louder transient than the settled tail (transient≈{transientPeakDb:F2} dB, settled≈{settledPeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_AnimatedPath_SmoothAcrossChunkBoundary()
+    {
+        // ProcessAnimated walks the input in fixed-size chunks. We send a buffer that straddles
+        // several chunk boundaries and verify that the envelope state survives them: a steady
+        // input must not show any visible discontinuity at sample indices that align with the
+        // chunk size, which would indicate the envelope was reset at the boundary.
+        const int chunkSize = 1024;
+        const int sampleCount = chunkSize * 3 + 137; // straddles several boundaries
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        // Animate threshold trivially so ProcessAnimated is taken; the value stays the same so
+        // the gain reduction itself should be smooth.
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.FromSeconds(sampleCount / (double)SampleRate) });
+        var thresholdProperty = Property.CreateAnimatable(-20f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(4f),
             Attack = Property.CreateAnimatable(5f),
             Release = Property.CreateAnimatable(50f),
             Knee = Property.CreateAnimatable(0f),
-            MakeupGain = Property.CreateAnimatable(6f)
+            MakeupGain = Property.CreateAnimatable(0f)
         };
-        node.AddInput(source);
+        node.AddInput(new StubSourceNode { Buffer = input });
 
-        var ctx = new AudioProcessContext(
-            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)),
-            SampleRate,
-            new AnimationSampler(),
-            null);
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate));
+        using var output = node.Process(ctx);
 
-        var output = node.Process(ctx);
+        // Across each chunk boundary, the absolute change between adjacent samples must remain
+        // bounded by the change inside the previous window — i.e. no sudden jump caused by
+        // resetting state at a boundary.
+        var data = output.GetChannelData(0);
+        for (int boundary = chunkSize; boundary < sampleCount; boundary += chunkSize)
+        {
+            float prevDelta = MathF.Abs(data[boundary - 1] - data[boundary - 2]);
+            float boundaryDelta = MathF.Abs(data[boundary] - data[boundary - 1]);
+            // Tolerance allows for a tiny natural variation in the sine-like product but rejects
+            // an envelope reset (which would create a step of order 0.1 or larger here).
+            Assert.That(boundaryDelta, Is.LessThanOrEqualTo(prevDelta + 0.01f),
+                $"Discontinuity at chunk boundary {boundary}: prevDelta={prevDelta:F6}, boundaryDelta={boundaryDelta:F6}");
+        }
+    }
 
-        float steadyStartSample = SampleRate / 2;
-        float outputPeakDb = PeakDb(output, (int)steadyStartSample);
+    public enum AnimatedParam { Threshold, Ratio, Attack, Release, Knee, MakeupGain }
 
-        // 6 dB makeup applied to ~-15 dB → ~-9 dB.
-        Assert.That(outputPeakDb, Is.LessThan(-6f));
-        Assert.That(outputPeakDb, Is.GreaterThan(-12f));
+    [TestCase(AnimatedParam.Threshold)]
+    [TestCase(AnimatedParam.Ratio)]
+    [TestCase(AnimatedParam.Attack)]
+    [TestCase(AnimatedParam.Release)]
+    [TestCase(AnimatedParam.Knee)]
+    [TestCase(AnimatedParam.MakeupGain)]
+    public void Process_AnimatedNonFiniteValue_FallsBackWithoutMutingOutput(AnimatedParam param)
+    {
+        // A KeyFrame with NaN or Infinity on any animated parameter must not propagate to the
+        // output sanitizer (which would silently mute the entire chunk). Instead each parameter
+        // must fall back to its DefaultValue. We test every animated parameter so the
+        // SafeParameter call cannot be silently dropped from any one of them.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var threshold = Property.CreateAnimatable(-20f);
+        var ratio = Property.CreateAnimatable(4f);
+        var attack = Property.CreateAnimatable(5f);
+        var release = Property.CreateAnimatable(50f);
+        var knee = Property.CreateAnimatable(0f);
+        var makeup = Property.CreateAnimatable(0f);
+
+        IProperty<float> target = param switch
+        {
+            AnimatedParam.Threshold => threshold,
+            AnimatedParam.Ratio => ratio,
+            AnimatedParam.Attack => attack,
+            AnimatedParam.Release => release,
+            AnimatedParam.Knee => knee,
+            AnimatedParam.MakeupGain => makeup,
+            _ => throw new ArgumentOutOfRangeException(nameof(param))
+        };
+        var anim = new KeyFrameAnimation<float>();
+        anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
+        anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
+        ((AnimatableProperty<float>)target).Animation = anim;
+
+        var node = new CompressorNode
+        {
+            Threshold = threshold,
+            Ratio = ratio,
+            Attack = attack,
+            Release = release,
+            Knee = knee,
+            MakeupGain = makeup
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        // If the NaN had reached the gain calc the output sanitizer would have zeroed every
+        // sample and the peak would be -100 dB. Anything well above that proves the fallback
+        // engaged for the parameter under test.
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.GreaterThan(-25f),
+            $"Fallback failed for {param}: output appears to have been zeroed by NaN propagation");
+    }
+
+    [Test]
+    public void Process_TooManyInputs_Throws()
+    {
+        const int sampleCount = SampleRate / 10;
+        using var bufA = CreateConstantBuffer(0.1f, sampleCount);
+        using var bufB = CreateConstantBuffer(0.1f, sampleCount);
+        var node = CreateNode();
+        node.AddInput(new StubSourceNode { Buffer = bufA });
+        node.AddInput(new StubSourceNode { Buffer = bufB });
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1));
+        Assert.Throws<InvalidOperationException>(() => node.Process(ctx));
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -120,6 +120,81 @@ public class CompressorNodeTests
     }
 
     [Test]
+    public void Process_SilenceInput_ProducesExactSilenceAndKeepsEnvelopeAtFloor()
+    {
+        // peak == 0f must short-circuit to inputDb = MinDb at the `peak > 0f` guard. Without it,
+        // MathF.Log10(0) returns -Infinity, the envelope formula produces NaN, the recovery path
+        // would mask it, and any future change to that recovery path could leave the bug
+        // undetectable. We therefore feed an exactly-zero buffer and assert exact-zero output —
+        // any non-zero sample would prove the inputDb guard or makeup math is broken.
+        const int sampleCount = SampleRate / 4;
+        using var input = new AudioBuffer(SampleRate, 2, sampleCount);
+        // Default-constructed AudioBuffer is zeroed, so no fill needed.
+        var source = new StubSourceNode { Buffer = input };
+        var node = CreateNode();
+        node.AddInput(source);
+
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
+        using var output = node.Process(ctx);
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(data[i], Is.EqualTo(0f),
+                    $"Silent input must produce exact-zero output, but [{ch}][{i}] = {data[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_AttackTimeConstant_EnvelopeReachesAbout63PercentAfterAttackMs()
+    {
+        // Step input drives the envelope from MinDb toward inputDb_max. After exactly attackMs
+        // milliseconds, a one-pole IIR with time constant attackMs should have reached
+        // ~(1 - 1/e) ≈ 63% of the way to its target. This is the contract the ComputeCoeff
+        // formula encodes, and a future regression that, e.g., dropped the ms→s conversion
+        // (`timeMs * sampleRate` instead of `timeMs * 0.001f * sampleRate`) would leave the
+        // envelope barely moving — caught here.
+        const float attackMs = 50f;
+        const int sampleCount = SampleRate; // 1 s
+        const int stepAt = SampleRate / 10; // step at 100 ms; envelope below MinDb until then
+        using var input = new AudioBuffer(SampleRate, 1, sampleCount);
+        var data = input.GetChannelData(0);
+        for (int i = stepAt; i < sampleCount; i++)
+        {
+            data[i] = 1f; // exactly 0 dB peak after the step
+        }
+
+        // Threshold well below the input so above-threshold compression engages immediately.
+        // Release is irrelevant here (envelope is rising). Knee=0 keeps the gain reduction a
+        // simple linear function of envelopeDb above threshold so we can back-solve the envelope.
+        var node = CreateNode(threshold: -40f, ratio: 4f, attack: attackMs, release: 100f, knee: 0f);
+        node.AddInput(new StubSourceNode { Buffer = input });
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
+        using var output = node.Process(ctx);
+
+        // Sample exactly attackMs after the step. At that point, in dB-domain:
+        //   envelopeDb(t) = inputDb_max - (inputDb_max - inputDb_initial) * exp(-t / attackMs)
+        // With inputDb_max = 0 dB (peak 1.0) and inputDb_initial ≈ MinDb = -100 dB:
+        //   envelopeDb ≈ 0 - 100 * (1/e) ≈ -36.79 dB at t = attackMs.
+        int probeIdx = stepAt + (int)(attackMs * 0.001f * SampleRate);
+        // Reconstruct envelopeDb from the observed gain reduction:
+        //   gainLinear = 10^(-gainReductionDb / 20), envelope = output / input.
+        float gainLinear = MathF.Abs(output.GetChannelData(0)[probeIdx] / data[probeIdx]);
+        float gainReductionDb = -20f * MathF.Log10(gainLinear);
+        // gainReductionDb = slope * (envelopeDb - thresholdDb), slope = 1 - 1/4 = 0.75, threshold = -40:
+        //   envelopeDb = thresholdDb + gainReductionDb / slope.
+        float reconstructedEnvelopeDb = -40f + gainReductionDb / 0.75f;
+        // 1 - 1/e ≈ 0.632; envelope should sit at ~-36.79 dB (i.e. 63.2% of the way from -100 to 0).
+        // Tolerance is generous (~±5 dB) because the dB-domain peak ripples slightly with the
+        // sine-like product, but a missing ms→s conversion would land near -100 dB — far outside.
+        Assert.That(reconstructedEnvelopeDb, Is.EqualTo(-36.79f).Within(5f),
+            $"After attackMs={attackMs} ms, envelope should reach ~63% (≈-36.79 dB) but got {reconstructedEnvelopeDb:F2} dB");
+    }
+
+    [Test]
     public void Process_BelowThreshold_LeavesSignalUnchanged()
     {
         // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should be a

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -120,13 +120,15 @@ public class CompressorNodeTests
     }
 
     [Test]
-    public void Process_SilenceInput_ProducesExactSilenceAndKeepsEnvelopeAtFloor()
+    public void Process_SilenceInput_ProducesExactSilenceOutput()
     {
-        // peak == 0f must short-circuit to inputDb = MinDb at the `peak > 0f` guard. Without it,
-        // MathF.Log10(0) returns -Infinity, the envelope formula produces NaN, the recovery path
-        // would mask it, and any future change to that recovery path could leave the bug
-        // undetectable. We therefore feed an exactly-zero buffer and assert exact-zero output —
-        // any non-zero sample would prove the inputDb guard or makeup math is broken.
+        // End-to-end "silence in → silence out" smoke test. Note: this does NOT specifically
+        // isolate the `peak > 0f` guard, because RecoverEnvelopeIfNonFinite would mask a NaN
+        // envelope produced by Log10(0) — the gain calculation against a 0-amplitude sample
+        // still yields exactly 0. Genuinely isolating that guard would require log capture or
+        // exposing internal state. What this test does catch: any future bug that injects DC,
+        // noise, or non-zero offset into a silent stream (e.g., a stray makeup application that
+        // mishandles the additive identity, or a sanitizer that fails open).
         const int sampleCount = SampleRate / 4;
         using var input = new AudioBuffer(SampleRate, 2, sampleCount);
         // Default-constructed AudioBuffer is zeroed, so no fill needed.
@@ -154,12 +156,11 @@ public class CompressorNodeTests
         // Step input drives the envelope from MinDb toward inputDb_max. After exactly attackMs
         // milliseconds, a one-pole IIR with time constant attackMs should have reached
         // ~(1 - 1/e) ≈ 63% of the way to its target. This is the contract the ComputeCoeff
-        // formula encodes, and a future regression that, e.g., dropped the ms→s conversion
-        // (`timeMs * sampleRate` instead of `timeMs * 0.001f * sampleRate`) would leave the
-        // envelope barely moving — caught here.
+        // formula encodes; a regression like dropping the ms→s conversion (timeMs * sampleRate
+        // instead of timeMs * 0.001f * sampleRate) would leave the envelope still near -100 dB.
         const float attackMs = 50f;
         const int sampleCount = SampleRate; // 1 s
-        const int stepAt = SampleRate / 10; // step at 100 ms; envelope below MinDb until then
+        const int stepAt = SampleRate / 10; // step at 100 ms; envelope sits at MinDb until then
         using var input = new AudioBuffer(SampleRate, 1, sampleCount);
         var data = input.GetChannelData(0);
         for (int i = stepAt; i < sampleCount; i++)
@@ -167,29 +168,42 @@ public class CompressorNodeTests
             data[i] = 1f; // exactly 0 dB peak after the step
         }
 
-        // Threshold well below the input so above-threshold compression engages immediately.
-        // Release is irrelevant here (envelope is rising). Knee=0 keeps the gain reduction a
-        // simple linear function of envelopeDb above threshold so we can back-solve the envelope.
-        var node = CreateNode(threshold: -40f, ratio: 4f, attack: attackMs, release: 100f, knee: 0f);
+        // Threshold = -50 dB is the load-bearing choice. With the bug, envelope stays near
+        // -100 dB (below threshold) → gainReductionDb = 0 → output = input → reconstructed
+        // envelope clamps to thresholdDb = -50 dB. Setting threshold ABOVE the buggy envelope
+        // (at -50, far above -100) makes the buggy reconstruction 13.21 dB away from the target
+        // (-36.79 dB), well outside the ±5 dB tolerance. A threshold of -40 or lower would put
+        // the buggy reconstruction within tolerance and the test would falsely pass.
+        // Knee=0 keeps the gain formula linear so we can back-solve the envelope value.
+        const float thresholdDb = -50f;
+        const float ratio = 4f;
+        const float slope = 1f - 1f / ratio; // 0.75
+        var node = CreateNode(threshold: thresholdDb, ratio: ratio, attack: attackMs, release: 100f, knee: 0f);
         node.AddInput(new StubSourceNode { Buffer = input });
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
         using var output = node.Process(ctx);
 
         // Sample exactly attackMs after the step. At that point, in dB-domain:
         //   envelopeDb(t) = inputDb_max - (inputDb_max - inputDb_initial) * exp(-t / attackMs)
-        // With inputDb_max = 0 dB (peak 1.0) and inputDb_initial ≈ MinDb = -100 dB:
+        // With inputDb_max = 0 dB (peak 1.0) and inputDb_initial = MinDb = -100 dB:
         //   envelopeDb ≈ 0 - 100 * (1/e) ≈ -36.79 dB at t = attackMs.
         int probeIdx = stepAt + (int)(attackMs * 0.001f * SampleRate);
         // Reconstruct envelopeDb from the observed gain reduction:
         //   gainLinear = 10^(-gainReductionDb / 20), envelope = output / input.
         float gainLinear = MathF.Abs(output.GetChannelData(0)[probeIdx] / data[probeIdx]);
         float gainReductionDb = -20f * MathF.Log10(gainLinear);
-        // gainReductionDb = slope * (envelopeDb - thresholdDb), slope = 1 - 1/4 = 0.75, threshold = -40:
-        //   envelopeDb = thresholdDb + gainReductionDb / slope.
-        float reconstructedEnvelopeDb = -40f + gainReductionDb / 0.75f;
-        // 1 - 1/e ≈ 0.632; envelope should sit at ~-36.79 dB (i.e. 63.2% of the way from -100 to 0).
-        // Tolerance is generous (~±5 dB) because the dB-domain peak ripples slightly with the
-        // sine-like product, but a missing ms→s conversion would land near -100 dB — far outside.
+
+        // Direct assertion: the expected gain reduction at t = attackMs is
+        //   slope * (-36.79 - thresholdDb) = 0.75 * (-36.79 - (-50)) = 0.75 * 13.21 ≈ 9.91 dB.
+        // Under the ms→s bug, envelope stays below threshold so gainReductionDb is 0 — the
+        // tolerance below excludes that. This is the load-bearing assertion.
+        Assert.That(gainReductionDb, Is.EqualTo(9.91f).Within(2f),
+            $"At t = attackMs ({attackMs} ms), expected ≈9.91 dB reduction but got {gainReductionDb:F2} dB. " +
+            $"Near 0 dB indicates ComputeCoeff lost its ms→s conversion.");
+
+        // Secondary back-solve for human readability of the failure mode:
+        //   gainReductionDb = slope * (envelopeDb - thresholdDb) for envelopeDb > thresholdDb.
+        float reconstructedEnvelopeDb = thresholdDb + gainReductionDb / slope;
         Assert.That(reconstructedEnvelopeDb, Is.EqualTo(-36.79f).Within(5f),
             $"After attackMs={attackMs} ms, envelope should reach ~63% (≈-36.79 dB) but got {reconstructedEnvelopeDb:F2} dB");
     }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -123,10 +123,12 @@ public class CompressorNodeTests
     public void Process_SilenceInput_ProducesExactSilenceOutput()
     {
         // End-to-end "silence in → silence out" smoke test. Note: this does NOT specifically
-        // isolate the `peak > 0f` guard, because RecoverEnvelopeIfNonFinite would mask a NaN
-        // envelope produced by Log10(0) — the gain calculation against a 0-amplitude sample
-        // still yields exactly 0. Genuinely isolating that guard would require log capture or
-        // exposing internal state. What this test does catch: any future bug that injects DC,
+        // isolate the `peak > 0f` guard, because RecoverEnvelopeIfNonFinite would mask the
+        // non-finite envelope state produced when Log10(0) = -Infinity propagates through the
+        // IIR formula `inputDb + coeff * (_envelopeDb - inputDb)` (NaN appears at the
+        // (-∞) + coeff·(+∞) step). The gain calculation against a 0-amplitude sample still
+        // yields exactly 0 either way. Genuinely isolating that guard would require log capture
+        // or exposing internal state. What this test does catch: any future bug that injects DC,
         // noise, or non-zero offset into a silent stream (e.g., a stray makeup application that
         // mishandles the additive identity, or a sanitizer that fails open).
         const int sampleCount = SampleRate / 4;

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -50,6 +50,19 @@ public class CompressorNodeTests
         return buffer;
     }
 
+    // A normal sine buffer with a single +Infinity head sample on every channel. Feeding it drives
+    // the envelope non-finite (recovered to MinDb) and the product non-finite (zeroed by
+    // SanitizeOutput), emitting the one-shot non-finite-sample warning exactly once per armed period.
+    private static AudioBuffer MakeInfinityHeadBuffer(int sampleCount, int sampleRate = SampleRate)
+    {
+        var buffer = CreateSineBuffer(0.9f, 1000f, sampleCount, 2, sampleRate);
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            buffer.GetChannelData(ch)[0] = float.PositiveInfinity;
+        }
+        return buffer;
+    }
+
     private static float PeakDb(AudioBuffer buffer, int startSample)
     {
         float peak = 0f;
@@ -216,8 +229,10 @@ public class CompressorNodeTests
     public void Process_BelowThreshold_LeavesSignalUnchanged()
     {
         // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should be a
-        // bit-identical pass-through. We verify per-sample equality (not just peak) so that any
-        // unexpected residual gain reduction is caught immediately.
+        // bit-identical pass-through: the envelope never crosses the threshold, gainReductionDb is
+        // always 0, makeup is 0, so gainLinear = 10^0 = 1.0f exactly and output == input bit-for-bit.
+        // We assert exact equality (no tolerance) so any future bug injecting a near-zero residual
+        // gain is caught immediately.
         const int sampleCount = SampleRate / 2;
         using var input = CreateSineBuffer(0.05f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
@@ -235,7 +250,7 @@ public class CompressorNodeTests
             var outData = output.GetChannelData(ch);
             for (int i = 0; i < sampleCount; i++)
             {
-                Assert.That(outData[i], Is.EqualTo(inData[i]).Within(1e-5f));
+                Assert.That(outData[i], Is.EqualTo(inData[i]));
             }
         }
     }
@@ -243,10 +258,12 @@ public class CompressorNodeTests
     [Test]
     public void Process_AboveThreshold_AppliesExpectedGainReduction()
     {
-        // Sine well above the threshold: the per-sample peak detector dips at every zero crossing
-        // so the steady-state reduction is somewhat below the textbook ratio formula. Tolerance
-        // is loose enough to absorb that envelope ripple but tight enough to catch a slope sign
-        // flip or a missing makeup application.
+        // Sine well above the threshold. The analytic steady-state for a 0.9 peak (-0.92 dB) at
+        // threshold -20, ratio 4 is -0.92 - 0.75*(-0.92+20) = -15.23 dB, but the per-sample peak
+        // detector dips at every zero crossing so the measured peak sits a little above that, near
+        // -13.5 dB. The band [-16, -11] (center -13.5, ±2.5) intentionally spans BOTH the analytic
+        // ratio value and the ripple-attenuated measurement, so it stays sensitive to a slope sign
+        // flip or a missing makeup while not encoding a peak-detector-specific magic number.
         const int sampleCount = SampleRate;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
@@ -261,7 +278,7 @@ public class CompressorNodeTests
         float steadyStartSample = SampleRate / 2;
         float outputPeakDb = PeakDb(output, (int)steadyStartSample);
 
-        Assert.That(outputPeakDb, Is.EqualTo(-13.5f).Within(1.5f));
+        Assert.That(outputPeakDb, Is.EqualTo(-13.5f).Within(2.5f));
     }
 
     [Test]
@@ -281,8 +298,9 @@ public class CompressorNodeTests
         float steadyStartSample = SampleRate / 2;
         float outputPeakDb = PeakDb(output, (int)steadyStartSample);
 
-        // Makeup gain should add directly on top of the compressed level.
-        Assert.That(outputPeakDb, Is.EqualTo(-7.5f).Within(1.5f));
+        // Makeup gain should add directly on top of the compressed level. Same ±2.5 band as the
+        // no-makeup case, shifted up by the +6 dB makeup (analytic -9.23 dB, measured near -7.5 dB).
+        Assert.That(outputPeakDb, Is.EqualTo(-7.5f).Within(2.5f));
     }
 
     [Test]
@@ -362,8 +380,8 @@ public class CompressorNodeTests
         float leftPeakDb = ChannelPeakDb(output, 0, steadyStart);
         float rightPeakDb = ChannelPeakDb(output, 1, steadyStart);
 
-        // L should be compressed to ~-13.5 dB (same as the steady-state test above).
-        Assert.That(leftPeakDb, Is.EqualTo(-13.5f).Within(1.5f),
+        // L should be compressed to ~-13.5 dB (same ±2.5 band as the steady-state test above).
+        Assert.That(leftPeakDb, Is.EqualTo(-13.5f).Within(2.5f),
             "Sanity check: this test relies on L being compressed; if this fails the linked-gain expectation below is moot.");
 
         // The L-channel gain reduction (positive dB number) inferred from the measurement is
@@ -670,7 +688,7 @@ public class CompressorNodeTests
 
         Assert.That(output.ChannelCount, Is.EqualTo(1));
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
-        Assert.That(steadyPeakDb, Is.EqualTo(-13.5f).Within(1.5f));
+        Assert.That(steadyPeakDb, Is.EqualTo(-13.5f).Within(2.5f));
     }
 
     [Test]
@@ -801,8 +819,10 @@ public class CompressorNodeTests
     {
         // A KeyFrame with NaN or Infinity on any animated parameter must not propagate to the
         // output sanitizer (which would silently mute the entire chunk). Instead each parameter
-        // must fall back to its DefaultValue. We test every animated parameter so the
-        // SafeParameter call cannot be silently dropped from any one of them.
+        // must fall back to the value ReadStaticParameters supplies — i.e. the property's static
+        // CurrentValue (which itself only drops to DefaultValue if CurrentValue is non-finite). We
+        // test every animated parameter so the SafeParameter call cannot be silently dropped from
+        // any one of them.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -1223,5 +1243,163 @@ public class CompressorNodeTests
                     $"Expression-backed parameter must route to the static path and ignore the expression; mismatch at [{ch}][{i}]");
             }
         }
+    }
+
+    [Test]
+    public void Process_NonFiniteSampleLatch_SurvivesSeekDiscontinuity()
+    {
+        // The diagnostic latch must be PRESERVED across a time-range discontinuity (seek). A
+        // stuttering scrubber produces many discontinuities within one session; re-arming the
+        // one-shot warning on each would let a persistent fault re-log once per Process() call.
+        // The seek path calls ResetEnvelope() only (not ResetDiagnostics), so a second seeked chunk
+        // carrying the same fault must emit NO second warning. This pins the node's most heavily
+        // justified design decision (the 8-line comment at CompressorNode.Process).
+        var node = CreateNode();
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = first });
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1),
+            "The first non-finite sample must emit exactly one warning.");
+
+        node.ClearInputs();
+        using var second = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = second });
+        // Non-contiguous start time → ResetEnvelope only; diagnostics are deliberately NOT re-armed.
+        using var seekedOut = node.Process(CreateContext(TimeSpan.FromSeconds(5.0), chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1),
+            "A seek discontinuity must NOT re-arm the latch, so no second warning should be emitted.");
+    }
+
+    [Test]
+    public void Process_NonFiniteSampleLatch_ReArmsOnSampleRateChange()
+    {
+        // A sample-rate change is a genuine session boundary: Process() calls the full Reset(),
+        // which DOES re-arm diagnostics. The same fault at the new rate must therefore warn again.
+        var node = CreateNode();
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = first });
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1));
+
+        node.ClearInputs();
+        const int altSampleRate = 44100;
+        using var second = MakeInfinityHeadBuffer(altSampleRate / 10, altSampleRate);
+        node.AddInput(new StubSourceNode { Buffer = second });
+        using var secondOut = node.Process(new AudioProcessContext(
+            new TimeRange(chunkDuration, TimeSpan.FromSeconds(0.1)),
+            altSampleRate, new AnimationSampler(), null));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(2),
+            "A sample-rate change re-arms the latch, so the recurring fault must warn a second time.");
+    }
+
+    [Test]
+    public void Reset_ReArmsNonFiniteSampleLatch()
+    {
+        // Explicit Reset() (deliberate re-render / orchestrated stop) re-arms diagnostics too. We
+        // keep the second chunk CONTIGUOUS in time so only the explicit Reset() — not a
+        // discontinuity — can be responsible for re-arming the latch.
+        var node = CreateNode();
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = first });
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1));
+
+        node.Reset();
+        node.ClearInputs();
+        using var second = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new StubSourceNode { Buffer = second });
+        using var secondOut = node.Process(CreateContext(chunkDuration, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(2),
+            "Explicit Reset() re-arms the latch, so the recurring fault must warn a second time.");
+    }
+
+    [Test]
+    public void Process_LinkedSurround_AppliesLoudestChannelGainToAllChannels()
+    {
+        // Peak detection links across ALL channels (not just the first two) and MapChannels
+        // reallocates its caches for a >2-channel count, exercising the channel-major fallback loop.
+        // We drive a 4-channel buffer where the loudest channel is channel 2 (NOT channel 0); the
+        // other three sit below threshold. Linked behaviour must attenuate every channel by channel
+        // 2's gain reduction — a peak loop that only scanned channels 0..1, or an off-by-one in the
+        // channel bound, would fail here.
+        const int sampleCount = SampleRate;
+        const int channels = 4;
+        using var input = new AudioBuffer(SampleRate, channels, sampleCount);
+        float[] amps = [0.05f, 0.05f, 0.9f, 0.05f]; // loudest is channel 2
+        for (int ch = 0; ch < channels; ch++)
+        {
+            var data = input.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                data[i] = amps[ch] * MathF.Sin(2f * MathF.PI * 1000f * i / SampleRate);
+            }
+        }
+
+        var node = CreateNode();
+        node.AddInput(new StubSourceNode { Buffer = input });
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)));
+
+        Assert.That(output.ChannelCount, Is.EqualTo(channels));
+
+        int steadyStart = SampleRate / 2;
+        // Channel 2 drives compression to ~-13.5 dB (same ±2.5 band as the stereo case).
+        float loudestPeakDb = ChannelPeakDb(output, 2, steadyStart);
+        Assert.That(loudestPeakDb, Is.EqualTo(-13.5f).Within(2.5f),
+            "Sanity check: the loudest channel (2) must be compressed for the linked-gain expectation to be meaningful.");
+
+        float loudestInputPeakDb = 20f * MathF.Log10(0.9f);
+        float gainReductionDb = loudestInputPeakDb - loudestPeakDb;
+        float quietInputPeakDb = 20f * MathF.Log10(0.05f);
+        float expectedQuietDb = quietInputPeakDb - gainReductionDb;
+
+        // Every quiet channel must receive the SAME gain reduction derived from channel 2.
+        foreach (int ch in new[] { 0, 1, 3 })
+        {
+            float quietPeakDb = ChannelPeakDb(output, ch, steadyStart);
+            Assert.That(quietPeakDb, Is.EqualTo(expectedQuietDb).Within(1.5f),
+                $"Channel {ch} should be attenuated by channel 2's linked gain reduction.");
+        }
+    }
+
+    [Test]
+    public void Process_AnimatedOutOfRangeParameter_LogsClampWarningOncePerParameter()
+    {
+        // A finite but out-of-[Range] animated value (Attack = 1e9 ms) is clamped to keep the DSP
+        // safe, and must emit exactly one clamp warning for that parameter — not zero (a silently
+        // hidden misconfiguration) and not one-per-sample (audio-thread spam). The other five
+        // parameters stay in range, so the count isolates the single offending parameter.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var attackAnim = new KeyFrameAnimation<float>();
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.Zero });
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.FromSeconds(0.25) });
+        var attackProperty = Property.CreateAnimatable(5f);
+        attackProperty.Animation = attackAnim;
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(-20f),
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = attackProperty,
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        node.AddInput(new StubSourceNode { Buffer = input });
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        Assert.That(node.ClampWarnings, Is.EqualTo(1),
+            "An out-of-range animated Attack must warn exactly once for the whole chunk, not zero and not per-sample.");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -4,10 +4,12 @@ using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
+using Beutl.Engine.Expressions;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine.Audio;
 
+[TestFixture]
 public class CompressorNodeTests
 {
     private const int SampleRate = 48000;
@@ -824,7 +826,8 @@ public class CompressorNodeTests
         var anim = new KeyFrameAnimation<float>();
         anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
         anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
-        ((AnimatableProperty<float>)target).Animation = anim;
+        // IProperty<float> exposes the Animation setter directly; no concrete-type cast needed.
+        target.Animation = anim;
 
         var node = new CompressorNode
         {
@@ -882,8 +885,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_ZeroLengthInput_Animated_ReturnsEmptyBuffer()
     {
-        // Same as above but on the animated path: a stackalloc[0] would otherwise be allocated
-        // and the chunk loop must handle SampleCount == 0 cleanly.
+        // Same as above, but with an animated parameter. The zero-length early-return in Process()
+        // intercepts BOTH the static and animated paths before ProcessAnimated (and its
+        // stackalloc float[bufferSize]) is ever entered, so this asserts the early-return contract
+        // — not the animated chunk loop itself, which is unreachable for SampleCount == 0.
         using var input = new AudioBuffer(SampleRate, 2, 0);
 
         var thresholdAnim = new KeyFrameAnimation<float>();
@@ -1083,5 +1088,140 @@ public class CompressorNodeTests
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
         Assert.That(steadyPeakDb, Is.GreaterThan(-25f),
             $"Both NaN parameters must fall back so output remains audible; got {steadyPeakDb:F2} dB");
+    }
+
+    [Test]
+    public void Process_StaticAndAnimatedPaths_ProduceIdenticalOutputForConstantParameters()
+    {
+        // ProcessStatic and ProcessAnimated deliberately share ComputeCoeff / ComputeGainReductionDb
+        // / ComputeGainLinear so the two paths cannot drift. This pins that parity directly: with a
+        // constant-valued (two identical keyframes) Threshold animation, the animated path runs but
+        // every sampled parameter equals what the static path reads, so the outputs must be
+        // sample-for-sample identical. A coefficient-cache off-by-one, a chunk-boundary coefficient
+        // reset, or a slope re-derivation bug that uniformly scaled the animated output would break
+        // this even though Process_AnimatedPath_SmoothAcrossChunkBoundary (smoothness only) passes.
+        const int sampleCount = SampleRate / 2; // straddles many 1024-sample chunks
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        // Static reference path (knee>0 and makeup!=0 so both branches are exercised in both paths).
+        var staticNode = CreateNode(threshold: -20f, ratio: 4f, attack: 5f, release: 50f, knee: 6f, makeup: 3f);
+        staticNode.AddInput(new StubSourceNode { Buffer = input });
+        using var staticOut = staticNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        // Animated path forced on via a constant Threshold animation (-20 → -20). The remaining
+        // parameters have no animation, so AnimationSampler fills each with the same CurrentValue
+        // the static path reads.
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = duration });
+        var thresholdProperty = Property.CreateAnimatable(-20f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var animatedNode = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(6f),
+            MakeupGain = Property.CreateAnimatable(3f)
+        };
+        animatedNode.AddInput(new StubSourceNode { Buffer = input });
+        using var animatedOut = animatedNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        for (int ch = 0; ch < staticOut.ChannelCount; ch++)
+        {
+            var s = staticOut.GetChannelData(ch);
+            var a = animatedOut.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(a[i], Is.EqualTo(s[i]).Within(1e-4f),
+                    $"Static and animated paths diverged at [{ch}][{i}]: static={s[i]}, animated={a[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_SoftKnee_InKneeReductionMatchesClosedForm()
+    {
+        // Validate the soft-knee quadratic numerically, not just "soft < hard". A DC signal whose
+        // peak level equals the threshold drives the envelope to a known value (= thresholdDb), so
+        // diff = 0, landing in the middle of the knee. The closed form there is
+        //   GR = slope * x^2 / (2*knee)  with x = diff + halfKnee = halfKnee.
+        // The hard-knee formula would give 0 dB at diff == 0, so this point distinctively exercises
+        // the quadratic branch of CompressorNode.ComputeGainReductionDb.
+        const int sampleCount = SampleRate / 2; // long enough for the envelope to settle to inputDb
+        const float thresholdDb = -20f;
+        const float ratio = 4f;
+        const float kneeDb = 12f;
+        float amplitude = MathF.Pow(10f, thresholdDb / 20f); // 0.1 → peak dB == threshold
+        using var input = CreateConstantBuffer(amplitude, sampleCount);
+
+        var node = CreateNode(threshold: thresholdDb, ratio: ratio, attack: 1f, release: 1f, knee: kneeDb, makeup: 0f);
+        node.AddInput(new StubSourceNode { Buffer = input });
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        // After settling, output[last] = amplitude * 10^(-GR/20). Recover GR and compare to the
+        // closed-form value at diff = 0.
+        float settled = MathF.Abs(output.GetChannelData(0)[sampleCount - 1]);
+        float measuredGrDb = -20f * MathF.Log10(settled / amplitude);
+
+        float slope = 1f - 1f / ratio;                            // 0.75
+        float halfKnee = kneeDb * 0.5f;                           // 6
+        float expectedGrDb = slope * halfKnee * halfKnee / (2f * kneeDb); // 1.125 dB
+
+        Assert.That(measuredGrDb, Is.EqualTo(expectedGrDb).Within(0.1f),
+            $"In-knee reduction at the threshold must match the quadratic closed form " +
+            $"(expected {expectedGrDb:F3} dB, got {measuredGrDb:F3} dB)");
+    }
+
+    [Test]
+    public void Process_ExpressionBackedParameter_RoutesToStaticPathAndIgnoresExpression()
+    {
+        // hasAnimation keys solely on Animation != null, so an expression-backed property
+        // (Animation == null, HasExpression == true) routes to ProcessStatic, which reads
+        // CurrentValue and does NOT evaluate the expression per-sample. This pins that documented
+        // contract: the output must equal a fully-static node with the same CurrentValue even
+        // though the expression evaluates to a different number. If a future change flips the gate
+        // to treat HasExpression as live (the FIXME's eventual goal), this test forces a deliberate
+        // update instead of silently changing rendered audio.
+        const int sampleCount = SampleRate / 2;
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
+
+        var staticNode = CreateNode(threshold: -20f);
+        staticNode.AddInput(new StubSourceNode { Buffer = input });
+        using var staticOut = staticNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        // CurrentValue stays -20; the expression evaluates to -40 (which would compress harder).
+        // Because the static path ignores the expression, -40 must NOT take effect.
+        var thresholdProperty = Property.CreateAnimatable(-20f);
+        thresholdProperty.Expression = new StringExpression<float>("-40");
+        Assert.That(thresholdProperty.HasExpression, Is.True);
+        Assert.That(thresholdProperty.Animation, Is.Null);
+
+        var exprNode = new CompressorNode
+        {
+            Threshold = thresholdProperty,
+            Ratio = Property.CreateAnimatable(4f),
+            Attack = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(50f),
+            Knee = Property.CreateAnimatable(0f),
+            MakeupGain = Property.CreateAnimatable(0f)
+        };
+        exprNode.AddInput(new StubSourceNode { Buffer = input });
+        using var exprOut = exprNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        for (int ch = 0; ch < staticOut.ChannelCount; ch++)
+        {
+            var s = staticOut.GetChannelData(ch);
+            var e = exprOut.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(e[i], Is.EqualTo(s[i]).Within(1e-6f),
+                    $"Expression-backed parameter must route to the static path and ignore the expression; mismatch at [{ch}][{i}]");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Adds a new audio **Compressor** effect (Threshold, Ratio, Attack, Release, Knee, Makeup Gain), registered under the Audio Effect group in the library.

### DSP
- Peak-detector envelope follower with a one-pole attack/release smoother and a soft-knee gain computer (C¹-continuous across the knee) in `CompressorNode`.
- Supports both static and animated parameters; animated parameters are sampled per-sample in fixed 1024-sample chunks, with the attack/release coefficients recomputed only when the sampled value changes.
- `ProcessStatic` and `ProcessAnimated` share `NextGain` / `ComputeGainReductionDb` / `ComputeGainLinear`, so the two paths cannot drift; a parity test pins them sample-for-sample.

### State & lifecycle
- Resets the envelope on a sample-rate change or a non-contiguous time range, so stale state from the cached node instance does not bleed across seeks or stop/restart.
- One-shot non-finite diagnostics (envelope / output sample / per-parameter) are re-armed on a sample-rate change or explicit `Reset()`, but deliberately preserved across seeks to avoid per-`Process` log spam.

### Robustness
- Recovers a non-finite envelope to the floor and sanitizes non-finite output samples to 0 to protect downstream nodes, logging once per condition (the output-sample warning notes the cause is almost certainly upstream).
- Substitutes a fallback for non-finite animated parameters and clamps finite out-of-range animated values to the declared `[Range]`, warning once per parameter when a clamp occurs so a malformed keyframe is not silently hidden.

### Consistency / maintainability
- `CompressorParameters` is the single source of truth for the ranges/defaults shared between `CompressorEffect`'s `[Range]` declarations and `CompressorNode`'s per-sample clamps; their internal consistency (Min < Max, Min ≤ Default ≤ Max) is asserted by a plain unit test.

### Performance
- Hot loops materialize per-channel spans once for the common mono/stereo case (removing the per-sample `Memory<float>.Span` getter), with a general fallback for >2 channels; the animated coefficient `Exp` is gated by a change check; animation-sampling buffers are stack-allocated with a 1024-sample cap.

### Tests
- 51 unit tests across `CompressorNodeTests` / `CompressorEffectTests` covering DSP correctness (attack time constant, gain reduction, soft-knee closed form, static/animated parity), state & lifecycle (envelope continuity, seek/sample-rate reset, diagnostic-latch re-arm), non-finite hardening, multi-channel linking (mono / stereo / 4-ch surround), and the effect wiring/registration.

## Breaking changes
None

## Fixed issues
None
