### PR TITLE
feat: Add audio Limiter (brick-wall peak limiter) effect

### DIFF
--- a/src/Beutl.Engine/Audio/AudioBuffer.cs
+++ b/src/Beutl.Engine/Audio/AudioBuffer.cs
@@ -60,10 +60,9 @@ public sealed class AudioBuffer : IDisposable
     }
 
     /// <summary>
-    /// Returns the full channel-major backing span: channel 0's samples, then channel 1's, and so
-    /// on. Channel <paramref name="channel"/> sample <c>i</c> lives at index
-    /// <c>channel * SampleCount + i</c>. Intended for hot DSP loops that would otherwise pay
-    /// <see cref="GetChannelData"/>'s per-call disposed/bounds/Slice overhead on every sample.
+    /// Returns the full channel-major backing span (channel <c>ch</c> sample <c>i</c> at index
+    /// <c>ch * SampleCount + i</c>). Intended for hot DSP loops that would otherwise pay
+    /// <see cref="GetChannelData"/>'s per-call overhead on every sample.
     /// </summary>
     internal Span<float> GetRawSpan()
     {

--- a/src/Beutl.Engine/Audio/AudioBuffer.cs
+++ b/src/Beutl.Engine/Audio/AudioBuffer.cs
@@ -59,6 +59,18 @@ public sealed class AudioBuffer : IDisposable
         return _memory.Slice(start, _channelSampleCount);
     }
 
+    /// <summary>
+    /// Returns the full channel-major backing span: channel 0's samples, then channel 1's, and so
+    /// on. Channel <paramref name="channel"/> sample <c>i</c> lives at index
+    /// <c>channel * SampleCount + i</c>. Intended for hot DSP loops that would otherwise pay
+    /// <see cref="GetChannelData"/>'s per-call disposed/bounds/Slice overhead on every sample.
+    /// </summary>
+    internal Span<float> GetRawSpan()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _memory.Span;
+    }
+
     public Pcm<Stereo32BitFloat> ToPcm()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Language;
+
+namespace Beutl.Audio.Effects;
+
+[Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
+public sealed partial class LimiterEffect : AudioEffect
+{
+    public LimiterEffect()
+    {
+        ScanProperties<LimiterEffect>();
+    }
+
+    [Range(-60f, 0f)]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Threshold), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(-1.0f);
+
+    [Range(1f, 5000f)]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Release), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Release { get; } = Property.CreateAnimatable(50f);
+
+    [Range(0f, 20f)]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> Lookahead { get; } = Property.CreateAnimatable(5f);
+
+    [Range(-24f, 24f)]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(0f);
+
+    public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
+    {
+        var limiterNode = context.AddNode(new LimiterNode
+        {
+            Threshold = Threshold,
+            Release = Release,
+            Lookahead = Lookahead,
+            MakeupGain = MakeupGain
+        });
+
+        context.Connect(inputNode, limiterNode);
+        return limiterNode;
+    }
+}

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -15,32 +15,19 @@ namespace Beutl.Audio.Effects;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The DSP layer (<see cref="Beutl.Audio.Graph.Nodes.LimiterNode"/>) re-clamps
-/// every parameter to the ranges declared here, so the constants double as the
-/// authoritative range and as the safety net for animations or restored project
-/// files that bypass the <see cref="RangeAttribute"/> validation.
+/// <see cref="Lookahead"/> above 0 ms delays the whole signal by that amount so gain
+/// reduction can precede a peak. Beutl's audio graph runs effects inline (output length
+/// equals input length) with no latency compensation, so at a contiguous-run boundary
+/// (clip end, seek, loop, edit) the limiter resets and the buffered tail is dropped. The
+/// default 0 ms keeps audio sample-accurate and A/V-synchronized; raise it to trade a
+/// fixed delay for better transient transparency.
 /// </para>
 /// <para>
-/// Setting <see cref="Lookahead"/> above 0 ms shifts the entire signal later by
-/// that amount. Within a single contiguous run of audio it is a pure phase shift —
-/// no samples are lost, the trailing samples emerge in the next contiguous chunk.
-/// At a contiguous-run boundary (clip end, seek, loop, or edit) the limiter resets
-/// its internal state, so the still-buffered tail of the previous run is discarded
-/// and the same number of samples are effectively dropped at the boundary. This is
-/// because Beutl's audio graph processes effects inline (output length equals input
-/// length) and has no latency-reporting/compensation hook. The default is therefore
-/// 0 ms, which keeps audio sample-accurate and A/V-synchronized out of the box and
-/// degrades the algorithm to a zero-latency brick wall; raise it to trade a fixed
-/// delay for the transient transparency of a standard external lookahead limiter.
-/// </para>
-/// <para>
-/// A master limiter (<see cref="Beutl.Audio.Composing.Composer"/>) is always applied
-/// to the mixed bus after this effect. It re-limits anything above 0 dBFS with different
-/// (ratio-based) characteristics, so the brick-wall ceiling configured here is only
-/// guaranteed end-to-end when the summed bus — this effect's output plus everything mixed
-/// alongside it — stays at or below 0 dBFS. That can be exceeded even when a single limiter's
-/// <see cref="Threshold"/> + <see cref="MakeupGain"/> is at or below 0 dBFS, because multiple
-/// sounds sum on the master bus.
+/// A master limiter (<see cref="Beutl.Audio.Composing.Composer"/>) always re-limits the
+/// mixed bus after this effect, so the brick-wall ceiling configured here holds end-to-end
+/// only when the summed bus stays at or below 0 dBFS — multiple sounds sum on the master
+/// bus, so that can be exceeded even when this limiter's
+/// <see cref="Threshold"/> + <see cref="MakeupGain"/> is within 0 dBFS.
 /// </para>
 /// </remarks>
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -8,9 +8,15 @@ namespace Beutl.Audio.Effects;
 
 /// <summary>
 /// Brick-wall peak limiter effect with lookahead. Prevents the output peak
-/// amplitude from exceeding <see cref="Threshold"/> by applying instant gain
-/// reduction with an IIR-shaped release.
+/// amplitude from exceeding <see cref="Threshold"/> using instant attack and
+/// exponential (one-pole IIR) release.
 /// </summary>
+/// <remarks>
+/// The DSP layer (<see cref="Beutl.Audio.Graph.Nodes.LimiterNode"/>) re-clamps
+/// every parameter to the ranges declared here, so the constants double as the
+/// authoritative range and as the safety net for animations or restored project
+/// files that bypass the <see cref="RangeAttribute"/> validation.
+/// </remarks>
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
 public sealed partial class LimiterEffect : AudioEffect
 {
@@ -23,6 +29,11 @@ public sealed partial class LimiterEffect : AudioEffect
     internal const float MinMakeupGainDb = -24f;
     internal const float MaxMakeupGainDb = 24f;
 
+    internal const float DefaultThresholdDb = -1.0f;
+    internal const float DefaultReleaseMs = 50f;
+    internal const float DefaultLookaheadMs = 5f;
+    internal const float DefaultMakeupGainDb = 0f;
+
     public LimiterEffect()
     {
         ScanProperties<LimiterEffect>();
@@ -32,40 +43,38 @@ public sealed partial class LimiterEffect : AudioEffect
     /// Output ceiling in decibels. The peak detector evaluates the maximum
     /// absolute sample value within the lookahead window; whenever it exceeds
     /// this threshold the gain is reduced so the delayed output stays at or
-    /// below this ceiling. Range: -60 dB to 0 dB.
+    /// below this ceiling.
     /// </summary>
     [Range(MinThresholdDb, MaxThresholdDb)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Threshold), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(-1.0f);
+    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(DefaultThresholdDb);
 
     /// <summary>
     /// Time constant of the gain recovery (one-pole IIR) in milliseconds.
-    /// Range: 1 ms to 5000 ms.
     /// </summary>
     [Range(MinReleaseMs, MaxReleaseMs)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Release), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Release { get; } = Property.CreateAnimatable(50f);
+    public IProperty<float> Release { get; } = Property.CreateAnimatable(DefaultReleaseMs);
 
     /// <summary>
     /// Lookahead window in milliseconds. The output is delayed by this amount
-    /// so that gain reduction can begin before a peak arrives. Range: 0 ms to 20 ms.
+    /// so that gain reduction can begin before a peak arrives.
     /// </summary>
     [Range(MinLookaheadMs, MaxLookaheadMs)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Lookahead { get; } = Property.CreateAnimatable(5f);
+    public IProperty<float> Lookahead { get; } = Property.CreateAnimatable(DefaultLookaheadMs);
 
     /// <summary>
-    /// Gain applied to the output after limiting, in decibels. Note that
-    /// makeup gain can push the output back above the threshold.
-    /// Range: -24 dB to +24 dB.
+    /// Gain applied to the output after the limiter stage, in decibels. The
+    /// final peak can therefore reach <c>Threshold + MakeupGain</c> dB.
     /// </summary>
     [Range(MinMakeupGainDb, MaxMakeupGainDb)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(0f);
+    public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(DefaultMakeupGainDb);
 
     public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
     {

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -6,30 +6,63 @@ using Beutl.Language;
 
 namespace Beutl.Audio.Effects;
 
+/// <summary>
+/// Brick-wall peak limiter effect with lookahead. Prevents the output peak
+/// amplitude from exceeding <see cref="Threshold"/> by applying instant gain
+/// reduction with an IIR-shaped release.
+/// </summary>
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
 public sealed partial class LimiterEffect : AudioEffect
 {
+    internal const float MinThresholdDb = -60f;
+    internal const float MaxThresholdDb = 0f;
+    internal const float MinReleaseMs = 1f;
+    internal const float MaxReleaseMs = 5000f;
+    internal const float MinLookaheadMs = 0f;
+    internal const float MaxLookaheadMs = 20f;
+    internal const float MinMakeupGainDb = -24f;
+    internal const float MaxMakeupGainDb = 24f;
+
     public LimiterEffect()
     {
         ScanProperties<LimiterEffect>();
     }
 
-    [Range(-60f, 0f)]
+    /// <summary>
+    /// Output ceiling in decibels. The peak detector evaluates the maximum
+    /// absolute sample value within the lookahead window; whenever it exceeds
+    /// this threshold the gain is reduced so the delayed output stays at or
+    /// below this ceiling. Range: -60 dB to 0 dB.
+    /// </summary>
+    [Range(MinThresholdDb, MaxThresholdDb)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Threshold), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
     public IProperty<float> Threshold { get; } = Property.CreateAnimatable(-1.0f);
 
-    [Range(1f, 5000f)]
+    /// <summary>
+    /// Time constant of the gain recovery (one-pole IIR) in milliseconds.
+    /// Range: 1 ms to 5000 ms.
+    /// </summary>
+    [Range(MinReleaseMs, MaxReleaseMs)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Release), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
     public IProperty<float> Release { get; } = Property.CreateAnimatable(50f);
 
-    [Range(0f, 20f)]
+    /// <summary>
+    /// Lookahead window in milliseconds. The output is delayed by this amount
+    /// so that gain reduction can begin before a peak arrives. Range: 0 ms to 20 ms.
+    /// </summary>
+    [Range(MinLookaheadMs, MaxLookaheadMs)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
     public IProperty<float> Lookahead { get; } = Property.CreateAnimatable(5f);
 
-    [Range(-24f, 24f)]
+    /// <summary>
+    /// Gain applied to the output after limiting, in decibels. Note that
+    /// makeup gain can push the output back above the threshold.
+    /// Range: -24 dB to +24 dB.
+    /// </summary>
+    [Range(MinMakeupGainDb, MaxMakeupGainDb)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
     public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(0f);

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -20,9 +20,13 @@ namespace Beutl.Audio.Effects;
 /// </para>
 /// <para>
 /// Setting <see cref="Lookahead"/> above 0 ms shifts the entire signal later by
-/// that amount and drops the same number of samples at the end of each clip,
-/// because Beutl's audio graph processes effects inline (output length equals
-/// input length) and has no latency-reporting/compensation hook. Use 0 ms when
+/// that amount. Within a single contiguous run of audio it is a pure phase shift —
+/// no samples are lost, the trailing samples emerge in the next contiguous chunk.
+/// At a contiguous-run boundary (clip end, seek, loop, or edit) the limiter resets
+/// its internal state, so the still-buffered tail of the previous run is discarded
+/// and the same number of samples are effectively dropped at the boundary. This is
+/// because Beutl's audio graph processes effects inline (output length equals input
+/// length) and has no latency-reporting/compensation hook. Use 0 ms when
 /// sample-accurate timing matters; non-zero values trade transient transparency
 /// for a fixed delay matching standard external lookahead limiters.
 /// </para>

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -26,9 +26,19 @@ namespace Beutl.Audio.Effects;
 /// its internal state, so the still-buffered tail of the previous run is discarded
 /// and the same number of samples are effectively dropped at the boundary. This is
 /// because Beutl's audio graph processes effects inline (output length equals input
-/// length) and has no latency-reporting/compensation hook. Use 0 ms when
-/// sample-accurate timing matters; non-zero values trade transient transparency
-/// for a fixed delay matching standard external lookahead limiters.
+/// length) and has no latency-reporting/compensation hook. The default is therefore
+/// 0 ms, which keeps audio sample-accurate and A/V-synchronized out of the box and
+/// degrades the algorithm to a zero-latency brick wall; raise it to trade a fixed
+/// delay for the transient transparency of a standard external lookahead limiter.
+/// </para>
+/// <para>
+/// A master limiter (<see cref="Beutl.Audio.Composing.Composer"/>) is always applied
+/// to the mixed bus after this effect. It re-limits anything above 0 dBFS with different
+/// (ratio-based) characteristics, so the brick-wall ceiling configured here is only
+/// guaranteed end-to-end when the summed bus — this effect's output plus everything mixed
+/// alongside it — stays at or below 0 dBFS. That can be exceeded even when a single limiter's
+/// <see cref="Threshold"/> + <see cref="MakeupGain"/> is at or below 0 dBFS, because multiple
+/// sounds sum on the master bus.
 /// </para>
 /// </remarks>
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
@@ -45,7 +55,7 @@ public sealed partial class LimiterEffect : AudioEffect
 
     internal const float DefaultThresholdDb = -1.0f;
     internal const float DefaultReleaseMs = 50f;
-    internal const float DefaultLookaheadMs = 5f;
+    internal const float DefaultLookaheadMs = 0f;
     internal const float DefaultMakeupGainDb = 0f;
 
     public LimiterEffect()

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -4,6 +4,8 @@ using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 using Beutl.Language;
 
+using static Beutl.Audio.Effects.LimiterParameters;
+
 namespace Beutl.Audio.Effects;
 
 /// <summary>
@@ -44,20 +46,6 @@ namespace Beutl.Audio.Effects;
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
 public sealed partial class LimiterEffect : AudioEffect
 {
-    internal const float MinThresholdDb = -60f;
-    internal const float MaxThresholdDb = 0f;
-    internal const float MinReleaseMs = 1f;
-    internal const float MaxReleaseMs = 5000f;
-    internal const float MinLookaheadMs = 0f;
-    internal const float MaxLookaheadMs = 20f;
-    internal const float MinMakeupGainDb = -24f;
-    internal const float MaxMakeupGainDb = 24f;
-
-    internal const float DefaultThresholdDb = -1.0f;
-    internal const float DefaultReleaseMs = 50f;
-    internal const float DefaultLookaheadMs = 0f;
-    internal const float DefaultMakeupGainDb = 0f;
-
     public LimiterEffect()
     {
         ScanProperties<LimiterEffect>();
@@ -70,16 +58,18 @@ public sealed partial class LimiterEffect : AudioEffect
     /// below this ceiling.
     /// </summary>
     [Range(MinThresholdDb, MaxThresholdDb)]
-    [Display(Name = nameof(AudioStrings.LimiterEffect_Threshold), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Threshold), Description = nameof(AudioStrings.LimiterEffect_Threshold_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
     public IProperty<float> Threshold { get; } = Property.CreateAnimatable(DefaultThresholdDb);
 
     /// <summary>
     /// Time constant of the gain recovery (one-pole IIR) in milliseconds.
     /// </summary>
     [Range(MinReleaseMs, MaxReleaseMs)]
-    [Display(Name = nameof(AudioStrings.LimiterEffect_Release), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Release), Description = nameof(AudioStrings.LimiterEffect_Release_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(100, 10)]
     public IProperty<float> Release { get; } = Property.CreateAnimatable(DefaultReleaseMs);
 
     /// <summary>
@@ -89,8 +79,9 @@ public sealed partial class LimiterEffect : AudioEffect
     /// and drop the same number of samples from the tail.
     /// </summary>
     [Range(MinLookaheadMs, MaxLookaheadMs)]
-    [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), Description = nameof(AudioStrings.LimiterEffect_Lookahead_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(5, 0.5)]
     public IProperty<float> Lookahead { get; } = Property.CreateAnimatable(DefaultLookaheadMs);
 
     /// <summary>
@@ -98,8 +89,9 @@ public sealed partial class LimiterEffect : AudioEffect
     /// final peak can therefore reach <c>Threshold + MakeupGain</c> dB.
     /// </summary>
     [Range(MinMakeupGainDb, MaxMakeupGainDb)]
-    [Display(Name = nameof(AudioStrings.LimiterEffect_MakeupGain), ResourceType = typeof(AudioStrings))]
+    [Display(Name = nameof(AudioStrings.LimiterEffect_MakeupGain), Description = nameof(AudioStrings.LimiterEffect_MakeupGain_Description), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
+    [NumberStep(1, 0.1)]
     public IProperty<float> MakeupGain { get; } = Property.CreateAnimatable(DefaultMakeupGainDb);
 
     public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)

--- a/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterEffect.cs
@@ -12,10 +12,20 @@ namespace Beutl.Audio.Effects;
 /// exponential (one-pole IIR) release.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The DSP layer (<see cref="Beutl.Audio.Graph.Nodes.LimiterNode"/>) re-clamps
 /// every parameter to the ranges declared here, so the constants double as the
 /// authoritative range and as the safety net for animations or restored project
 /// files that bypass the <see cref="RangeAttribute"/> validation.
+/// </para>
+/// <para>
+/// Setting <see cref="Lookahead"/> above 0 ms shifts the entire signal later by
+/// that amount and drops the same number of samples at the end of each clip,
+/// because Beutl's audio graph processes effects inline (output length equals
+/// input length) and has no latency-reporting/compensation hook. Use 0 ms when
+/// sample-accurate timing matters; non-zero values trade transient transparency
+/// for a fixed delay matching standard external lookahead limiters.
+/// </para>
 /// </remarks>
 [Display(Name = nameof(AudioStrings.LimiterEffect), ResourceType = typeof(AudioStrings))]
 public sealed partial class LimiterEffect : AudioEffect
@@ -60,7 +70,9 @@ public sealed partial class LimiterEffect : AudioEffect
 
     /// <summary>
     /// Lookahead window in milliseconds. The output is delayed by this amount
-    /// so that gain reduction can begin before a peak arrives.
+    /// so that gain reduction can begin before a peak arrives. See the type-level
+    /// remarks for the latency trade-off — non-zero values shift the clip later
+    /// and drop the same number of samples from the tail.
     /// </summary>
     [Range(MinLookaheadMs, MaxLookaheadMs)]
     [Display(Name = nameof(AudioStrings.LimiterEffect_Lookahead), ResourceType = typeof(AudioStrings))]

--- a/src/Beutl.Engine/Audio/Effects/LimiterParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterParameters.cs
@@ -2,14 +2,12 @@
 
 // Single source of truth for the limiter's ranges and defaults, shared by LimiterEffect's
 // [Range] declarations and LimiterNode's per-sample clamps so the two cannot drift.
-// LimiterNodeTests.LimiterParameters_RangeIsConsistent asserts each entry's consistency.
 internal static class LimiterParameters
 {
     public const float MinThresholdDb = -60f;
     public const float MaxThresholdDb = 0f;
     // Threshold defaults to -1 dB (not 0 dB) so a single-sound output peaks at ~0.891 linear,
-    // strictly below the always-on master limiter's 1.0 ceiling — no double-limiting on the
-    // default path. See LimiterEffect remarks.
+    // below the always-on master limiter's 1.0 ceiling — no double-limiting on the default path.
     public const float DefaultThresholdDb = -1.0f;
 
     public const float MinReleaseMs = 1f;
@@ -17,7 +15,7 @@ internal static class LimiterParameters
     public const float DefaultReleaseMs = 50f;
 
     // Lookahead defaults to 0 ms so the effect is sample-accurate / A/V-synchronized out of the box
-    // (Beutl's inline audio graph has no plugin-delay-compensation). See LimiterEffect remarks.
+    // (Beutl's inline audio graph has no plugin-delay-compensation).
     public const float MinLookaheadMs = 0f;
     public const float MaxLookaheadMs = 20f;
     public const float DefaultLookaheadMs = 0f;

--- a/src/Beutl.Engine/Audio/Effects/LimiterParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/LimiterParameters.cs
@@ -1,0 +1,28 @@
+﻿namespace Beutl.Audio.Effects;
+
+// Single source of truth for the limiter's ranges and defaults, shared by LimiterEffect's
+// [Range] declarations and LimiterNode's per-sample clamps so the two cannot drift.
+// LimiterNodeTests.LimiterParameters_RangeIsConsistent asserts each entry's consistency.
+internal static class LimiterParameters
+{
+    public const float MinThresholdDb = -60f;
+    public const float MaxThresholdDb = 0f;
+    // Threshold defaults to -1 dB (not 0 dB) so a single-sound output peaks at ~0.891 linear,
+    // strictly below the always-on master limiter's 1.0 ceiling — no double-limiting on the
+    // default path. See LimiterEffect remarks.
+    public const float DefaultThresholdDb = -1.0f;
+
+    public const float MinReleaseMs = 1f;
+    public const float MaxReleaseMs = 5000f;
+    public const float DefaultReleaseMs = 50f;
+
+    // Lookahead defaults to 0 ms so the effect is sample-accurate / A/V-synchronized out of the box
+    // (Beutl's inline audio graph has no plugin-delay-compensation). See LimiterEffect remarks.
+    public const float MinLookaheadMs = 0f;
+    public const float MaxLookaheadMs = 20f;
+    public const float DefaultLookaheadMs = 0f;
+
+    public const float MinMakeupGainDb = -24f;
+    public const float MaxMakeupGainDb = 24f;
+    public const float DefaultMakeupGainDb = 0f;
+}

--- a/src/Beutl.Engine/Audio/Graph/AudioMath.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioMath.cs
@@ -67,6 +67,13 @@ public static class AudioMath
         return peak;
     }
 
+    /// <summary>
+    /// Soft, ratio-based downward compressor applied in place: samples above <paramref name="threshold"/>
+    /// are reduced toward <c>threshold + (excess / ratio)</c> but are NOT held at a hard ceiling, so the
+    /// output can still exceed the threshold. Despite the name this is NOT a brick-wall peak limiter;
+    /// for that, see <see cref="Beutl.Audio.Effects.LimiterEffect"/> / <see cref="Beutl.Audio.Graph.Nodes.LimiterNode"/>.
+    /// It is used as the always-on master clip-protection backstop in <see cref="Beutl.Audio.Composing.Composer"/>.
+    /// </summary>
     public static void ApplyLimiter(Span<float> buffer, float threshold = 1.0f, float ratio = 10.0f)
     {
         for (int i = 0; i < buffer.Length; i++)

--- a/src/Beutl.Engine/Audio/Graph/AudioMath.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioMath.cs
@@ -69,10 +69,10 @@ public static class AudioMath
 
     /// <summary>
     /// Soft, ratio-based downward compressor applied in place: samples above <paramref name="threshold"/>
-    /// are reduced toward <c>threshold + (excess / ratio)</c> but are NOT held at a hard ceiling, so the
-    /// output can still exceed the threshold. Despite the name this is NOT a brick-wall peak limiter;
-    /// for that, see <see cref="Beutl.Audio.Effects.LimiterEffect"/> / <see cref="Beutl.Audio.Graph.Nodes.LimiterNode"/>.
-    /// It is used as the always-on master clip-protection backstop in <see cref="Beutl.Audio.Composing.Composer"/>.
+    /// are reduced toward <c>threshold + (excess / ratio)</c> but not held at a hard ceiling, so the
+    /// output can still exceed the threshold. Despite the name this is NOT a brick-wall peak limiter
+    /// (see <see cref="Beutl.Audio.Effects.LimiterEffect"/>); it is the always-on master
+    /// clip-protection backstop in <see cref="Beutl.Audio.Composing.Composer"/>.
     /// </summary>
     public static void ApplyLimiter(Span<float> buffer, float threshold = 1.0f, float ratio = 10.0f)
     {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,4 +1,4 @@
-using Beutl.Audio.Effects;
+﻿using Beutl.Audio.Effects;
 using Beutl.Engine;
 using Beutl.Media;
 

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -13,7 +13,7 @@ public sealed class LimiterNode : AudioNode
     private CircularBuffer<float>? _peakBuffer;
     private int _maxLookaheadSamples;
     private int _lastSampleRate;
-    private TimeSpan? _lastTimeRangeStart;
+    private TimeSpan? _lastTimeRangeEnd;
     private float _currentGain = 1f;
 
     public required IProperty<float> Threshold { get; init; }
@@ -39,17 +39,20 @@ public sealed class LimiterNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        if (!_lastTimeRangeStart.HasValue || _lastTimeRangeStart.Value > context.TimeRange.Start)
+        // Reset whenever the chunk does not continue directly from the previous one, because the
+        // node instance is cached across Compose() calls and stale lookahead/gain state would
+        // otherwise bleed into the first samples after a seek or stop/restart.
+        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
             Reset();
         }
 
-        _lastTimeRangeStart = context.TimeRange.Start;
+        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
-        bool hasAnimation = Threshold.IsAnimatable
-                            || Release.IsAnimatable
-                            || Lookahead.IsAnimatable
-                            || MakeupGain.IsAnimatable;
+        bool hasAnimation = Threshold.Animation != null
+                            || Release.Animation != null
+                            || Lookahead.Animation != null
+                            || MakeupGain.Animation != null;
 
         return hasAnimation
             ? ProcessAnimated(input, context)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,0 +1,245 @@
+using Beutl.Audio.Effects;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.Audio.Graph.Nodes;
+
+public sealed class LimiterNode : AudioNode
+{
+    private const float MaxLookaheadMs = 20f;
+    private const float MinReleaseMs = 1f;
+
+    private CircularBuffer<float>[]? _delayLines;
+    private CircularBuffer<float>? _peakBuffer;
+    private int _maxLookaheadSamples;
+    private int _lastSampleRate;
+    private TimeSpan? _lastTimeRangeStart;
+    private float _currentGain = 1f;
+
+    public required IProperty<float> Threshold { get; init; }
+
+    public required IProperty<float> Release { get; init; }
+
+    public required IProperty<float> Lookahead { get; init; }
+
+    public required IProperty<float> MakeupGain { get; init; }
+
+    public override AudioBuffer Process(AudioProcessContext context)
+    {
+        if (Inputs.Count != 1)
+            throw new InvalidOperationException("Limiter node requires exactly one input.");
+
+        var input = Inputs[0].Process(context);
+
+        if (_delayLines == null || _peakBuffer == null
+            || _lastSampleRate != context.SampleRate
+            || _delayLines.Length != input.ChannelCount)
+        {
+            InitializeBuffers(context.SampleRate, input.ChannelCount);
+            _lastSampleRate = context.SampleRate;
+        }
+
+        if (!_lastTimeRangeStart.HasValue || _lastTimeRangeStart.Value > context.TimeRange.Start)
+        {
+            Reset();
+        }
+
+        _lastTimeRangeStart = context.TimeRange.Start;
+
+        bool hasAnimation = Threshold.IsAnimatable
+                            || Release.IsAnimatable
+                            || Lookahead.IsAnimatable
+                            || MakeupGain.IsAnimatable;
+
+        return hasAnimation
+            ? ProcessAnimated(input, context)
+            : ProcessStatic(input, context);
+    }
+
+    private void InitializeBuffers(int sampleRate, int channelCount)
+    {
+        if (_delayLines != null)
+        {
+            foreach (var line in _delayLines)
+            {
+                line.Dispose();
+            }
+        }
+
+        _peakBuffer?.Dispose();
+
+        _maxLookaheadSamples = Math.Max(1, (int)(MaxLookaheadMs / 1000f * sampleRate) + 1);
+        _delayLines = new CircularBuffer<float>[channelCount];
+        for (int i = 0; i < _delayLines.Length; i++)
+        {
+            _delayLines[i] = new CircularBuffer<float>(_maxLookaheadSamples);
+        }
+
+        _peakBuffer = new CircularBuffer<float>(_maxLookaheadSamples);
+        _currentGain = 1f;
+    }
+
+    private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+    {
+        float thresholdDb = Threshold.CurrentValue;
+        float releaseMs = Math.Max(MinReleaseMs, Release.CurrentValue);
+        float lookaheadMs = Math.Clamp(Lookahead.CurrentValue, 0f, MaxLookaheadMs);
+        float makeupDb = MakeupGain.CurrentValue;
+
+        float thresholdLin = AudioMath.ConvertDbToLinear(thresholdDb);
+        float makeupLin = AudioMath.ConvertDbToLinear(makeupDb);
+        int lookaheadSamples = Math.Clamp((int)(lookaheadMs / 1000f * context.SampleRate), 0, _maxLookaheadSamples - 1);
+        float releaseCoef = MathF.Exp(-1f / (releaseMs * 0.001f * context.SampleRate));
+
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+
+        for (int i = 0; i < input.SampleCount; i++)
+        {
+            ProcessSingleSample(input, output, i, thresholdLin, makeupLin, lookaheadSamples, releaseCoef);
+        }
+
+        return output;
+    }
+
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+
+        Span<float> thresholds = stackalloc float[Math.Min(input.SampleCount, 1024)];
+        Span<float> releases = stackalloc float[Math.Min(input.SampleCount, 1024)];
+        Span<float> lookaheads = stackalloc float[Math.Min(input.SampleCount, 1024)];
+        Span<float> makeups = stackalloc float[Math.Min(input.SampleCount, 1024)];
+
+        int processed = 0;
+        while (processed < input.SampleCount)
+        {
+            int chunkSize = Math.Min(thresholds.Length, input.SampleCount - processed);
+
+            var chunkStart = context.GetTimeForSample(processed);
+            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+            context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(Lookahead, chunkRange, context.SampleRate, lookaheads[..chunkSize]);
+            context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
+
+            for (int i = 0; i < chunkSize; i++)
+            {
+                float thresholdLin = AudioMath.ConvertDbToLinear(thresholds[i]);
+                float makeupLin = AudioMath.ConvertDbToLinear(makeups[i]);
+                float releaseMs = Math.Max(MinReleaseMs, releases[i]);
+                float lookaheadMs = Math.Clamp(lookaheads[i], 0f, MaxLookaheadMs);
+                int lookaheadSamples = Math.Clamp((int)(lookaheadMs / 1000f * context.SampleRate), 0, _maxLookaheadSamples - 1);
+                float releaseCoef = MathF.Exp(-1f / (releaseMs * 0.001f * context.SampleRate));
+
+                ProcessSingleSample(input, output, processed + i, thresholdLin, makeupLin, lookaheadSamples, releaseCoef);
+            }
+
+            processed += chunkSize;
+        }
+
+        return output;
+    }
+
+    private void ProcessSingleSample(
+        AudioBuffer input,
+        AudioBuffer output,
+        int sampleIndex,
+        float thresholdLin,
+        float makeupLin,
+        int lookaheadSamples,
+        float releaseCoef)
+    {
+        int channelCount = Math.Min(input.ChannelCount, _delayLines!.Length);
+
+        // Stereo-linked peak detection: max of |L|, |R|, ...
+        float currentPeak = 0f;
+        for (int ch = 0; ch < channelCount; ch++)
+        {
+            float s = input.GetChannelData(ch)[sampleIndex];
+            float abs = MathF.Abs(s);
+            if (abs > currentPeak)
+                currentPeak = abs;
+
+            _delayLines[ch].Write(s);
+        }
+
+        // Push current peak into the peak ring; the windowed-max over the lookahead window
+        // tells us the worst incoming peak that has not yet exited the delay line.
+        _peakBuffer!.Write(currentPeak);
+
+        float windowPeak = 0f;
+        int windowSize = lookaheadSamples + 1;
+        for (int j = 0; j < windowSize; j++)
+        {
+            float v = _peakBuffer.Read(j);
+            if (v > windowPeak)
+                windowPeak = v;
+        }
+
+        // Brick-wall target gain: ratio is effectively infinity.
+        float targetGain;
+        if (windowPeak > thresholdLin && windowPeak > 0f)
+        {
+            targetGain = thresholdLin / windowPeak;
+        }
+        else
+        {
+            targetGain = 1f;
+        }
+
+        // Instant attack, IIR release.
+        if (targetGain < _currentGain)
+        {
+            _currentGain = targetGain;
+        }
+        else
+        {
+            _currentGain = targetGain + (_currentGain - targetGain) * releaseCoef;
+        }
+
+        float finalGain = _currentGain * makeupLin;
+
+        for (int ch = 0; ch < channelCount; ch++)
+        {
+            float delayed = _delayLines[ch].Read(lookaheadSamples);
+            output.GetChannelData(ch)[sampleIndex] = delayed * finalGain;
+        }
+    }
+
+    public void Reset()
+    {
+        if (_delayLines != null)
+        {
+            foreach (var line in _delayLines)
+            {
+                line.Clear();
+            }
+        }
+
+        _peakBuffer?.Clear();
+        _currentGain = 1f;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (_delayLines != null)
+            {
+                foreach (var line in _delayLines)
+                {
+                    line.Dispose();
+                }
+
+                _delayLines = null;
+            }
+
+            _peakBuffer?.Dispose();
+            _peakBuffer = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -62,7 +62,8 @@ public sealed class LimiterNode : AudioNode
             throw new InvalidOperationException(
                 $"LimiterNode requires exactly one input but has {Inputs.Count}.");
 
-        var input = Inputs[0].Process(context)
+        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
+        using var input = Inputs[0].Process(context)
             ?? throw new InvalidOperationException("LimiterNode: upstream Process returned null.");
 
         if (input.SampleRate != context.SampleRate)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -6,8 +6,7 @@ namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class LimiterNode : AudioNode
 {
-    private const float MaxLookaheadMs = 20f;
-    private const float MinReleaseMs = 1f;
+    private const int AnimationChunkSize = 1024;
 
     private CircularBuffer<float>[]? _delayLines;
     private CircularBuffer<float>? _peakBuffer;
@@ -27,9 +26,18 @@ public sealed class LimiterNode : AudioNode
     public override AudioBuffer Process(AudioProcessContext context)
     {
         if (Inputs.Count != 1)
-            throw new InvalidOperationException("Limiter node requires exactly one input.");
+            throw new InvalidOperationException(
+                $"LimiterNode requires exactly one input but has {Inputs.Count}.");
 
-        var input = Inputs[0].Process(context);
+        var input = Inputs[0].Process(context)
+            ?? throw new InvalidOperationException("LimiterNode: upstream Process returned null.");
+
+        if (input.SampleRate != context.SampleRate)
+            throw new InvalidOperationException(
+                $"LimiterNode: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
+
+        if (input.SampleCount == 0)
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
 
         if (_delayLines == null || _peakBuffer == null
             || _lastSampleRate != context.SampleRate
@@ -39,24 +47,29 @@ public sealed class LimiterNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        // Reset whenever the chunk does not continue directly from the previous one, because the
-        // node instance is cached across Compose() calls and stale lookahead/gain state would
-        // otherwise bleed into the first samples after a seek or stop/restart.
+        // The node instance is cached across Compose() calls, so when the next chunk does not
+        // continue directly from the previous one (seek, stop/restart) we must drop the
+        // delay-line and gain state — otherwise audio from the previous segment would leak
+        // into the first lookahead-window worth of output samples.
         if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
             Reset();
         }
-
-        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         bool hasAnimation = Threshold.Animation != null
                             || Release.Animation != null
                             || Lookahead.Animation != null
                             || MakeupGain.Animation != null;
 
-        return hasAnimation
+        var output = hasAnimation
             ? ProcessAnimated(input, context)
             : ProcessStatic(input, context);
+
+        // Update only on success so that a thrown exception lets the next call detect the
+        // discontinuity and reset, instead of silently inheriting corrupt state.
+        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
+
+        return output;
     }
 
     private void InitializeBuffers(int sampleRate, int channelCount)
@@ -71,7 +84,9 @@ public sealed class LimiterNode : AudioNode
 
         _peakBuffer?.Dispose();
 
-        _maxLookaheadSamples = Math.Max(1, (int)(MaxLookaheadMs / 1000f * sampleRate) + 1);
+        // +1 because Read(lookaheadSamples) needs lookaheadSamples + 1 valid slots when
+        // lookaheadSamples is at its maximum (LimiterEffect.MaxLookaheadMs · sampleRate).
+        _maxLookaheadSamples = Math.Max(1, (int)(LimiterEffect.MaxLookaheadMs / 1000f * sampleRate) + 1);
         _delayLines = new CircularBuffer<float>[channelCount];
         for (int i = 0; i < _delayLines.Length; i++)
         {
@@ -82,12 +97,17 @@ public sealed class LimiterNode : AudioNode
         _currentGain = 1f;
     }
 
+    // Math.Clamp propagates NaN — wrap to fall back to a safe value before NaN can poison
+    // _currentGain (a NaN there persists across every subsequent sample).
+    private static float ClampFinite(float value, float min, float max, float fallback)
+        => float.IsFinite(value) ? Math.Clamp(value, min, max) : fallback;
+
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
-        float thresholdDb = Threshold.CurrentValue;
-        float releaseMs = Math.Max(MinReleaseMs, Release.CurrentValue);
-        float lookaheadMs = Math.Clamp(Lookahead.CurrentValue, 0f, MaxLookaheadMs);
-        float makeupDb = MakeupGain.CurrentValue;
+        float thresholdDb = ClampFinite(Threshold.CurrentValue, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb);
+        float releaseMs = ClampFinite(Release.CurrentValue, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs);
+        float lookaheadMs = ClampFinite(Lookahead.CurrentValue, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs);
+        float makeupDb = ClampFinite(MakeupGain.CurrentValue, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f);
 
         float thresholdLin = AudioMath.ConvertDbToLinear(thresholdDb);
         float makeupLin = AudioMath.ConvertDbToLinear(makeupDb);
@@ -108,10 +128,10 @@ public sealed class LimiterNode : AudioNode
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        Span<float> thresholds = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> releases = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> lookaheads = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> makeups = stackalloc float[Math.Min(input.SampleCount, 1024)];
+        Span<float> thresholds = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
+        Span<float> releases = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
+        Span<float> lookaheads = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
+        Span<float> makeups = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
 
         int processed = 0;
         while (processed < input.SampleCount)
@@ -129,10 +149,13 @@ public sealed class LimiterNode : AudioNode
 
             for (int i = 0; i < chunkSize; i++)
             {
-                float thresholdLin = AudioMath.ConvertDbToLinear(thresholds[i]);
-                float makeupLin = AudioMath.ConvertDbToLinear(makeups[i]);
-                float releaseMs = Math.Max(MinReleaseMs, releases[i]);
-                float lookaheadMs = Math.Clamp(lookaheads[i], 0f, MaxLookaheadMs);
+                float thresholdDb = ClampFinite(thresholds[i], LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb);
+                float releaseMs = ClampFinite(releases[i], LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs);
+                float lookaheadMs = ClampFinite(lookaheads[i], LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs);
+                float makeupDb = ClampFinite(makeups[i], LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f);
+
+                float thresholdLin = AudioMath.ConvertDbToLinear(thresholdDb);
+                float makeupLin = AudioMath.ConvertDbToLinear(makeupDb);
                 int lookaheadSamples = Math.Clamp((int)(lookaheadMs / 1000f * context.SampleRate), 0, _maxLookaheadSamples - 1);
                 float releaseCoef = MathF.Exp(-1f / (releaseMs * 0.001f * context.SampleRate));
 
@@ -154,13 +177,19 @@ public sealed class LimiterNode : AudioNode
         int lookaheadSamples,
         float releaseCoef)
     {
-        int channelCount = Math.Min(input.ChannelCount, _delayLines!.Length);
+        int channelCount = _delayLines!.Length;
 
-        // Stereo-linked peak detection: max of |L|, |R|, ...
+        // Channel-linked peak detection: take max(|s_ch|) across all channels so that a
+        // single shared gain is applied to every channel — preserves inter-channel phase.
+        // NaN/Infinity samples from upstream are coerced to 0 here: writing them into the
+        // delay line would either pass NaN straight through to the output or produce
+        // Inf*0 = NaN once the gain reduction kicks in.
         float currentPeak = 0f;
         for (int ch = 0; ch < channelCount; ch++)
         {
             float s = input.GetChannelData(ch)[sampleIndex];
+            if (!float.IsFinite(s)) s = 0f;
+
             float abs = MathF.Abs(s);
             if (abs > currentPeak)
                 currentPeak = abs;
@@ -168,10 +197,10 @@ public sealed class LimiterNode : AudioNode
             _delayLines[ch].Write(s);
         }
 
-        // Push current peak into the peak ring; the windowed-max over the lookahead window
-        // tells us the worst incoming peak that has not yet exited the delay line.
         _peakBuffer!.Write(currentPeak);
 
+        // Maximum peak that has not yet exited the delay line. This is the worst-case peak
+        // the sample being read from the delay line is allowed to encounter.
         float windowPeak = 0f;
         int windowSize = lookaheadSamples + 1;
         for (int j = 0; j < windowSize; j++)
@@ -181,7 +210,6 @@ public sealed class LimiterNode : AudioNode
                 windowPeak = v;
         }
 
-        // Brick-wall target gain: ratio is effectively infinity.
         float targetGain;
         if (windowPeak > thresholdLin && windowPeak > 0f)
         {
@@ -192,7 +220,8 @@ public sealed class LimiterNode : AudioNode
             targetGain = 1f;
         }
 
-        // Instant attack, IIR release.
+        // Instant attack is safe here: the lookahead delay means we apply the reduction
+        // before the offending sample reaches the output, avoiding distortion.
         if (targetGain < _currentGain)
         {
             _currentGain = targetGain;
@@ -211,6 +240,11 @@ public sealed class LimiterNode : AudioNode
         }
     }
 
+    /// <summary>
+    /// Clears delay-line state and resets the internal gain to unity.
+    /// Process() invokes this automatically on chunk discontinuity, so external
+    /// callers do not normally need to call it.
+    /// </summary>
     public void Reset()
     {
         if (_delayLines != null)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Audio.Effects;
+﻿using System.Diagnostics;
+using Beutl.Audio.Effects;
 using Beutl.Engine;
 using Beutl.Logging;
 using Beutl.Media;
@@ -322,6 +323,9 @@ public sealed class LimiterNode : AudioNode
 
             for (int i = 0; i < chunkSize; i++)
             {
+                // Derive recomputes one Exp + two Pow per sample here. That per-sample transcendental
+                // cost is a deliberate trade-off for sample-accurate parameter automation; the common
+                // no-animation case takes ProcessStatic, which derives the coefficients once per call.
                 var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
                 int idx = processed + i;
                 float currentPeak = IngestSample(inRaw, sampleCount, channelCount, idx);
@@ -459,6 +463,13 @@ public sealed class LimiterNode : AudioNode
 
         while (_dqCount > 0 && _dqVal[(_dqHead + _dqCount - 1) % cap] <= value)
             _dqCount--;
+
+        // After the monotonic back-eviction the deque holds at most the in-window count =
+        // lookaheadSamples + 1 <= _maxLookaheadSamples = cap - 2, so a free slot for this push is
+        // guaranteed (_dqCount < cap, i.e. tail != _dqHead). Assert BEFORE the write so a future change
+        // that breaks the bound is caught before it overwrites the front, not one step after the
+        // corruption (Debug-only; compiled out of Release).
+        Debug.Assert(_dqCount < cap, "LimiterNode deque overflow: no free slot, front would be overwritten.");
 
         int tail = (_dqHead + _dqCount) % cap;
         _dqVal[tail] = value;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -5,13 +5,17 @@ using Beutl.Logging;
 using Beutl.Media;
 using Microsoft.Extensions.Logging;
 
+using static Beutl.Audio.Effects.LimiterParameters;
+
 namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class LimiterNode : AudioNode
 {
-    // AnimationChunkSize × number-of-animated-parameters × sizeof(float). With four
-    // parameters today this is 16 KiB per ProcessAnimated call — well within a thread's
-    // default stack budget while still amortizing the per-chunk animation sampling overhead.
+    // Upper bound on the per-chunk animation-sampling scratch: AnimationChunkSize ×
+    // number-of-animated-parameters × sizeof(float). With four parameters today this caps the
+    // stack scratch at 16 KiB per ProcessAnimated call (smaller buffers allocate proportionally
+    // less) — well within a thread's default stack budget while still amortizing the per-chunk
+    // animation sampling overhead.
     private const int AnimationChunkSize = 1024;
 
     private static readonly ILogger s_logger = Log.CreateLogger<LimiterNode>();
@@ -121,14 +125,19 @@ public sealed class LimiterNode : AudioNode
             ? ProcessAnimated(input, context)
             : ProcessStatic(input, context);
 
-        // Update only on success: if Process throws mid-buffer, _currentGain and the delay line
-        // may be partially mutated. Two cases for the next call:
+        // Update only on success: if Process throws mid-buffer (realistically only from
+        // AnimationSampler on a later inner chunk of ProcessAnimated, after earlier samples were
+        // already ingested), _currentGain and the delay line may be partially mutated. No production
+        // caller re-invokes Process with an identical context after a throw — Composer,
+        // SampleProviderImpl, and PlayerViewModel all propagate the exception and stop — so the
+        // same-chunk-retry branch below is a latent/defensive consideration, not an active path.
+        // For completeness, the next call resolves as:
         //  - Contiguous throw (no Reset() ran this call): _lastTimeRangeEnd retains the previous
-        //    end. If the next call's Start differs, the discontinuity branch fires Reset() and
-        //    discards partial state. If the next call's Start matches (same-chunk retry), the
-        //    contiguous path inherits partial state — accepted as a deliberate trade-off
-        //    because the alternative (always Reset() after a throw) would discard correct
-        //    delay-line state in the common transient-failure case.
+        //    end. A next call at a different Start hits the discontinuity branch, which Reset()s and
+        //    discards the partial state. A next call at the same Start (a hypothetical same-chunk
+        //    retry that no current caller performs) would instead inherit the partial state; this is
+        //    tolerated rather than guarded, because the alternative — always Reset() after a throw —
+        //    would needlessly discard correct delay-line state and no caller actually retries.
         //  - Throw after Reset() ran: _lastTimeRangeEnd was already cleared to null by Reset(),
         //    so the next call hits the `!HasValue` branch and Reset()s again before processing,
         //    discarding any partial state.
@@ -156,10 +165,10 @@ public sealed class LimiterNode : AudioNode
 
         // +1 because CircularBuffer.Read(samplesBack) returns silence when samplesBack >= length,
         // so the requested length must be strictly greater than the maximum lookaheadSamples we
-        // will ever clamp to (LimiterEffect.MaxLookaheadMs · sampleRate). The buffer rounds this
+        // will ever clamp to (MaxLookaheadMs · sampleRate). The buffer rounds this
         // up to the next power of two internally — the +1 is for the read-bounds check, not the
         // rounding.
-        int max = Math.Max(1, (int)(LimiterEffect.MaxLookaheadMs / 1000f * sampleRate) + 1);
+        int max = Math.Max(1, (int)(MaxLookaheadMs / 1000f * sampleRate) + 1);
 
         var lines = new CircularBuffer<float>[channelCount];
         try
@@ -245,10 +254,10 @@ public sealed class LimiterNode : AudioNode
         // 0 dB here would silently disable limiting for the rest of the session — exactly the
         // silent-failure mode this guard is meant to prevent. -1 dB still limits while keeping
         // the substitution audible (peaks just under unity) so the issue surfaces.
-        float thresholdDb = ClampFinite(thresholdDbRaw, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.DefaultThresholdDb, nameof(Threshold), ref _warnedNonFiniteThreshold);
-        float releaseMs = ClampFinite(releaseMsRaw, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs, nameof(Release), ref _warnedNonFiniteRelease);
-        float lookaheadMs = ClampFinite(lookaheadMsRaw, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs, nameof(Lookahead), ref _warnedNonFiniteLookahead);
-        float makeupDb = ClampFinite(makeupDbRaw, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f, nameof(MakeupGain), ref _warnedNonFiniteMakeup);
+        float thresholdDb = ClampFinite(thresholdDbRaw, MinThresholdDb, MaxThresholdDb, DefaultThresholdDb, nameof(Threshold), ref _warnedNonFiniteThreshold);
+        float releaseMs = ClampFinite(releaseMsRaw, MinReleaseMs, MaxReleaseMs, MinReleaseMs, nameof(Release), ref _warnedNonFiniteRelease);
+        float lookaheadMs = ClampFinite(lookaheadMsRaw, MinLookaheadMs, MaxLookaheadMs, MinLookaheadMs, nameof(Lookahead), ref _warnedNonFiniteLookahead);
+        float makeupDb = ClampFinite(makeupDbRaw, MinMakeupGainDb, MaxMakeupGainDb, 0f, nameof(MakeupGain), ref _warnedNonFiniteMakeup);
 
         return new DerivedCoefficients(
             ThresholdLin: AudioMath.ConvertDbToLinear(thresholdDb),
@@ -288,14 +297,15 @@ public sealed class LimiterNode : AudioNode
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        // Fixed-size stack allocation: the Math.Min against SampleCount would only shrink the
-        // allocation, never grow it past AnimationChunkSize, so it adds no safety. Pinning to the
-        // constant makes the 16 KiB stack budget provable and resilient to refactors that pass
-        // ambiguous SampleCount values.
-        Span<float> thresholds = stackalloc float[AnimationChunkSize];
-        Span<float> releases = stackalloc float[AnimationChunkSize];
-        Span<float> lookaheads = stackalloc float[AnimationChunkSize];
-        Span<float> makeups = stackalloc float[AnimationChunkSize];
+        // Per-chunk animation-sampling scratch, sized to the actual work (capped at
+        // AnimationChunkSize) so a small buffer pays a proportionally small stack cost, matching the
+        // sibling nodes (CompressorNode/DelayNode/GainNode). The inner loop's chunkSize never exceeds
+        // this. Worst case is four AnimationChunkSize-float spans = 16 KiB, well within the stack budget.
+        int scratchSize = Math.Min(AnimationChunkSize, input.SampleCount);
+        Span<float> thresholds = stackalloc float[scratchSize];
+        Span<float> releases = stackalloc float[scratchSize];
+        Span<float> lookaheads = stackalloc float[scratchSize];
+        Span<float> makeups = stackalloc float[scratchSize];
 
         // Lookahead can change per sample here, which the monotonic deque cannot track without
         // unbounded history, so this path uses the direct window rescan. Invalidate the deque so a
@@ -328,7 +338,10 @@ public sealed class LimiterNode : AudioNode
                 // no-animation case takes ProcessStatic, which derives the coefficients once per call.
                 var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
                 int idx = processed + i;
-                float currentPeak = IngestSample(inRaw, sampleCount, channelCount, idx);
+                // The animated path ignores IngestSample's returned per-sample peak (only its
+                // side-effects on the delay line and peak ring matter); the window maximum comes from
+                // ScanWindowPeak over the ring. The static path, by contrast, feeds it into PushWindowPeak.
+                _ = IngestSample(inRaw, sampleCount, channelCount, idx);
                 float windowPeak = ScanWindowPeak(c.LookaheadSamples);
                 EmitSample(outRaw, sampleCount, channelCount, idx, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
             }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -8,9 +8,9 @@ namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class LimiterNode : AudioNode
 {
-    // 4 × 1024 × sizeof(float) = 16 KiB per ProcessAnimated call — well within
-    // a thread's default stack budget while still amortizing the per-chunk
-    // animation sampling overhead.
+    // AnimationChunkSize × number-of-animated-parameters × sizeof(float). With four
+    // parameters today this is 16 KiB per ProcessAnimated call — well within a thread's
+    // default stack budget while still amortizing the per-chunk animation sampling overhead.
     private const int AnimationChunkSize = 1024;
 
     private static readonly ILogger s_logger = Log.CreateLogger<LimiterNode>();
@@ -22,9 +22,15 @@ public sealed class LimiterNode : AudioNode
     private TimeSpan? _lastTimeRangeEnd;
     private float _currentGain = 1f;
 
-    // Latched warning flags — keep audio-rate logging from spamming the sink.
-    // Cleared whenever Reset() runs so a new discontinuity can re-surface the warning.
-    private bool _warnedNonFiniteParameter;
+    // Latched warning flags — keep audio-rate logging from spamming the sink. Per-parameter
+    // latches so that, for example, a non-finite Threshold does not silence a subsequent
+    // non-finite Release. Cleared only on full re-initialization (sample-rate/channel-count
+    // change) — chunk discontinuities (seek/loop/edit) intentionally do NOT re-arm them, or
+    // a persistent upstream defect would log every chunk.
+    private bool _warnedNonFiniteThreshold;
+    private bool _warnedNonFiniteRelease;
+    private bool _warnedNonFiniteLookahead;
+    private bool _warnedNonFiniteMakeup;
     private bool _warnedNonFiniteInputSample;
 
     public required IProperty<float> Threshold { get; init; }
@@ -67,7 +73,7 @@ public sealed class LimiterNode : AudioNode
         {
             if (_lastTimeRangeEnd.HasValue)
             {
-                s_logger.LogTrace(
+                s_logger.LogDebug(
                     "LimiterNode: chunk discontinuity (last end={Last}, new start={Start}); resetting state.",
                     _lastTimeRangeEnd, context.TimeRange.Start);
             }
@@ -140,23 +146,37 @@ public sealed class LimiterNode : AudioNode
 
         _maxLookaheadSamples = max;
         _delayLines = lines;
+        // Format change is the one moment where the previous warning history is unrelated to
+        // the new state, so re-arm so that a persistent upstream defect surfaces once per
+        // format change rather than literally never logging again after the first hit.
         _currentGain = 1f;
+        _warnedNonFiniteThreshold = false;
+        _warnedNonFiniteRelease = false;
+        _warnedNonFiniteLookahead = false;
+        _warnedNonFiniteMakeup = false;
+        _warnedNonFiniteInputSample = false;
+
+        s_logger.LogDebug(
+            "LimiterNode: initialized buffers (sampleRate={SampleRate}, channels={Channels}, maxLookaheadSamples={MaxLookahead}).",
+            sampleRate, channelCount, max);
     }
 
     // Math.Clamp does not coerce NaN nor ±Infinity to the bounds — both would poison
     // _currentGain permanently if they slipped through. Substituting a safe fallback here keeps
-    // the DSP stable; the caller logs once when the substitution actually fires.
-    private float ClampFinite(float value, float min, float max, float fallback, string parameterName)
+    // the DSP stable; the caller logs once per parameter at error severity so an upstream
+    // animation/binding bug is visible in production logs (Sentry-grade) without spamming.
+    private float ClampFinite(float value, float min, float max, float fallback, string parameterName, ref bool warned)
     {
         if (float.IsFinite(value))
             return Math.Clamp(value, min, max);
 
-        if (!_warnedNonFiniteParameter)
+        if (!warned)
         {
-            s_logger.LogWarning(
-                "LimiterNode: non-finite {Parameter}={Value}; substituting {Fallback}. Likely an animation/binding bug upstream.",
+            s_logger.LogError(
+                "LimiterNode: non-finite {Parameter}={Value}; substituting {Fallback}. " +
+                "Likely an animation/binding bug upstream — limiter behavior will not match user settings.",
                 parameterName, value, fallback);
-            _warnedNonFiniteParameter = true;
+            warned = true;
         }
 
         return fallback;
@@ -170,10 +190,14 @@ public sealed class LimiterNode : AudioNode
 
     private DerivedCoefficients Derive(float thresholdDbRaw, float releaseMsRaw, float lookaheadMsRaw, float makeupDbRaw, int sampleRate)
     {
-        float thresholdDb = ClampFinite(thresholdDbRaw, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb, nameof(Threshold));
-        float releaseMs = ClampFinite(releaseMsRaw, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs, nameof(Release));
-        float lookaheadMs = ClampFinite(lookaheadMsRaw, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs, nameof(Lookahead));
-        float makeupDb = ClampFinite(makeupDbRaw, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f, nameof(MakeupGain));
+        // Threshold falls back to the *default* (-1 dB) rather than MaxThresholdDb (0 dB). Using
+        // 0 dB here would silently disable limiting for the rest of the session — exactly the
+        // silent-failure mode this guard is meant to prevent. -1 dB still limits while keeping
+        // the substitution audible (peaks just under unity) so the issue surfaces.
+        float thresholdDb = ClampFinite(thresholdDbRaw, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.DefaultThresholdDb, nameof(Threshold), ref _warnedNonFiniteThreshold);
+        float releaseMs = ClampFinite(releaseMsRaw, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs, nameof(Release), ref _warnedNonFiniteRelease);
+        float lookaheadMs = ClampFinite(lookaheadMsRaw, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs, nameof(Lookahead), ref _warnedNonFiniteLookahead);
+        float makeupDb = ClampFinite(makeupDbRaw, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f, nameof(MakeupGain), ref _warnedNonFiniteMakeup);
 
         return new DerivedCoefficients(
             ThresholdLin: AudioMath.ConvertDbToLinear(thresholdDb),
@@ -200,15 +224,19 @@ public sealed class LimiterNode : AudioNode
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        Span<float> thresholds = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
-        Span<float> releases = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
-        Span<float> lookaheads = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
-        Span<float> makeups = stackalloc float[Math.Min(input.SampleCount, AnimationChunkSize)];
+        // Fixed-size stack allocation: the Math.Min against SampleCount would only shrink the
+        // allocation, never grow it past AnimationChunkSize, so it adds no safety. Pinning to the
+        // constant makes the 16 KiB stack budget provable and resilient to refactors that pass
+        // ambiguous SampleCount values.
+        Span<float> thresholds = stackalloc float[AnimationChunkSize];
+        Span<float> releases = stackalloc float[AnimationChunkSize];
+        Span<float> lookaheads = stackalloc float[AnimationChunkSize];
+        Span<float> makeups = stackalloc float[AnimationChunkSize];
 
         int processed = 0;
         while (processed < input.SampleCount)
         {
-            int chunkSize = Math.Min(thresholds.Length, input.SampleCount - processed);
+            int chunkSize = Math.Min(AnimationChunkSize, input.SampleCount - processed);
 
             var chunkStart = context.GetTimeForSample(processed);
             var chunkEnd = context.GetTimeForSample(processed + chunkSize);
@@ -249,7 +277,8 @@ public sealed class LimiterNode : AudioNode
         //   - NaN written into the delay line passes straight through to the output.
         //   - Inf forces currentPeak → Inf, then targetGain = thresholdLin / Inf = 0,
         //     and finally `delayed * 0` = `Inf * 0` = NaN once the gain reduction kicks in.
-        // We log at most once per Reset() so an upstream bug surfaces without flooding the sink.
+        // We log at most once per format change so an upstream bug surfaces without flooding
+        // the sink across every chunk discontinuity.
         float currentPeak = 0f;
         for (int ch = 0; ch < channelCount; ch++)
         {
@@ -319,8 +348,12 @@ public sealed class LimiterNode : AudioNode
     }
 
     /// <summary>
-    /// Clears delay-line state and resets the internal gain to unity. Process() invokes this
-    /// automatically on chunk discontinuity, so external callers do not normally need to call it.
+    /// Clears the per-channel delay lines and the peak-detection buffer, resets the internal
+    /// gain to unity, and clears the cached chunk timestamp so the next Process() call does
+    /// not consider itself contiguous. Process() invokes this automatically on chunk
+    /// discontinuity, so external callers do not normally need to call it. Per-parameter
+    /// non-finite warning latches are intentionally NOT cleared here — see InitializeBuffers
+    /// for the spam-protection rationale.
     /// </summary>
     public void Reset()
     {
@@ -334,8 +367,7 @@ public sealed class LimiterNode : AudioNode
 
         _peakBuffer?.Clear();
         _currentGain = 1f;
-        _warnedNonFiniteParameter = false;
-        _warnedNonFiniteInputSample = false;
+        _lastTimeRangeEnd = null;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -58,10 +58,12 @@ public sealed class LimiterNode : AudioNode
         if (input.SampleCount == 0)
         {
             // Empty chunks are not produced by the normal scheduling path (GetSampleCount uses
-            // Math.Ceiling so only TimeRange.Duration == Zero gets here). Treat them as a
-            // notable event — log once-per-format-change and keep _lastTimeRangeEnd advancing
-            // so a non-empty follow-up chunk that resumes from `Start + Duration` is not
-            // misclassified as a discontinuity.
+            // Math.Ceiling so only TimeRange.Duration == Zero reaches here). Treat them as a
+            // notable upstream event and log once-per-format-change. Crucially, do NOT touch
+            // _lastTimeRangeEnd: an empty chunk processes no audio, so the next non-empty chunk
+            // must be evaluated against the previous *non-empty* chunk's end. Updating it here
+            // would silently mask a discontinuity when the empty chunk happens to land at a
+            // different position than the previous chunk's end.
             if (!_warnedEmptyChunk)
             {
                 s_logger.LogDebug(
@@ -70,7 +72,6 @@ public sealed class LimiterNode : AudioNode
                 _warnedEmptyChunk = true;
             }
 
-            _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
             return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
         }
 
@@ -108,13 +109,16 @@ public sealed class LimiterNode : AudioNode
             : ProcessStatic(input, context);
 
         // Update only on success: if Process throws mid-buffer, _currentGain and the delay line
-        // may be partially mutated. Two cases for partial-state recovery on the next call:
+        // may be partially mutated. Two cases for the next call:
         //  - Contiguous throw (no Reset() ran this call): _lastTimeRangeEnd retains the previous
-        //    end, so the next call still detects the new chunk as a discontinuity if Start
-        //    differs — and equally, a same-Start retry would fail to update and re-route.
+        //    end. If the next call's Start differs, the discontinuity branch fires Reset() and
+        //    discards partial state. If the next call's Start matches (same-chunk retry), the
+        //    contiguous path inherits partial state — accepted as a deliberate trade-off
+        //    because the alternative (always Reset() after a throw) would discard correct
+        //    delay-line state in the common transient-failure case.
         //  - Throw after Reset() ran: _lastTimeRangeEnd was already cleared to null by Reset(),
-        //    so the next call hits the `!HasValue` branch and Reset()s again before processing.
-        // Either way, partial state from a failed Process is discarded before the next chunk.
+        //    so the next call hits the `!HasValue` branch and Reset()s again before processing,
+        //    discarding any partial state.
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -12,11 +12,8 @@ namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class LimiterNode : AudioNode
 {
-    // Upper bound on the per-chunk animation-sampling scratch: AnimationChunkSize ×
-    // number-of-animated-parameters × sizeof(float). With four parameters today this caps the
-    // stack scratch at 16 KiB per ProcessAnimated call (smaller buffers allocate proportionally
-    // less) — well within a thread's default stack budget while still amortizing the per-chunk
-    // animation sampling overhead.
+    // Caps the per-chunk animation-sampling scratch at 4 parameters × 1024 floats = 16 KiB of
+    // stackalloc per ProcessAnimated call, while still amortizing the per-chunk sampling overhead.
     private const int AnimationChunkSize = 1024;
     private const long TimestampQuantizationToleranceTicks = 1;
 
@@ -29,11 +26,10 @@ public sealed class LimiterNode : AudioNode
     private TimeSpan? _lastTimeRangeEnd;
     private float _currentGain = 1f;
 
-    // O(1)-amortized sliding-window maximum for the static path. A monotonic-decreasing deque
-    // (ring buffer over peak positions) replaces the per-sample O(lookahead) rescan. It persists
-    // across contiguous chunks like the delay line, is rebuilt from _peakBuffer only when the
-    // lookahead length changes (rare), and is cleared on Reset/format change. The animated path,
-    // where the lookahead can vary per sample, keeps the direct rescan (ScanWindowPeak).
+    // Monotonic-decreasing deque (ring buffer over peak positions) giving the static path an
+    // O(1)-amortized sliding-window maximum instead of a per-sample O(lookahead) rescan. Persists
+    // across contiguous chunks, rebuilt only when the lookahead length changes, cleared on
+    // Reset/format change. The animated path varies lookahead per sample and uses ScanWindowPeak.
     private float[]? _dqVal;
     private long[]? _dqPos;
     private int _dqMask;
@@ -42,11 +38,9 @@ public sealed class LimiterNode : AudioNode
     private int _dequeLookahead = -1;
     private long _globalPos;
 
-    // Latched warning flags — keep audio-rate logging from spamming the sink. Per-parameter
-    // latches so that, for example, a non-finite Threshold does not silence a subsequent
-    // non-finite Release. Cleared only on full re-initialization (sample-rate/channel-count
-    // change) — chunk discontinuities (seek/loop/edit) intentionally do NOT re-arm them, or
-    // a persistent upstream defect would log every chunk.
+    // Per-parameter latches that keep audio-rate logging from spamming the sink (one latch each so
+    // a non-finite Threshold doesn't mask a non-finite Release). Cleared only on full
+    // re-initialization, not on chunk discontinuity — otherwise a persistent defect logs every chunk.
     private bool _warnedNonFiniteThreshold;
     private bool _warnedNonFiniteRelease;
     private bool _warnedNonFiniteLookahead;
@@ -77,13 +71,10 @@ public sealed class LimiterNode : AudioNode
 
         if (input.SampleCount == 0)
         {
-            // Empty chunks are not produced by the normal scheduling path (GetSampleCount uses
-            // Math.Ceiling so only TimeRange.Duration == Zero reaches here). Treat them as a
-            // notable upstream event and log once-per-format-change. Crucially, do NOT touch
-            // _lastTimeRangeEnd: an empty chunk processes no audio, so the next non-empty chunk
-            // must be evaluated against the previous *non-empty* chunk's end. Updating it here
-            // would silently mask a discontinuity when the empty chunk happens to land at a
-            // different position than the previous chunk's end.
+            // Empty chunks only reach here when TimeRange.Duration == Zero, so log once as a
+            // notable upstream event. Do NOT touch _lastTimeRangeEnd: an empty chunk processes no
+            // audio, so the next non-empty chunk must be evaluated against the previous *non-empty*
+            // chunk's end — updating it here would mask a discontinuity.
             if (!_warnedEmptyChunk)
             {
                 s_logger.LogDebug(
@@ -103,11 +94,9 @@ public sealed class LimiterNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        // The node instance is cached and reused across chunks. When the next chunk does not
-        // continue from the previous one (seek, loop, edit, restart) we must drop the delay line
-        // and gain state — otherwise audio from the previous segment would leak into the first
-        // lookahead-window worth of output samples. IsTimestampContiguous tolerates only the
-        // one-tick rounding error introduced by independently quantized TimeSpan boundaries.
+        // The node is reused across chunks. When the next chunk doesn't continue from the previous
+        // one (seek, loop, edit, restart), drop the delay line and gain state — otherwise the
+        // previous segment leaks into the first lookahead window of output.
         if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
         {
             if (_lastTimeRangeEnd.HasValue)
@@ -129,22 +118,12 @@ public sealed class LimiterNode : AudioNode
             ? ProcessAnimated(input, context)
             : ProcessStatic(input, context);
 
-        // Update only on success: if Process throws mid-buffer (realistically only from
-        // AnimationSampler on a later inner chunk of ProcessAnimated, after earlier samples were
-        // already ingested), _currentGain and the delay line may be partially mutated. No production
-        // caller re-invokes Process with an identical context after a throw — Composer,
-        // SampleProviderImpl, and PlayerViewModel all propagate the exception and stop — so the
-        // same-chunk-retry branch below is a latent/defensive consideration, not an active path.
-        // For completeness, the next call resolves as:
-        //  - Contiguous throw (no Reset() ran this call): _lastTimeRangeEnd retains the previous
-        //    end. A next call at a different Start hits the discontinuity branch, which Reset()s and
-        //    discards the partial state. A next call at the same Start (a hypothetical same-chunk
-        //    retry that no current caller performs) would instead inherit the partial state; this is
-        //    tolerated rather than guarded, because the alternative — always Reset() after a throw —
-        //    would needlessly discard correct delay-line state and no caller actually retries.
-        //  - Throw after Reset() ran: _lastTimeRangeEnd was already cleared to null by Reset(),
-        //    so the next call hits the `!HasValue` branch and Reset()s again before processing,
-        //    discarding any partial state.
+        // Update only on success. If Process throws mid-buffer the state is left partially mutated,
+        // but no production caller retries the same chunk: a next call at a different Start hits the
+        // discontinuity branch and Reset()s, and a throw after Reset() already cleared
+        // _lastTimeRangeEnd so the next call Reset()s again. A same-Start retry would inherit the
+        // partial state; that's tolerated rather than guarded, since always resetting after a throw
+        // would needlessly discard correct delay-line state no caller actually retries.
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;
@@ -152,17 +131,16 @@ public sealed class LimiterNode : AudioNode
 
     private static bool IsTimestampContiguous(TimeSpan previousEnd, TimeSpan nextStart)
     {
-        // Independently rounded TimeSpan sample boundaries can differ by one tick even when the
-        // underlying sample indices are adjacent. A two-tick difference remains a real seek/edit
-        // boundary and must reset the delay line.
+        // Adjacent sample boundaries can differ by one tick from independent TimeSpan rounding; a
+        // two-tick difference is a real seek/edit boundary and must reset the delay line.
         long difference = nextStart.Ticks - previousEnd.Ticks;
         return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
     }
 
     private void InitializeBuffers(int sampleRate, int channelCount)
     {
-        // Tear the previous state down first and null the fields immediately so a throw inside
-        // the construction loop below cannot leave us referencing half-initialized buffers.
+        // Null the fields up front so a throw in the construction loop below can't leave us
+        // referencing half-initialized buffers.
         if (_delayLines != null)
         {
             foreach (var line in _delayLines)
@@ -177,10 +155,9 @@ public sealed class LimiterNode : AudioNode
         _peakBuffer = null;
 
         // +1 because CircularBuffer.Read(samplesBack) returns silence when samplesBack >= length,
-        // so the requested length must be strictly greater than the maximum lookaheadSamples we
-        // will ever clamp to (MaxLookaheadMs · sampleRate). The buffer rounds this
-        // up to the next power of two internally — the +1 is for the read-bounds check, not the
-        // rounding.
+        // so length must exceed the maximum lookaheadSamples we ever clamp to (MaxLookaheadMs ·
+        // sampleRate). The buffer rounds up to a power of two internally; the +1 is for the
+        // read-bounds check, not the rounding.
         int max = Math.Max(1, (int)(MaxLookaheadMs / 1000f * sampleRate) + 1);
 
         var lines = new CircularBuffer<float>[channelCount];
@@ -208,11 +185,9 @@ public sealed class LimiterNode : AudioNode
         _maxLookaheadSamples = max;
         _delayLines = lines;
 
-        // Sliding-window-max deque capacity must exceed the largest possible window (max elements)
-        // by two slots: a push transiently holds up to (window + 1) entries before the out-of-window
-        // eviction runs, so the ring must hold at least max + 2 entries to never overwrite its own
-        // front. Round that up to a power of two so the per-sample ring wrapping in PushWindowPeak
-        // is a mask (& _dqMask) instead of an integer division, mirroring CircularBuffer<T>.
+        // The deque capacity needs max + 2 entries: a push transiently holds (window + 1) entries
+        // before the out-of-window eviction runs, so the ring must never overwrite its own front.
+        // Round up to a power of two so PushWindowPeak's ring wrapping is a mask, not a division.
         int dqCap = (int)BitOperations.RoundUpToPowerOf2((uint)(max + 2));
         _dqVal = new float[dqCap];
         _dqPos = new long[dqCap];
@@ -222,9 +197,8 @@ public sealed class LimiterNode : AudioNode
         _dequeLookahead = -1;
         _globalPos = 0;
 
-        // Format change is the one moment where the previous warning history is unrelated to
-        // the new state, so re-arm so that a persistent upstream defect surfaces once per
-        // format change rather than literally never logging again after the first hit.
+        // A format change makes the previous warning history irrelevant, so re-arm the latches:
+        // a persistent upstream defect should surface once per format change, not just once ever.
         _currentGain = 1f;
         _warnedNonFiniteThreshold = false;
         _warnedNonFiniteRelease = false;
@@ -238,10 +212,9 @@ public sealed class LimiterNode : AudioNode
             sampleRate, channelCount, max);
     }
 
-    // Math.Clamp does not coerce NaN nor ±Infinity to the bounds — both would poison
-    // _currentGain permanently if they slipped through. Substituting a safe fallback here keeps
-    // the DSP stable; the caller logs once per parameter at error severity so an upstream
-    // animation/binding bug is visible in production logs (Sentry-grade) without spamming.
+    // Math.Clamp does not coerce NaN/±Infinity to the bounds, and either would permanently poison
+    // _currentGain. Substituting a safe fallback keeps the DSP stable; the first hit per parameter
+    // is logged at error severity so an upstream animation/binding bug stays visible.
     private float ClampFinite(float value, float min, float max, float fallback, string parameterName, ref bool warned)
     {
         if (float.IsFinite(value))
@@ -267,10 +240,9 @@ public sealed class LimiterNode : AudioNode
 
     private DerivedCoefficients Derive(float thresholdDbRaw, float releaseMsRaw, float lookaheadMsRaw, float makeupDbRaw, int sampleRate)
     {
-        // Threshold falls back to the *default* (-1 dB) rather than MaxThresholdDb (0 dB). Using
-        // 0 dB here would silently disable limiting for the rest of the session — exactly the
-        // silent-failure mode this guard is meant to prevent. -1 dB still limits while keeping
-        // the substitution audible (peaks just under unity) so the issue surfaces.
+        // Threshold falls back to the default (-1 dB), not MaxThresholdDb (0 dB): 0 dB would
+        // silently disable limiting for the rest of the session — the exact silent failure this
+        // guard prevents. -1 dB still limits, peaking just under unity so the issue stays audible.
         float thresholdDb = ClampFinite(thresholdDbRaw, MinThresholdDb, MaxThresholdDb, DefaultThresholdDb, nameof(Threshold), ref _warnedNonFiniteThreshold);
         float releaseMs = ClampFinite(releaseMsRaw, MinReleaseMs, MaxReleaseMs, MinReleaseMs, nameof(Release), ref _warnedNonFiniteRelease);
         float lookaheadMs = ClampFinite(lookaheadMsRaw, MinLookaheadMs, MaxLookaheadMs, MinLookaheadMs, nameof(Lookahead), ref _warnedNonFiniteLookahead);
@@ -289,10 +261,8 @@ public sealed class LimiterNode : AudioNode
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        // Lookahead is constant for the whole call, so the window maximum can be tracked with an
-        // O(1)-amortized monotonic deque instead of rescanning the window every sample. Rebuild it
-        // only when the lookahead length differs from what the deque currently tracks (first call
-        // after a reset, or a static parameter edit on a reused node).
+        // Lookahead is constant for the whole call, so the window maximum comes from the
+        // O(1)-amortized deque; rebuild it only when the tracked lookahead length changes.
         EnsureDeque(c.LookaheadSamples);
 
         int channelCount = _delayLines!.Length;
@@ -315,18 +285,16 @@ public sealed class LimiterNode : AudioNode
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
         // Per-chunk animation-sampling scratch, sized to the actual work (capped at
-        // AnimationChunkSize) so a small buffer pays a proportionally small stack cost, matching the
-        // sibling nodes (CompressorNode/DelayNode/GainNode). The inner loop's chunkSize never exceeds
-        // this. Worst case is four AnimationChunkSize-float spans = 16 KiB, well within the stack budget.
+        // AnimationChunkSize) so small buffers pay a proportionally small stack cost, matching the
+        // sibling nodes (CompressorNode/DelayNode/GainNode).
         int scratchSize = Math.Min(AnimationChunkSize, input.SampleCount);
         Span<float> thresholds = stackalloc float[scratchSize];
         Span<float> releases = stackalloc float[scratchSize];
         Span<float> lookaheads = stackalloc float[scratchSize];
         Span<float> makeups = stackalloc float[scratchSize];
 
-        // Lookahead can change per sample here, which the monotonic deque cannot track without
-        // unbounded history, so this path uses the direct window rescan. Invalidate the deque so a
-        // later static chunk on the same (non-reset) node rebuilds it from the retained peak ring.
+        // Lookahead can vary per sample here, which the deque cannot track, so this path rescans
+        // directly. Invalidate the deque so a later static chunk on the same node rebuilds it.
         _dequeLookahead = -1;
 
         int channelCount = _delayLines!.Length;
@@ -350,14 +318,13 @@ public sealed class LimiterNode : AudioNode
 
             for (int i = 0; i < chunkSize; i++)
             {
-                // Derive recomputes one Exp + two Pow per sample here. That per-sample transcendental
-                // cost is a deliberate trade-off for sample-accurate parameter automation; the common
-                // no-animation case takes ProcessStatic, which derives the coefficients once per call.
+                // Derive recomputes one Exp + two Pow per sample — the deliberate cost of
+                // sample-accurate automation. The common no-animation case takes ProcessStatic,
+                // which derives the coefficients once per call.
                 var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
                 int idx = processed + i;
-                // The animated path ignores IngestSample's returned per-sample peak (only its
-                // side-effects on the delay line and peak ring matter); the window maximum comes from
-                // ScanWindowPeak over the ring. The static path, by contrast, feeds it into PushWindowPeak.
+                // The window maximum comes from ScanWindowPeak over the ring, so IngestSample's
+                // returned peak is ignored here (only its delay-line/peak-ring side-effects matter).
                 _ = IngestSample(inRaw, sampleCount, channelCount, idx);
                 float windowPeak = ScanWindowPeak(c.LookaheadSamples);
                 EmitSample(outRaw, sampleCount, channelCount, idx, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
@@ -370,20 +337,13 @@ public sealed class LimiterNode : AudioNode
     }
 
     // Reads one input sample per channel, coerces non-finite values, feeds the delay lines and the
-    // peak-detection ring, advances the global sample position, and returns the channel-linked peak.
-    // inRaw is the channel-major backing span (channel ch sample i lives at ch * sampleCount + i),
-    // fetched once per call so the hot loop avoids AudioBuffer.GetChannelData's per-sample
-    // disposed/bounds/Slice overhead.
+    // peak-detection ring, advances the global position, and returns the channel-linked peak.
+    // inRaw is the channel-major backing span (channel ch sample i at ch * sampleCount + i),
+    // passed in so the hot loop avoids AudioBuffer.GetChannelData's per-sample overhead.
     //
-    // Channel-linked peak detection: take max(|s_ch|) across all channels so that a single shared
-    // gain is applied to every channel — preserves inter-channel phase.
-    //
-    // NaN/Infinity input samples are coerced to 0 here. Without this guard:
-    //   - NaN written into the delay line passes straight through to the output.
-    //   - Inf forces currentPeak → Inf, then targetGain = thresholdLin / Inf = 0,
-    //     and finally `delayed * 0` = `Inf * 0` = NaN once the gain reduction kicks in.
-    // We log at most once per format change so an upstream bug surfaces without flooding the sink
-    // across every chunk discontinuity.
+    // The peak is max(|s_ch|) across channels, so one shared gain applies to every channel and
+    // inter-channel phase is preserved. NaN/Inf samples are coerced to 0 — otherwise NaN passes
+    // through the delay line and Inf drives targetGain to 0, turning `Inf * 0` into NaN.
     private float IngestSample(ReadOnlySpan<float> inRaw, int sampleCount, int channelCount, int sampleIndex)
     {
         float currentPeak = 0f;
@@ -394,9 +354,8 @@ public sealed class LimiterNode : AudioNode
             {
                 if (!_warnedNonFiniteInputSample)
                 {
-                    // Error severity matches the non-finite-parameter path in ClampFinite: a NaN/Inf
-                    // in the audio stream is an upstream DSP defect that would corrupt output, so it
-                    // is surfaced at the same level rather than as a quieter warning.
+                    // Error severity, matching ClampFinite: a NaN/Inf in the stream is an upstream
+                    // DSP defect that would corrupt output.
                     s_logger.LogError(
                         "LimiterNode: non-finite input sample at channel={Channel}, index={Index}, value={Value}. " +
                         "Likely an upstream DSP defect corrupting the audio stream; coercing to 0.",
@@ -419,11 +378,9 @@ public sealed class LimiterNode : AudioNode
         return currentPeak;
     }
 
-    // Applies the gain envelope for one output sample and writes it to every channel. outRaw is the
-    // channel-major backing span (see IngestSample).
-    //
-    // With non-zero lookahead the reduction is applied before the offending sample reaches the
-    // output, so a hard attack stays transparent. With lookahead=0 this degrades to a
+    // Applies the gain envelope for one output sample and writes it to every channel (outRaw is the
+    // channel-major backing span, see IngestSample). With non-zero lookahead the reduction lands
+    // before the offending sample reaches the output; with lookahead=0 it degrades to a
     // hard-clipper-style limiter (still correct, just less transparent).
     private void EmitSample(
         Span<float> outRaw,
@@ -465,9 +422,8 @@ public sealed class LimiterNode : AudioNode
     }
 
     // Direct O(lookahead) window maximum over the peak ring [0..lookaheadSamples]. Read(0) is the
-    // just-written peak and Read(lookaheadSamples) is the peak that the sample currently exiting the
-    // delay line is about to face, so the reduction is in place before that peak arrives. Used by the
-    // animated path where the window length varies per sample.
+    // just-written peak; Read(lookaheadSamples) is the peak the sample now exiting the delay line is
+    // about to face, so reduction lands before it. Used by the animated path (per-sample window).
     private float ScanWindowPeak(int lookaheadSamples)
     {
         float windowPeak = 0f;
@@ -482,10 +438,9 @@ public sealed class LimiterNode : AudioNode
         return windowPeak;
     }
 
-    // O(1)-amortized sliding-window maximum: pushes the just-written peak (at position _globalPos-1)
-    // onto the monotonic-decreasing deque, evicts entries older than the window
-    // [pos - lookaheadSamples, pos], and returns the current maximum (the deque front). Equivalent to
-    // ScanWindowPeak for a constant lookahead. Requires EnsureDeque(lookaheadSamples) first.
+    // O(1)-amortized sliding-window maximum: pushes the just-written peak (at _globalPos-1) onto the
+    // monotonic deque, evicts entries older than [pos - lookaheadSamples, pos], and returns the
+    // front (the max). Equivalent to ScanWindowPeak for constant lookahead; needs EnsureDeque first.
     private float PushWindowPeak(float value, int lookaheadSamples)
     {
         int mask = _dqMask;
@@ -494,11 +449,9 @@ public sealed class LimiterNode : AudioNode
         while (_dqCount > 0 && _dqVal![(_dqHead + _dqCount - 1) & mask] <= value)
             _dqCount--;
 
-        // After the monotonic back-eviction the deque holds at most the in-window count =
-        // lookaheadSamples + 1 <= _maxLookaheadSamples <= cap - 2, so a free slot for this push is
-        // guaranteed (_dqCount < cap, i.e. tail != _dqHead). Assert BEFORE the write so a future change
-        // that breaks the bound is caught before it overwrites the front, not one step after the
-        // corruption (Debug-only; compiled out of Release).
+        // After the back-eviction the deque holds at most lookaheadSamples + 1 <= cap - 2 entries,
+        // so a free slot is guaranteed. Assert before the write so a future change that breaks the
+        // bound is caught before it overwrites the front (Debug-only).
         Debug.Assert(_dqCount < _dqVal!.Length, "LimiterNode deque overflow: no free slot, front would be overwritten.");
 
         int tail = (_dqHead + _dqCount) & mask;
@@ -517,9 +470,8 @@ public sealed class LimiterNode : AudioNode
     }
 
     // (Re)builds the monotonic deque so PushWindowPeak can continue incrementally for the given
-    // lookahead. No-op when the deque already tracks this length. After a reset _globalPos is 0 and
-    // the peak history is empty, so the deque simply starts empty; when the lookahead changes on a
-    // reused node the candidate set is reconstructed from the retained peak ring (O(lookahead) once).
+    // lookahead. No-op when it already tracks this length. After a reset the deque starts empty;
+    // when the lookahead changes on a reused node it is rebuilt from the retained peak ring once.
     private void EnsureDeque(int lookaheadSamples)
     {
         if (_dequeLookahead == lookaheadSamples)
@@ -533,8 +485,8 @@ public sealed class LimiterNode : AudioNode
         if (last >= 0)
         {
             int span = (int)Math.Min(lookaheadSamples + 1L, last + 1L);
-            // Iterate the window oldest-to-newest (Read(j) is the peak j samples back) so the deque
-            // ends up ordered front=oldest with values monotonically decreasing front-to-back.
+            // Iterate oldest-to-newest (Read(j) is the peak j samples back) so the deque ends up
+            // front=oldest with values monotonically decreasing front-to-back.
             for (int j = span - 1; j >= 0; j--)
             {
                 float v = _peakBuffer!.Read(j);
@@ -554,12 +506,10 @@ public sealed class LimiterNode : AudioNode
     }
 
     /// <summary>
-    /// Clears the per-channel delay lines and the peak-detection buffer, resets the internal
-    /// gain to unity, and clears the cached chunk timestamp so the next Process() call does
-    /// not consider itself contiguous. Process() invokes this automatically on chunk
-    /// discontinuity, so external callers do not normally need to call it. Per-parameter
-    /// non-finite warning latches are intentionally NOT cleared here — see InitializeBuffers
-    /// for the spam-protection rationale.
+    /// Clears the delay lines and peak buffer, resets the gain to unity, and clears the cached
+    /// chunk timestamp so the next Process() call is not treated as contiguous. Process() calls
+    /// this automatically on a chunk discontinuity, so external callers rarely need it. The
+    /// non-finite warning latches are intentionally NOT cleared here (see InitializeBuffers).
     /// </summary>
     public void Reset()
     {
@@ -575,9 +525,8 @@ public sealed class LimiterNode : AudioNode
         _currentGain = 1f;
         _lastTimeRangeEnd = null;
 
-        // Discard the sliding-window deque along with the peak history it tracks. _globalPos restarts
-        // at 0 so positions stay aligned with the freshly-cleared _peakBuffer, and the lookahead
-        // marker is invalidated so the next static chunk rebuilds the deque from scratch.
+        // Discard the deque. _globalPos restarts at 0 to stay aligned with the cleared _peakBuffer,
+        // and the lookahead marker is invalidated so the next static chunk rebuilds from scratch.
         _dqHead = 0;
         _dqCount = 0;
         _dequeLookahead = -1;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Numerics;
 using Beutl.Audio.Effects;
 using Beutl.Engine;
 using Beutl.Logging;
@@ -35,6 +36,7 @@ public sealed class LimiterNode : AudioNode
     // where the lookahead can vary per sample, keeps the direct rescan (ScanWindowPeak).
     private float[]? _dqVal;
     private long[]? _dqPos;
+    private int _dqMask;
     private int _dqHead;
     private int _dqCount;
     private int _dequeLookahead = -1;
@@ -208,9 +210,13 @@ public sealed class LimiterNode : AudioNode
 
         // Sliding-window-max deque capacity must exceed the largest possible window (max elements)
         // by two slots: a push transiently holds up to (window + 1) entries before the out-of-window
-        // eviction runs, so sizing to max + 2 guarantees the ring never overwrites its own front.
-        _dqVal = new float[max + 2];
-        _dqPos = new long[max + 2];
+        // eviction runs, so the ring must hold at least max + 2 entries to never overwrite its own
+        // front. Round that up to a power of two so the per-sample ring wrapping in PushWindowPeak
+        // is a mask (& _dqMask) instead of an integer division, mirroring CircularBuffer<T>.
+        int dqCap = (int)BitOperations.RoundUpToPowerOf2((uint)(max + 2));
+        _dqVal = new float[dqCap];
+        _dqPos = new long[dqCap];
+        _dqMask = dqCap - 1;
         _dqHead = 0;
         _dqCount = 0;
         _dequeLookahead = -1;
@@ -482,20 +488,20 @@ public sealed class LimiterNode : AudioNode
     // ScanWindowPeak for a constant lookahead. Requires EnsureDeque(lookaheadSamples) first.
     private float PushWindowPeak(float value, int lookaheadSamples)
     {
-        int cap = _dqVal!.Length;
+        int mask = _dqMask;
         long pos = _globalPos - 1;
 
-        while (_dqCount > 0 && _dqVal[(_dqHead + _dqCount - 1) % cap] <= value)
+        while (_dqCount > 0 && _dqVal![(_dqHead + _dqCount - 1) & mask] <= value)
             _dqCount--;
 
         // After the monotonic back-eviction the deque holds at most the in-window count =
-        // lookaheadSamples + 1 <= _maxLookaheadSamples = cap - 2, so a free slot for this push is
+        // lookaheadSamples + 1 <= _maxLookaheadSamples <= cap - 2, so a free slot for this push is
         // guaranteed (_dqCount < cap, i.e. tail != _dqHead). Assert BEFORE the write so a future change
         // that breaks the bound is caught before it overwrites the front, not one step after the
         // corruption (Debug-only; compiled out of Release).
-        Debug.Assert(_dqCount < cap, "LimiterNode deque overflow: no free slot, front would be overwritten.");
+        Debug.Assert(_dqCount < _dqVal!.Length, "LimiterNode deque overflow: no free slot, front would be overwritten.");
 
-        int tail = (_dqHead + _dqCount) % cap;
+        int tail = (_dqHead + _dqCount) & mask;
         _dqVal[tail] = value;
         _dqPos![tail] = pos;
         _dqCount++;
@@ -503,7 +509,7 @@ public sealed class LimiterNode : AudioNode
         long windowStart = pos - lookaheadSamples;
         while (_dqPos[_dqHead] < windowStart)
         {
-            _dqHead = (_dqHead + 1) % cap;
+            _dqHead = (_dqHead + 1) & mask;
             _dqCount--;
         }
 
@@ -522,7 +528,7 @@ public sealed class LimiterNode : AudioNode
         _dqHead = 0;
         _dqCount = 0;
 
-        int cap = _dqVal!.Length;
+        int mask = _dqMask;
         long last = _globalPos - 1;
         if (last >= 0)
         {
@@ -534,11 +540,11 @@ public sealed class LimiterNode : AudioNode
                 float v = _peakBuffer!.Read(j);
                 long pos = last - j;
 
-                while (_dqCount > 0 && _dqVal[(_dqHead + _dqCount - 1) % cap] <= v)
+                while (_dqCount > 0 && _dqVal![(_dqHead + _dqCount - 1) & mask] <= v)
                     _dqCount--;
 
-                int tail = (_dqHead + _dqCount) % cap;
-                _dqVal[tail] = v;
+                int tail = (_dqHead + _dqCount) & mask;
+                _dqVal![tail] = v;
                 _dqPos![tail] = pos;
                 _dqCount++;
             }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -22,6 +22,18 @@ public sealed class LimiterNode : AudioNode
     private TimeSpan? _lastTimeRangeEnd;
     private float _currentGain = 1f;
 
+    // O(1)-amortized sliding-window maximum for the static path. A monotonic-decreasing deque
+    // (ring buffer over peak positions) replaces the per-sample O(lookahead) rescan. It persists
+    // across contiguous chunks like the delay line, is rebuilt from _peakBuffer only when the
+    // lookahead length changes (rare), and is cleared on Reset/format change. The animated path,
+    // where the lookahead can vary per sample, keeps the direct rescan (ScanWindowPeak).
+    private float[]? _dqVal;
+    private long[]? _dqPos;
+    private int _dqHead;
+    private int _dqCount;
+    private int _dequeLookahead = -1;
+    private long _globalPos;
+
     // Latched warning flags — keep audio-rate logging from spamming the sink. Per-parameter
     // latches so that, for example, a non-finite Threshold does not silence a subsequent
     // non-finite Release. Cleared only on full re-initialization (sample-rate/channel-count
@@ -172,6 +184,17 @@ public sealed class LimiterNode : AudioNode
 
         _maxLookaheadSamples = max;
         _delayLines = lines;
+
+        // Sliding-window-max deque capacity must exceed the largest possible window (max elements)
+        // by two slots: a push transiently holds up to (window + 1) entries before the out-of-window
+        // eviction runs, so sizing to max + 2 guarantees the ring never overwrites its own front.
+        _dqVal = new float[max + 2];
+        _dqPos = new long[max + 2];
+        _dqHead = 0;
+        _dqCount = 0;
+        _dequeLookahead = -1;
+        _globalPos = 0;
+
         // Format change is the one moment where the previous warning history is unrelated to
         // the new state, so re-arm so that a persistent upstream defect surfaces once per
         // format change rather than literally never logging again after the first hit.
@@ -239,9 +262,22 @@ public sealed class LimiterNode : AudioNode
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-        for (int i = 0; i < input.SampleCount; i++)
+        // Lookahead is constant for the whole call, so the window maximum can be tracked with an
+        // O(1)-amortized monotonic deque instead of rescanning the window every sample. Rebuild it
+        // only when the lookahead length differs from what the deque currently tracks (first call
+        // after a reset, or a static parameter edit on a reused node).
+        EnsureDeque(c.LookaheadSamples);
+
+        int channelCount = _delayLines!.Length;
+        int sampleCount = input.SampleCount;
+        ReadOnlySpan<float> inRaw = input.GetRawSpan();
+        Span<float> outRaw = output.GetRawSpan();
+
+        for (int i = 0; i < sampleCount; i++)
         {
-            ProcessSingleSample(input, output, i, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
+            float currentPeak = IngestSample(inRaw, sampleCount, channelCount, i);
+            float windowPeak = PushWindowPeak(currentPeak, c.LookaheadSamples);
+            EmitSample(outRaw, sampleCount, channelCount, i, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
         }
 
         return output;
@@ -260,10 +296,20 @@ public sealed class LimiterNode : AudioNode
         Span<float> lookaheads = stackalloc float[AnimationChunkSize];
         Span<float> makeups = stackalloc float[AnimationChunkSize];
 
+        // Lookahead can change per sample here, which the monotonic deque cannot track without
+        // unbounded history, so this path uses the direct window rescan. Invalidate the deque so a
+        // later static chunk on the same (non-reset) node rebuilds it from the retained peak ring.
+        _dequeLookahead = -1;
+
+        int channelCount = _delayLines!.Length;
+        int sampleCount = input.SampleCount;
+        ReadOnlySpan<float> inRaw = input.GetRawSpan();
+        Span<float> outRaw = output.GetRawSpan();
+
         int processed = 0;
-        while (processed < input.SampleCount)
+        while (processed < sampleCount)
         {
-            int chunkSize = Math.Min(AnimationChunkSize, input.SampleCount - processed);
+            int chunkSize = Math.Min(AnimationChunkSize, sampleCount - processed);
 
             var chunkStart = context.GetTimeForSample(processed);
             var chunkEnd = context.GetTimeForSample(processed + chunkSize);
@@ -277,7 +323,10 @@ public sealed class LimiterNode : AudioNode
             for (int i = 0; i < chunkSize; i++)
             {
                 var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
-                ProcessSingleSample(input, output, processed + i, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
+                int idx = processed + i;
+                float currentPeak = IngestSample(inRaw, sampleCount, channelCount, idx);
+                float windowPeak = ScanWindowPeak(c.LookaheadSamples);
+                EmitSample(outRaw, sampleCount, channelCount, idx, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
             }
 
             processed += chunkSize;
@@ -286,36 +335,37 @@ public sealed class LimiterNode : AudioNode
         return output;
     }
 
-    private void ProcessSingleSample(
-        AudioBuffer input,
-        AudioBuffer output,
-        int sampleIndex,
-        float thresholdLin,
-        float makeupLin,
-        int lookaheadSamples,
-        float releaseCoef)
+    // Reads one input sample per channel, coerces non-finite values, feeds the delay lines and the
+    // peak-detection ring, advances the global sample position, and returns the channel-linked peak.
+    // inRaw is the channel-major backing span (channel ch sample i lives at ch * sampleCount + i),
+    // fetched once per call so the hot loop avoids AudioBuffer.GetChannelData's per-sample
+    // disposed/bounds/Slice overhead.
+    //
+    // Channel-linked peak detection: take max(|s_ch|) across all channels so that a single shared
+    // gain is applied to every channel — preserves inter-channel phase.
+    //
+    // NaN/Infinity input samples are coerced to 0 here. Without this guard:
+    //   - NaN written into the delay line passes straight through to the output.
+    //   - Inf forces currentPeak → Inf, then targetGain = thresholdLin / Inf = 0,
+    //     and finally `delayed * 0` = `Inf * 0` = NaN once the gain reduction kicks in.
+    // We log at most once per format change so an upstream bug surfaces without flooding the sink
+    // across every chunk discontinuity.
+    private float IngestSample(ReadOnlySpan<float> inRaw, int sampleCount, int channelCount, int sampleIndex)
     {
-        int channelCount = _delayLines!.Length;
-
-        // Channel-linked peak detection: take max(|s_ch|) across all channels so that a
-        // single shared gain is applied to every channel — preserves inter-channel phase.
-        //
-        // NaN/Infinity input samples are coerced to 0 here. Without this guard:
-        //   - NaN written into the delay line passes straight through to the output.
-        //   - Inf forces currentPeak → Inf, then targetGain = thresholdLin / Inf = 0,
-        //     and finally `delayed * 0` = `Inf * 0` = NaN once the gain reduction kicks in.
-        // We log at most once per format change so an upstream bug surfaces without flooding
-        // the sink across every chunk discontinuity.
         float currentPeak = 0f;
         for (int ch = 0; ch < channelCount; ch++)
         {
-            float s = input.GetChannelData(ch)[sampleIndex];
+            float s = inRaw[ch * sampleCount + sampleIndex];
             if (!float.IsFinite(s))
             {
                 if (!_warnedNonFiniteInputSample)
                 {
-                    s_logger.LogWarning(
-                        "LimiterNode: non-finite input sample at channel={Channel}, index={Index}, value={Value}. Likely upstream bug; coercing to 0.",
+                    // Error severity matches the non-finite-parameter path in ClampFinite: a NaN/Inf
+                    // in the audio stream is an upstream DSP defect that would corrupt output, so it
+                    // is surfaced at the same level rather than as a quieter warning.
+                    s_logger.LogError(
+                        "LimiterNode: non-finite input sample at channel={Channel}, index={Index}, value={Value}. " +
+                        "Likely an upstream DSP defect corrupting the audio stream; coercing to 0.",
                         ch, sampleIndex, s);
                     _warnedNonFiniteInputSample = true;
                 }
@@ -327,22 +377,31 @@ public sealed class LimiterNode : AudioNode
             if (abs > currentPeak)
                 currentPeak = abs;
 
-            _delayLines[ch].Write(s);
+            _delayLines![ch].Write(s);
         }
 
         _peakBuffer!.Write(currentPeak);
+        _globalPos++;
+        return currentPeak;
+    }
 
-        // Worst-case future peak that the sample currently exiting the delay line is about to
-        // face — feeds the gain calculation so the reduction is in place before the peak arrives.
-        float windowPeak = 0f;
-        int windowSize = lookaheadSamples + 1;
-        for (int j = 0; j < windowSize; j++)
-        {
-            float v = _peakBuffer.Read(j);
-            if (v > windowPeak)
-                windowPeak = v;
-        }
-
+    // Applies the gain envelope for one output sample and writes it to every channel. outRaw is the
+    // channel-major backing span (see IngestSample).
+    //
+    // With non-zero lookahead the reduction is applied before the offending sample reaches the
+    // output, so a hard attack stays transparent. With lookahead=0 this degrades to a
+    // hard-clipper-style limiter (still correct, just less transparent).
+    private void EmitSample(
+        Span<float> outRaw,
+        int sampleCount,
+        int channelCount,
+        int sampleIndex,
+        float windowPeak,
+        float thresholdLin,
+        float makeupLin,
+        int lookaheadSamples,
+        float releaseCoef)
+    {
         float targetGain;
         if (windowPeak > thresholdLin && windowPeak > 0f)
         {
@@ -353,9 +412,6 @@ public sealed class LimiterNode : AudioNode
             targetGain = 1f;
         }
 
-        // With non-zero lookahead the reduction is applied before the offending sample reaches
-        // the output, so a hard attack stays transparent. With lookahead=0 this degrades to a
-        // hard-clipper-style limiter (still correct, just less transparent).
         if (targetGain < _currentGain)
         {
             _currentGain = targetGain;
@@ -369,9 +425,91 @@ public sealed class LimiterNode : AudioNode
 
         for (int ch = 0; ch < channelCount; ch++)
         {
-            float delayed = _delayLines[ch].Read(lookaheadSamples);
-            output.GetChannelData(ch)[sampleIndex] = delayed * finalGain;
+            float delayed = _delayLines![ch].Read(lookaheadSamples);
+            outRaw[ch * sampleCount + sampleIndex] = delayed * finalGain;
         }
+    }
+
+    // Direct O(lookahead) window maximum over the peak ring [0..lookaheadSamples]. Read(0) is the
+    // just-written peak and Read(lookaheadSamples) is the peak that the sample currently exiting the
+    // delay line is about to face, so the reduction is in place before that peak arrives. Used by the
+    // animated path where the window length varies per sample.
+    private float ScanWindowPeak(int lookaheadSamples)
+    {
+        float windowPeak = 0f;
+        int windowSize = lookaheadSamples + 1;
+        for (int j = 0; j < windowSize; j++)
+        {
+            float v = _peakBuffer!.Read(j);
+            if (v > windowPeak)
+                windowPeak = v;
+        }
+
+        return windowPeak;
+    }
+
+    // O(1)-amortized sliding-window maximum: pushes the just-written peak (at position _globalPos-1)
+    // onto the monotonic-decreasing deque, evicts entries older than the window
+    // [pos - lookaheadSamples, pos], and returns the current maximum (the deque front). Equivalent to
+    // ScanWindowPeak for a constant lookahead. Requires EnsureDeque(lookaheadSamples) first.
+    private float PushWindowPeak(float value, int lookaheadSamples)
+    {
+        int cap = _dqVal!.Length;
+        long pos = _globalPos - 1;
+
+        while (_dqCount > 0 && _dqVal[(_dqHead + _dqCount - 1) % cap] <= value)
+            _dqCount--;
+
+        int tail = (_dqHead + _dqCount) % cap;
+        _dqVal[tail] = value;
+        _dqPos![tail] = pos;
+        _dqCount++;
+
+        long windowStart = pos - lookaheadSamples;
+        while (_dqPos[_dqHead] < windowStart)
+        {
+            _dqHead = (_dqHead + 1) % cap;
+            _dqCount--;
+        }
+
+        return _dqVal[_dqHead];
+    }
+
+    // (Re)builds the monotonic deque so PushWindowPeak can continue incrementally for the given
+    // lookahead. No-op when the deque already tracks this length. After a reset _globalPos is 0 and
+    // the peak history is empty, so the deque simply starts empty; when the lookahead changes on a
+    // reused node the candidate set is reconstructed from the retained peak ring (O(lookahead) once).
+    private void EnsureDeque(int lookaheadSamples)
+    {
+        if (_dequeLookahead == lookaheadSamples)
+            return;
+
+        _dqHead = 0;
+        _dqCount = 0;
+
+        int cap = _dqVal!.Length;
+        long last = _globalPos - 1;
+        if (last >= 0)
+        {
+            int span = (int)Math.Min(lookaheadSamples + 1L, last + 1L);
+            // Iterate the window oldest-to-newest (Read(j) is the peak j samples back) so the deque
+            // ends up ordered front=oldest with values monotonically decreasing front-to-back.
+            for (int j = span - 1; j >= 0; j--)
+            {
+                float v = _peakBuffer!.Read(j);
+                long pos = last - j;
+
+                while (_dqCount > 0 && _dqVal[(_dqHead + _dqCount - 1) % cap] <= v)
+                    _dqCount--;
+
+                int tail = (_dqHead + _dqCount) % cap;
+                _dqVal[tail] = v;
+                _dqPos![tail] = pos;
+                _dqCount++;
+            }
+        }
+
+        _dequeLookahead = lookaheadSamples;
     }
 
     /// <summary>
@@ -395,6 +533,14 @@ public sealed class LimiterNode : AudioNode
         _peakBuffer?.Clear();
         _currentGain = 1f;
         _lastTimeRangeEnd = null;
+
+        // Discard the sliding-window deque along with the peak history it tracks. _globalPos restarts
+        // at 0 so positions stay aligned with the freshly-cleared _peakBuffer, and the lookahead
+        // marker is invalidated so the next static chunk rebuilds the deque from scratch.
+        _dqHead = 0;
+        _dqCount = 0;
+        _dequeLookahead = -1;
+        _globalPos = 0;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -17,6 +17,7 @@ public sealed class LimiterNode : AudioNode
     // less) — well within a thread's default stack budget while still amortizing the per-chunk
     // animation sampling overhead.
     private const int AnimationChunkSize = 1024;
+    private const long TimestampQuantizationToleranceTicks = 1;
 
     private static readonly ILogger s_logger = Log.CreateLogger<LimiterNode>();
 
@@ -101,10 +102,11 @@ public sealed class LimiterNode : AudioNode
         }
 
         // The node instance is cached and reused across chunks. When the next chunk does not
-        // start exactly where the previous one ended (seek, loop, edit, restart) we must drop
-        // the delay line and gain state — otherwise audio from the previous segment would leak
-        // into the first lookahead-window worth of output samples.
-        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
+        // continue from the previous one (seek, loop, edit, restart) we must drop the delay line
+        // and gain state — otherwise audio from the previous segment would leak into the first
+        // lookahead-window worth of output samples. IsTimestampContiguous tolerates only the
+        // one-tick rounding error introduced by independently quantized TimeSpan boundaries.
+        if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
         {
             if (_lastTimeRangeEnd.HasValue)
             {
@@ -144,6 +146,15 @@ public sealed class LimiterNode : AudioNode
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;
+    }
+
+    private static bool IsTimestampContiguous(TimeSpan previousEnd, TimeSpan nextStart)
+    {
+        // Independently rounded TimeSpan sample boundaries can differ by one tick even when the
+        // underlying sample indices are adjacent. A two-tick difference remains a real seek/edit
+        // boundary and must reset the delay line.
+        long difference = nextStart.Ticks - previousEnd.Ticks;
+        return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
     }
 
     private void InitializeBuffers(int sampleRate, int channelCount)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,12 +1,19 @@
 ﻿using Beutl.Audio.Effects;
 using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.Media;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class LimiterNode : AudioNode
 {
+    // 4 × 1024 × sizeof(float) = 16 KiB per ProcessAnimated call — well within
+    // a thread's default stack budget while still amortizing the per-chunk
+    // animation sampling overhead.
     private const int AnimationChunkSize = 1024;
+
+    private static readonly ILogger s_logger = Log.CreateLogger<LimiterNode>();
 
     private CircularBuffer<float>[]? _delayLines;
     private CircularBuffer<float>? _peakBuffer;
@@ -14,6 +21,11 @@ public sealed class LimiterNode : AudioNode
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
     private float _currentGain = 1f;
+
+    // Latched warning flags — keep audio-rate logging from spamming the sink.
+    // Cleared whenever Reset() runs so a new discontinuity can re-surface the warning.
+    private bool _warnedNonFiniteParameter;
+    private bool _warnedNonFiniteInputSample;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -47,12 +59,19 @@ public sealed class LimiterNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        // The node instance is cached across Compose() calls, so when the next chunk does not
-        // continue directly from the previous one (seek, stop/restart) we must drop the
-        // delay-line and gain state — otherwise audio from the previous segment would leak
+        // The node instance is cached and reused across chunks. When the next chunk does not
+        // start exactly where the previous one ended (seek, loop, edit, restart) we must drop
+        // the delay line and gain state — otherwise audio from the previous segment would leak
         // into the first lookahead-window worth of output samples.
         if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
+            if (_lastTimeRangeEnd.HasValue)
+            {
+                s_logger.LogTrace(
+                    "LimiterNode: chunk discontinuity (last end={Last}, new start={Start}); resetting state.",
+                    _lastTimeRangeEnd, context.TimeRange.Start);
+            }
+
             Reset();
         }
 
@@ -65,8 +84,9 @@ public sealed class LimiterNode : AudioNode
             ? ProcessAnimated(input, context)
             : ProcessStatic(input, context);
 
-        // Update only on success so that a thrown exception lets the next call detect the
-        // discontinuity and reset, instead of silently inheriting corrupt state.
+        // Update only on success: if Process throws mid-buffer, _currentGain and the delay line
+        // may be partially mutated. Leaving _lastTimeRangeEnd untouched routes the next call
+        // through Reset() instead of inheriting that partial state.
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;
@@ -74,51 +94,103 @@ public sealed class LimiterNode : AudioNode
 
     private void InitializeBuffers(int sampleRate, int channelCount)
     {
+        // Tear the previous state down first and null the fields immediately so a throw inside
+        // the construction loop below cannot leave us referencing half-initialized buffers.
         if (_delayLines != null)
         {
             foreach (var line in _delayLines)
             {
                 line.Dispose();
             }
+
+            _delayLines = null;
         }
 
         _peakBuffer?.Dispose();
+        _peakBuffer = null;
 
-        // +1 because Read(lookaheadSamples) needs lookaheadSamples + 1 valid slots when
-        // lookaheadSamples is at its maximum (LimiterEffect.MaxLookaheadMs · sampleRate).
-        _maxLookaheadSamples = Math.Max(1, (int)(LimiterEffect.MaxLookaheadMs / 1000f * sampleRate) + 1);
-        _delayLines = new CircularBuffer<float>[channelCount];
-        for (int i = 0; i < _delayLines.Length; i++)
+        // +1 because CircularBuffer.Read(samplesBack) returns silence when samplesBack >= length,
+        // so the requested length must be strictly greater than the maximum lookaheadSamples we
+        // will ever clamp to (LimiterEffect.MaxLookaheadMs · sampleRate). The buffer rounds this
+        // up to the next power of two internally — the +1 is for the read-bounds check, not the
+        // rounding.
+        int max = Math.Max(1, (int)(LimiterEffect.MaxLookaheadMs / 1000f * sampleRate) + 1);
+
+        var lines = new CircularBuffer<float>[channelCount];
+        try
         {
-            _delayLines[i] = new CircularBuffer<float>(_maxLookaheadSamples);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                lines[i] = new CircularBuffer<float>(max);
+            }
+
+            _peakBuffer = new CircularBuffer<float>(max);
+        }
+        catch
+        {
+            foreach (var l in lines)
+            {
+                l?.Dispose();
+            }
+
+            _peakBuffer?.Dispose();
+            _peakBuffer = null;
+            throw;
         }
 
-        _peakBuffer = new CircularBuffer<float>(_maxLookaheadSamples);
+        _maxLookaheadSamples = max;
+        _delayLines = lines;
         _currentGain = 1f;
     }
 
-    // Math.Clamp propagates NaN — wrap to fall back to a safe value before NaN can poison
-    // _currentGain (a NaN there persists across every subsequent sample).
-    private static float ClampFinite(float value, float min, float max, float fallback)
-        => float.IsFinite(value) ? Math.Clamp(value, min, max) : fallback;
+    // Math.Clamp does not coerce NaN nor ±Infinity to the bounds — both would poison
+    // _currentGain permanently if they slipped through. Substituting a safe fallback here keeps
+    // the DSP stable; the caller logs once when the substitution actually fires.
+    private float ClampFinite(float value, float min, float max, float fallback, string parameterName)
+    {
+        if (float.IsFinite(value))
+            return Math.Clamp(value, min, max);
+
+        if (!_warnedNonFiniteParameter)
+        {
+            s_logger.LogWarning(
+                "LimiterNode: non-finite {Parameter}={Value}; substituting {Fallback}. Likely an animation/binding bug upstream.",
+                parameterName, value, fallback);
+            _warnedNonFiniteParameter = true;
+        }
+
+        return fallback;
+    }
+
+    private readonly record struct DerivedCoefficients(
+        float ThresholdLin,
+        float MakeupLin,
+        int LookaheadSamples,
+        float ReleaseCoef);
+
+    private DerivedCoefficients Derive(float thresholdDbRaw, float releaseMsRaw, float lookaheadMsRaw, float makeupDbRaw, int sampleRate)
+    {
+        float thresholdDb = ClampFinite(thresholdDbRaw, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb, nameof(Threshold));
+        float releaseMs = ClampFinite(releaseMsRaw, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs, nameof(Release));
+        float lookaheadMs = ClampFinite(lookaheadMsRaw, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs, nameof(Lookahead));
+        float makeupDb = ClampFinite(makeupDbRaw, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f, nameof(MakeupGain));
+
+        return new DerivedCoefficients(
+            ThresholdLin: AudioMath.ConvertDbToLinear(thresholdDb),
+            MakeupLin: AudioMath.ConvertDbToLinear(makeupDb),
+            LookaheadSamples: Math.Clamp((int)(lookaheadMs / 1000f * sampleRate), 0, _maxLookaheadSamples - 1),
+            ReleaseCoef: MathF.Exp(-1f / (releaseMs * 0.001f * sampleRate)));
+    }
 
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
-        float thresholdDb = ClampFinite(Threshold.CurrentValue, LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb);
-        float releaseMs = ClampFinite(Release.CurrentValue, LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs);
-        float lookaheadMs = ClampFinite(Lookahead.CurrentValue, LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs);
-        float makeupDb = ClampFinite(MakeupGain.CurrentValue, LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f);
-
-        float thresholdLin = AudioMath.ConvertDbToLinear(thresholdDb);
-        float makeupLin = AudioMath.ConvertDbToLinear(makeupDb);
-        int lookaheadSamples = Math.Clamp((int)(lookaheadMs / 1000f * context.SampleRate), 0, _maxLookaheadSamples - 1);
-        float releaseCoef = MathF.Exp(-1f / (releaseMs * 0.001f * context.SampleRate));
+        var c = Derive(Threshold.CurrentValue, Release.CurrentValue, Lookahead.CurrentValue, MakeupGain.CurrentValue, context.SampleRate);
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
         for (int i = 0; i < input.SampleCount; i++)
         {
-            ProcessSingleSample(input, output, i, thresholdLin, makeupLin, lookaheadSamples, releaseCoef);
+            ProcessSingleSample(input, output, i, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
         }
 
         return output;
@@ -149,17 +221,8 @@ public sealed class LimiterNode : AudioNode
 
             for (int i = 0; i < chunkSize; i++)
             {
-                float thresholdDb = ClampFinite(thresholds[i], LimiterEffect.MinThresholdDb, LimiterEffect.MaxThresholdDb, LimiterEffect.MaxThresholdDb);
-                float releaseMs = ClampFinite(releases[i], LimiterEffect.MinReleaseMs, LimiterEffect.MaxReleaseMs, LimiterEffect.MinReleaseMs);
-                float lookaheadMs = ClampFinite(lookaheads[i], LimiterEffect.MinLookaheadMs, LimiterEffect.MaxLookaheadMs, LimiterEffect.MinLookaheadMs);
-                float makeupDb = ClampFinite(makeups[i], LimiterEffect.MinMakeupGainDb, LimiterEffect.MaxMakeupGainDb, 0f);
-
-                float thresholdLin = AudioMath.ConvertDbToLinear(thresholdDb);
-                float makeupLin = AudioMath.ConvertDbToLinear(makeupDb);
-                int lookaheadSamples = Math.Clamp((int)(lookaheadMs / 1000f * context.SampleRate), 0, _maxLookaheadSamples - 1);
-                float releaseCoef = MathF.Exp(-1f / (releaseMs * 0.001f * context.SampleRate));
-
-                ProcessSingleSample(input, output, processed + i, thresholdLin, makeupLin, lookaheadSamples, releaseCoef);
+                var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
+                ProcessSingleSample(input, output, processed + i, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
             }
 
             processed += chunkSize;
@@ -181,14 +244,28 @@ public sealed class LimiterNode : AudioNode
 
         // Channel-linked peak detection: take max(|s_ch|) across all channels so that a
         // single shared gain is applied to every channel — preserves inter-channel phase.
-        // NaN/Infinity samples from upstream are coerced to 0 here: writing them into the
-        // delay line would either pass NaN straight through to the output or produce
-        // Inf*0 = NaN once the gain reduction kicks in.
+        //
+        // NaN/Infinity input samples are coerced to 0 here. Without this guard:
+        //   - NaN written into the delay line passes straight through to the output.
+        //   - Inf forces currentPeak → Inf, then targetGain = thresholdLin / Inf = 0,
+        //     and finally `delayed * 0` = `Inf * 0` = NaN once the gain reduction kicks in.
+        // We log at most once per Reset() so an upstream bug surfaces without flooding the sink.
         float currentPeak = 0f;
         for (int ch = 0; ch < channelCount; ch++)
         {
             float s = input.GetChannelData(ch)[sampleIndex];
-            if (!float.IsFinite(s)) s = 0f;
+            if (!float.IsFinite(s))
+            {
+                if (!_warnedNonFiniteInputSample)
+                {
+                    s_logger.LogWarning(
+                        "LimiterNode: non-finite input sample at channel={Channel}, index={Index}, value={Value}. Likely upstream bug; coercing to 0.",
+                        ch, sampleIndex, s);
+                    _warnedNonFiniteInputSample = true;
+                }
+
+                s = 0f;
+            }
 
             float abs = MathF.Abs(s);
             if (abs > currentPeak)
@@ -199,8 +276,8 @@ public sealed class LimiterNode : AudioNode
 
         _peakBuffer!.Write(currentPeak);
 
-        // Maximum peak that has not yet exited the delay line. This is the worst-case peak
-        // the sample being read from the delay line is allowed to encounter.
+        // Worst-case future peak that the sample currently exiting the delay line is about to
+        // face — feeds the gain calculation so the reduction is in place before the peak arrives.
         float windowPeak = 0f;
         int windowSize = lookaheadSamples + 1;
         for (int j = 0; j < windowSize; j++)
@@ -220,8 +297,9 @@ public sealed class LimiterNode : AudioNode
             targetGain = 1f;
         }
 
-        // Instant attack is safe here: the lookahead delay means we apply the reduction
-        // before the offending sample reaches the output, avoiding distortion.
+        // With non-zero lookahead the reduction is applied before the offending sample reaches
+        // the output, so a hard attack stays transparent. With lookahead=0 this degrades to a
+        // hard-clipper-style limiter (still correct, just less transparent).
         if (targetGain < _currentGain)
         {
             _currentGain = targetGain;
@@ -241,9 +319,8 @@ public sealed class LimiterNode : AudioNode
     }
 
     /// <summary>
-    /// Clears delay-line state and resets the internal gain to unity.
-    /// Process() invokes this automatically on chunk discontinuity, so external
-    /// callers do not normally need to call it.
+    /// Clears delay-line state and resets the internal gain to unity. Process() invokes this
+    /// automatically on chunk discontinuity, so external callers do not normally need to call it.
     /// </summary>
     public void Reset()
     {
@@ -257,6 +334,8 @@ public sealed class LimiterNode : AudioNode
 
         _peakBuffer?.Clear();
         _currentGain = 1f;
+        _warnedNonFiniteParameter = false;
+        _warnedNonFiniteInputSample = false;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -32,6 +32,7 @@ public sealed class LimiterNode : AudioNode
     private bool _warnedNonFiniteLookahead;
     private bool _warnedNonFiniteMakeup;
     private bool _warnedNonFiniteInputSample;
+    private bool _warnedEmptyChunk;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -55,7 +56,23 @@ public sealed class LimiterNode : AudioNode
                 $"LimiterNode: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
 
         if (input.SampleCount == 0)
+        {
+            // Empty chunks are not produced by the normal scheduling path (GetSampleCount uses
+            // Math.Ceiling so only TimeRange.Duration == Zero gets here). Treat them as a
+            // notable event — log once-per-format-change and keep _lastTimeRangeEnd advancing
+            // so a non-empty follow-up chunk that resumes from `Start + Duration` is not
+            // misclassified as a discontinuity.
+            if (!_warnedEmptyChunk)
+            {
+                s_logger.LogDebug(
+                    "LimiterNode: received empty input chunk at {Range}; passing through.",
+                    context.TimeRange);
+                _warnedEmptyChunk = true;
+            }
+
+            _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
             return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+        }
 
         if (_delayLines == null || _peakBuffer == null
             || _lastSampleRate != context.SampleRate
@@ -91,8 +108,13 @@ public sealed class LimiterNode : AudioNode
             : ProcessStatic(input, context);
 
         // Update only on success: if Process throws mid-buffer, _currentGain and the delay line
-        // may be partially mutated. Leaving _lastTimeRangeEnd untouched routes the next call
-        // through Reset() instead of inheriting that partial state.
+        // may be partially mutated. Two cases for partial-state recovery on the next call:
+        //  - Contiguous throw (no Reset() ran this call): _lastTimeRangeEnd retains the previous
+        //    end, so the next call still detects the new chunk as a discontinuity if Start
+        //    differs — and equally, a same-Start retry would fail to update and re-route.
+        //  - Throw after Reset() ran: _lastTimeRangeEnd was already cleared to null by Reset(),
+        //    so the next call hits the `!HasValue` branch and Reset()s again before processing.
+        // Either way, partial state from a failed Process is discarded before the next chunk.
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;
@@ -155,6 +177,7 @@ public sealed class LimiterNode : AudioNode
         _warnedNonFiniteLookahead = false;
         _warnedNonFiniteMakeup = false;
         _warnedNonFiniteInputSample = false;
+        _warnedEmptyChunk = false;
 
         s_logger.LogDebug(
             "LimiterNode: initialized buffers (sampleRate={SampleRate}, channels={Channels}, maxLookaheadSamples={MaxLookahead}).",

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -117,6 +117,12 @@ public sealed partial class SourceSound : IThumbnailsProvider
             int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
             int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
             int fullSpan = endSample - startSample;
+            // samplesPerChunk caps the work per chunk. When fullSpan exceeds it the chunk composes
+            // only a prefix of its span, so consecutive Compose ranges are tick-contiguous (and a
+            // stateful effect such as the limiter genuinely carries state across the whole strip)
+            // ONLY when fullSpan <= samplesPerChunk — i.e. short or zoomed-in clips. For longer clips
+            // the waveform is a sparse approximation and the effect restarts per chunk; that is an
+            // accepted quality trade-off for bounded per-chunk cost, not a correctness guarantee.
             int sampleCount = Math.Min(fullSpan, samplesPerChunk);
             var chunkTime = TimeSpan.FromSeconds((double)startSample / sampleRate);
             TimeSpan startTime = TimeRange.Start + chunkTime;

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -120,29 +120,16 @@ public sealed partial class SourceSound : IThumbnailsProvider
             int sampleCount = Math.Min(fullSpan, samplesPerChunk);
             var chunkTime = TimeSpan.FromSeconds((double)startSample / sampleRate);
             TimeSpan startTime = TimeRange.Start + chunkTime;
-
-            // Derive the chunk duration from the difference between adjacent chunk-boundary
-            // timestamps rather than rounding sampleCount independently. Rounding Start and
-            // Duration separately makes chunkN.Start + chunkN.Duration drift ~1 tick from
-            // chunkN+1.Start, which a stateful effect (e.g. LimiterNode) reads as a
-            // discontinuity and resets mid-stream, glitching the rendered waveform.
-            // Subtracting two FromSeconds-rounded boundaries keeps successive chunks
-            // tick-contiguous. When samplesPerChunk caps the span we intentionally skip
-            // samples, so contiguity does not apply and the sampleCount-based duration is used.
-            TimeSpan durationTime = sampleCount < fullSpan
-                ? TimeSpan.FromSeconds((double)sampleCount / sampleRate)
-                : TimeSpan.FromSeconds((double)endSample / sampleRate) - chunkTime;
+            TimeSpan durationTime = GetWaveformChunkDuration(sampleCount, sampleRate);
 
             if (sampleCount <= 0)
                 continue;
 
-            if (cacheKey != null
-                && cacheService!.TryGetWaveform(cacheKey, chunkTime, cacheThreshold, out var cachedMin,
-                    out var cachedMax))
-            {
-                yield return new WaveformChunk(chunkIndex, cachedMin, cachedMax);
-                continue;
-            }
+            float cachedMin = 0f;
+            float cachedMax = 0f;
+            bool cacheHit = cacheKey != null
+                && cacheService!.TryGetWaveform(
+                    cacheKey, chunkTime, cacheThreshold, out cachedMin, out cachedMax);
 
             var chunk = await ComposeThread.Dispatcher.InvokeAsync(() =>
             {
@@ -153,13 +140,19 @@ public sealed partial class SourceSound : IThumbnailsProvider
                 if (buffer == null || buffer.SampleCount == 0)
                     return null;
 
+                // Stateful effects must process every chunk even when its waveform min/max is
+                // cached. Skipping Compose here would make the next cache miss start with reset
+                // delay/envelope state and produce a different waveform from a cold-cache run.
+                if (cacheHit)
+                    return new WaveformChunk(chunkIndex, cachedMin, cachedMax);
+
                 var firstChannel = buffer.GetChannelData(0);
                 var secondChannel = buffer.GetChannelData(1);
 
                 float minValue = float.MaxValue;
                 float maxValue = float.MinValue;
 
-                for (int i = 0; i < buffer.SampleCount; i++)
+                for (int i = 0; i < Math.Min(sampleCount, buffer.SampleCount); i++)
                 {
                     float left = firstChannel[i];
                     float right = secondChannel[i];
@@ -174,11 +167,25 @@ public sealed partial class SourceSound : IThumbnailsProvider
 
             if (chunk.HasValue)
             {
-                if (cacheKey != null)
+                if (cacheKey != null && !cacheHit)
                     cacheService!.SaveWaveform(cacheKey, chunkTime, chunk.Value.MinValue, chunk.Value.MaxValue);
 
                 yield return chunk.Value;
             }
         }
+    }
+
+    internal static TimeSpan GetWaveformChunkDuration(int sampleCount, int sampleRate)
+    {
+        if (sampleCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleCount));
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+
+        // TimeSpan.FromSeconds rounds to the nearest tick. If that rounds upward,
+        // AudioProcessContext.GetSampleCount's ceiling can request one extra sample. Flooring the
+        // tick count guarantees that a positive duration maps back to exactly sampleCount samples.
+        long ticks = (long)((decimal)sampleCount * TimeSpan.TicksPerSecond / sampleRate);
+        return TimeSpan.FromTicks(ticks);
     }
 }

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -117,12 +117,11 @@ public sealed partial class SourceSound : IThumbnailsProvider
             int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
             int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
             int fullSpan = endSample - startSample;
-            // samplesPerChunk caps the work per chunk. When fullSpan exceeds it the chunk composes
-            // only a prefix of its span, so consecutive Compose ranges are tick-contiguous (and a
-            // stateful effect such as the limiter genuinely carries state across the whole strip)
-            // ONLY when fullSpan <= samplesPerChunk — i.e. short or zoomed-in clips. For longer clips
-            // the waveform is a sparse approximation and the effect restarts per chunk; that is an
-            // accepted quality trade-off for bounded per-chunk cost, not a correctness guarantee.
+            // samplesPerChunk caps the work per chunk. Compose ranges stay tick-contiguous — so a
+            // stateful effect like the limiter carries state across the strip — only when
+            // fullSpan <= samplesPerChunk (short or zoomed-in clips). For longer clips the waveform
+            // is a sparse approximation and the effect restarts per chunk: a deliberate quality
+            // trade-off for bounded per-chunk cost, not a correctness guarantee.
             int sampleCount = Math.Min(fullSpan, samplesPerChunk);
             var chunkTime = TimeSpan.FromSeconds((double)startSample / sampleRate);
             TimeSpan startTime = TimeRange.Start + chunkTime;
@@ -146,9 +145,8 @@ public sealed partial class SourceSound : IThumbnailsProvider
                 if (buffer == null || buffer.SampleCount == 0)
                     return null;
 
-                // Stateful effects must process every chunk even when its waveform min/max is
-                // cached. Skipping Compose here would make the next cache miss start with reset
-                // delay/envelope state and produce a different waveform from a cold-cache run.
+                // Compose must run on every chunk even when its min/max is cached: skipping it would
+                // leave the next cache miss starting from reset state, diverging from a cold run.
                 if (cacheHit)
                     return new WaveformChunk(chunkIndex, cachedMin, cachedMax);
 
@@ -188,9 +186,9 @@ public sealed partial class SourceSound : IThumbnailsProvider
         if (sampleRate <= 0)
             throw new ArgumentOutOfRangeException(nameof(sampleRate));
 
-        // TimeSpan.FromSeconds rounds to the nearest tick. If that rounds upward,
-        // AudioProcessContext.GetSampleCount's ceiling can request one extra sample. Flooring the
-        // tick count guarantees that a positive duration maps back to exactly sampleCount samples.
+        // Floor the tick count: TimeSpan.FromSeconds rounds to nearest, and rounding up would let
+        // AudioProcessContext.GetSampleCount's ceiling request one extra sample. Flooring maps a
+        // positive duration back to exactly sampleCount samples.
         long ticks = (long)((decimal)sampleCount * TimeSpan.TicksPerSecond / sampleRate);
         return TimeSpan.FromTicks(ticks);
     }

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -116,10 +116,22 @@ public sealed partial class SourceSound : IThumbnailsProvider
 
             int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
             int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
-            int sampleCount = Math.Min(endSample - startSample, samplesPerChunk);
+            int fullSpan = endSample - startSample;
+            int sampleCount = Math.Min(fullSpan, samplesPerChunk);
             var chunkTime = TimeSpan.FromSeconds((double)startSample / sampleRate);
             TimeSpan startTime = TimeRange.Start + chunkTime;
-            TimeSpan durationTime = TimeSpan.FromSeconds((double)sampleCount / sampleRate);
+
+            // Derive the chunk duration from the difference between adjacent chunk-boundary
+            // timestamps rather than rounding sampleCount independently. Rounding Start and
+            // Duration separately makes chunkN.Start + chunkN.Duration drift ~1 tick from
+            // chunkN+1.Start, which a stateful effect (e.g. LimiterNode) reads as a
+            // discontinuity and resets mid-stream, glitching the rendered waveform.
+            // Subtracting two FromSeconds-rounded boundaries keeps successive chunks
+            // tick-contiguous. When samplesPerChunk caps the span we intentionally skip
+            // samples, so contiguity does not apply and the sampleCount-based duration is used.
+            TimeSpan durationTime = sampleCount < fullSpan
+                ? TimeSpan.FromSeconds((double)sampleCount / sampleRate)
+                : TimeSpan.FromSeconds((double)endSample / sampleRate) - chunkTime;
 
             if (sampleCount <= 0)
                 continue;

--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -136,4 +136,16 @@
   <data name="LimiterEffect_MakeupGain" xml:space="preserve">
     <value>メイクアップゲイン (dB)</value>
   </data>
+  <data name="LimiterEffect_Threshold_Description" xml:space="preserve">
+    <value>出力の上限。ルックアヘッド窓内のピークが抑えられ、出力はこのレベル以下に保たれます。</value>
+  </data>
+  <data name="LimiterEffect_Release_Description" xml:space="preserve">
+    <value>ピークが過ぎたあとゲインが回復するまでの速さ。</value>
+  </data>
+  <data name="LimiterEffect_Lookahead_Description" xml:space="preserve">
+    <value>ピークが到達する前に捉えるために先読みする時間。0 ms ではサンプル精度を保ち、大きくすると一定の遅延と引き換えに滑らかな制限になります。</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
+    <value>制限後に適用するゲイン。最終ピークは スレッショルド + メイクアップゲイン まで達することがあります。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -121,4 +121,19 @@
   <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
     <value>圧縮で下がった出力レベルを補正するゲイン。</value>
   </data>
+  <data name="LimiterEffect" xml:space="preserve">
+    <value>リミッター</value>
+  </data>
+  <data name="LimiterEffect_Threshold" xml:space="preserve">
+    <value>スレッショルド (dB)</value>
+  </data>
+  <data name="LimiterEffect_Release" xml:space="preserve">
+    <value>リリース (ms)</value>
+  </data>
+  <data name="LimiterEffect_Lookahead" xml:space="preserve">
+    <value>ルックアヘッド (ms)</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain" xml:space="preserve">
+    <value>メイクアップゲイン (dB)</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -141,4 +141,16 @@
   <data name="LimiterEffect_MakeupGain" xml:space="preserve">
     <value>Makeup Gain (dB)</value>
   </data>
+  <data name="LimiterEffect_Threshold_Description" xml:space="preserve">
+    <value>The output ceiling. Peaks within the lookahead window are reduced so the output stays at or below this level.</value>
+  </data>
+  <data name="LimiterEffect_Release_Description" xml:space="preserve">
+    <value>How quickly the gain recovers after a peak passes.</value>
+  </data>
+  <data name="LimiterEffect_Lookahead_Description" xml:space="preserve">
+    <value>How far ahead the limiter looks to catch peaks before they arrive. 0 ms keeps audio sample-accurate; higher values trade a fixed delay for smoother limiting.</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
+    <value>Gain applied after limiting. The final peak can reach Threshold + Makeup Gain.</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -126,4 +126,19 @@
   <data name="CompressorEffect_MakeupGain_Description" xml:space="preserve">
     <value>Gain applied after compression to compensate for the reduced level.</value>
   </data>
+  <data name="LimiterEffect" xml:space="preserve">
+    <value>Limiter</value>
+  </data>
+  <data name="LimiterEffect_Threshold" xml:space="preserve">
+    <value>Threshold (dB)</value>
+  </data>
+  <data name="LimiterEffect_Release" xml:space="preserve">
+    <value>Release (ms)</value>
+  </data>
+  <data name="LimiterEffect_Lookahead" xml:space="preserve">
+    <value>Lookahead (ms)</value>
+  </data>
+  <data name="LimiterEffect_MakeupGain" xml:space="preserve">
+    <value>Makeup Gain (dB)</value>
+  </data>
 </root>

--- a/src/Beutl/Services/LibraryRegistrar.cs
+++ b/src/Beutl/Services/LibraryRegistrar.cs
@@ -211,6 +211,7 @@ public static class LibraryRegistrar
                 .AddAudioEffect<DelayEffect>(AudioStrings.DelayEffect)
                 .AddAudioEffect<EqualizerEffect>(AudioStrings.Equalizer)
                 .AddAudioEffect<CompressorEffect>(AudioStrings.CompressorEffect)
+                .AddAudioEffect<LimiterEffect>(AudioStrings.LimiterEffect)
             );
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1,0 +1,205 @@
+using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+public class LimiterNodeTests
+{
+    private const int SampleRate = 48000;
+    private const int LookaheadMs = 5;
+
+    private static AudioProcessContext CreateContext(int sampleCount)
+    {
+        var duration = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
+        var range = new TimeRange(TimeSpan.Zero, duration);
+        return new AudioProcessContext(range, SampleRate, new AnimationSampler(), null);
+    }
+
+    private static AudioBuffer CreateBuffer(int channelCount, int sampleCount, Func<int, int, float> generator)
+    {
+        var buffer = new AudioBuffer(SampleRate, channelCount, sampleCount);
+        for (int ch = 0; ch < channelCount; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                data[i] = generator(ch, i);
+            }
+        }
+
+        return buffer;
+    }
+
+    private static LimiterNode CreateNode(
+        float thresholdDb = -1f,
+        float releaseMs = 50f,
+        float lookaheadMs = LookaheadMs,
+        float makeupGainDb = 0f)
+    {
+        return new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(releaseMs),
+            Lookahead = Property.CreateAnimatable(lookaheadMs),
+            MakeupGain = Property.CreateAnimatable(makeupGainDb),
+        };
+    }
+
+    private sealed class StubInputNode(AudioBuffer buffer) : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context) => buffer;
+    }
+
+    [Test]
+    public void Process_BelowThreshold_PassesThroughUnchanged()
+    {
+        const int sampleCount = 4096;
+        // Threshold = -1 dB ~= 0.891. Use peak 0.5 (~ -6 dB).
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        var ctx = CreateContext(sampleCount);
+        using var output = node.Process(ctx);
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+
+        // After the lookahead delay, the output should match the delayed input exactly
+        // (no gain reduction applied because the signal stays below threshold).
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(outData[i], Is.EqualTo(inData[i - lookaheadSamples]).Within(1e-5f),
+                    $"Channel {ch} sample {i} should pass through unchanged.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_AboveThreshold_PeakDoesNotExceedThreshold()
+    {
+        const int sampleCount = 4096;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        // Hot sine well above threshold (peak 2.0 ~= +6 dB).
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+        node.AddInput(new StubInputNode(input));
+
+        var ctx = CreateContext(sampleCount);
+        using var output = node.Process(ctx);
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+
+        // After the lookahead window has fully filled, every output sample must be
+        // at or below threshold (modulo tiny float epsilon).
+        const float epsilon = 1e-4f;
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var outData = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(outData[i]), Is.LessThanOrEqualTo(thresholdLin + epsilon),
+                    $"Channel {ch} sample {i} ({outData[i]}) exceeded threshold {thresholdLin}.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_MakeupGain_AppliedToOutput()
+    {
+        const int sampleCount = 2048;
+        const float makeupDb = 6f;
+        float makeupLin = MathF.Pow(10f, makeupDb / 20f);
+
+        // Signal stays well below threshold so only makeup gain is applied.
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 0.25f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        // Use a generous threshold so the limiter never engages.
+        using var node = CreateNode(thresholdDb: 0f, makeupGainDb: makeupDb);
+        node.AddInput(new StubInputNode(input));
+
+        var ctx = CreateContext(sampleCount);
+        using var output = node.Process(ctx);
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                float expected = inData[i - lookaheadSamples] * makeupLin;
+                Assert.That(outData[i], Is.EqualTo(expected).Within(1e-4f),
+                    $"Channel {ch} sample {i} should equal input * makeup gain.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_StereoLink_ReducesBothChannelsTogether()
+    {
+        const int sampleCount = 2048;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        // Only the left channel exceeds the threshold; the right is well below.
+        using var input = CreateBuffer(2, sampleCount, (ch, i) =>
+        {
+            float baseSig = MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+            return ch == 0 ? 2.0f * baseSig : 0.1f * baseSig;
+        });
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+        node.AddInput(new StubInputNode(input));
+
+        var ctx = CreateContext(sampleCount);
+        using var output = node.Process(ctx);
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+
+        // The right channel should have been attenuated proportionally even though it
+        // never crossed the threshold on its own.
+        var inR = input.GetChannelData(1);
+        var outR = output.GetChannelData(1);
+
+        // Find a region with a large left peak to confirm the right channel was scaled.
+        bool foundReduction = false;
+        const float epsilon = 1e-3f;
+        for (int i = lookaheadSamples; i < sampleCount; i++)
+        {
+            float originalRight = inR[i - lookaheadSamples];
+            if (MathF.Abs(originalRight) < 0.05f) continue;
+
+            if (MathF.Abs(outR[i]) < MathF.Abs(originalRight) - epsilon)
+            {
+                foundReduction = true;
+                break;
+            }
+        }
+
+        Assert.That(foundReduction, Is.True,
+            "Right channel should be attenuated due to stereo-linked gain reduction.");
+
+        // And the left channel must still respect the threshold.
+        var outL = output.GetChannelData(0);
+        for (int i = lookaheadSamples; i < sampleCount; i++)
+        {
+            Assert.That(MathF.Abs(outL[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -11,7 +11,10 @@ namespace Beutl.UnitTests.Engine.Audio;
 public class LimiterNodeTests
 {
     private const int SampleRate = 48000;
-    private const int LookaheadMs = 5;
+    private const float LookaheadMs = LimiterEffect.DefaultLookaheadMs;
+
+    private static int LookaheadSamples(int sampleRate = SampleRate, float lookaheadMs = LookaheadMs)
+        => (int)(lookaheadMs / 1000f * sampleRate);
 
     private static AudioProcessContext CreateContext(int sampleCount, int sampleRate = SampleRate, TimeSpan? start = null)
     {
@@ -36,10 +39,10 @@ public class LimiterNodeTests
     }
 
     private static LimiterNode CreateNode(
-        float thresholdDb = -1f,
-        float releaseMs = 50f,
-        float lookaheadMs = LookaheadMs,
-        float makeupGainDb = 0f)
+        float thresholdDb = LimiterEffect.DefaultThresholdDb,
+        float releaseMs = LimiterEffect.DefaultReleaseMs,
+        float lookaheadMs = LimiterEffect.DefaultLookaheadMs,
+        float makeupGainDb = LimiterEffect.DefaultMakeupGainDb)
     {
         return new LimiterNode
         {
@@ -64,17 +67,15 @@ public class LimiterNodeTests
     public void Process_BelowThreshold_PassesThroughUnchanged()
     {
         const int sampleCount = 4096;
-        // Threshold = -1 dB ~= 0.891. Use peak 0.5 (~ -6 dB).
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
         using var node = CreateNode();
         node.AddInput(new StubInputNode(input));
 
-        var ctx = CreateContext(sampleCount);
-        using var output = node.Process(ctx);
+        using var output = node.Process(CreateContext(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
 
         // After the lookahead delay, the output should match the delayed input exactly
         // (no gain reduction applied because the signal stays below threshold).
@@ -97,20 +98,16 @@ public class LimiterNodeTests
         const float thresholdDb = -1f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
 
-        // Hot sine well above threshold (peak 2.0 ~= +6 dB).
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
         using var node = CreateNode(thresholdDb: thresholdDb);
         node.AddInput(new StubInputNode(input));
 
-        var ctx = CreateContext(sampleCount);
-        using var output = node.Process(ctx);
+        using var output = node.Process(CreateContext(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
 
-        // After the lookahead window has fully filled, every output sample must be
-        // at or below threshold (modulo tiny float epsilon).
         const float epsilon = 1e-4f;
         for (int ch = 0; ch < 2; ch++)
         {
@@ -130,18 +127,16 @@ public class LimiterNodeTests
         const float makeupDb = 6f;
         float makeupLin = MathF.Pow(10f, makeupDb / 20f);
 
-        // Signal stays well below threshold so only makeup gain is applied.
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 0.25f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
-        // Use a generous threshold so the limiter never engages.
+        // Generous threshold so the limiter never engages — only makeup gain shapes the output.
         using var node = CreateNode(thresholdDb: 0f, makeupGainDb: makeupDb);
         node.AddInput(new StubInputNode(input));
 
-        var ctx = CreateContext(sampleCount);
-        using var output = node.Process(ctx);
+        using var output = node.Process(CreateContext(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
 
         for (int ch = 0; ch < 2; ch++)
         {
@@ -173,17 +168,15 @@ public class LimiterNodeTests
         using var node = CreateNode(thresholdDb: thresholdDb);
         node.AddInput(new StubInputNode(input));
 
-        var ctx = CreateContext(sampleCount);
-        using var output = node.Process(ctx);
+        using var output = node.Process(CreateContext(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
 
-        // The right channel should have been attenuated proportionally even though it
-        // never crossed the threshold on its own.
         var inR = input.GetChannelData(1);
         var outR = output.GetChannelData(1);
 
-        // Find a region with a large left peak to confirm the right channel was scaled.
+        // Channel-linked gain reduction must scale the right channel even though it never
+        // crossed the threshold on its own.
         bool foundReduction = false;
         const float epsilon = 1e-3f;
         for (int i = lookaheadSamples; i < sampleCount; i++)
@@ -201,7 +194,6 @@ public class LimiterNodeTests
         Assert.That(foundReduction, Is.True,
             "Right channel should be attenuated due to channel-linked gain reduction.");
 
-        // And the left channel must still respect the threshold.
         var outL = output.GetChannelData(0);
         for (int i = lookaheadSamples; i < sampleCount; i++)
         {
@@ -212,7 +204,6 @@ public class LimiterNodeTests
     [Test]
     public void Process_NonContiguousChunks_ResetsState()
     {
-        // First chunk: hot sine that drives the limiter into reduction.
         const int firstSampleCount = 1024;
         using var hotInput = CreateBuffer(2, firstSampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
@@ -221,7 +212,7 @@ public class LimiterNodeTests
         node.AddInput(new StubInputNode(hotInput));
 
         var firstCtx = CreateContext(firstSampleCount, start: TimeSpan.Zero);
-        using (var firstOut = node.Process(firstCtx)) { /* prime the state */ }
+        using (var _ = node.Process(firstCtx)) { }
 
         // Replace input with silence and jump the time range so it is NOT contiguous.
         using var silence = CreateBuffer(2, firstSampleCount, (_, _) => 0f);
@@ -248,9 +239,8 @@ public class LimiterNodeTests
     public void Process_ContiguousChunks_PreserveDelayState()
     {
         const int chunkSamples = 1024;
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
 
-        // Hot first chunk to fill the delay line.
         using var hotInput = CreateBuffer(2, chunkSamples,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
@@ -258,9 +248,8 @@ public class LimiterNodeTests
         node.AddInput(new StubInputNode(hotInput));
 
         var firstCtx = CreateContext(chunkSamples, start: TimeSpan.Zero);
-        using (var _ = node.Process(firstCtx)) { /* fill delay line */ }
+        using (var _ = node.Process(firstCtx)) { }
 
-        // Second chunk: silence following directly after the first chunk (no time gap).
         var secondStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration;
         using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
         node.RemoveInput(node.Inputs[0]);
@@ -269,25 +258,25 @@ public class LimiterNodeTests
         var secondCtx = CreateContext(chunkSamples, start: secondStart);
         using var secondOut = node.Process(secondCtx);
 
-        // The first lookahead-window worth of samples in the second chunk reads the
-        // tail of the first chunk out of the delay line. If Reset() had fired
-        // erroneously the delay line would have been cleared and these samples would
-        // all be zero — the non-zero leak proves continuity is preserved.
-        bool foundLeak = false;
-        for (int ch = 0; ch < 2 && !foundLeak; ch++)
+        // The first lookahead-window worth of samples in the second chunk reads the tail of
+        // the first chunk out of the delay line. If Reset() had fired erroneously the delay
+        // line would have been cleared and these samples would all be zero — the non-zero
+        // residual proves continuity is preserved.
+        bool foundResidual = false;
+        for (int ch = 0; ch < 2 && !foundResidual; ch++)
         {
             var data = secondOut.GetChannelData(ch);
             for (int i = 0; i < lookaheadSamples; i++)
             {
                 if (MathF.Abs(data[i]) > 1e-3f)
                 {
-                    foundLeak = true;
+                    foundResidual = true;
                     break;
                 }
             }
         }
 
-        Assert.That(foundLeak, Is.True,
+        Assert.That(foundResidual, Is.True,
             "Contiguous chunk should preserve delay-line state from the previous chunk.");
     }
 
@@ -300,12 +289,11 @@ public class LimiterNodeTests
 
         using var node = CreateNode(thresholdDb: thresholdDb);
 
-        // Stereo first.
         using var stereoIn = CreateBuffer(2, sampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
         node.AddInput(new StubInputNode(stereoIn));
 
-        using (var stereoOut = node.Process(CreateContext(sampleCount, start: TimeSpan.Zero))) { /* prime */ }
+        using (var _ = node.Process(CreateContext(sampleCount, start: TimeSpan.Zero))) { }
 
         // Switch to mono input — buffers must be re-initialized for the new channel count.
         using var monoIn = CreateBuffer(1, sampleCount,
@@ -316,7 +304,7 @@ public class LimiterNodeTests
         using var monoOut = node.Process(CreateContext(sampleCount, start: TimeSpan.FromSeconds(1)));
 
         Assert.That(monoOut.ChannelCount, Is.EqualTo(1));
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
         var data = monoOut.GetChannelData(0);
         for (int i = lookaheadSamples; i < sampleCount; i++)
         {
@@ -340,13 +328,12 @@ public class LimiterNodeTests
             using var node = CreateNode(thresholdDb: thresholdDb);
             node.AddInput(new StubInputNode(input));
 
-            var ctx = CreateContext(sampleCount, sampleRate: sr);
-            using var output = node.Process(ctx);
+            using var output = node.Process(CreateContext(sampleCount, sampleRate: sr));
 
             Assert.That(output.SampleCount, Is.EqualTo(sampleCount), $"SR={sr} sample count mismatch");
             Assert.That(output.SampleRate, Is.EqualTo(sr));
 
-            int lookaheadSamples = (int)(LookaheadMs / 1000f * sr);
+            int lookaheadSamples = LookaheadSamples(sr);
             for (int ch = 0; ch < 2; ch++)
             {
                 var data = output.GetChannelData(ch);
@@ -355,6 +342,43 @@ public class LimiterNodeTests
                     Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
                         $"SR={sr} channel {ch} sample {i} exceeded threshold");
                 }
+            }
+        }
+    }
+
+    [Test]
+    public void Process_SampleRateChange_OnSameNode_ReinitializesBuffers()
+    {
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: LimiterEffect.MaxLookaheadMs);
+
+        using var input48 = CreateBuffer(2, 4800,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / 48000),
+            sampleRate: 48000);
+        node.AddInput(new StubInputNode(input48));
+        using (var _ = node.Process(CreateContext(4800, sampleRate: 48000, start: TimeSpan.Zero))) { }
+
+        // Switch the same node to a higher sample rate. The internal _maxLookaheadSamples must
+        // grow to fit MaxLookaheadMs at the new rate, otherwise reads at the maximum lookahead
+        // would silently return zero.
+        node.RemoveInput(node.Inputs[0]);
+        using var input96 = CreateBuffer(2, 9600,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / 96000),
+            sampleRate: 96000);
+        node.AddInput(new StubInputNode(input96));
+
+        using var output = node.Process(CreateContext(9600, sampleRate: 96000, start: TimeSpan.FromSeconds(5)));
+
+        Assert.That(output.SampleRate, Is.EqualTo(96000));
+        int lookaheadSamples = LookaheadSamples(96000, LimiterEffect.MaxLookaheadMs);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < 9600; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
             }
         }
     }
@@ -372,11 +396,8 @@ public class LimiterNodeTests
         using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: 0f);
         node.AddInput(new StubInputNode(input));
 
-        var ctx = CreateContext(sampleCount);
-        using var output = node.Process(ctx);
+        using var output = node.Process(CreateContext(sampleCount));
 
-        // With lookahead=0 every output sample must respect the threshold (no
-        // negative-index reads, no off-by-one crash).
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -389,15 +410,54 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_MaxLookahead_DoesNotCollapseToSilence()
+    {
+        const int sampleCount = 4096;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: LimiterEffect.MaxLookaheadMs);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        // Off-by-one in the lookahead clamp would collapse Read(_maxLookaheadSamples) to 0
+        // (silence) for every sample. Assert non-zero output past the lookahead window.
+        int lookaheadSamples = LookaheadSamples(SampleRate, LimiterEffect.MaxLookaheadMs);
+        bool foundNonZero = false;
+        for (int i = lookaheadSamples; i < sampleCount; i++)
+        {
+            if (MathF.Abs(output.GetChannelData(0)[i]) > 1e-3f)
+            {
+                foundNonZero = true;
+                break;
+            }
+        }
+
+        Assert.That(foundNonZero, Is.True, "Output collapsed to silence at MaxLookaheadMs.");
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+            }
+        }
+    }
+
+    [Test]
     public void Process_NegativePeak_TriggersLimiter()
     {
         const int sampleCount = 2048;
         const float thresholdDb = -1f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
 
-        // DC bias of -1.5 — only negative peaks exceed threshold. This catches a
-        // half-wave-rectification bug where the limiter would only respond to
-        // positive samples.
+        // DC bias of -1.5 — only negative peaks exceed threshold. Catches a half-wave-
+        // rectification bug where the limiter would only respond to positive samples.
         using var input = CreateBuffer(2, sampleCount, (_, _) => -1.5f);
 
         using var node = CreateNode(thresholdDb: thresholdDb);
@@ -405,7 +465,7 @@ public class LimiterNodeTests
 
         using var output = node.Process(CreateContext(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -455,11 +515,125 @@ public class LimiterNodeTests
 
         Assert.That(output.ChannelCount, Is.EqualTo(1));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
         var data = output.GetChannelData(0);
         for (int i = lookaheadSamples; i < sampleCount; i++)
         {
             Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+        }
+    }
+
+    [Test]
+    public void Process_ThresholdAt0Db_PassesUnitPeak()
+    {
+        const int sampleCount = 2048;
+
+        // Input peak = exactly 1.0. Threshold = 0 dB → thresholdLin = 1.0.
+        // Branch `windowPeak > thresholdLin` is FALSE (equal), so no reduction is applied.
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        int lookaheadSamples = LookaheadSamples();
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(outData[i], Is.EqualTo(inData[i - lookaheadSamples]).Within(1e-4f),
+                    $"Channel {ch} sample {i} should pass through unchanged at threshold = peak.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_ThresholdAt0Db_PeakAboveOne_LimitsToOne()
+    {
+        const int sampleCount = 2048;
+        const float thresholdLin = 1f;
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 1.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        int lookaheadSamples = LookaheadSamples();
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_TinyPeakBelowThreshold_StaysFinite()
+    {
+        const int sampleCount = 1024;
+
+        // windowPeak guard `> 0f` matters here: tiny non-zero input should not divide by ~0
+        // and produce extreme targetGain values.
+        using var input = CreateBuffer(2, sampleCount, (_, _) => 1e-12f);
+
+        using var node = CreateNode(thresholdDb: -60f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True);
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(1e-3f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_LookaheadDelay_IsAccurate()
+    {
+        // Impulse at index 0 of an otherwise silent buffer — the impulse should re-emerge at
+        // exactly index `lookaheadSamples` in the output.
+        foreach (float lookaheadMs in new[] { 1f, 5f, 10f, LimiterEffect.MaxLookaheadMs })
+        {
+            const int sampleCount = 2048;
+            using var input = CreateBuffer(1, sampleCount, (_, i) => i == 0 ? 0.5f : 0f);
+
+            using var node = CreateNode(thresholdDb: 0f, lookaheadMs: lookaheadMs);
+            node.AddInput(new StubInputNode(input));
+
+            using var output = node.Process(CreateContext(sampleCount));
+
+            int expectedDelay = LookaheadSamples(SampleRate, lookaheadMs);
+            var data = output.GetChannelData(0);
+
+            int peakIndex = 0;
+            float peakValue = 0f;
+            for (int i = 0; i < sampleCount; i++)
+            {
+                if (MathF.Abs(data[i]) > peakValue)
+                {
+                    peakValue = MathF.Abs(data[i]);
+                    peakIndex = i;
+                }
+            }
+
+            Assert.That(peakIndex, Is.EqualTo(expectedDelay).Within(1),
+                $"Impulse delay mismatch at lookaheadMs={lookaheadMs}: got {peakIndex}, expected {expectedDelay}.");
+            Assert.That(peakValue, Is.GreaterThan(0.1f),
+                $"Impulse was attenuated below recoverable threshold at lookaheadMs={lookaheadMs}.");
         }
     }
 
@@ -471,6 +645,24 @@ public class LimiterNodeTests
         {
             Value = value,
             KeyTime = TimeSpan.Zero,
+        });
+        prop.Animation = animation;
+        return prop;
+    }
+
+    private static IProperty<float> CreateAnimatedRamp(float startValue, float endValue, TimeSpan duration)
+    {
+        var prop = Property.CreateAnimatable(startValue);
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            Value = startValue,
+            KeyTime = TimeSpan.Zero,
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            Value = endValue,
+            KeyTime = duration,
         });
         prop.Animation = animation;
         return prop;
@@ -490,16 +682,14 @@ public class LimiterNodeTests
         {
             Threshold = CreateAnimatedConstant(thresholdDb),
             Release = Property.CreateAnimatable(50f),
-            Lookahead = Property.CreateAnimatable((float)LookaheadMs),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
             MakeupGain = Property.CreateAnimatable(0f),
         };
         node.AddInput(new StubInputNode(input));
 
         using var output = node.Process(CreateContext(sampleCount));
 
-        // Output past the lookahead window must stay at or below threshold even when
-        // the property is sourced from an animated path (per-sample buffer sampling).
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -512,9 +702,47 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_AnimatedRampedThreshold_TracksCurve()
+    {
+        // Threshold ramps from 0 dB at t=0 to -20 dB at t=duration. The output ceiling must
+        // follow the curve — early samples allowed near 1.0, late samples capped near 0.1.
+        const int sampleCount = SampleRate; // 1 second
+        var duration = TimeSpan.FromSeconds(1);
+
+        using var input = CreateBuffer(1, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedRamp(0f, -20f, duration),
+            Release = Property.CreateAnimatable(1f),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        int lookaheadSamples = LookaheadSamples();
+        var data = output.GetChannelData(0);
+
+        float earlyPeak = 0f;
+        for (int i = lookaheadSamples; i < sampleCount / 8; i++)
+            earlyPeak = MathF.Max(earlyPeak, MathF.Abs(data[i]));
+
+        float latePeak = 0f;
+        for (int i = (sampleCount * 7) / 8; i < sampleCount; i++)
+            latePeak = MathF.Max(latePeak, MathF.Abs(data[i]));
+
+        Assert.That(earlyPeak, Is.GreaterThan(0.5f),
+            $"Early region should follow the ~0 dB threshold (got peak {earlyPeak}).");
+        Assert.That(latePeak, Is.LessThan(0.2f),
+            $"Late region should follow the ~-20 dB threshold (got peak {latePeak}).");
+    }
+
+    [Test]
     public void Process_LongAnimatedChunk_ProcessesAllSamples()
     {
-        // SampleCount > the internal stackalloc chunk size to exercise the inner while loop.
         const int sampleCount = 5000;
         const float thresholdDb = -1f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
@@ -526,7 +754,7 @@ public class LimiterNodeTests
         {
             Threshold = CreateAnimatedConstant(thresholdDb),
             Release = Property.CreateAnimatable(50f),
-            Lookahead = Property.CreateAnimatable((float)LookaheadMs),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
             MakeupGain = Property.CreateAnimatable(0f),
         };
         node.AddInput(new StubInputNode(input));
@@ -535,7 +763,7 @@ public class LimiterNodeTests
 
         Assert.That(output.SampleCount, Is.EqualTo(sampleCount));
 
-        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples();
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -547,11 +775,147 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_AnimatedExactlyChunkSize_ProcessesAllSamples()
+    {
+        // SampleCount equal to the internal AnimationChunkSize (1024). An off-by-one in the
+        // chunk-loop bound would either skip the last batch or over-run.
+        const int sampleCount = 1024;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedConstant(thresholdDb),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        Assert.That(output.SampleCount, Is.EqualTo(sampleCount));
+
+        int lookaheadSamples = LookaheadSamples();
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_ReleaseIir_RecoversExponentially()
+    {
+        // Hot burst followed by silence. After the burst the gain envelope must approach 1.0
+        // along an exponential curve whose time constant is set by Release. A bug that flipped
+        // attack/release direction or used the wrong sign would either snap immediately or
+        // never recover.
+        const int burstSamples = 1024;
+        const float thresholdDb = -12f;
+        const float releaseMs = 100f;
+        int tailSamples = (int)(SampleRate * 0.6f); // ≈ 6 release time constants
+        int total = burstSamples + tailSamples;
+
+        using var input = CreateBuffer(1, total, (_, i) =>
+            i < burstSamples
+                ? 2.0f * MathF.Sin(2f * MathF.PI * 1000f * i / SampleRate)
+                : 0.1f * MathF.Sin(2f * MathF.PI * 1000f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(total));
+
+        var data = output.GetChannelData(0);
+        var inData = input.GetChannelData(0);
+
+        // Sample the gain envelope at ~0.5τ, ~1τ, and ~5τ into the silent tail. At each
+        // non-zero input sample, gain ≈ output / input. The envelope should rise monotonically
+        // and approach 1.0 within several time constants.
+        int oneTau = (int)(releaseMs * 0.001f * SampleRate);
+        var samplePoints = new[]
+        {
+            burstSamples + oneTau / 2,
+            burstSamples + oneTau,
+            burstSamples + oneTau * 5,
+        };
+
+        var gains = new float[samplePoints.Length];
+        for (int k = 0; k < samplePoints.Length; k++)
+        {
+            int idx = samplePoints[k];
+            // Step forward to the next non-trivial input sample so we are not dividing by ~0.
+            while (idx < total - 1 && MathF.Abs(inData[idx]) < 0.05f) idx++;
+            gains[k] = data[idx] / inData[idx];
+        }
+
+        Assert.That(gains[1], Is.GreaterThan(gains[0]),
+            $"Gain should rise during release (early={gains[0]}, mid={gains[1]}).");
+        Assert.That(gains[2], Is.GreaterThan(gains[1]),
+            $"Gain should keep rising toward unity (mid={gains[1]}, late={gains[2]}).");
+        Assert.That(gains[2], Is.GreaterThan(0.95f).And.LessThanOrEqualTo(1.0f + 1e-3f),
+            $"Gain should approach 1.0 after ~5 time constants (got {gains[2]}).");
+    }
+
+    [Test]
+    public void Process_ContiguousChunks_PreserveGainEnvelope()
+    {
+        // Cap a hot signal with a long release in chunk 1, then process silence in chunk 2.
+        // Output[0] of chunk 2 (which uses the gain from end of chunk 1) should NOT jump back
+        // to unity — that would only happen if Reset() fired erroneously between contiguous
+        // chunks.
+        const int chunkSamples = 1024;
+        const float thresholdDb = -12f;
+
+        using var hotInput = CreateBuffer(1, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, releaseMs: 5000f, lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(chunkSamples, start: TimeSpan.Zero);
+        using var firstOut = node.Process(firstCtx);
+        var firstData = firstOut.GetChannelData(0);
+
+        // Find the last non-trivial input sample to estimate the gain at end of chunk 1.
+        int lastIdx = chunkSamples - 1;
+        while (lastIdx > 0 && MathF.Abs(hotInput.GetChannelData(0)[lastIdx]) < 0.5f) lastIdx--;
+        float endGainChunk1 = firstData[lastIdx] / hotInput.GetChannelData(0)[lastIdx];
+
+        Assert.That(endGainChunk1, Is.LessThan(0.7f),
+            $"Sanity: limiter should be heavily attenuating at end of chunk 1 (gain={endGainChunk1}).");
+
+        // Chunk 2: hot input again, contiguous in time. The first sample's gain should be
+        // close to endGainChunk1 (release barely had time to recover), not 1.0.
+        var secondStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration;
+        node.RemoveInput(node.Inputs[0]);
+        using var hotInput2 = CreateBuffer(1, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+        node.AddInput(new StubInputNode(hotInput2));
+
+        using var secondOut = node.Process(CreateContext(chunkSamples, start: secondStart));
+        var secondData = secondOut.GetChannelData(0);
+
+        int firstNonTrivial = 0;
+        while (firstNonTrivial < chunkSamples && MathF.Abs(hotInput2.GetChannelData(0)[firstNonTrivial]) < 0.5f) firstNonTrivial++;
+        float startGainChunk2 = secondData[firstNonTrivial] / hotInput2.GetChannelData(0)[firstNonTrivial];
+
+        Assert.That(startGainChunk2, Is.LessThan(0.9f),
+            $"Gain envelope should carry across contiguous chunks (got start gain {startGainChunk2}).");
+    }
+
+    [Test]
     public void Process_NoInputs_Throws()
     {
         using var node = CreateNode();
-        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
-        Assert.That(ex!.Message, Does.Contain("0"));
+        Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
     }
 
     [Test]
@@ -564,8 +928,7 @@ public class LimiterNodeTests
         node.AddInput(new StubInputNode(input1));
         node.AddInput(new StubInputNode(input2));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
-        Assert.That(ex!.Message, Does.Contain("2"));
+        Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
     }
 
     [Test]
@@ -574,8 +937,7 @@ public class LimiterNodeTests
         using var node = CreateNode();
         node.AddInput(new NullInputNode());
 
-        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
-        Assert.That(ex!.Message, Does.Contain("null"));
+        Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
     }
 
     [Test]
@@ -587,9 +949,8 @@ public class LimiterNodeTests
 
         // Context says 48000, input is 44100 — must surface as a clear error rather than
         // silently producing wrong-pitch output.
-        var ex = Assert.Throws<InvalidOperationException>(
+        Assert.Throws<InvalidOperationException>(
             () => node.Process(CreateContext(128, sampleRate: SampleRate)));
-        Assert.That(ex!.Message, Does.Contain("sample rate"));
     }
 
     [Test]
@@ -599,9 +960,6 @@ public class LimiterNodeTests
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
-        // All four parameters set to NaN. Math.Clamp propagates NaN, so without the
-        // float.IsFinite guard each parameter would corrupt _currentGain and the output
-        // would become NaN samples that flow downstream into the audio device.
         using var node = new LimiterNode
         {
             Threshold = Property.CreateAnimatable(float.NaN),
@@ -628,12 +986,11 @@ public class LimiterNodeTests
     public void Process_OutOfRangeParameters_AreClampedNotThrown()
     {
         const int sampleCount = 2048;
-        const float thresholdLin = 1f; // 0 dB ceiling after clamp.
+        const float thresholdLin = 1f;
 
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
-        // Way out of [Range(...)] bounds — must be clamped silently, not raise.
         using var node = new LimiterNode
         {
             Threshold = Property.CreateAnimatable(999f),
@@ -645,11 +1002,8 @@ public class LimiterNodeTests
 
         using var output = node.Process(CreateContext(sampleCount));
 
-        // Output must be finite. The threshold is clamped to MaxThresholdDb (0 dB) and
-        // makeup to MaxMakeupGainDb, so the upper bound on the output magnitude is
-        // thresholdLin * 10^(MaxMakeupGainDb / 20).
         float upperBound = thresholdLin * MathF.Pow(10f, LimiterEffect.MaxMakeupGainDb / 20f);
-        int lookaheadSamples = (int)(LimiterEffect.MaxLookaheadMs / 1000f * SampleRate);
+        int lookaheadSamples = LookaheadSamples(SampleRate, LimiterEffect.MaxLookaheadMs);
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -664,12 +1018,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_NaNInputSamples_AreSanitizedToZero()
     {
+        // Asserts that NaN/Inf input samples are sanitized; rationale lives in
+        // LimiterNode.ProcessSingleSample.
         const int sampleCount = 1024;
 
-        // Sprinkle NaN and Infinity into the input. Without input sanitization NaN
-        // would be written into the delay line and propagate to the output, while
-        // Infinity would force currentPeak to Inf and produce Inf*0 = NaN once the
-        // gain reduction kicks in.
         using var input = CreateBuffer(2, sampleCount, (ch, i) =>
         {
             if (i % 100 == 0) return float.NaN;
@@ -703,5 +1055,47 @@ public class LimiterNodeTests
         using var output = node.Process(CreateContext(0));
         Assert.That(output.SampleCount, Is.EqualTo(0));
         Assert.That(output.ChannelCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Dispose_IsIdempotent()
+    {
+        var node = CreateNode();
+        using var input = CreateBuffer(2, 128,
+            (_, i) => 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+        node.AddInput(new StubInputNode(input));
+        using (var _ = node.Process(CreateContext(128))) { }
+
+        node.Dispose();
+        Assert.DoesNotThrow(() => node.Dispose(),
+            "Double Dispose() must not throw — CircularBuffer state is owned by the node.");
+    }
+
+    [Test]
+    public void Dispose_BeforeProcess_DoesNotThrow()
+    {
+        // Dispose before the first Process must not blow up — buffers were never allocated.
+        var node = CreateNode();
+        Assert.DoesNotThrow(() => node.Dispose());
+    }
+
+    [Test]
+    public void LimiterEffect_CreateNode_WiresPropertiesFromEffect()
+    {
+        var effect = new LimiterEffect();
+        var ctx = new AudioContext(SampleRate, 2);
+        var input = ctx.AddNode(new StubInputNode(new AudioBuffer(SampleRate, 2, 0)));
+
+        var node = (LimiterNode)effect.CreateNode(ctx, input);
+
+        Assert.That(node.Threshold, Is.SameAs(effect.Threshold));
+        Assert.That(node.Release, Is.SameAs(effect.Release));
+        Assert.That(node.Lookahead, Is.SameAs(effect.Lookahead));
+        Assert.That(node.MakeupGain, Is.SameAs(effect.MakeupGain));
+
+        Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(LimiterEffect.DefaultThresholdDb));
+        Assert.That(effect.Release.CurrentValue, Is.EqualTo(LimiterEffect.DefaultReleaseMs));
+        Assert.That(effect.Lookahead.CurrentValue, Is.EqualTo(LimiterEffect.DefaultLookaheadMs));
+        Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(LimiterEffect.DefaultMakeupGainDb));
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -11,7 +11,12 @@ namespace Beutl.UnitTests.Engine.Audio;
 public class LimiterNodeTests
 {
     private const int SampleRate = 48000;
-    private const float LookaheadMs = LimiterEffect.DefaultLookaheadMs;
+
+    // A fixed non-zero lookahead used as the default for these tests, deliberately decoupled from
+    // LimiterEffect.DefaultLookaheadMs (which is 0 for sample-accurate A/V sync). Keeping a non-zero
+    // value here ensures the delay-line / lookahead-window behavior stays exercised regardless of
+    // the production default. Tests that specifically need the zero-lookahead path pass lookaheadMs: 0f.
+    private const float LookaheadMs = 5f;
 
     private static int LookaheadSamples(int sampleRate = SampleRate, float lookaheadMs = LookaheadMs)
         => (int)(lookaheadMs / 1000f * sampleRate);
@@ -41,7 +46,7 @@ public class LimiterNodeTests
     private static LimiterNode CreateNode(
         float thresholdDb = LimiterEffect.DefaultThresholdDb,
         float releaseMs = LimiterEffect.DefaultReleaseMs,
-        float lookaheadMs = LimiterEffect.DefaultLookaheadMs,
+        float lookaheadMs = LookaheadMs,
         float makeupGainDb = LimiterEffect.DefaultMakeupGainDb)
     {
         return new LimiterNode
@@ -1019,7 +1024,7 @@ public class LimiterNodeTests
     public void Process_NaNInputSamples_AreSanitizedToZero()
     {
         // Asserts that NaN/Inf input samples are sanitized; rationale lives in
-        // LimiterNode.ProcessSingleSample.
+        // LimiterNode.IngestSample.
         const int sampleCount = 1024;
 
         using var input = CreateBuffer(2, sampleCount, (ch, i) =>
@@ -1307,5 +1312,218 @@ public class LimiterNodeTests
         Assert.That(effect.Release.CurrentValue, Is.EqualTo(LimiterEffect.DefaultReleaseMs));
         Assert.That(effect.Lookahead.CurrentValue, Is.EqualTo(LimiterEffect.DefaultLookaheadMs));
         Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(LimiterEffect.DefaultMakeupGainDb));
+    }
+
+    [Test]
+    public void LimiterEffect_DefaultLookahead_IsZeroForSampleAccurateSync()
+    {
+        // The default is intentionally 0 ms so that adding the effect does not shift audio or drop
+        // boundary samples in a video editor that has no plugin-delay-compensation. Guards against
+        // an accidental revert to a non-zero default.
+        Assert.That(LimiterEffect.DefaultLookaheadMs, Is.EqualTo(0f));
+        Assert.That(new LimiterEffect().Lookahead.CurrentValue, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void Process_LimitingWithPositiveMakeup_ReachesThresholdPlusMakeupCeiling()
+    {
+        // Documented contract (LimiterEffect XML): the final peak settles at Threshold + MakeupGain
+        // dB — the limiter caps to Threshold, then makeup scales it back up. The second case pushes
+        // the ceiling above 0 dBFS on purpose. A makeup-before-limiting bug would fail the lower bound.
+        foreach (var (thresholdDb, makeupDb) in new[] { (-6f, 6f), (-6f, 12f) })
+        {
+            const int sampleCount = 8192;
+            float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+            float makeupLin = MathF.Pow(10f, makeupDb / 20f);
+            float ceiling = thresholdLin * makeupLin;
+
+            using var input = CreateBuffer(2, sampleCount,
+                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+            using var node = CreateNode(thresholdDb: thresholdDb, makeupGainDb: makeupDb);
+            node.AddInput(new StubInputNode(input));
+
+            using var output = node.Process(CreateContext(sampleCount));
+
+            float maxPeak = 0f;
+            for (int ch = 0; ch < 2; ch++)
+            {
+                var data = output.GetChannelData(ch);
+                for (int i = sampleCount / 2; i < sampleCount; i++)
+                {
+                    maxPeak = MathF.Max(maxPeak, MathF.Abs(data[i]));
+                }
+            }
+
+            // Brick wall: never exceeds the ceiling (makeup only scales the capped signal).
+            Assert.That(maxPeak, Is.LessThanOrEqualTo(ceiling + 1e-3f),
+                $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} exceeded ceiling {ceiling}.");
+            // ...and actually reaches it (guards a makeup-before-limiting or wrong-ceiling bug).
+            Assert.That(maxPeak, Is.GreaterThan(ceiling * 0.95f),
+                $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} did not reach ceiling {ceiling}.");
+        }
+    }
+
+    [Test]
+    public void Process_ContiguousChannelCountChange_ReinitializesBuffersWithoutDiscontinuity()
+    {
+        // A channel-count change reallocates the per-channel buffers even when the chunk is
+        // contiguous (no discontinuity reset fires). Exercises shrink (stereo->mono) and grow
+        // (mono->stereo) and confirms the output adopts the new channel count, stays finite, and
+        // still limits.
+        const int chunkSamples = 1024;
+        const float thresholdDb = -6f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: 0f);
+
+        int[] channelSequence = [2, 1, 2];
+        TimeSpan start = TimeSpan.Zero;
+        foreach (int channels in channelSequence)
+        {
+            using var input = CreateBuffer(channels, chunkSamples,
+                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+            var ctx = CreateContext(chunkSamples, start: start);
+            node.ClearInputs();
+            node.AddInput(new StubInputNode(input));
+            using var output = node.Process(ctx);
+
+            Assert.That(output.ChannelCount, Is.EqualTo(channels));
+            for (int ch = 0; ch < channels; ch++)
+            {
+                var data = output.GetChannelData(ch);
+                for (int i = 0; i < chunkSamples; i++)
+                {
+                    Assert.That(float.IsFinite(data[i]), Is.True,
+                        $"channels={channels} ch={ch} sample {i} must be finite.");
+                    Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                        $"channels={channels} ch={ch} sample {i} must respect threshold.");
+                }
+            }
+
+            start += ctx.TimeRange.Duration;
+        }
+    }
+
+    [Test]
+    public void Process_AnimatedLookahead_StaysFiniteAndBoundedByThreshold()
+    {
+        // Animating Lookahead varies the delay tap and window length per sample (the animated scan
+        // path). Confirm the output stays finite and within the brick-wall ceiling throughout.
+        const int sampleCount = 8192;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+        var duration = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = CreateAnimatedRamp(0f, LimiterEffect.MaxLookaheadMs, duration),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"animated-lookahead ch={ch} sample {i} must be finite.");
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-3f),
+                    $"animated-lookahead ch={ch} sample {i} must respect threshold.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_MultiChannel_LinksGainAcrossAllChannels()
+    {
+        // Channel-linked detection: a peak on any single channel reduces ALL channels by the same
+        // gain (preserving inter-channel ratios). Exercises N > 2 (6-channel surround).
+        const int channels = 6;
+        const int sampleCount = 4096;
+        const int hotChannel = 3;
+        const float thresholdDb = -6f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(channels, sampleCount, (ch, i) =>
+        {
+            float wave = MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+            return ch == hotChannel ? 2.0f * wave : 0.1f * wave;
+        });
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        Assert.That(output.ChannelCount, Is.EqualTo(channels));
+
+        var hotIn = input.GetChannelData(hotChannel);
+        var hotOut = output.GetChannelData(hotChannel);
+        for (int i = 0; i < sampleCount; i++)
+        {
+            Assert.That(MathF.Abs(hotOut[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                $"hot channel sample {i} must respect threshold.");
+
+            if (MathF.Abs(hotIn[i]) > 1e-6f)
+            {
+                float linkedGain = hotOut[i] / hotIn[i];
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    if (ch == hotChannel) continue;
+                    var quietOut = output.GetChannelData(ch)[i];
+                    var quietIn = input.GetChannelData(ch)[i];
+                    Assert.That(quietOut, Is.EqualTo(quietIn * linkedGain).Within(1e-4f),
+                        $"channel {ch} sample {i} must share the hot channel's linked gain.");
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void Process_LargeLookaheadBurst_GainRecoversAfterPeakLeavesWindow()
+    {
+        // Guards the static-path sliding-window-max (monotonic deque): after a short loud burst
+        // leaves the lookahead window, the tracked window peak must drop so the gain recovers. A
+        // deque that failed to evict the stale max would keep attenuating the trailing quiet signal.
+        const int sampleCount = 16384;
+        const int burstLen = 64;
+        const float thresholdDb = -6f;
+        const float quietAmp = 0.2f; // below thresholdLin (~0.501)
+
+        using var input = CreateBuffer(2, sampleCount, (_, i) =>
+        {
+            float wave = MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+            return i < burstLen ? 4.0f * wave : quietAmp * wave;
+        });
+
+        using var node = CreateNode(thresholdDb: thresholdDb, releaseMs: 1f,
+            lookaheadMs: LimiterEffect.MaxLookaheadMs);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        float tailPeak = 0f;
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = sampleCount / 2; i < sampleCount; i++)
+            {
+                tailPeak = MathF.Max(tailPeak, MathF.Abs(data[i]));
+            }
+        }
+
+        Assert.That(tailPeak, Is.GreaterThan(0.18f),
+            "Quiet tail must recover after the burst leaves the window (deque must evict the stale max).");
+        Assert.That(tailPeak, Is.LessThanOrEqualTo(quietAmp + 1e-3f),
+            "Quiet tail is below threshold and must not be amplified.");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1058,13 +1058,13 @@ public class LimiterNodeTests
     }
 
     [Test]
-    public void Process_EmptyChunkBetweenContiguousChunks_DoesNotForceReset()
+    public void Process_EmptyChunkBetweenContiguousChunks_PreservesDelayState()
     {
-        // A degenerate empty chunk in the middle of a stream must advance _lastTimeRangeEnd
-        // so the follow-up non-empty chunk still resumes contiguously and the delay line is
-        // not erroneously cleared. Without that bookkeeping, the next chunk's Start would
-        // mismatch the stale _lastTimeRangeEnd and Reset() would fire — silently dropping the
-        // tail of the previous segment.
+        // An empty chunk wedged between contiguous non-empty chunks must be a pure pass-through:
+        // it must not call Reset() and must not advance _lastTimeRangeEnd, so the next non-empty
+        // chunk is evaluated against the previous *non-empty* chunk's end and resumes
+        // contiguously. A regression that called Reset() inside the empty-chunk branch would
+        // wipe the delay line and zero out the lookahead window of the resume chunk.
         const int chunkSamples = 1024;
         int lookaheadSamples = LookaheadSamples();
 
@@ -1077,18 +1077,12 @@ public class LimiterNodeTests
         var firstCtx = CreateContext(chunkSamples, start: TimeSpan.Zero);
         using (var _ = node.Process(firstCtx)) { }
 
-        // Empty chunk at the boundary — duration zero so Start == End, contiguity preserved.
         var emptyStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration;
-        var emptyCtx = new AudioProcessContext(
-            new TimeRange(emptyStart, TimeSpan.Zero), SampleRate, new AnimationSampler(), null);
         using var emptyInput = new AudioBuffer(SampleRate, 2, 0);
         node.RemoveInput(node.Inputs[0]);
         node.AddInput(new StubInputNode(emptyInput));
-        using (var _ = node.Process(emptyCtx)) { }
+        using (var _ = node.Process(CreateContext(0, start: emptyStart))) { }
 
-        // Resume with silence at the same instant the empty chunk ended. If Reset() had fired
-        // erroneously the delay line would now be all zeros — the residual proves the empty
-        // chunk advanced _lastTimeRangeEnd correctly.
         using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
         node.RemoveInput(node.Inputs[0]);
         node.AddInput(new StubInputNode(silence));
@@ -1111,6 +1105,51 @@ public class LimiterNodeTests
 
         Assert.That(foundResidual, Is.True,
             "Empty chunk at the boundary should not force a reset — delay-line residual must survive.");
+    }
+
+    [Test]
+    public void Process_EmptyChunkAtDiscontinuity_DoesNotMaskFollowupReset()
+    {
+        // The complement of the test above: if an empty chunk is silently used to advance the
+        // limiter's notion of time (e.g., a regression that did `_lastTimeRangeEnd = Start +
+        // Duration` inside the empty-chunk branch), then a non-empty chunk arriving at the
+        // empty chunk's position would be misclassified as contiguous and would replay stale
+        // delay-line audio from before the seek — a silent failure. Verify that the next
+        // non-empty chunk still triggers Reset() against the previous non-empty chunk's end.
+        const int chunkSamples = 1024;
+
+        using var hotInput = CreateBuffer(2, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(hotInput));
+        using (var _ = node.Process(CreateContext(chunkSamples, start: TimeSpan.Zero))) { }
+
+        // Empty chunk at a position that is NOT contiguous with the first chunk.
+        using var emptyInput = new AudioBuffer(SampleRate, 2, 0);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(emptyInput));
+        using (var _ = node.Process(CreateContext(0, start: TimeSpan.FromSeconds(10)))) { }
+
+        // Resume with silence at the empty chunk's position. The empty chunk must not have
+        // updated _lastTimeRangeEnd, so this chunk's Start (10s) differs from the previous
+        // non-empty chunk's end (1024/SR ≈ 0.021s) and Reset() must fire — wiping the delay
+        // line so the silent input produces silent output.
+        using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        using var resumeOut = node.Process(CreateContext(chunkSamples, start: TimeSpan.FromSeconds(10)));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = resumeOut.GetChannelData(ch);
+            for (int i = 0; i < chunkSamples; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(1e-6f),
+                    $"Empty chunk must not silently advance _lastTimeRangeEnd — channel {ch} sample {i} = {data[i]}.");
+            }
+        }
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -6,14 +6,17 @@ using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 using Beutl.Media;
 
+using static Beutl.Audio.Effects.LimiterParameters;
+
 namespace Beutl.UnitTests.Engine.Audio;
 
+[TestFixture]
 public class LimiterNodeTests
 {
     private const int SampleRate = 48000;
 
     // A fixed non-zero lookahead used as the default for these tests, deliberately decoupled from
-    // LimiterEffect.DefaultLookaheadMs (which is 0 for sample-accurate A/V sync). Keeping a non-zero
+    // DefaultLookaheadMs (which is 0 for sample-accurate A/V sync). Keeping a non-zero
     // value here ensures the delay-line / lookahead-window behavior stays exercised regardless of
     // the production default. Tests that specifically need the zero-lookahead path pass lookaheadMs: 0f.
     private const float LookaheadMs = 5f;
@@ -44,10 +47,10 @@ public class LimiterNodeTests
     }
 
     private static LimiterNode CreateNode(
-        float thresholdDb = LimiterEffect.DefaultThresholdDb,
-        float releaseMs = LimiterEffect.DefaultReleaseMs,
+        float thresholdDb = DefaultThresholdDb,
+        float releaseMs = DefaultReleaseMs,
         float lookaheadMs = LookaheadMs,
-        float makeupGainDb = LimiterEffect.DefaultMakeupGainDb)
+        float makeupGainDb = DefaultMakeupGainDb)
     {
         return new LimiterNode
         {
@@ -317,36 +320,35 @@ public class LimiterNodeTests
         }
     }
 
-    [Test]
-    public void Process_DifferentSampleRates_BehaveConsistently()
+    [TestCase(44100)]
+    [TestCase(48000)]
+    [TestCase(96000)]
+    public void Process_DifferentSampleRates_BehaveConsistently(int sr)
     {
         const float thresholdDb = -1f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
 
-        foreach (int sr in new[] { 44100, 48000, 96000 })
+        int sampleCount = sr / 10; // 0.1s
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / sr),
+            sampleRate: sr);
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount, sampleRate: sr));
+
+        Assert.That(output.SampleCount, Is.EqualTo(sampleCount), $"SR={sr} sample count mismatch");
+        Assert.That(output.SampleRate, Is.EqualTo(sr));
+
+        int lookaheadSamples = LookaheadSamples(sr);
+        for (int ch = 0; ch < 2; ch++)
         {
-            int sampleCount = sr / 10; // 0.1s
-            using var input = CreateBuffer(2, sampleCount,
-                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / sr),
-                sampleRate: sr);
-
-            using var node = CreateNode(thresholdDb: thresholdDb);
-            node.AddInput(new StubInputNode(input));
-
-            using var output = node.Process(CreateContext(sampleCount, sampleRate: sr));
-
-            Assert.That(output.SampleCount, Is.EqualTo(sampleCount), $"SR={sr} sample count mismatch");
-            Assert.That(output.SampleRate, Is.EqualTo(sr));
-
-            int lookaheadSamples = LookaheadSamples(sr);
-            for (int ch = 0; ch < 2; ch++)
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
             {
-                var data = output.GetChannelData(ch);
-                for (int i = lookaheadSamples; i < sampleCount; i++)
-                {
-                    Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
-                        $"SR={sr} channel {ch} sample {i} exceeded threshold");
-                }
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                    $"SR={sr} channel {ch} sample {i} exceeded threshold");
             }
         }
     }
@@ -357,7 +359,7 @@ public class LimiterNodeTests
         const float thresholdDb = -1f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
 
-        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: LimiterEffect.MaxLookaheadMs);
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: MaxLookaheadMs);
 
         using var input48 = CreateBuffer(2, 4800,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / 48000),
@@ -377,7 +379,7 @@ public class LimiterNodeTests
         using var output = node.Process(CreateContext(9600, sampleRate: 96000, start: TimeSpan.FromSeconds(5)));
 
         Assert.That(output.SampleRate, Is.EqualTo(96000));
-        int lookaheadSamples = LookaheadSamples(96000, LimiterEffect.MaxLookaheadMs);
+        int lookaheadSamples = LookaheadSamples(96000, MaxLookaheadMs);
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -424,14 +426,14 @@ public class LimiterNodeTests
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
 
-        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: LimiterEffect.MaxLookaheadMs);
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: MaxLookaheadMs);
         node.AddInput(new StubInputNode(input));
 
         using var output = node.Process(CreateContext(sampleCount));
 
         // Off-by-one in the lookahead clamp would collapse Read(_maxLookaheadSamples) to 0
         // (silence) for every sample. Assert non-zero output past the lookahead window.
-        int lookaheadSamples = LookaheadSamples(SampleRate, LimiterEffect.MaxLookaheadMs);
+        int lookaheadSamples = LookaheadSamples(SampleRate, MaxLookaheadMs);
         bool foundNonZero = false;
         for (int i = lookaheadSamples; i < sampleCount; i++)
         {
@@ -606,40 +608,43 @@ public class LimiterNodeTests
         }
     }
 
-    [Test]
-    public void Process_LookaheadDelay_IsAccurate()
+    [TestCase(1f)]
+    [TestCase(5f)]
+    [TestCase(10f)]
+    [TestCase(MaxLookaheadMs)]
+    public void Process_LookaheadDelay_IsAccurate(float lookaheadMs)
     {
-        // Impulse at index 0 of an otherwise silent buffer — the impulse should re-emerge at
-        // exactly index `lookaheadSamples` in the output.
-        foreach (float lookaheadMs in new[] { 1f, 5f, 10f, LimiterEffect.MaxLookaheadMs })
+        // Impulse at index 0 of an otherwise silent buffer. With threshold 0 dB the signal stays below
+        // the ceiling, so this is a pure passthrough delay: the impulse must re-emerge at EXACTLY index
+        // lookaheadSamples (no tolerance) with its full amplitude preserved. The MaxLookaheadMs case
+        // pins the boundary tap (clamped to _maxLookaheadSamples-1, the largest in-range Read offset)
+        // without slack, so a one-sample off-by-one at the buffer edge would fail.
+        const int sampleCount = 2048;
+        using var input = CreateBuffer(1, sampleCount, (_, i) => i == 0 ? 0.5f : 0f);
+
+        using var node = CreateNode(thresholdDb: 0f, lookaheadMs: lookaheadMs);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        int expectedDelay = LookaheadSamples(SampleRate, lookaheadMs);
+        var data = output.GetChannelData(0);
+
+        int peakIndex = 0;
+        float peakValue = 0f;
+        for (int i = 0; i < sampleCount; i++)
         {
-            const int sampleCount = 2048;
-            using var input = CreateBuffer(1, sampleCount, (_, i) => i == 0 ? 0.5f : 0f);
-
-            using var node = CreateNode(thresholdDb: 0f, lookaheadMs: lookaheadMs);
-            node.AddInput(new StubInputNode(input));
-
-            using var output = node.Process(CreateContext(sampleCount));
-
-            int expectedDelay = LookaheadSamples(SampleRate, lookaheadMs);
-            var data = output.GetChannelData(0);
-
-            int peakIndex = 0;
-            float peakValue = 0f;
-            for (int i = 0; i < sampleCount; i++)
+            if (MathF.Abs(data[i]) > peakValue)
             {
-                if (MathF.Abs(data[i]) > peakValue)
-                {
-                    peakValue = MathF.Abs(data[i]);
-                    peakIndex = i;
-                }
+                peakValue = MathF.Abs(data[i]);
+                peakIndex = i;
             }
-
-            Assert.That(peakIndex, Is.EqualTo(expectedDelay).Within(1),
-                $"Impulse delay mismatch at lookaheadMs={lookaheadMs}: got {peakIndex}, expected {expectedDelay}.");
-            Assert.That(peakValue, Is.GreaterThan(0.1f),
-                $"Impulse was attenuated below recoverable threshold at lookaheadMs={lookaheadMs}.");
         }
+
+        Assert.That(peakIndex, Is.EqualTo(expectedDelay),
+            $"Impulse delay mismatch at lookaheadMs={lookaheadMs}: got {peakIndex}, expected {expectedDelay}.");
+        Assert.That(peakValue, Is.EqualTo(0.5f).Within(1e-6f),
+            $"Impulse amplitude not preserved at lookaheadMs={lookaheadMs}: got {peakValue}.");
     }
 
     private static IProperty<float> CreateAnimatedConstant(float value)
@@ -1007,8 +1012,8 @@ public class LimiterNodeTests
 
         using var output = node.Process(CreateContext(sampleCount));
 
-        float upperBound = thresholdLin * MathF.Pow(10f, LimiterEffect.MaxMakeupGainDb / 20f);
-        int lookaheadSamples = LookaheadSamples(SampleRate, LimiterEffect.MaxLookaheadMs);
+        float upperBound = thresholdLin * MathF.Pow(10f, MaxMakeupGainDb / 20f);
+        int lookaheadSamples = LookaheadSamples(SampleRate, MaxLookaheadMs);
         for (int ch = 0; ch < 2; ch++)
         {
             var data = output.GetChannelData(ch);
@@ -1308,10 +1313,10 @@ public class LimiterNodeTests
         Assert.That(node.Lookahead, Is.SameAs(effect.Lookahead));
         Assert.That(node.MakeupGain, Is.SameAs(effect.MakeupGain));
 
-        Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(LimiterEffect.DefaultThresholdDb));
-        Assert.That(effect.Release.CurrentValue, Is.EqualTo(LimiterEffect.DefaultReleaseMs));
-        Assert.That(effect.Lookahead.CurrentValue, Is.EqualTo(LimiterEffect.DefaultLookaheadMs));
-        Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(LimiterEffect.DefaultMakeupGainDb));
+        Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(DefaultThresholdDb));
+        Assert.That(effect.Release.CurrentValue, Is.EqualTo(DefaultReleaseMs));
+        Assert.That(effect.Lookahead.CurrentValue, Is.EqualTo(DefaultLookaheadMs));
+        Assert.That(effect.MakeupGain.CurrentValue, Is.EqualTo(DefaultMakeupGainDb));
     }
 
     [Test]
@@ -1320,48 +1325,46 @@ public class LimiterNodeTests
         // The default is intentionally 0 ms so that adding the effect does not shift audio or drop
         // boundary samples in a video editor that has no plugin-delay-compensation. Guards against
         // an accidental revert to a non-zero default.
-        Assert.That(LimiterEffect.DefaultLookaheadMs, Is.EqualTo(0f));
+        Assert.That(DefaultLookaheadMs, Is.EqualTo(0f));
         Assert.That(new LimiterEffect().Lookahead.CurrentValue, Is.EqualTo(0f));
     }
 
-    [Test]
-    public void Process_LimitingWithPositiveMakeup_ReachesThresholdPlusMakeupCeiling()
+    [TestCase(-6f, 6f)]
+    [TestCase(-6f, 12f)]
+    public void Process_LimitingWithPositiveMakeup_ReachesThresholdPlusMakeupCeiling(float thresholdDb, float makeupDb)
     {
         // Documented contract (LimiterEffect XML): the final peak settles at Threshold + MakeupGain
         // dB — the limiter caps to Threshold, then makeup scales it back up. The second case pushes
         // the ceiling above 0 dBFS on purpose. A makeup-before-limiting bug would fail the lower bound.
-        foreach (var (thresholdDb, makeupDb) in new[] { (-6f, 6f), (-6f, 12f) })
+        const int sampleCount = 8192;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+        float makeupLin = MathF.Pow(10f, makeupDb / 20f);
+        float ceiling = thresholdLin * makeupLin;
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, makeupGainDb: makeupDb);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        float maxPeak = 0f;
+        for (int ch = 0; ch < 2; ch++)
         {
-            const int sampleCount = 8192;
-            float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
-            float makeupLin = MathF.Pow(10f, makeupDb / 20f);
-            float ceiling = thresholdLin * makeupLin;
-
-            using var input = CreateBuffer(2, sampleCount,
-                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
-
-            using var node = CreateNode(thresholdDb: thresholdDb, makeupGainDb: makeupDb);
-            node.AddInput(new StubInputNode(input));
-
-            using var output = node.Process(CreateContext(sampleCount));
-
-            float maxPeak = 0f;
-            for (int ch = 0; ch < 2; ch++)
+            var data = output.GetChannelData(ch);
+            for (int i = sampleCount / 2; i < sampleCount; i++)
             {
-                var data = output.GetChannelData(ch);
-                for (int i = sampleCount / 2; i < sampleCount; i++)
-                {
-                    maxPeak = MathF.Max(maxPeak, MathF.Abs(data[i]));
-                }
+                maxPeak = MathF.Max(maxPeak, MathF.Abs(data[i]));
             }
-
-            // Brick wall: never exceeds the ceiling (makeup only scales the capped signal).
-            Assert.That(maxPeak, Is.LessThanOrEqualTo(ceiling + 1e-3f),
-                $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} exceeded ceiling {ceiling}.");
-            // ...and actually reaches it (guards a makeup-before-limiting or wrong-ceiling bug).
-            Assert.That(maxPeak, Is.GreaterThan(ceiling * 0.95f),
-                $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} did not reach ceiling {ceiling}.");
         }
+
+        // Brick wall: never exceeds the ceiling (makeup only scales the capped signal).
+        Assert.That(maxPeak, Is.LessThanOrEqualTo(ceiling + 1e-3f),
+            $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} exceeded ceiling {ceiling}.");
+        // ...and actually reaches it (guards a makeup-before-limiting or wrong-ceiling bug).
+        Assert.That(maxPeak, Is.GreaterThan(ceiling * 0.95f),
+            $"threshold={thresholdDb}dB makeup={makeupDb}dB: {maxPeak} did not reach ceiling {ceiling}.");
     }
 
     [Test]
@@ -1423,7 +1426,7 @@ public class LimiterNodeTests
         {
             Threshold = Property.CreateAnimatable(thresholdDb),
             Release = Property.CreateAnimatable(50f),
-            Lookahead = CreateAnimatedRamp(0f, LimiterEffect.MaxLookaheadMs, duration),
+            Lookahead = CreateAnimatedRamp(0f, MaxLookaheadMs, duration),
             MakeupGain = Property.CreateAnimatable(0f),
         };
         node.AddInput(new StubInputNode(input));
@@ -1507,7 +1510,7 @@ public class LimiterNodeTests
         });
 
         using var node = CreateNode(thresholdDb: thresholdDb, releaseMs: 1f,
-            lookaheadMs: LimiterEffect.MaxLookaheadMs);
+            lookaheadMs: MaxLookaheadMs);
         node.AddInput(new StubInputNode(input));
 
         using var output = node.Process(CreateContext(sampleCount));
@@ -1554,7 +1557,7 @@ public class LimiterNodeTests
         const int chunks = 3;
         const float thresholdDb = -6f;
         const float releaseMs = 80f;
-        const float lookaheadMs = LimiterEffect.MaxLookaheadMs; // large window stresses the window-max
+        const float lookaheadMs = MaxLookaheadMs; // large window stresses the window-max
 
         // Deterministic, transient-rich signal so the window maximum changes often (spikes force evictions).
         static float Gen(int ch, int i)
@@ -1617,7 +1620,7 @@ public class LimiterNodeTests
         const float thresholdDb = -6f;
         const float releaseMs = 80f;
         const float lookA = 3f;
-        const float lookB = LimiterEffect.MaxLookaheadMs;
+        const float lookB = MaxLookaheadMs;
 
         static float Gen(int ch, int i)
         {
@@ -1681,7 +1684,7 @@ public class LimiterNodeTests
         // minimum threshold (-60 dB -> ~0.001 linear), confirming the gain math stays finite and capped
         // for sub-mill scale signals (no denormal/precision blow-up).
         const int sampleCount = 2048;
-        const float thresholdDb = LimiterEffect.MinThresholdDb; // -60 dB
+        const float thresholdDb = MinThresholdDb; // -60 dB
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);  // ~0.001
         float amp = thresholdLin * 1.1f;                          // just above threshold
 
@@ -1738,5 +1741,364 @@ public class LimiterNodeTests
                     $"animated non-finite params ch {ch} sample {i} must be sanitized.");
             }
         }
+    }
+
+    [Test]
+    public void Process_LookaheadChangeBeforeWindowFills_RebuildsFromPartialHistory()
+    {
+        // Exercises EnsureDeque's span-clamp branch (span = last+1 < lookahead+1): a static lookahead
+        // change on a reused node whose total history is SHORTER than the new window. The first chunk is
+        // only 64 samples, far below the MaxLookaheadMs window (~960 @48k), so the rebuild must clamp to
+        // the available history instead of reading past the written peak ring. Compared against an
+        // animated step-lookahead scan oracle fed the identical signal.
+        const int chunk1 = 64;
+        const int chunk2 = 2048;
+        const float thresholdDb = -6f;
+        const float releaseMs = 80f;
+        const float lookA = 1f;
+        const float lookB = MaxLookaheadMs;
+
+        static float Gen(int ch, int i)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 523f * i / SampleRate);
+            float spike = (i % 17 == 0) ? 3.0f : 0f;
+            return (1.4f * tone + spike) * (ch == 0 ? 1.0f : 0.8f);
+        }
+
+        var dur1 = TimeSpan.FromSeconds((double)chunk1 / SampleRate);
+
+        using var dequeNode = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookA);
+        using var scanNode = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(releaseMs),
+            Lookahead = CreateAnimatedStep(lookA, lookB, dur1),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+
+        // Chunk 1: tiny history at lookA.
+        using (var inDeque1 = CreateBuffer(2, chunk1, (ch, i) => Gen(ch, i)))
+        using (var inScan1 = CreateBuffer(2, chunk1, (ch, i) => Gen(ch, i)))
+        {
+            dequeNode.AddInput(new StubInputNode(inDeque1));
+            scanNode.AddInput(new StubInputNode(inScan1));
+            using var _d = dequeNode.Process(CreateContext(chunk1, start: TimeSpan.Zero));
+            using var _s = scanNode.Process(CreateContext(chunk1, start: TimeSpan.Zero));
+        }
+
+        // Switch the deque node's static lookahead to the large window; the rebuild must clamp to the
+        // 64-sample history rather than over-reading the peak ring.
+        dequeNode.Lookahead.CurrentValue = lookB;
+
+        using var inDeque2 = CreateBuffer(2, chunk2, (ch, i) => Gen(ch, chunk1 + i));
+        using var inScan2 = CreateBuffer(2, chunk2, (ch, i) => Gen(ch, chunk1 + i));
+        dequeNode.ClearInputs();
+        dequeNode.AddInput(new StubInputNode(inDeque2));
+        scanNode.ClearInputs();
+        scanNode.AddInput(new StubInputNode(inScan2));
+
+        using var outDeque = dequeNode.Process(CreateContext(chunk2, start: dur1));
+        using var outScan = scanNode.Process(CreateContext(chunk2, start: dur1));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var d = outDeque.GetChannelData(ch);
+            var s = outScan.GetChannelData(ch);
+            for (int i = 0; i < chunk2; i++)
+            {
+                Assert.That(d[i], Is.EqualTo(s[i]).Within(1e-6f),
+                    $"partial-history rebuild mismatch ch {ch} sample {i}: deque={d[i]} scan={s[i]}.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_StaticAfterAnimatedChunk_RebuildsDequeFromInvalidation()
+    {
+        // Pins ProcessAnimated's `_dequeLookahead = -1` invalidation: a static chunk that follows an
+        // animated chunk on the SAME reused node must REBUILD the deque from the peak ring, not reuse the
+        // stale deque left by an earlier static chunk (the animated chunk advances the peak ring but never
+        // touches the deque). Sequence on one node: static(L) -> animated-constant(L) -> static(L), all
+        // contiguous. Compared against a pure-static 3-chunk reference fed the identical stream; if the
+        // invalidation were removed, the 3rd chunk would reuse a deque that never saw the 2nd chunk.
+        const int chunkSamples = 2048;
+        const float thresholdDb = -6f;
+        const float releaseMs = 80f;
+        const float lookMs = MaxLookaheadMs;
+
+        static float Gen(int ch, int i)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 523f * i / SampleRate);
+            float spike = (i % 211 == 0) ? 3.0f : 0f;
+            return (1.4f * tone + spike) * (ch == 0 ? 1.0f : 0.85f);
+        }
+
+        using var node = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookMs);
+        using var reference = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookMs);
+
+        var constantAnim = new KeyFrameAnimation<float>();
+        constantAnim.KeyFrames.Add(new KeyFrame<float> { Value = lookMs, KeyTime = TimeSpan.Zero });
+
+        TimeSpan start = TimeSpan.Zero;
+        for (int c = 0; c < 3; c++)
+        {
+            // Middle chunk runs the animated path on `node`, forcing _dequeLookahead = -1.
+            node.Lookahead.Animation = c == 1 ? constantAnim : null;
+
+            using var inNode = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, c * chunkSamples + i));
+            using var inRef = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, c * chunkSamples + i));
+            var ctx = CreateContext(chunkSamples, start: start);
+
+            node.ClearInputs();
+            node.AddInput(new StubInputNode(inNode));
+            reference.ClearInputs();
+            reference.AddInput(new StubInputNode(inRef));
+
+            using var outNode = node.Process(ctx);
+            using var outRef = reference.Process(CreateContext(chunkSamples, start: start));
+
+            if (c == 2)
+            {
+                for (int ch = 0; ch < 2; ch++)
+                {
+                    var n = outNode.GetChannelData(ch);
+                    var r = outRef.GetChannelData(ch);
+                    for (int i = 0; i < chunkSamples; i++)
+                    {
+                        Assert.That(n[i], Is.EqualTo(r[i]).Within(1e-6f),
+                            $"post-animated static chunk diverged from pure-static reference ch {ch} sample {i}: {n[i]} vs {r[i]}.");
+                    }
+                }
+            }
+
+            start += ctx.TimeRange.Duration;
+        }
+    }
+
+    [TestCase(0f)]
+    [TestCase(0.02f)]
+    [TestCase(0.25f)]
+    [TestCase(MaxLookaheadMs)]
+    public void Process_StaticDeque_MatchesAnimatedScan_RandomizedSweep(float lookaheadMs)
+    {
+        // Property-style hardening of the deque==scan equivalence: a seeded PRNG (fixed seed for
+        // determinism, no flakiness) generates a transient-rich stereo signal that is fed identically to
+        // the static O(1) deque path and the animated O(lookahead) scan path across multiple contiguous
+        // chunks. Sweeps lookahead 0, sub-sample, small, and max so the window-max relation is checked
+        // far beyond the single hand-picked signal. Any divergence is a deque bug.
+        const int chunkSamples = 1024;
+        const int chunks = 4;
+        const float thresholdDb = -6f;
+        const float releaseMs = 60f;
+        int total = chunks * chunkSamples;
+
+        var rng = new Random(98765);
+        float[,] sig = new float[2, total];
+        for (int i = 0; i < total; i++)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+            float noise = (float)(rng.NextDouble() * 2.0 - 1.0);
+            float transient = rng.NextDouble() < 0.03 ? 3.0f * (float)(rng.NextDouble() * 2.0 - 1.0) : 0f;
+            sig[0, i] = 1.2f * tone + 0.3f * noise + transient;
+            sig[1, i] = 0.8f * (1.2f * tone + 0.3f * noise) + 0.5f * transient;
+        }
+
+        using var staticNode = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookaheadMs);
+        using var animatedNode = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(releaseMs),
+            Lookahead = CreateAnimatedConstant(lookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+
+        TimeSpan start = TimeSpan.Zero;
+        for (int c = 0; c < chunks; c++)
+        {
+            int baseIndex = c * chunkSamples;
+            using var inStatic = CreateBuffer(2, chunkSamples, (ch, i) => sig[ch, baseIndex + i]);
+            using var inAnimated = CreateBuffer(2, chunkSamples, (ch, i) => sig[ch, baseIndex + i]);
+            var ctx = CreateContext(chunkSamples, start: start);
+
+            staticNode.ClearInputs();
+            staticNode.AddInput(new StubInputNode(inStatic));
+            animatedNode.ClearInputs();
+            animatedNode.AddInput(new StubInputNode(inAnimated));
+
+            using var outStatic = staticNode.Process(ctx);
+            using var outAnimated = animatedNode.Process(CreateContext(chunkSamples, start: start));
+
+            for (int ch = 0; ch < 2; ch++)
+            {
+                var s = outStatic.GetChannelData(ch);
+                var a = outAnimated.GetChannelData(ch);
+                for (int i = 0; i < chunkSamples; i++)
+                {
+                    Assert.That(s[i], Is.EqualTo(a[i]).Within(1e-6f),
+                        $"deque vs scan mismatch lookaheadMs={lookaheadMs} chunk {c} ch {ch} sample {i}: static={s[i]} animated={a[i]}.");
+                }
+            }
+
+            start += ctx.TimeRange.Duration;
+        }
+    }
+
+    [Test]
+    public void Process_AnimatedLookahead_TakesEffect_DiffersFromFixedLookahead()
+    {
+        // The finite+bounded animated-lookahead test cannot fail on a lookahead-alignment regression
+        // (limiting is conservative, so almost any delay stays finite and capped). This proves the
+        // per-sample-varying delay is genuinely applied: a transient-rich signal run through a ramped
+        // lookahead (0 -> max) must produce output that DIFFERS from both a fixed-0 and a fixed-max
+        // lookahead run. If the animated lookahead were silently ignored, it would match one of them.
+        const int sampleCount = 8192;
+        const float thresholdDb = -3f;
+        var duration = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
+
+        static float Gen(int ch, int i)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 330f * i / SampleRate);
+            float spike = (i % 97 == 0) ? 3.0f : 0f;
+            return 1.5f * tone + spike;
+        }
+
+        using var ramped = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = CreateAnimatedRamp(0f, MaxLookaheadMs, duration),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        using var fixed0 = CreateNode(thresholdDb: thresholdDb, releaseMs: 50f, lookaheadMs: 0f, makeupGainDb: 0f);
+        using var fixedMax = CreateNode(thresholdDb: thresholdDb, releaseMs: 50f, lookaheadMs: MaxLookaheadMs, makeupGainDb: 0f);
+
+        using var inRamp = CreateBuffer(1, sampleCount, Gen);
+        using var in0 = CreateBuffer(1, sampleCount, Gen);
+        using var inMax = CreateBuffer(1, sampleCount, Gen);
+        ramped.AddInput(new StubInputNode(inRamp));
+        fixed0.AddInput(new StubInputNode(in0));
+        fixedMax.AddInput(new StubInputNode(inMax));
+
+        using var outRamp = ramped.Process(CreateContext(sampleCount));
+        using var out0 = fixed0.Process(CreateContext(sampleCount));
+        using var outMax = fixedMax.Process(CreateContext(sampleCount));
+
+        var r = outRamp.GetChannelData(0);
+        var z = out0.GetChannelData(0);
+        var m = outMax.GetChannelData(0);
+
+        int diffFrom0 = 0, diffFromMax = 0;
+        for (int i = 0; i < sampleCount; i++)
+        {
+            if (MathF.Abs(r[i] - z[i]) > 1e-4f) diffFrom0++;
+            if (MathF.Abs(r[i] - m[i]) > 1e-4f) diffFromMax++;
+        }
+
+        Assert.That(diffFrom0, Is.GreaterThan(sampleCount / 20),
+            $"Ramped lookahead output is suspiciously close to fixed-0 ({diffFrom0} differing samples) — animation may be ignored.");
+        Assert.That(diffFromMax, Is.GreaterThan(sampleCount / 20),
+            $"Ramped lookahead output is suspiciously close to fixed-max ({diffFromMax} differing samples) — animation may be ignored.");
+    }
+
+    [Test]
+    public void Process_ChannelGrowWithLookahead_NewChannelDelayLineIsClean()
+    {
+        // Strengthens channel-count-change coverage with an EXACT per-channel delay assertion under a
+        // non-zero lookahead. After a mono->stereo grow (which reallocates the per-channel delay lines via
+        // InitializeBuffers), an impulse on both channels of the grown buffer must re-emerge at exactly
+        // lookaheadSamples on each channel — proving the channel-major indexing (ch*sampleCount+i) is
+        // correct on the resized buffer and the newly-added channel's delay line starts clean (no leakage).
+        const int sampleCount = 2048;
+        const float lookaheadMs = 5f;
+        int lookaheadSamples = LookaheadSamples(SampleRate, lookaheadMs);
+
+        using var node = CreateNode(thresholdDb: 0f, lookaheadMs: lookaheadMs);
+
+        // Chunk 1: mono, silent — establishes the node at one channel.
+        using (var mono = CreateBuffer(1, sampleCount, (_, _) => 0f))
+        {
+            node.AddInput(new StubInputNode(mono));
+            using var _ = node.Process(CreateContext(sampleCount, start: TimeSpan.Zero));
+        }
+
+        // Chunk 2: grow to stereo (contiguous) with an impulse at index 0 on both channels.
+        var dur = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
+        using var stereo = CreateBuffer(2, sampleCount, (_, i) => i == 0 ? 0.5f : 0f);
+        node.ClearInputs();
+        node.AddInput(new StubInputNode(stereo));
+        using var output = node.Process(CreateContext(sampleCount, start: dur));
+
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float expected = i == lookaheadSamples ? 0.5f : 0f;
+                Assert.That(data[i], Is.EqualTo(expected).Within(1e-6f),
+                    $"grown channel {ch} sample {i}: expected {expected}, got {data[i]} (delay line not clean or mis-indexed).");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_DefaultLimiter_OutputStaysBelowMasterLimiterCeiling()
+    {
+        // The always-on master limiter (Composer -> AudioMath.ApplyLimiter at 1.0 linear) must not
+        // re-limit a default-configured LimiterEffect's output: with Threshold -1 dB and 0 dB makeup the
+        // capped peak is ~0.891 < 1.0, so the master leaves the buffer bit-identical. This pins the
+        // no-double-limiting invariant that justifies the -1 dB default; a change to the master ceiling or
+        // DefaultThresholdDb that reintroduced double-limiting would fail here.
+        const int sampleCount = 8192;
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(
+            thresholdDb: DefaultThresholdDb,
+            releaseMs: DefaultReleaseMs,
+            lookaheadMs: DefaultLookaheadMs,
+            makeupGainDb: DefaultMakeupGainDb);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        float thresholdLin = MathF.Pow(10f, DefaultThresholdDb / 20f); // ~0.891
+        for (int ch = 0; ch < 2; ch++)
+        {
+            float[] limited = output.GetChannelData(ch).ToArray();
+
+            // Sanity: the limiter already keeps peaks at/below its own ceiling, which is < 1.0.
+            foreach (float s in limited)
+                Assert.That(MathF.Abs(s), Is.LessThanOrEqualTo(thresholdLin + 1e-3f));
+
+            // Apply the same master limiter the Composer always applies after effects.
+            float[] mastered = (float[])limited.Clone();
+            AudioMath.ApplyLimiter(mastered, 1.0f, 10.0f);
+
+            for (int i = 0; i < mastered.Length; i++)
+            {
+                Assert.That(mastered[i], Is.EqualTo(limited[i]),
+                    $"master limiter altered a default-limited sample at ch {ch} index {i} " +
+                    $"({limited[i]} -> {mastered[i]}); the default path must not double-limit.");
+            }
+        }
+    }
+
+    private static IEnumerable<TestCaseData> ParameterRanges()
+    {
+        yield return new TestCaseData(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb).SetName("Threshold");
+        yield return new TestCaseData(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs).SetName("Release");
+        yield return new TestCaseData(MinLookaheadMs, DefaultLookaheadMs, MaxLookaheadMs).SetName("Lookahead");
+        yield return new TestCaseData(MinMakeupGainDb, DefaultMakeupGainDb, MaxMakeupGainDb).SetName("MakeupGain");
+    }
+
+    [TestCaseSource(nameof(ParameterRanges))]
+    public void LimiterParameters_RangeIsConsistent(float min, float def, float max)
+    {
+        // Catches an edit that puts a default outside its range or inverts a min/max at CI time — the
+        // [Range] attributes and LimiterNode's per-sample clamps both read these constants, so a desync
+        // within the set would ship silently. Mirrors CompressorParameters_RangeIsConsistent.
+        Assert.That(min, Is.LessThan(max), "Min must be strictly less than Max.");
+        Assert.That(def, Is.InRange(min, max), "Default must lie within [Min, Max].");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -15,10 +15,9 @@ public class LimiterNodeTests
 {
     private const int SampleRate = 48000;
 
-    // A fixed non-zero lookahead used as the default for these tests, deliberately decoupled from
-    // DefaultLookaheadMs (which is 0 for sample-accurate A/V sync). Keeping a non-zero
-    // value here ensures the delay-line / lookahead-window behavior stays exercised regardless of
-    // the production default. Tests that specifically need the zero-lookahead path pass lookaheadMs: 0f.
+    // Fixed non-zero lookahead used as the default for these tests, decoupled from
+    // DefaultLookaheadMs (which is 0), so the delay-line / lookahead-window behavior stays
+    // exercised. Tests that need the zero-lookahead path pass lookaheadMs: 0f.
     private const float LookaheadMs = 5f;
 
     private static int LookaheadSamples(int sampleRate = SampleRate, float lookaheadMs = LookaheadMs)
@@ -266,10 +265,9 @@ public class LimiterNodeTests
         var secondCtx = CreateContext(chunkSamples, start: secondStart);
         using var secondOut = node.Process(secondCtx);
 
-        // The first lookahead-window worth of samples in the second chunk reads the tail of
-        // the first chunk out of the delay line. If Reset() had fired erroneously the delay
-        // line would have been cleared and these samples would all be zero — the non-zero
-        // residual proves continuity is preserved.
+        // The first lookahead window of the second chunk reads the first chunk's tail from the
+        // delay line. An erroneous Reset() would have zeroed it; the non-zero residual proves
+        // continuity is preserved.
         bool foundResidual = false;
         for (int ch = 0; ch < 2 && !foundResidual; ch++)
         {
@@ -416,9 +414,8 @@ public class LimiterNodeTests
         node.AddInput(new StubInputNode(input48));
         using (var _ = node.Process(CreateContext(4800, sampleRate: 48000, start: TimeSpan.Zero))) { }
 
-        // Switch the same node to a higher sample rate. The internal _maxLookaheadSamples must
-        // grow to fit MaxLookaheadMs at the new rate, otherwise reads at the maximum lookahead
-        // would silently return zero.
+        // Switch to a higher sample rate: _maxLookaheadSamples must grow to fit MaxLookaheadMs at
+        // the new rate, or reads at the maximum lookahead would silently return zero.
         node.RemoveInput(node.Inputs[0]);
         using var input96 = CreateBuffer(2, 9600,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / 96000),
@@ -663,11 +660,10 @@ public class LimiterNodeTests
     [TestCase(MaxLookaheadMs)]
     public void Process_LookaheadDelay_IsAccurate(float lookaheadMs)
     {
-        // Impulse at index 0 of an otherwise silent buffer. With threshold 0 dB the signal stays below
-        // the ceiling, so this is a pure passthrough delay: the impulse must re-emerge at EXACTLY index
-        // lookaheadSamples (no tolerance) with its full amplitude preserved. The MaxLookaheadMs case
-        // pins the boundary tap (clamped to _maxLookaheadSamples-1, the largest in-range Read offset)
-        // without slack, so a one-sample off-by-one at the buffer edge would fail.
+        // Impulse at index 0, threshold 0 dB so the signal stays below the ceiling: a pure
+        // passthrough delay. The impulse must re-emerge at exactly index lookaheadSamples with full
+        // amplitude. The MaxLookaheadMs case pins the boundary tap (clamped to
+        // _maxLookaheadSamples-1, the largest in-range Read offset), catching an edge off-by-one.
         const int sampleCount = 2048;
         using var input = CreateBuffer(1, sampleCount, (_, i) => i == 0 ? 0.5f : 0f);
 
@@ -872,10 +868,9 @@ public class LimiterNodeTests
     [Test]
     public void Process_ReleaseIir_RecoversExponentially()
     {
-        // Hot burst followed by silence. After the burst the gain envelope must approach 1.0
-        // along an exponential curve whose time constant is set by Release. A bug that flipped
-        // attack/release direction or used the wrong sign would either snap immediately or
-        // never recover.
+        // Hot burst followed by silence. After the burst the gain envelope must approach 1.0 along
+        // an exponential whose time constant is Release. A flipped attack/release direction or
+        // wrong sign would either snap immediately or never recover.
         const int burstSamples = 1024;
         const float thresholdDb = -12f;
         const float releaseMs = 100f;
@@ -895,9 +890,8 @@ public class LimiterNodeTests
         var data = output.GetChannelData(0);
         var inData = input.GetChannelData(0);
 
-        // Sample the gain envelope at ~0.5τ, ~1τ, and ~5τ into the silent tail. At each
-        // non-zero input sample, gain ≈ output / input. The envelope should rise monotonically
-        // and approach 1.0 within several time constants.
+        // Sample the gain envelope (≈ output / input) at ~0.5τ, ~1τ, and ~5τ into the silent tail.
+        // It should rise monotonically and approach 1.0 within several time constants.
         int oneTau = (int)(releaseMs * 0.001f * SampleRate);
         var samplePoints = new[]
         {
@@ -926,10 +920,9 @@ public class LimiterNodeTests
     [Test]
     public void Process_ContiguousChunks_PreserveGainEnvelope()
     {
-        // Cap a hot signal with a long release in chunk 1, then process silence in chunk 2.
-        // Output[0] of chunk 2 (which uses the gain from end of chunk 1) should NOT jump back
-        // to unity — that would only happen if Reset() fired erroneously between contiguous
-        // chunks.
+        // Cap a hot signal with a long release in chunk 1, then silence in chunk 2. Chunk 2's
+        // output[0] inherits the gain from the end of chunk 1 and must not jump back to unity —
+        // that would only happen if Reset() fired erroneously between contiguous chunks.
         const int chunkSamples = 1024;
         const float thresholdDb = -12f;
 
@@ -1107,9 +1100,9 @@ public class LimiterNodeTests
     [Test]
     public void Process_ContiguousNonFiniteBurst_AreSanitizedToZero()
     {
-        // The strided NaN/Inf test never places non-finite values on consecutive samples. A
-        // realistic upstream corruption is a clustered burst; IngestSample sanitizes each sample
-        // independently, so a contiguous run must still produce finite, bounded output.
+        // The strided NaN/Inf test never puts non-finite values on consecutive samples. A clustered
+        // burst is more realistic; IngestSample sanitizes each sample independently, so a contiguous
+        // run must still produce finite, bounded output.
         const int sampleCount = 1024;
         const int burstStart = 400;
         const int burstLength = 64;
@@ -1184,11 +1177,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_EmptyChunkBetweenContiguousChunks_PreservesDelayState()
     {
-        // An empty chunk wedged between contiguous non-empty chunks must be a pure pass-through:
-        // it must not call Reset() and must not advance _lastTimeRangeEnd, so the next non-empty
-        // chunk is evaluated against the previous *non-empty* chunk's end and resumes
-        // contiguously. A regression that called Reset() inside the empty-chunk branch would
-        // wipe the delay line and zero out the lookahead window of the resume chunk.
+        // An empty chunk between contiguous non-empty chunks must be a pure pass-through: no
+        // Reset(), no advance of _lastTimeRangeEnd, so the next non-empty chunk resumes against the
+        // previous *non-empty* chunk's end. A Reset() in the empty-chunk branch would wipe the
+        // delay line and zero the resume chunk's lookahead window.
         const int chunkSamples = 1024;
         int lookaheadSamples = LookaheadSamples();
 
@@ -1234,12 +1226,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_EmptyChunkAtDiscontinuity_DoesNotMaskFollowupReset()
     {
-        // The complement of the test above: if an empty chunk is silently used to advance the
-        // limiter's notion of time (e.g., a regression that did `_lastTimeRangeEnd = Start +
-        // Duration` inside the empty-chunk branch), then a non-empty chunk arriving at the
-        // empty chunk's position would be misclassified as contiguous and would replay stale
-        // delay-line audio from before the seek — a silent failure. Verify that the next
-        // non-empty chunk still triggers Reset() against the previous non-empty chunk's end.
+        // Complement of the test above: if the empty-chunk branch advanced _lastTimeRangeEnd, a
+        // non-empty chunk at the empty chunk's position would be misclassified as contiguous and
+        // replay stale pre-seek delay-line audio. Verify the next non-empty chunk still Reset()s
+        // against the previous non-empty chunk's end.
         const int chunkSamples = 1024;
 
         using var hotInput = CreateBuffer(2, chunkSamples,
@@ -1255,10 +1245,9 @@ public class LimiterNodeTests
         node.AddInput(new StubInputNode(emptyInput));
         using (var _ = node.Process(CreateContext(0, start: TimeSpan.FromSeconds(10)))) { }
 
-        // Resume with silence at the empty chunk's position. The empty chunk must not have
-        // updated _lastTimeRangeEnd, so this chunk's Start (10s) differs from the previous
-        // non-empty chunk's end (1024/SR ≈ 0.021s) and Reset() must fire — wiping the delay
-        // line so the silent input produces silent output.
+        // Resume with silence at the empty chunk's position. Since the empty chunk didn't update
+        // _lastTimeRangeEnd, this Start (10s) differs from the previous non-empty end (≈0.021s),
+        // so Reset() must fire and the silent input must produce silent output.
         using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
         node.RemoveInput(node.Inputs[0]);
         node.AddInput(new StubInputNode(silence));
@@ -1301,12 +1290,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_AnimatedRamp_AcrossContiguousChunks_TracksCurve()
     {
-        // The single-chunk ramp test (Process_AnimatedRampedThreshold_TracksCurve) only exercises
-        // the inner AnimationChunkSize loop. Splitting the same ramp into multiple contiguous
-        // outer Process() calls verifies that the curve is sampled at the correct absolute time
-        // in each chunk — a regression where chunkRange computation reset to t=0 per outer call
-        // would make every chunk see the start-of-ramp threshold and not be detected by the
-        // single-chunk test.
+        // The single-chunk ramp test only exercises the inner AnimationChunkSize loop. Splitting
+        // the ramp across multiple contiguous outer Process() calls verifies the curve is sampled
+        // at the correct absolute time per chunk — catching a regression where chunkRange resets to
+        // t=0 each outer call, which the single-chunk test would miss.
         const int chunkCount = 4;
         const int chunkSamples = SampleRate / chunkCount; // 0.25s each, 1s total ramp
         var totalDuration = TimeSpan.FromSeconds(1);
@@ -1371,11 +1358,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_AnimatedNonContiguousChunks_ResetsState()
     {
-        // The static-path counterpart (Process_NonContiguousChunks_ResetsState) covers the
-        // _lastTimeRangeEnd discontinuity branch. Repeating it under an animated path guarantees
-        // that the discontinuity check is not gated on `hasAnimation == false` — a refactor
-        // that moved the Reset() call into ProcessStatic would silently bypass it for animated
-        // properties and let the previous segment's audio leak across seeks.
+        // The static-path counterpart covers the _lastTimeRangeEnd discontinuity branch. Repeating
+        // it under animation guarantees the discontinuity check isn't gated on hasAnimation: a
+        // refactor moving Reset() into ProcessStatic would bypass it for animated properties and
+        // leak the previous segment's audio across seeks.
         const int firstSampleCount = 1024;
         var duration = TimeSpan.FromSeconds((double)firstSampleCount / SampleRate);
 
@@ -1484,11 +1470,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_ContiguousChannelCountChange_ReinitializesBuffersAndStillLimits()
     {
-        // A channel-count change reallocates the per-channel buffers (InitializeBuffers) regardless of
-        // time-range contiguity, so the resulting state is always fresh and there is no carried-over
-        // envelope to observe (this test cannot, by design, distinguish a discontinuity reset from the
-        // buffer re-init). It asserts the observable contract: across shrink (stereo->mono) and grow
-        // (mono->stereo) the output adopts the new channel count, stays finite, and still limits.
+        // A channel-count change reallocates the per-channel buffers regardless of contiguity, so
+        // there's no carried-over envelope to observe. This asserts the observable contract: across
+        // shrink (stereo->mono) and grow (mono->stereo) the output adopts the new channel count,
+        // stays finite, and still limits.
         const int chunkSamples = 1024;
         const float thresholdDb = -6f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
@@ -1662,11 +1647,11 @@ public class LimiterNodeTests
     [Test]
     public void Process_StaticDeque_MatchesAnimatedScan_ForEqualConstantLookahead()
     {
-        // Pins the perf commit's core correctness claim: the static path's O(1) monotonic-deque window
-        // maximum (PushWindowPeak) must produce output bit-identical to the animated path's direct
-        // O(lookahead) scan (ScanWindowPeak) when the lookahead is an equal constant. A constant
-        // KeyFrameAnimation on Lookahead forces the animated/scan path; everything else is identical, so
-        // any divergence is a deque bug. Runs multiple contiguous chunks to also cover deque persistence.
+        // Core correctness claim of the deque optimization: with an equal constant lookahead, the
+        // static path's O(1) deque max (PushWindowPeak) must produce output bit-identical to the
+        // animated path's O(lookahead) scan (ScanWindowPeak). A constant KeyFrameAnimation forces
+        // the scan path; everything else is identical, so any divergence is a deque bug. Multiple
+        // contiguous chunks also cover deque persistence.
         const int chunkSamples = 2048;
         const int chunks = 3;
         const float thresholdDb = -6f;
@@ -1725,11 +1710,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_StaticLookaheadChange_RebuildsDequeToMatchScan()
     {
-        // Exercises the EnsureDeque rebuild-from-peak-ring branch: changing a STATIC lookahead between
-        // two contiguous chunks on a reused node forces a deque rebuild. The reused deque node is
-        // compared against an independent animated/scan node fed the identical signal with a step
-        // lookahead schedule (lookA during chunk 1, lookB during chunk 2). Equal output on chunk 2
-        // proves the rebuild reconstructs the correct window state for the new lookahead.
+        // Exercises EnsureDeque's rebuild-from-peak-ring branch: changing a static lookahead between
+        // two contiguous chunks on a reused node forces a rebuild. Compared against an independent
+        // scan-path node fed the identical signal with a step lookahead schedule (lookA then lookB).
+        // Equal output on chunk 2 proves the rebuild reconstructs the correct window state.
         const int chunkSamples = 2048;
         const float thresholdDb = -6f;
         const float releaseMs = 80f;
@@ -1825,11 +1809,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_NonFiniteAnimatedParameters_AreClampedOnPerSamplePath()
     {
-        // Mirrors the static non-finite-parameter test on the ANIMATED per-sample Derive path. All four
-        // parameters are animated to non-finite values. Release is the load-bearing one: without
+        // Mirrors the static non-finite-parameter test on the animated per-sample Derive path, with
+        // all four parameters animated to non-finite values. Release is load-bearing: without
         // ClampFinite a NaN Release makes releaseCoef = Exp(NaN) = NaN, which poisons _currentGain
-        // through the IIR and turns the output NaN — so this test genuinely fails if per-sample coercion
-        // is removed (a Threshold/Lookahead-only variant would pass even uncoerced and prove nothing).
+        // through the IIR and turns the output NaN — so this fails if per-sample coercion is removed.
         const int sampleCount = 2048;
 
         using var input = CreateBuffer(2, sampleCount,
@@ -1861,10 +1844,10 @@ public class LimiterNodeTests
     public void Process_LookaheadChangeBeforeWindowFills_RebuildsFromPartialHistory()
     {
         // Exercises EnsureDeque's span-clamp branch (span = last+1 < lookahead+1): a static lookahead
-        // change on a reused node whose total history is SHORTER than the new window. The first chunk is
-        // only 64 samples, far below the MaxLookaheadMs window (~960 @48k), so the rebuild must clamp to
-        // the available history instead of reading past the written peak ring. Compared against an
-        // animated step-lookahead scan oracle fed the identical signal.
+        // change on a reused node whose history is shorter than the new window. Chunk 1 is only 64
+        // samples, far below the MaxLookaheadMs window (~960 @48k), so the rebuild must clamp to the
+        // available history rather than read past the written peak ring. Compared against a
+        // step-lookahead scan oracle fed the identical signal.
         const int chunk1 = 64;
         const int chunk2 = 2048;
         const float thresholdDb = -6f;
@@ -1929,12 +1912,11 @@ public class LimiterNodeTests
     [Test]
     public void Process_StaticAfterAnimatedChunk_RebuildsDequeFromInvalidation()
     {
-        // Pins ProcessAnimated's `_dequeLookahead = -1` invalidation: a static chunk that follows an
-        // animated chunk on the SAME reused node must REBUILD the deque from the peak ring, not reuse the
-        // stale deque left by an earlier static chunk (the animated chunk advances the peak ring but never
-        // touches the deque). Sequence on one node: static(L) -> animated-constant(L) -> static(L), all
-        // contiguous. Compared against a pure-static 3-chunk reference fed the identical stream; if the
-        // invalidation were removed, the 3rd chunk would reuse a deque that never saw the 2nd chunk.
+        // Pins ProcessAnimated's `_dequeLookahead = -1` invalidation: a static chunk following an
+        // animated chunk on the same node must rebuild the deque from the peak ring, since the
+        // animated chunk advances the ring but never touches the deque. Sequence (all contiguous):
+        // static(L) -> animated-constant(L) -> static(L), compared against a pure-static 3-chunk
+        // reference. Without the invalidation the 3rd chunk would reuse a deque that never saw the 2nd.
         const int chunkSamples = 2048;
         const float thresholdDb = -6f;
         const float releaseMs = 80f;
@@ -1995,11 +1977,10 @@ public class LimiterNodeTests
     [TestCase(MaxLookaheadMs)]
     public void Process_StaticDeque_MatchesAnimatedScan_RandomizedSweep(float lookaheadMs)
     {
-        // Property-style hardening of the deque==scan equivalence: a seeded PRNG (fixed seed for
-        // determinism, no flakiness) generates a transient-rich stereo signal that is fed identically to
-        // the static O(1) deque path and the animated O(lookahead) scan path across multiple contiguous
-        // chunks. Sweeps lookahead 0, sub-sample, small, and max so the window-max relation is checked
-        // far beyond the single hand-picked signal. Any divergence is a deque bug.
+        // Property-style hardening of the deque==scan equivalence: a seeded PRNG generates a
+        // transient-rich stereo signal fed identically to the static deque path and the animated
+        // scan path across multiple contiguous chunks. Sweeps lookahead 0, sub-sample, small, and
+        // max so the relation is checked far beyond the single hand-picked signal.
         const int chunkSamples = 1024;
         const int chunks = 4;
         const float thresholdDb = -6f;
@@ -2060,11 +2041,11 @@ public class LimiterNodeTests
     [Test]
     public void Process_AnimatedLookahead_TakesEffect_DiffersFromFixedLookahead()
     {
-        // The finite+bounded animated-lookahead test cannot fail on a lookahead-alignment regression
-        // (limiting is conservative, so almost any delay stays finite and capped). This proves the
-        // per-sample-varying delay is genuinely applied: a transient-rich signal run through a ramped
-        // lookahead (0 -> max) must produce output that DIFFERS from both a fixed-0 and a fixed-max
-        // lookahead run. If the animated lookahead were silently ignored, it would match one of them.
+        // The finite+bounded test can't catch a lookahead-alignment regression, since limiting is
+        // conservative enough that almost any delay stays bounded. This proves the per-sample
+        // varying delay is genuinely applied: a transient-rich signal through a ramped lookahead
+        // (0 -> max) must differ from both a fixed-0 and a fixed-max run. If the animated lookahead
+        // were ignored, it would match one of them.
         const int sampleCount = 8192;
         const float thresholdDb = -3f;
         var duration = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
@@ -2117,11 +2098,10 @@ public class LimiterNodeTests
     [Test]
     public void Process_ChannelGrowWithLookahead_NewChannelDelayLineIsClean()
     {
-        // Strengthens channel-count-change coverage with an EXACT per-channel delay assertion under a
-        // non-zero lookahead. After a mono->stereo grow (which reallocates the per-channel delay lines via
-        // InitializeBuffers), an impulse on both channels of the grown buffer must re-emerge at exactly
-        // lookaheadSamples on each channel — proving the channel-major indexing (ch*sampleCount+i) is
-        // correct on the resized buffer and the newly-added channel's delay line starts clean (no leakage).
+        // Exact per-channel delay assertion under a non-zero lookahead. After a mono->stereo grow
+        // (which reallocates the delay lines), an impulse on both channels must re-emerge at exactly
+        // lookaheadSamples on each — proving channel-major indexing (ch*sampleCount+i) is correct on
+        // the resized buffer and the new channel's delay line starts clean.
         const int sampleCount = 2048;
         const float lookaheadMs = 5f;
         int lookaheadSamples = LookaheadSamples(SampleRate, lookaheadMs);
@@ -2159,10 +2139,9 @@ public class LimiterNodeTests
     public void Process_DefaultLimiter_OutputStaysBelowMasterLimiterCeiling()
     {
         // The always-on master limiter (Composer -> AudioMath.ApplyLimiter at 1.0 linear) must not
-        // re-limit a default-configured LimiterEffect's output: with Threshold -1 dB and 0 dB makeup the
-        // capped peak is ~0.891 < 1.0, so the master leaves the buffer bit-identical. This pins the
-        // no-double-limiting invariant that justifies the -1 dB default; a change to the master ceiling or
-        // DefaultThresholdDb that reintroduced double-limiting would fail here.
+        // re-limit a default-configured output: with Threshold -1 dB and 0 dB makeup the capped peak
+        // is ~0.891 < 1.0, so the master leaves the buffer bit-identical. Pins the no-double-limiting
+        // invariant behind the -1 dB default.
         const int sampleCount = 8192;
         using var input = CreateBuffer(2, sampleCount,
             (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -62,7 +62,14 @@ public class LimiterNodeTests
 
     private sealed class StubInputNode(AudioBuffer buffer) : AudioNode
     {
-        public override AudioBuffer Process(AudioProcessContext context) => buffer;
+        // LimiterNode disposes the input it consumes, so return a fresh copy each call and keep the
+        // original alive for the test's own assertions.
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            var copy = new AudioBuffer(buffer.SampleRate, buffer.ChannelCount, buffer.SampleCount);
+            buffer.CopyTo(copy);
+            return copy;
+        }
     }
 
     private sealed class NullInputNode : AudioNode

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1365,12 +1365,13 @@ public class LimiterNodeTests
     }
 
     [Test]
-    public void Process_ContiguousChannelCountChange_ReinitializesBuffersWithoutDiscontinuity()
+    public void Process_ContiguousChannelCountChange_ReinitializesBuffersAndStillLimits()
     {
-        // A channel-count change reallocates the per-channel buffers even when the chunk is
-        // contiguous (no discontinuity reset fires). Exercises shrink (stereo->mono) and grow
-        // (mono->stereo) and confirms the output adopts the new channel count, stays finite, and
-        // still limits.
+        // A channel-count change reallocates the per-channel buffers (InitializeBuffers) regardless of
+        // time-range contiguity, so the resulting state is always fresh and there is no carried-over
+        // envelope to observe (this test cannot, by design, distinguish a discontinuity reset from the
+        // buffer re-init). It asserts the observable contract: across shrink (stereo->mono) and grow
+        // (mono->stereo) the output adopts the new channel count, stays finite, and still limits.
         const int chunkSamples = 1024;
         const float thresholdDb = -6f;
         float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
@@ -1525,5 +1526,217 @@ public class LimiterNodeTests
             "Quiet tail must recover after the burst leaves the window (deque must evict the stale max).");
         Assert.That(tailPeak, Is.LessThanOrEqualTo(quietAmp + 1e-3f),
             "Quiet tail is below threshold and must not be amplified.");
+    }
+
+    // Step animation: holds `first` for the whole [0, boundary) range and switches to `second` from
+    // `boundary` onward. Used to drive the animated/scan path with a per-chunk-constant lookahead so it
+    // can serve as an independent oracle for the static deque path across a lookahead change.
+    private static IProperty<float> CreateAnimatedStep(float first, float second, TimeSpan boundary)
+    {
+        var prop = Property.CreateAnimatable(first);
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float> { Value = first, KeyTime = TimeSpan.Zero });
+        animation.KeyFrames.Add(new KeyFrame<float> { Value = first, KeyTime = boundary - TimeSpan.FromTicks(1) });
+        animation.KeyFrames.Add(new KeyFrame<float> { Value = second, KeyTime = boundary });
+        prop.Animation = animation;
+        return prop;
+    }
+
+    [Test]
+    public void Process_StaticDeque_MatchesAnimatedScan_ForEqualConstantLookahead()
+    {
+        // Pins the perf commit's core correctness claim: the static path's O(1) monotonic-deque window
+        // maximum (PushWindowPeak) must produce output bit-identical to the animated path's direct
+        // O(lookahead) scan (ScanWindowPeak) when the lookahead is an equal constant. A constant
+        // KeyFrameAnimation on Lookahead forces the animated/scan path; everything else is identical, so
+        // any divergence is a deque bug. Runs multiple contiguous chunks to also cover deque persistence.
+        const int chunkSamples = 2048;
+        const int chunks = 3;
+        const float thresholdDb = -6f;
+        const float releaseMs = 80f;
+        const float lookaheadMs = LimiterEffect.MaxLookaheadMs; // large window stresses the window-max
+
+        // Deterministic, transient-rich signal so the window maximum changes often (spikes force evictions).
+        static float Gen(int ch, int i)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 523f * i / SampleRate);
+            float env = 0.6f + 0.4f * MathF.Sin(2f * MathF.PI * 3f * i / SampleRate);
+            float spike = (i % 311 == 0) ? 3.0f : 0f;
+            return (1.4f * tone * env + spike) * (ch == 0 ? 1.0f : 0.85f);
+        }
+
+        using var staticNode = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookaheadMs);
+        using var animatedNode = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(releaseMs),
+            Lookahead = CreateAnimatedConstant(lookaheadMs), // forces ProcessAnimated/ScanWindowPeak
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+
+        TimeSpan start = TimeSpan.Zero;
+        for (int c = 0; c < chunks; c++)
+        {
+            int baseIndex = c * chunkSamples;
+            using var inStatic = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, baseIndex + i));
+            using var inAnimated = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, baseIndex + i));
+            var ctx = CreateContext(chunkSamples, start: start);
+
+            staticNode.ClearInputs();
+            staticNode.AddInput(new StubInputNode(inStatic));
+            animatedNode.ClearInputs();
+            animatedNode.AddInput(new StubInputNode(inAnimated));
+
+            using var outStatic = staticNode.Process(ctx);
+            using var outAnimated = animatedNode.Process(ctx);
+
+            for (int ch = 0; ch < 2; ch++)
+            {
+                var s = outStatic.GetChannelData(ch);
+                var a = outAnimated.GetChannelData(ch);
+                for (int i = 0; i < chunkSamples; i++)
+                {
+                    Assert.That(s[i], Is.EqualTo(a[i]).Within(1e-6f),
+                        $"deque vs scan mismatch chunk {c} ch {ch} sample {i}: static={s[i]} animated={a[i]}.");
+                }
+            }
+
+            start += ctx.TimeRange.Duration;
+        }
+    }
+
+    [Test]
+    public void Process_StaticLookaheadChange_RebuildsDequeToMatchScan()
+    {
+        // Exercises the EnsureDeque rebuild-from-peak-ring branch: changing a STATIC lookahead between
+        // two contiguous chunks on a reused node forces a deque rebuild. The reused deque node is
+        // compared against an independent animated/scan node fed the identical signal with a step
+        // lookahead schedule (lookA during chunk 1, lookB during chunk 2). Equal output on chunk 2
+        // proves the rebuild reconstructs the correct window state for the new lookahead.
+        const int chunkSamples = 2048;
+        const float thresholdDb = -6f;
+        const float releaseMs = 80f;
+        const float lookA = 3f;
+        const float lookB = LimiterEffect.MaxLookaheadMs;
+
+        static float Gen(int ch, int i)
+        {
+            float tone = MathF.Sin(2f * MathF.PI * 523f * i / SampleRate);
+            float spike = (i % 167 == 0) ? 3.0f : 0f;
+            return (1.4f * tone + spike) * (ch == 0 ? 1.0f : 0.8f);
+        }
+
+        var dur1 = TimeSpan.FromSeconds((double)chunkSamples / SampleRate);
+
+        // Deque node: chunk 1 @ lookA (builds deque for A), chunk 2 @ lookB (rebuild for B).
+        using var dequeNode = CreateNode(thresholdDb: thresholdDb, releaseMs: releaseMs, lookaheadMs: lookA);
+        // Scan oracle: animated step lookahead A -> B at the chunk boundary.
+        using var scanNode = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(thresholdDb),
+            Release = Property.CreateAnimatable(releaseMs),
+            Lookahead = CreateAnimatedStep(lookA, lookB, dur1),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+
+        // Chunk 1 (both nodes @ lookA).
+        using (var inDeque1 = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, i)))
+        using (var inScan1 = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, i)))
+        {
+            dequeNode.AddInput(new StubInputNode(inDeque1));
+            scanNode.AddInput(new StubInputNode(inScan1));
+            using var _d = dequeNode.Process(CreateContext(chunkSamples, start: TimeSpan.Zero));
+            using var _s = scanNode.Process(CreateContext(chunkSamples, start: TimeSpan.Zero));
+        }
+
+        // Switch the deque node's static lookahead to B; the scan node steps to B automatically.
+        dequeNode.Lookahead.CurrentValue = lookB;
+
+        using var inDeque2 = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, chunkSamples + i));
+        using var inScan2 = CreateBuffer(2, chunkSamples, (ch, i) => Gen(ch, chunkSamples + i));
+        dequeNode.ClearInputs();
+        dequeNode.AddInput(new StubInputNode(inDeque2));
+        scanNode.ClearInputs();
+        scanNode.AddInput(new StubInputNode(inScan2));
+
+        using var outDeque = dequeNode.Process(CreateContext(chunkSamples, start: dur1));
+        using var outScan = scanNode.Process(CreateContext(chunkSamples, start: dur1));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var d = outDeque.GetChannelData(ch);
+            var s = outScan.GetChannelData(ch);
+            for (int i = 0; i < chunkSamples; i++)
+            {
+                Assert.That(d[i], Is.EqualTo(s[i]).Within(1e-6f),
+                    $"rebuild deque vs scan mismatch ch {ch} sample {i}: deque={d[i]} scan={s[i]}.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_TinyAboveThreshold_LimitsAndStaysFinite()
+    {
+        // Drives the limiting branch (windowPeak > thresholdLin) at a tiny magnitude just above the
+        // minimum threshold (-60 dB -> ~0.001 linear), confirming the gain math stays finite and capped
+        // for sub-mill scale signals (no denormal/precision blow-up).
+        const int sampleCount = 2048;
+        const float thresholdDb = LimiterEffect.MinThresholdDb; // -60 dB
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);  // ~0.001
+        float amp = thresholdLin * 1.1f;                          // just above threshold
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => amp * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True, $"ch {ch} sample {i} must be finite.");
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-6f),
+                    $"ch {ch} sample {i} must be capped at the tiny threshold.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NonFiniteAnimatedParameters_AreClampedOnPerSamplePath()
+    {
+        // Mirrors the static non-finite-parameter test on the ANIMATED per-sample Derive path. All four
+        // parameters are animated to non-finite values. Release is the load-bearing one: without
+        // ClampFinite a NaN Release makes releaseCoef = Exp(NaN) = NaN, which poisons _currentGain
+        // through the IIR and turns the output NaN — so this test genuinely fails if per-sample coercion
+        // is removed (a Threshold/Lookahead-only variant would pass even uncoerced and prove nothing).
+        const int sampleCount = 2048;
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedConstant(float.NaN),
+            Release = CreateAnimatedConstant(float.NaN),
+            Lookahead = CreateAnimatedConstant(float.PositiveInfinity),
+            MakeupGain = CreateAnimatedConstant(float.NaN),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"animated non-finite params ch {ch} sample {i} must be sanitized.");
+            }
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1080,6 +1080,121 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_AnimatedRamp_AcrossContiguousChunks_TracksCurve()
+    {
+        // The single-chunk ramp test (Process_AnimatedRampedThreshold_TracksCurve) only exercises
+        // the inner AnimationChunkSize loop. Splitting the same ramp into multiple contiguous
+        // outer Process() calls verifies that the curve is sampled at the correct absolute time
+        // in each chunk — a regression where chunkRange computation reset to t=0 per outer call
+        // would make every chunk see the start-of-ramp threshold and not be detected by the
+        // single-chunk test.
+        const int chunkCount = 4;
+        const int chunkSamples = SampleRate / chunkCount; // 0.25s each, 1s total ramp
+        var totalDuration = TimeSpan.FromSeconds(1);
+
+        var thresholdProp = CreateAnimatedRamp(0f, -20f, totalDuration);
+        var releaseProp = Property.CreateAnimatable(1f);
+        var lookaheadProp = Property.CreateAnimatable(LookaheadMs);
+        var makeupProp = Property.CreateAnimatable(0f);
+
+        using var node = new LimiterNode
+        {
+            Threshold = thresholdProp,
+            Release = releaseProp,
+            Lookahead = lookaheadProp,
+            MakeupGain = makeupProp,
+        };
+
+        var firstPeaks = new float[chunkCount];
+        var lastPeaks = new float[chunkCount];
+        int lookaheadSamples = LookaheadSamples();
+
+        for (int c = 0; c < chunkCount; c++)
+        {
+            using var input = CreateBuffer(1, chunkSamples,
+                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * (c * chunkSamples + i) / SampleRate));
+
+            if (node.Inputs.Count > 0)
+                node.RemoveInput(node.Inputs[0]);
+            node.AddInput(new StubInputNode(input));
+
+            var chunkStart = TimeSpan.FromTicks(totalDuration.Ticks * c / chunkCount);
+            using var output = node.Process(CreateContext(chunkSamples, start: chunkStart));
+            var data = output.GetChannelData(0);
+
+            // Sample peaks in the early and late portions of each chunk (after the lookahead
+            // delay so we read post-limit output, not the silence prefix on chunk 0).
+            int startIdx = c == 0 ? lookaheadSamples : 0;
+            int mid = chunkSamples / 2;
+            float peak1 = 0f;
+            for (int i = startIdx; i < mid; i++) peak1 = MathF.Max(peak1, MathF.Abs(data[i]));
+            float peak2 = 0f;
+            for (int i = mid; i < chunkSamples; i++) peak2 = MathF.Max(peak2, MathF.Abs(data[i]));
+            firstPeaks[c] = peak1;
+            lastPeaks[c] = peak2;
+        }
+
+        // Each successive chunk's late peak should be <= a chunk earlier (monotonic ramp down).
+        // Allow a small slack for envelope overshoot at chunk boundaries.
+        for (int c = 1; c < chunkCount; c++)
+        {
+            Assert.That(lastPeaks[c], Is.LessThanOrEqualTo(lastPeaks[c - 1] + 0.05f),
+                $"Chunk {c} late peak ({lastPeaks[c]}) should not exceed chunk {c - 1} late peak ({lastPeaks[c - 1]}).");
+        }
+
+        // Chunk 0 (≈0 dB threshold) should pass much hotter audio than chunk 3 (≈-20 dB).
+        Assert.That(firstPeaks[0], Is.GreaterThan(0.5f),
+            $"First chunk should follow the ~0 dB threshold (got peak {firstPeaks[0]}).");
+        Assert.That(lastPeaks[chunkCount - 1], Is.LessThan(0.2f),
+            $"Last chunk should follow the ~-20 dB threshold (got peak {lastPeaks[chunkCount - 1]}).");
+    }
+
+    [Test]
+    public void Process_AnimatedNonContiguousChunks_ResetsState()
+    {
+        // The static-path counterpart (Process_NonContiguousChunks_ResetsState) covers the
+        // _lastTimeRangeEnd discontinuity branch. Repeating it under an animated path guarantees
+        // that the discontinuity check is not gated on `hasAnimation == false` — a refactor
+        // that moved the Reset() call into ProcessStatic would silently bypass it for animated
+        // properties and let the previous segment's audio leak across seeks.
+        const int firstSampleCount = 1024;
+        var duration = TimeSpan.FromSeconds((double)firstSampleCount / SampleRate);
+
+        using var hotInput = CreateBuffer(2, firstSampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedRamp(-1f, -1f, duration),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(firstSampleCount, start: TimeSpan.Zero);
+        using (var _ = node.Process(firstCtx)) { }
+
+        using var silence = CreateBuffer(2, firstSampleCount, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        // Jump ten seconds — must be detected as a discontinuity even on the animated path.
+        var secondCtx = CreateContext(firstSampleCount, start: TimeSpan.FromSeconds(10));
+        using var secondOut = node.Process(secondCtx);
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = secondOut.GetChannelData(ch);
+            for (int i = 0; i < firstSampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(1e-6f),
+                    $"Reset should clear delay-line state on the animated path — channel {ch} sample {i} = {data[i]}.");
+            }
+        }
+    }
+
+    [Test]
     public void LimiterEffect_CreateNode_WiresPropertiesFromEffect()
     {
         var effect = new LimiterEffect();

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1105,6 +1105,71 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_ContiguousNonFiniteBurst_AreSanitizedToZero()
+    {
+        // The strided NaN/Inf test never places non-finite values on consecutive samples. A
+        // realistic upstream corruption is a clustered burst; IngestSample sanitizes each sample
+        // independently, so a contiguous run must still produce finite, bounded output.
+        const int sampleCount = 1024;
+        const int burstStart = 400;
+        const int burstLength = 64;
+
+        using var input = CreateBuffer(2, sampleCount, (_, i) =>
+        {
+            if (i >= burstStart && i < burstStart + burstLength)
+                return (i & 1) == 0 ? float.NaN : float.PositiveInfinity;
+            return 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+        });
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        float upperBound = MathF.Pow(10f, DefaultThresholdDb / 20f) * MathF.Pow(10f, DefaultMakeupGainDb / 20f);
+        int lookaheadSamples = LookaheadSamples();
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Channel {ch} sample {i} = {data[i]} (contiguous NaN/Inf burst must be sanitized).");
+                if (i >= lookaheadSamples)
+                    Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(upperBound + 1e-3f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NonFiniteFinalSample_IsSanitizedToZero()
+    {
+        // A non-finite value at the very last sample lands inside the lookahead window at the chunk
+        // boundary, the one position the strided test never covers. It must still be coerced.
+        const int sampleCount = 1024;
+
+        using var input = CreateBuffer(2, sampleCount, (_, i) =>
+            i == sampleCount - 1
+                ? float.NaN
+                : 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Channel {ch} sample {i} = {data[i]} (non-finite final sample must be sanitized).");
+            }
+        }
+    }
+
+    [Test]
     public void Process_ZeroSampleCountInput_ReturnsEmptyBuffer()
     {
         using var input = new AudioBuffer(SampleRate, 2, 0);

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Beutl.Animation;
 using Beutl.Audio;
+using Beutl.Audio.Effects;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
@@ -12,16 +13,16 @@ public class LimiterNodeTests
     private const int SampleRate = 48000;
     private const int LookaheadMs = 5;
 
-    private static AudioProcessContext CreateContext(int sampleCount)
+    private static AudioProcessContext CreateContext(int sampleCount, int sampleRate = SampleRate, TimeSpan? start = null)
     {
-        var duration = TimeSpan.FromSeconds((double)sampleCount / SampleRate);
-        var range = new TimeRange(TimeSpan.Zero, duration);
-        return new AudioProcessContext(range, SampleRate, new AnimationSampler(), null);
+        var duration = TimeSpan.FromSeconds((double)sampleCount / sampleRate);
+        var range = new TimeRange(start ?? TimeSpan.Zero, duration);
+        return new AudioProcessContext(range, sampleRate, new AnimationSampler(), null);
     }
 
-    private static AudioBuffer CreateBuffer(int channelCount, int sampleCount, Func<int, int, float> generator)
+    private static AudioBuffer CreateBuffer(int channelCount, int sampleCount, Func<int, int, float> generator, int sampleRate = SampleRate)
     {
-        var buffer = new AudioBuffer(SampleRate, channelCount, sampleCount);
+        var buffer = new AudioBuffer(sampleRate, channelCount, sampleCount);
         for (int ch = 0; ch < channelCount; ch++)
         {
             var data = buffer.GetChannelData(ch);
@@ -52,6 +53,11 @@ public class LimiterNodeTests
     private sealed class StubInputNode(AudioBuffer buffer) : AudioNode
     {
         public override AudioBuffer Process(AudioProcessContext context) => buffer;
+    }
+
+    private sealed class NullInputNode : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context) => null!;
     }
 
     [Test]
@@ -193,7 +199,7 @@ public class LimiterNodeTests
         }
 
         Assert.That(foundReduction, Is.True,
-            "Right channel should be attenuated due to stereo-linked gain reduction.");
+            "Right channel should be attenuated due to channel-linked gain reduction.");
 
         // And the left channel must still respect the threshold.
         var outL = output.GetChannelData(0);
@@ -201,5 +207,501 @@ public class LimiterNodeTests
         {
             Assert.That(MathF.Abs(outL[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
         }
+    }
+
+    [Test]
+    public void Process_NonContiguousChunks_ResetsState()
+    {
+        // First chunk: hot sine that drives the limiter into reduction.
+        const int firstSampleCount = 1024;
+        using var hotInput = CreateBuffer(2, firstSampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(firstSampleCount, start: TimeSpan.Zero);
+        using (var firstOut = node.Process(firstCtx)) { /* prime the state */ }
+
+        // Replace input with silence and jump the time range so it is NOT contiguous.
+        using var silence = CreateBuffer(2, firstSampleCount, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        var secondCtx = CreateContext(firstSampleCount, start: TimeSpan.FromSeconds(10));
+        using var secondOut = node.Process(secondCtx);
+
+        // After reset, no audio from the previous segment should bleed into the first
+        // lookahead-window worth of samples.
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = secondOut.GetChannelData(ch);
+            for (int i = 0; i < firstSampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(1e-6f),
+                    $"Reset should clear delay-line state — channel {ch} sample {i} = {data[i]}.");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_ContiguousChunks_PreserveDelayState()
+    {
+        const int chunkSamples = 1024;
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+
+        // Hot first chunk to fill the delay line.
+        using var hotInput = CreateBuffer(2, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(releaseMs: 5000f);
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(chunkSamples, start: TimeSpan.Zero);
+        using (var _ = node.Process(firstCtx)) { /* fill delay line */ }
+
+        // Second chunk: silence following directly after the first chunk (no time gap).
+        var secondStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration;
+        using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        var secondCtx = CreateContext(chunkSamples, start: secondStart);
+        using var secondOut = node.Process(secondCtx);
+
+        // The first lookahead-window worth of samples in the second chunk reads the
+        // tail of the first chunk out of the delay line. If Reset() had fired
+        // erroneously the delay line would have been cleared and these samples would
+        // all be zero — the non-zero leak proves continuity is preserved.
+        bool foundLeak = false;
+        for (int ch = 0; ch < 2 && !foundLeak; ch++)
+        {
+            var data = secondOut.GetChannelData(ch);
+            for (int i = 0; i < lookaheadSamples; i++)
+            {
+                if (MathF.Abs(data[i]) > 1e-3f)
+                {
+                    foundLeak = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.That(foundLeak, Is.True,
+            "Contiguous chunk should preserve delay-line state from the previous chunk.");
+    }
+
+    [Test]
+    public void Process_ChannelCountChange_ReinitializesBuffers()
+    {
+        const int sampleCount = 1024;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+
+        // Stereo first.
+        using var stereoIn = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+        node.AddInput(new StubInputNode(stereoIn));
+
+        using (var stereoOut = node.Process(CreateContext(sampleCount, start: TimeSpan.Zero))) { /* prime */ }
+
+        // Switch to mono input — buffers must be re-initialized for the new channel count.
+        using var monoIn = CreateBuffer(1, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(monoIn));
+
+        using var monoOut = node.Process(CreateContext(sampleCount, start: TimeSpan.FromSeconds(1)));
+
+        Assert.That(monoOut.ChannelCount, Is.EqualTo(1));
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        var data = monoOut.GetChannelData(0);
+        for (int i = lookaheadSamples; i < sampleCount; i++)
+        {
+            Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+        }
+    }
+
+    [Test]
+    public void Process_DifferentSampleRates_BehaveConsistently()
+    {
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        foreach (int sr in new[] { 44100, 48000, 96000 })
+        {
+            int sampleCount = sr / 10; // 0.1s
+            using var input = CreateBuffer(2, sampleCount,
+                (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / sr),
+                sampleRate: sr);
+
+            using var node = CreateNode(thresholdDb: thresholdDb);
+            node.AddInput(new StubInputNode(input));
+
+            var ctx = CreateContext(sampleCount, sampleRate: sr);
+            using var output = node.Process(ctx);
+
+            Assert.That(output.SampleCount, Is.EqualTo(sampleCount), $"SR={sr} sample count mismatch");
+            Assert.That(output.SampleRate, Is.EqualTo(sr));
+
+            int lookaheadSamples = (int)(LookaheadMs / 1000f * sr);
+            for (int ch = 0; ch < 2; ch++)
+            {
+                var data = output.GetChannelData(ch);
+                for (int i = lookaheadSamples; i < sampleCount; i++)
+                {
+                    Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                        $"SR={sr} channel {ch} sample {i} exceeded threshold");
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void Process_LookaheadZero_LimitsCorrectly()
+    {
+        const int sampleCount = 2048;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb, lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        var ctx = CreateContext(sampleCount);
+        using var output = node.Process(ctx);
+
+        // With lookahead=0 every output sample must respect the threshold (no
+        // negative-index reads, no off-by-one crash).
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                    $"Channel {ch} sample {i} exceeded threshold with zero lookahead");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NegativePeak_TriggersLimiter()
+    {
+        const int sampleCount = 2048;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        // DC bias of -1.5 — only negative peaks exceed threshold. This catches a
+        // half-wave-rectification bug where the limiter would only respond to
+        // positive samples.
+        using var input = CreateBuffer(2, sampleCount, (_, _) => -1.5f);
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                    $"Negative peak at channel {ch} sample {i} ({data[i]}) was not limited");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_AllZeros_OutputIsAllZeros()
+    {
+        const int sampleCount = 1024;
+        using var input = CreateBuffer(2, sampleCount, (_, _) => 0f);
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(data[i], Is.EqualTo(0f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_MonoInput_LimitsCorrectly()
+    {
+        const int sampleCount = 2048;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(1, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(thresholdDb: thresholdDb);
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        Assert.That(output.ChannelCount, Is.EqualTo(1));
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        var data = output.GetChannelData(0);
+        for (int i = lookaheadSamples; i < sampleCount; i++)
+        {
+            Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+        }
+    }
+
+    private static IProperty<float> CreateAnimatedConstant(float value)
+    {
+        var prop = Property.CreateAnimatable(value);
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            Value = value,
+            KeyTime = TimeSpan.Zero,
+        });
+        prop.Animation = animation;
+        return prop;
+    }
+
+    [Test]
+    public void Process_AnimatedThreshold_LimitsCorrectly()
+    {
+        const int sampleCount = 4096;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedConstant(thresholdDb),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = Property.CreateAnimatable((float)LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        // Output past the lookahead window must stay at or below threshold even when
+        // the property is sourced from an animated path (per-sample buffer sampling).
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f),
+                    $"Animated path: channel {ch} sample {i} exceeded threshold");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_LongAnimatedChunk_ProcessesAllSamples()
+    {
+        // SampleCount > the internal stackalloc chunk size to exercise the inner while loop.
+        const int sampleCount = 5000;
+        const float thresholdDb = -1f;
+        float thresholdLin = MathF.Pow(10f, thresholdDb / 20f);
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = new LimiterNode
+        {
+            Threshold = CreateAnimatedConstant(thresholdDb),
+            Release = Property.CreateAnimatable(50f),
+            Lookahead = Property.CreateAnimatable((float)LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(0f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        Assert.That(output.SampleCount, Is.EqualTo(sampleCount));
+
+        int lookaheadSamples = (int)(LookaheadMs / 1000f * SampleRate);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(thresholdLin + 1e-4f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NoInputs_Throws()
+    {
+        using var node = CreateNode();
+        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
+        Assert.That(ex!.Message, Does.Contain("0"));
+    }
+
+    [Test]
+    public void Process_MultipleInputs_Throws()
+    {
+        using var input1 = CreateBuffer(2, 128, (_, _) => 0f);
+        using var input2 = CreateBuffer(2, 128, (_, _) => 0f);
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input1));
+        node.AddInput(new StubInputNode(input2));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
+        Assert.That(ex!.Message, Does.Contain("2"));
+    }
+
+    [Test]
+    public void Process_NullUpstream_Throws()
+    {
+        using var node = CreateNode();
+        node.AddInput(new NullInputNode());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(128)));
+        Assert.That(ex!.Message, Does.Contain("null"));
+    }
+
+    [Test]
+    public void Process_SampleRateMismatch_Throws()
+    {
+        using var input = CreateBuffer(2, 128, (_, _) => 0f, sampleRate: 44100);
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        // Context says 48000, input is 44100 — must surface as a clear error rather than
+        // silently producing wrong-pitch output.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => node.Process(CreateContext(128, sampleRate: SampleRate)));
+        Assert.That(ex!.Message, Does.Contain("sample rate"));
+    }
+
+    [Test]
+    public void Process_NaNParameter_DoesNotProduceNaNOutput()
+    {
+        const int sampleCount = 1024;
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        // All four parameters set to NaN. Math.Clamp propagates NaN, so without the
+        // float.IsFinite guard each parameter would corrupt _currentGain and the output
+        // would become NaN samples that flow downstream into the audio device.
+        using var node = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(float.NaN),
+            Release = Property.CreateAnimatable(float.NaN),
+            Lookahead = Property.CreateAnimatable(float.NaN),
+            MakeupGain = Property.CreateAnimatable(float.NaN),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Channel {ch} sample {i} = {data[i]} (NaN/Inf must not reach the output).");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_OutOfRangeParameters_AreClampedNotThrown()
+    {
+        const int sampleCount = 2048;
+        const float thresholdLin = 1f; // 0 dB ceiling after clamp.
+
+        using var input = CreateBuffer(2, sampleCount,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        // Way out of [Range(...)] bounds — must be clamped silently, not raise.
+        using var node = new LimiterNode
+        {
+            Threshold = Property.CreateAnimatable(999f),
+            Release = Property.CreateAnimatable(-100f),
+            Lookahead = Property.CreateAnimatable(9999f),
+            MakeupGain = Property.CreateAnimatable(999f),
+        };
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        // Output must be finite. The threshold is clamped to MaxThresholdDb (0 dB) and
+        // makeup to MaxMakeupGainDb, so the upper bound on the output magnitude is
+        // thresholdLin * 10^(MaxMakeupGainDb / 20).
+        float upperBound = thresholdLin * MathF.Pow(10f, LimiterEffect.MaxMakeupGainDb / 20f);
+        int lookaheadSamples = (int)(LimiterEffect.MaxLookaheadMs / 1000f * SampleRate);
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = lookaheadSamples; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True);
+                Assert.That(MathF.Abs(data[i]), Is.LessThanOrEqualTo(upperBound + 1e-3f));
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NaNInputSamples_AreSanitizedToZero()
+    {
+        const int sampleCount = 1024;
+
+        // Sprinkle NaN and Infinity into the input. Without input sanitization NaN
+        // would be written into the delay line and propagate to the output, while
+        // Infinity would force currentPeak to Inf and produce Inf*0 = NaN once the
+        // gain reduction kicks in.
+        using var input = CreateBuffer(2, sampleCount, (ch, i) =>
+        {
+            if (i % 100 == 0) return float.NaN;
+            if (i % 100 == 50) return float.PositiveInfinity;
+            return 0.5f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate);
+        });
+
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(sampleCount));
+
+        for (int ch = 0; ch < 2; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Channel {ch} sample {i} = {data[i]} (NaN/Inf input must be sanitized).");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_ZeroSampleCountInput_ReturnsEmptyBuffer()
+    {
+        using var input = new AudioBuffer(SampleRate, 2, 0);
+        using var node = CreateNode();
+        node.AddInput(new StubInputNode(input));
+
+        using var output = node.Process(CreateContext(0));
+        Assert.That(output.SampleCount, Is.EqualTo(0));
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -289,6 +289,55 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_OneTickTimestampQuantization_PreservesDelayState()
+    {
+        AssertTimestampOffsetPreservesDelayState(TimeSpan.FromTicks(1), expectedResidual: true);
+    }
+
+    [Test]
+    public void Process_TwoTickTimestampGap_ResetsDelayState()
+    {
+        AssertTimestampOffsetPreservesDelayState(TimeSpan.FromTicks(2), expectedResidual: false);
+    }
+
+    private static void AssertTimestampOffsetPreservesDelayState(TimeSpan offset, bool expectedResidual)
+    {
+        const int chunkSamples = 1024;
+        int lookaheadSamples = LookaheadSamples();
+
+        using var hotInput = CreateBuffer(2, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+        using var node = CreateNode(releaseMs: 5000f);
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(chunkSamples);
+        using (var _ = node.Process(firstCtx)) { }
+
+        using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        var nextStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration + offset;
+        using var output = node.Process(CreateContext(chunkSamples, start: nextStart));
+
+        bool foundResidual = false;
+        for (int ch = 0; ch < 2 && !foundResidual; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < lookaheadSamples; i++)
+            {
+                if (MathF.Abs(data[i]) > 1e-3f)
+                {
+                    foundResidual = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.That(foundResidual, Is.EqualTo(expectedResidual));
+    }
+
+    [Test]
     public void Process_ChannelCountChange_ReinitializesBuffers()
     {
         const int sampleCount = 1024;

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1058,6 +1058,62 @@ public class LimiterNodeTests
     }
 
     [Test]
+    public void Process_EmptyChunkBetweenContiguousChunks_DoesNotForceReset()
+    {
+        // A degenerate empty chunk in the middle of a stream must advance _lastTimeRangeEnd
+        // so the follow-up non-empty chunk still resumes contiguously and the delay line is
+        // not erroneously cleared. Without that bookkeeping, the next chunk's Start would
+        // mismatch the stale _lastTimeRangeEnd and Reset() would fire — silently dropping the
+        // tail of the previous segment.
+        const int chunkSamples = 1024;
+        int lookaheadSamples = LookaheadSamples();
+
+        using var hotInput = CreateBuffer(2, chunkSamples,
+            (_, i) => 2.0f * MathF.Sin(2f * MathF.PI * 440f * i / SampleRate));
+
+        using var node = CreateNode(releaseMs: 5000f);
+        node.AddInput(new StubInputNode(hotInput));
+
+        var firstCtx = CreateContext(chunkSamples, start: TimeSpan.Zero);
+        using (var _ = node.Process(firstCtx)) { }
+
+        // Empty chunk at the boundary — duration zero so Start == End, contiguity preserved.
+        var emptyStart = firstCtx.TimeRange.Start + firstCtx.TimeRange.Duration;
+        var emptyCtx = new AudioProcessContext(
+            new TimeRange(emptyStart, TimeSpan.Zero), SampleRate, new AnimationSampler(), null);
+        using var emptyInput = new AudioBuffer(SampleRate, 2, 0);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(emptyInput));
+        using (var _ = node.Process(emptyCtx)) { }
+
+        // Resume with silence at the same instant the empty chunk ended. If Reset() had fired
+        // erroneously the delay line would now be all zeros — the residual proves the empty
+        // chunk advanced _lastTimeRangeEnd correctly.
+        using var silence = CreateBuffer(2, chunkSamples, (_, _) => 0f);
+        node.RemoveInput(node.Inputs[0]);
+        node.AddInput(new StubInputNode(silence));
+
+        using var resumeOut = node.Process(CreateContext(chunkSamples, start: emptyStart));
+
+        bool foundResidual = false;
+        for (int ch = 0; ch < 2 && !foundResidual; ch++)
+        {
+            var data = resumeOut.GetChannelData(ch);
+            for (int i = 0; i < lookaheadSamples; i++)
+            {
+                if (MathF.Abs(data[i]) > 1e-3f)
+                {
+                    foundResidual = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.That(foundResidual, Is.True,
+            "Empty chunk at the boundary should not force a reset — delay-line residual must survive.");
+    }
+
+    [Test]
     public void Dispose_IsIdempotent()
     {
         var node = CreateNode();

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -1,12 +1,18 @@
 ﻿using Beutl.Audio;
 using Beutl.Audio.Graph;
+using Beutl.Engine;
 using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Audio;
 
 [TestFixture]
 public class SourceSoundThumbnailTests
 {
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => TestMediaHelper.RegisterTestDecoder();
+
     [TestCase(1, 44100)]
     [TestCase(44, 44100)]
     [TestCase(45, 44100)]
@@ -36,6 +42,121 @@ public class SourceSoundThumbnailTests
             var nextStart = TimeSpan.FromSeconds((double)endSample / sampleRate);
 
             Assert.That(Math.Abs((start + duration - nextStart).Ticks), Is.LessThanOrEqualTo(1));
+        }
+    }
+
+    // Pins the documented contiguity contract of GetWaveformChunksAsync: consecutive Compose ranges
+    // are tick-contiguous (so a stateful effect carries state across the strip) ONLY when each
+    // chunk's full span fits within samplesPerChunk. When fullSpan exceeds samplesPerChunk the chunk
+    // composes a prefix and a real gap opens between consecutive ranges (the effect restarts per
+    // chunk — an accepted approximation, not a bug).
+    [TestCase(48000, 48000, 1000, 4096, true)]   // 1s over 1000 chunks: fullSpan=48 <= 4096 -> contiguous
+    [TestCase(48000, 2880000, 500, 4096, false)] // 60s over 500 chunks: fullSpan=5760 > 4096 -> gap
+    public void WaveformChunkRanges_AreContiguous_OnlyWhenSpanFitsChunkBudget(
+        int sampleRate, int totalSamples, int chunkCount, int samplesPerChunk, bool expectContiguous)
+    {
+        bool sawGap = false;
+        for (int chunkIndex = 0; chunkIndex < chunkCount - 1; chunkIndex++)
+        {
+            int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
+            int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
+            int sampleCount = Math.Min(endSample - startSample, samplesPerChunk);
+
+            var start = TimeSpan.FromSeconds((double)startSample / sampleRate);
+            var duration = SourceSound.GetWaveformChunkDuration(sampleCount, sampleRate);
+            var nextStart = TimeSpan.FromSeconds((double)endSample / sampleRate);
+
+            if (Math.Abs((start + duration - nextStart).Ticks) > 1)
+                sawGap = true;
+        }
+
+        Assert.That(sawGap, Is.EqualTo(!expectContiguous));
+    }
+
+    // Cache-control-flow contract of GetWaveformChunksAsync: a cache miss computes the chunk and
+    // saves it; a cache hit returns the cached value and is NOT re-saved; every chunk is still
+    // produced either way (the cache-hit early-return is placed AFTER Compose so stateful effects
+    // keep advancing — that intent lives in the production comment; here we pin the observable
+    // control flow, which is what a regression to the loop structure would break).
+    [Test]
+    public async Task GetWaveformChunks_CacheMissComputesAndSaves_CacheHitReturnsCachedAndSkipsSave()
+    {
+        const int chunkCount = 50;
+        const int samplesPerChunk = 4096; // > per-chunk span (88200/50 = 1764) so ranges are contiguous
+
+        string path = TestMediaHelper.CreateTestAudioFile(sampleRate: 44100, channels: 2, durationSeconds: 2.0);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource },
+            TimeRange = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(2)),
+        };
+
+        // Cold run: empty cache. Every chunk is a miss, computed from audio and saved.
+        var coldCache = new FakeWaveformCache();
+        var coldChunks = await CollectAsync(sound, chunkCount, samplesPerChunk, coldCache);
+
+        Assert.That(coldChunks, Has.Count.EqualTo(chunkCount), "every chunk in range should be produced");
+        Assert.That(coldCache.SaveCount, Is.EqualTo(chunkCount), "each cache miss should save its waveform");
+        Assert.That(coldChunks.Select(c => c.Index), Is.EqualTo(Enumerable.Range(0, chunkCount)));
+
+        // Warm run: cache reports a hit for every query with a fixed sentinel. Each chunk must come
+        // back with the sentinel value and nothing must be re-saved.
+        const float sentinelMin = -0.25f;
+        const float sentinelMax = 0.75f;
+        var warmCache = new FakeWaveformCache(sentinelMin, sentinelMax);
+        var warmChunks = await CollectAsync(sound, chunkCount, samplesPerChunk, warmCache);
+
+        Assert.That(warmChunks, Has.Count.EqualTo(chunkCount));
+        Assert.That(warmCache.SaveCount, Is.Zero, "cache hits must not be re-saved");
+        Assert.That(warmChunks, Is.All.Matches<WaveformChunk>(
+            c => c.MinValue == sentinelMin && c.MaxValue == sentinelMax),
+            "a cache hit must return the cached min/max verbatim");
+    }
+
+    private static async Task<List<WaveformChunk>> CollectAsync(
+        SourceSound sound, int chunkCount, int samplesPerChunk, IThumbnailCacheService cache)
+    {
+        var chunks = new List<WaveformChunk>();
+        await foreach (var chunk in sound.GetWaveformChunksAsync(chunkCount, samplesPerChunk, cache))
+            chunks.Add(chunk);
+        return chunks;
+    }
+
+    // Returns a hit (with the configured sentinel) for every waveform query when sentinels are set;
+    // otherwise always misses. Counts SaveWaveform calls so tests can assert the !cacheHit guard.
+    private sealed class FakeWaveformCache(float? hitMin = null, float? hitMax = null) : IThumbnailCacheService
+    {
+        public int SaveCount { get; private set; }
+
+        public bool TryGetWaveform(string cacheKey, TimeSpan time, TimeSpan threshold, out float minValue, out float maxValue)
+        {
+            if (hitMin is { } min && hitMax is { } max)
+            {
+                minValue = min;
+                maxValue = max;
+                return true;
+            }
+
+            minValue = 0f;
+            maxValue = 0f;
+            return false;
+        }
+
+        public void SaveWaveform(string cacheKey, TimeSpan time, float minValue, float maxValue) => SaveCount++;
+
+        public bool TryGet(string cacheKey, TimeSpan time, TimeSpan threshold, out Bitmap? bitmap)
+        {
+            bitmap = null;
+            return false;
+        }
+
+        public void Save(string cacheKey, TimeSpan time, Bitmap bitmap) => throw new NotSupportedException();
+
+        public void Invalidate(string cacheKey)
+        {
         }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -1,0 +1,41 @@
+﻿using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class SourceSoundThumbnailTests
+{
+    [TestCase(1, 44100)]
+    [TestCase(44, 44100)]
+    [TestCase(45, 44100)]
+    [TestCase(1024, 48000)]
+    public void GetWaveformChunkDuration_MapsBackToRequestedSampleCount(int sampleCount, int sampleRate)
+    {
+        TimeSpan duration = SourceSound.GetWaveformChunkDuration(sampleCount, sampleRate);
+
+        Assert.That(
+            AudioProcessContext.GetSampleCount(new TimeRange(TimeSpan.Zero, duration), sampleRate),
+            Is.EqualTo(sampleCount));
+    }
+
+    [Test]
+    public void GetWaveformChunkDuration_AdjacentBoundariesDifferByAtMostOneTick()
+    {
+        const int sampleRate = 44100;
+        const int totalSamples = 44100;
+        const int chunkCount = 1000;
+
+        for (int chunkIndex = 0; chunkIndex < chunkCount - 1; chunkIndex++)
+        {
+            int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
+            int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
+            var start = TimeSpan.FromSeconds((double)startSample / sampleRate);
+            var duration = SourceSound.GetWaveformChunkDuration(endSample - startSample, sampleRate);
+            var nextStart = TimeSpan.FromSeconds((double)endSample / sampleRate);
+
+            Assert.That(Math.Abs((start + duration - nextStart).Ticks), Is.LessThanOrEqualTo(1));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -45,11 +45,10 @@ public class SourceSoundThumbnailTests
         }
     }
 
-    // Pins the documented contiguity contract of GetWaveformChunksAsync: consecutive Compose ranges
-    // are tick-contiguous (so a stateful effect carries state across the strip) ONLY when each
-    // chunk's full span fits within samplesPerChunk. When fullSpan exceeds samplesPerChunk the chunk
-    // composes a prefix and a real gap opens between consecutive ranges (the effect restarts per
-    // chunk — an accepted approximation, not a bug).
+    // Pins the contiguity contract of GetWaveformChunksAsync: consecutive Compose ranges are
+    // tick-contiguous (so a stateful effect carries state across the strip) only when each chunk's
+    // full span fits within samplesPerChunk. When fullSpan exceeds it the chunk composes a prefix
+    // and a gap opens between ranges — the effect restarts per chunk, an accepted approximation.
     [TestCase(48000, 48000, 1000, 4096, true)]   // 1s over 1000 chunks: fullSpan=48 <= 4096 -> contiguous
     [TestCase(48000, 2880000, 500, 4096, false)] // 60s over 500 chunks: fullSpan=5760 > 4096 -> gap
     public void WaveformChunkRanges_AreContiguous_OnlyWhenSpanFitsChunkBudget(
@@ -73,11 +72,8 @@ public class SourceSoundThumbnailTests
         Assert.That(sawGap, Is.EqualTo(!expectContiguous));
     }
 
-    // Cache-control-flow contract of GetWaveformChunksAsync: a cache miss computes the chunk and
-    // saves it; a cache hit returns the cached value and is NOT re-saved; every chunk is still
-    // produced either way (the cache-hit early-return is placed AFTER Compose so stateful effects
-    // keep advancing — that intent lives in the production comment; here we pin the observable
-    // control flow, which is what a regression to the loop structure would break).
+    // Cache-control-flow contract of GetWaveformChunksAsync: a miss computes and saves the chunk, a
+    // hit returns the cached value and is not re-saved, and every chunk is still produced either way.
     [Test]
     public async Task GetWaveformChunks_CacheMissComputesAndSaves_CacheHitReturnsCachedAndSkipsSave()
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
@@ -13,9 +13,9 @@ namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 [TestFixture]
 public class ParticleRenderNodeScaleTests
 {
-    // With the ParticleEmitter defaults (EmissionRate=60/s, Lifetime=2s, MaxParticles=5000) and TimeRange.Start
-    // at TimeSpan.Zero, context.Time is the elapsed simulation time. At t=1s the simulation deterministically
-    // holds alive particles, so Process emits an op.
+    // With the ParticleEmitter defaults (EmissionRate=60/s, Lifetime=2s, MaxParticles=5000) and
+    // TimeRange.Start at zero, the simulation deterministically holds alive particles at t=1s, so
+    // Process emits an op.
     private static ParticleEmitter.Resource BuildResourceWithAliveParticles()
     {
         var emitter = new ParticleEmitter();


### PR DESCRIPTION
## Description

Adds a new **Limiter** audio effect (brick-wall peak limiter with lookahead).

### Effect
- `LimiterEffect` with configurable **Threshold**, **Release**, **Lookahead**, and **Makeup Gain**, all animatable. Parameter ranges are declared once as constants and re-clamped (NaN/Inf-safe) in the DSP layer.
- `LimiterNode` DSP: channel-linked peak detection (a single shared gain preserves inter-channel phase), a lookahead delay line, instant attack with one-pole IIR release, and per-sample animation sampling on the animated path.
- Resets internal state when the incoming chunk is not contiguous with the previous one so cached node state does not bleed across seeks/loops/edits; only takes the per-sample animated path when a parameter actually has an animation.
- Registered under the Audio Effect group with localized strings (en/ja).

### Defaults & docs
- **Default Lookahead is 0 ms** so adding the effect is sample-accurate and A/V-synchronized out of the box. Beutl's audio graph processes effects inline and has no plugin-delay-compensation, so a non-zero lookahead shifts the clip and drops its tail at run boundaries; users opt into lookahead transparency explicitly, and the algorithm degrades to a correct zero-latency brick wall at 0 ms.
- Documented that the always-on master limiter re-limits anything above 0 dBFS, so the brick-wall ceiling is only guaranteed end-to-end while the summed bus stays at or below 0 dBFS.
- Clarified that `AudioMath.ApplyLimiter` is a ratio compressor (not a brick-wall limiter) to disambiguate it from this effect.

### Performance
- The lookahead window maximum is tracked with an **O(1)-amortized monotonic-deque sliding-window maximum** on the static path, replacing the per-sample O(N·lookahead) rescan (~46M `CircularBuffer.Read` calls/sec at max lookahead). The animated path (where lookahead can vary per sample) keeps the direct scan. Per-sample channel access is hoisted to a channel-major backing span (new internal `AudioBuffer.GetRawSpan`).

### Fix (waveform thumbnails)
- Waveform-thumbnail chunk boundaries are now tick-contiguous (each chunk's duration is derived from adjacent rounded boundaries instead of rounding the sample count independently). Previously the ~1-tick drift made a stateful effect such as the Limiter reset mid-render, glitching the rendered waveform. Audible playback/export was unaffected (its chunking is already tick-contiguous).

### Tests
- `LimiterNodeTests` covers threshold passthrough/limiting, the makeup ceiling (Threshold + MakeupGain, including > 0 dBFS), stereo and > 2-channel gain linking, contiguous/non-contiguous reset on both the static and animated paths, empty chunks, sample-rate and channel-count changes, lookahead delay accuracy, IIR release recovery, NaN/Inf sanitization (static and per-sample animated), animated parameters (including Lookahead), the tiny -60 dB limiting branch, and the 0 ms default.
- The O(1) sliding-window-max is pinned by dedicated regression tests: a static-deque-vs-animated-scan sample-for-sample equivalence test, and a rebuild test that forces the `EnsureDeque` lookahead-change path against an independent step-lookahead scan oracle. The deque and coercion tests were mutation-verified — each fails when the eviction, rebuild, or parameter coercion is deliberately broken — and a `Debug.Assert` guards the deque's free-slot invariant in Debug builds.
- Beutl.Engine and the test project build with 0 warnings/0 errors; all audio tests pass.

## Breaking changes

None — the effect is new, and `AudioBuffer.GetRawSpan` is `internal` and additive.

## Fixed issues

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Limiter audio effect with configurable threshold, release, lookahead, and makeup gain parameters for dynamic audio processing and peak control.

* **Documentation**
  * Added English and Japanese localization strings for the new Limiter audio effect and its parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->