### PR TITLE
feat: Extend timeline snap with playhead, scene bounds, and toggle

### DIFF
--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -63,6 +63,7 @@ public sealed partial class EditorConfig : ConfigurationBase
     public static readonly CoreProperty<int> NodeCacheMinPixelsProperty;
     public static readonly CoreProperty<bool> SwapTimelineScrollDirectionProperty;
     public static readonly CoreProperty<bool> ClampResizeToOriginalLengthProperty;
+    public static readonly CoreProperty<bool> IsTimelineSnapEnabledProperty;
     public static readonly CoreProperty<TimelineAutoScrollMode> TimelineAutoScrollModeProperty;
     public static readonly CoreProperty<UIToneMappingOperator> ToneMappingModeProperty;
     public static readonly CoreProperty<float> ToneMappingExposureProperty;
@@ -122,6 +123,10 @@ public sealed partial class EditorConfig : ConfigurationBase
             .Register();
 
         ClampResizeToOriginalLengthProperty = ConfigureProperty<bool, EditorConfig>(nameof(ClampResizeToOriginalLength))
+            .DefaultValue(true)
+            .Register();
+
+        IsTimelineSnapEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsTimelineSnapEnabled))
             .DefaultValue(true)
             .Register();
 
@@ -217,6 +222,12 @@ public sealed partial class EditorConfig : ConfigurationBase
     {
         get => GetValue(ClampResizeToOriginalLengthProperty);
         set => SetValue(ClampResizeToOriginalLengthProperty, value);
+    }
+
+    public bool IsTimelineSnapEnabled
+    {
+        get => GetValue(IsTimelineSnapEnabledProperty);
+        set => SetValue(IsTimelineSnapEnabledProperty, value);
     }
 
     public TimelineAutoScrollMode TimelineAutoScrollMode

--- a/src/Beutl.Editor.Components/Helpers/SnapHelper.cs
+++ b/src/Beutl.Editor.Components/Helpers/SnapHelper.cs
@@ -1,0 +1,59 @@
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Components.Helpers;
+
+public readonly record struct SnapResult(TimeSpan Time, TimeSpan? Snapped)
+{
+    public bool DidSnap => Snapped.HasValue;
+}
+
+public static class SnapHelper
+{
+    public const double DefaultThresholdPixel = 8;
+
+    public static SnapResult Snap(
+        TimeSpan time,
+        IEnumerable<TimeSpan> candidates,
+        float scale,
+        double thresholdPixel = DefaultThresholdPixel)
+    {
+        TimeSpan threshold = thresholdPixel.PixelToTimeSpan(scale);
+        TimeSpan bestDelta = TimeSpan.MaxValue;
+        TimeSpan? best = null;
+
+        foreach (TimeSpan candidate in candidates)
+        {
+            TimeSpan delta = (candidate - time).Duration();
+            if (delta <= threshold && delta < bestDelta)
+            {
+                bestDelta = delta;
+                best = candidate;
+            }
+        }
+
+        return best.HasValue ? new SnapResult(best.Value, best.Value) : new SnapResult(time, null);
+    }
+
+    public static IEnumerable<TimeSpan> CollectElementCandidates(
+        IEnumerable<Element> elements,
+        Element? exclude,
+        int? sameZIndex = null)
+    {
+        foreach (Element item in elements)
+        {
+            if (item == exclude) continue;
+            if (sameZIndex is { } z && item.ZIndex != z) continue;
+
+            yield return item.Start;
+            yield return item.Start + item.Length;
+        }
+    }
+
+    public static IEnumerable<TimeSpan> CollectSceneCandidates(Scene scene, TimeSpan currentTime)
+    {
+        yield return scene.Start;
+        yield return scene.Start + scene.Duration;
+        yield return currentTime;
+        if (currentTime != TimeSpan.Zero) yield return TimeSpan.Zero;
+    }
+}

--- a/src/Beutl.Editor.Components/Helpers/SnapHelper.cs
+++ b/src/Beutl.Editor.Components/Helpers/SnapHelper.cs
@@ -1,4 +1,4 @@
-using Beutl.ProjectSystem;
+﻿using Beutl.ProjectSystem;
 
 namespace Beutl.Editor.Components.Helpers;
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -145,6 +145,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
             editorConfig.AutoAdjustSceneDuration = b;
         });
 
+        IsSnapEnabled = editorConfig.GetObservable(EditorConfig.IsTimelineSnapEnabledProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        IsSnapEnabled.Subscribe(b => editorConfig.IsTimelineSnapEnabled = b)
+            .DisposeWith(_disposables);
+
         IsLockCacheButtonEnabled = HoveredCacheBlock.Select(v => v is { IsLocked: false })
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
@@ -349,6 +355,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
     public ReactiveCommandSlim UnlockFrameCache { get; }
 
     public ReactiveProperty<bool> AutoAdjustSceneDuration { get; }
+
+    public ReactiveProperty<bool> IsSnapEnabled { get; }
+
+    public ReactivePropertySlim<double?> SnapBarPosition { get; } = new();
 
     public ReactivePropertySlim<CacheBlock?> HoveredCacheBlock { get; } = new();
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -249,36 +249,25 @@ public sealed partial class ElementView : UserControl
         }
     }
 
-    private TimeSpan RoundStartTime(TimeSpan time, float scale, bool flag)
+    private TimeSpan RoundStartTime(TimeSpan time, float scale, bool flag, int? sameZIndex = null)
     {
         Element model = ViewModel.Model;
+        TimelineTabViewModel timeline = ViewModel.Timeline;
 
-        if (!flag)
+        if (flag || !timeline.IsSnapEnabled.Value)
         {
-            foreach (Element item in ViewModel.Scene.Children.GetMarshal().Value)
-            {
-                if (item != model)
-                {
-                    const double ThreadholdPixel = 10;
-                    TimeSpan threadhold = ThreadholdPixel.PixelToTimeSpan(scale);
-                    TimeSpan start = item.Start;
-                    TimeSpan end = start + item.Length;
-                    var startRange = new Media.TimeRange(start - threadhold, threadhold);
-                    var endRange = new Media.TimeRange(end - threadhold, threadhold);
-
-                    if (endRange.Contains(time))
-                    {
-                        return end;
-                    }
-                    else if (startRange.Contains(time))
-                    {
-                        return start;
-                    }
-                }
-            }
+            timeline.SnapBarPosition.Value = null;
+            return time;
         }
 
-        return time;
+        IEditorClock clock = timeline.EditorContext.GetRequiredService<IEditorClock>();
+        IEnumerable<TimeSpan> candidates = SnapHelper
+            .CollectElementCandidates(timeline.Scene.Children, model, sameZIndex)
+            .Concat(SnapHelper.CollectSceneCandidates(timeline.Scene, clock.CurrentTime.Value));
+
+        SnapResult result = SnapHelper.Snap(time, candidates, scale);
+        timeline.SnapBarPosition.Value = result.DidSnap ? result.Time.TimeToPixel(scale) : null;
+        return result.Time;
     }
 
     private sealed class _ResizeBehavior : Behavior<ElementView>
@@ -450,6 +439,7 @@ public sealed partial class ElementView : UserControl
 
                 if (AssociatedObject is { ViewModel: { } viewModel })
                 {
+                    viewModel.Timeline.SnapBarPosition.Value = null;
                     e.Handled = true;
 
                     if (_resizeContexts.Length == 1)
@@ -615,6 +605,7 @@ public sealed partial class ElementView : UserControl
 
                 if (AssociatedObject is { ViewModel: { } viewModel })
                 {
+                    viewModel.Timeline.SnapBarPosition.Value = null;
                     HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
                     e.Handled = true;
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -140,6 +140,7 @@
                                            InputGesture="{h:GetCommandGesture SetEndTime}"
                                            Text="{x:Static lang:Strings.SetEndTime}" />
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsStrings.AutoAdjustSceneDuration}" />
+                        <ui:ToggleMenuFlyoutItem IsChecked="{Binding IsSnapEnabled.Value, Mode=TwoWay}" Text="{x:Static lang:Strings.TimelineSnap}" />
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutItem Click="ShowSceneSettings" Text="{x:Static lang:Strings.Settings}">
                             <ui:MenuFlyoutItem.IconSource>
@@ -203,6 +204,8 @@
                                      EndingBarMargin="{CompiledBinding EndingBarMargin.Value}"
                                      SeekBarBrush="{DynamicResource AccentFillColorDefaultBrush}"
                                      SeekBarMargin="{CompiledBinding SeekBarMargin.Value}"
+                                     SnapBarBrush="{DynamicResource SystemFillColorAttentionBrush}"
+                                     SnapBarPosition="{CompiledBinding SnapBarPosition.Value}"
                                      StartingBarBrush="{DynamicResource SystemFillColorCriticalBrush}"
                                      StartingBarMargin="{CompiledBinding StartingBarMargin.Value}"
                                      Viewport="{Binding #ContentScroll.Viewport, Mode=OneWay}"

--- a/src/Beutl.Editor.Components/Views/TimelineOverlay.cs
+++ b/src/Beutl.Editor.Components/Views/TimelineOverlay.cs
@@ -31,6 +31,10 @@ public sealed class TimelineOverlay : Control
         = AvaloniaProperty.RegisterDirect<TimelineOverlay, Thickness>(
             nameof(SeekBarMargin), o => o.SeekBarMargin, (o, v) => o.SeekBarMargin = v);
 
+    public static readonly DirectProperty<TimelineOverlay, double?> SnapBarPositionProperty
+        = AvaloniaProperty.RegisterDirect<TimelineOverlay, double?>(
+            nameof(SnapBarPosition), o => o.SnapBarPosition, (o, v) => o.SnapBarPosition = v);
+
     public static readonly StyledProperty<IBrush?> SeekBarBrushProperty
         = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(SeekBarBrush));
 
@@ -40,15 +44,20 @@ public sealed class TimelineOverlay : Control
     public static readonly StyledProperty<IBrush?> EndingBarBrushProperty
         = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(EndingBarBrush));
 
+    public static readonly StyledProperty<IBrush?> SnapBarBrushProperty
+        = AvaloniaProperty.Register<TimelineOverlay, IBrush?>(nameof(SnapBarBrush));
+
     private Vector _offset;
     private Thickness _startingBarMargin;
     private Thickness _endingBarMargin;
     private Thickness _seekBarMargin;
+    private double? _snapBarPosition;
     private Size _viewport;
     private Rect _selectionRange;
     private ImmutablePen? _seekBarPen;
     private ImmutablePen? _startingBarPen;
     private ImmutablePen? _endingBarPen;
+    private ImmutablePen? _snapBarPen;
 
     static TimelineOverlay()
     {
@@ -59,9 +68,11 @@ public sealed class TimelineOverlay : Control
             StartingBarMarginProperty,
             EndingBarMarginProperty,
             SeekBarMarginProperty,
+            SnapBarPositionProperty,
             SeekBarBrushProperty,
             StartingBarBrushProperty,
-            EndingBarBrushProperty);
+            EndingBarBrushProperty,
+            SnapBarBrushProperty);
     }
 
     public TimelineOverlay()
@@ -105,6 +116,18 @@ public sealed class TimelineOverlay : Control
         set => SetAndRaise(SeekBarMarginProperty, ref _seekBarMargin, value);
     }
 
+    public double? SnapBarPosition
+    {
+        get => _snapBarPosition;
+        set => SetAndRaise(SnapBarPositionProperty, ref _snapBarPosition, value);
+    }
+
+    public IBrush? SnapBarBrush
+    {
+        get => GetValue(SnapBarBrushProperty);
+        set => SetValue(SnapBarBrushProperty, value);
+    }
+
     public IBrush? SeekBarBrush
     {
         get => GetValue(SeekBarBrushProperty);
@@ -138,6 +161,10 @@ public sealed class TimelineOverlay : Control
         {
             _endingBarPen = new ImmutablePen(EndingBarBrush?.ToImmutable(), 1.25);
         }
+        else if (change.Property == SnapBarBrushProperty)
+        {
+            _snapBarPen = new ImmutablePen(SnapBarBrush?.ToImmutable(), 1.0, new ImmutableDashStyle([3, 3], 0));
+        }
     }
 
     public override void Render(DrawingContext context)
@@ -163,6 +190,13 @@ public sealed class TimelineOverlay : Control
             context.DrawLine(_seekBarPen, seekbar, seekbar + bottom);
             context.DrawLine(_startingBarPen, startingbar, startingbar + bottom);
             context.DrawLine(_endingBarPen, endingbar, endingbar + bottom);
+
+            if (_snapBarPosition is { } snap)
+            {
+                _snapBarPen ??= new ImmutablePen(SnapBarBrush?.ToImmutable(), 1.0, new ImmutableDashStyle([3, 3], 0));
+                var snapBar = new Point(snap, 0);
+                context.DrawLine(_snapBarPen, snapBar, snapBar + bottom);
+            }
         }
     }
 }

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -435,6 +435,9 @@
   <data name="TimelineZoom" xml:space="preserve">
     <value>拡大率</value>
   </data>
+  <data name="TimelineSnap" xml:space="preserve">
+    <value>スナップ</value>
+  </data>
   <data name="UseGlobalClock" xml:space="preserve">
     <value>グローバル時計を使う</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -440,6 +440,9 @@
   <data name="TimelineZoom" xml:space="preserve">
     <value>Zoom</value>
   </data>
+  <data name="TimelineSnap" xml:space="preserve">
+    <value>Snap</value>
+  </data>
   <data name="UseGlobalClock" xml:space="preserve">
     <value>Use the Global Clock</value>
   </data>


### PR DESCRIPTION
## Description
- Extend the existing clip-edge snap so that dragging or resizing also snaps to the current playhead, scene start/end, and zero.
- Add a dashed snap indicator on the timeline overlay so users can see what their clip is snapping to.
- Add an `IsTimelineSnapEnabled` setting (default on) with a toggle in the timeline menu to disable snapping.
- Refactor the inline snap logic in `ElementView` into a reusable `SnapHelper` that collects element and scene candidates.

## Breaking changes
None.

## Fixed issues
None.