### PR TITLE
feat: improve export progress UX with ETA and frame count

### DIFF
--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -356,4 +356,7 @@
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>貼り付けできません: クリップボードに互換性のあるオブジェクトがありません。</value>
   </data>
+  <data name="ExportCompleted_File" xml:space="preserve">
+    <value>書き出し完了: {0}</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -361,4 +361,7 @@ Do you want to restart the application?</value>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>Cannot paste: clipboard does not contain a compatible object.</value>
   </data>
+  <data name="ExportCompleted_File" xml:space="preserve">
+    <value>Export completed: {0}</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1003,4 +1003,22 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="Preset_Discord_8MB" xml:space="preserve">
     <value>Discord 8MB 制限 (約 1 分)</value>
   </data>
+  <data name="Encoding" xml:space="preserve">
+    <value>エンコード中...</value>
+  </data>
+  <data name="RemainingTime" xml:space="preserve">
+    <value>残り時間</value>
+  </data>
+  <data name="Frames" xml:space="preserve">
+    <value>フレーム</value>
+  </data>
+  <data name="FileSize" xml:space="preserve">
+    <value>サイズ</value>
+  </data>
+  <data name="EstimatedSize" xml:space="preserve">
+    <value>推定サイズ</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>再生</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1018,7 +1018,4 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="EstimatedSize" xml:space="preserve">
     <value>推定サイズ</value>
   </data>
-  <data name="Play" xml:space="preserve">
-    <value>再生</value>
-  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1024,7 +1024,4 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="EstimatedSize" xml:space="preserve">
     <value>Estimated</value>
   </data>
-  <data name="Play" xml:space="preserve">
-    <value>Play</value>
-  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1009,4 +1009,22 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="Preset_Discord_8MB" xml:space="preserve">
     <value>Discord 8MB (~1 min)</value>
   </data>
+  <data name="Encoding" xml:space="preserve">
+    <value>Encoding...</value>
+  </data>
+  <data name="RemainingTime" xml:space="preserve">
+    <value>Remaining</value>
+  </data>
+  <data name="Frames" xml:space="preserve">
+    <value>Frames</value>
+  </data>
+  <data name="FileSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="EstimatedSize" xml:space="preserve">
+    <value>Estimated</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
 </root>

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -301,20 +301,20 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                 FrameProgressText.Value = TotalFrames.Value > 0
                     ? $"{TotalFrames.Value} / {TotalFrames.Value}"
                     : FrameProgressText.Value;
+                ProgressText.Value = Strings.Completed;
+                ProgressMain.Value = Strings.Completed;
+                ProgressSub.Value = string.Empty;
+                Eta.Value = "00:00:00";
+                _logger.LogInformation("Encoding process completed successfully.");
             }
-            ProgressText.Value = Strings.Completed;
-            ProgressMain.Value = Strings.Completed;
-            ProgressSub.Value = string.Empty;
-            Eta.Value = "00:00:00";
-            _logger.LogInformation("Encoding process completed successfully.");
+            else
+            {
+                HandleCancellation();
+            }
         }
         catch (OperationCanceledException)
         {
-            WasCancelled.Value = true;
-            ProgressText.Value = Strings.Cancel;
-            ProgressMain.Value = Strings.Cancel;
-            _logger.LogInformation("Encoding cancelled.");
-            TryDeletePartialFile(_activeDestination);
+            HandleCancellation();
         }
         catch (Exception ex)
         {
@@ -340,6 +340,15 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                 ShowCompletionNotification(completedPath);
             }
         }
+    }
+
+    private void HandleCancellation()
+    {
+        WasCancelled.Value = true;
+        ProgressText.Value = Strings.Cancel;
+        ProgressMain.Value = Strings.Cancel;
+        _logger.LogInformation("Encoding cancelled.");
+        TryDeletePartialFile(_activeDestination);
     }
 
     private void UpdateProgressIndicators(TimeSpan elapsed, double value, double max, string? destinationPath)

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -99,6 +99,21 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             .Bind(out _encoders)
             .Subscribe()
             .DisposeWith(_disposable);
+
+        PrimaryButtonText = IsCompleted
+            .Select(c => c ? Strings.Play : null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposable);
+
+        SecondaryButtonText = IsCompleted
+            .Select(c => c ? Strings.OpenFolder : null)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposable);
+
+        CloseButtonText = IsEncoding
+            .Select(e => e ? Strings.Cancel : Strings.Close)
+            .ToReadOnlyReactivePropertySlim(Strings.Close)
+            .DisposeWith(_disposable);
     }
 
     public OutputExtension Extension => SceneOutputExtension.Instance;
@@ -150,6 +165,12 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
     public ReactiveProperty<bool> IsCompleted { get; } = new();
 
     public ReactiveProperty<bool> WasCancelled { get; } = new();
+
+    public ReadOnlyReactivePropertySlim<string?> PrimaryButtonText { get; }
+
+    public ReadOnlyReactivePropertySlim<string?> SecondaryButtonText { get; }
+
+    public ReadOnlyReactivePropertySlim<string> CloseButtonText { get; }
 
     public IReadOnlyReactiveProperty<bool> IsIndeterminate => _isIndeterminate;
 

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -100,16 +100,6 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             .Subscribe()
             .DisposeWith(_disposable);
 
-        PrimaryButtonText = IsCompleted
-            .Select(c => c ? Strings.Play : null)
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposable);
-
-        SecondaryButtonText = IsCompleted
-            .Select(c => c ? Strings.OpenFolder : null)
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposable);
-
         CloseButtonText = IsEncoding
             .Select(e => e ? Strings.Cancel : Strings.Close)
             .ToReadOnlyReactivePropertySlim(Strings.Close)
@@ -165,10 +155,6 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
     public ReactiveProperty<bool> IsCompleted { get; } = new();
 
     public ReactiveProperty<bool> WasCancelled { get; } = new();
-
-    public ReadOnlyReactivePropertySlim<string?> PrimaryButtonText { get; }
-
-    public ReadOnlyReactivePropertySlim<string?> SecondaryButtonText { get; }
 
     public ReadOnlyReactivePropertySlim<string> CloseButtonText { get; }
 
@@ -464,20 +450,6 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
         }
     }
 
-    public void OpenContainingFolder()
-    {
-        if (!string.IsNullOrEmpty(DestinationFile.Value))
-        {
-            OpenContainingFolder(DestinationFile.Value);
-        }
-    }
-
-    public void PlayOutput()
-    {
-        if (string.IsNullOrEmpty(DestinationFile.Value)) return;
-        OpenWithDefaultApp(DestinationFile.Value);
-    }
-
     private void OpenContainingFolder(string filePath)
     {
         try
@@ -520,28 +492,6 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to open containing folder for {Path}", filePath);
-        }
-    }
-
-    private void OpenWithDefaultApp(string filePath)
-    {
-        try
-        {
-            if (!File.Exists(filePath)) return;
-            if (OperatingSystem.IsMacOS())
-            {
-                var psi = new ProcessStartInfo("open") { UseShellExecute = false };
-                psi.ArgumentList.Add(filePath);
-                Process.Start(psi);
-            }
-            else
-            {
-                Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true, Verb = "open" });
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to open output file {Path}", filePath);
         }
     }
 

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
@@ -31,6 +32,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
     private readonly ReadOnlyObservableCollection<ControllableEncodingExtension> _encoders;
     private readonly CompositeDisposable _disposable = [];
     private CancellationTokenSource? _lastCts;
+    private string? _activeDestination;
 
     public OutputViewModel(EditViewModel editViewModel)
     {
@@ -127,6 +129,28 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
     public ReactiveProperty<string> ProgressText { get; } = new();
 
+    public ReactiveProperty<string> ProgressMain { get; } = new(string.Empty);
+
+    public ReactiveProperty<string> ProgressSub { get; } = new(string.Empty);
+
+    public ReactiveProperty<string> Elapsed { get; } = new("00:00:00");
+
+    public ReactiveProperty<string> Eta { get; } = new("--:--:--");
+
+    public ReactiveProperty<string> CurrentSize { get; } = new("0 MB");
+
+    public ReactiveProperty<string> EstimatedSize { get; } = new("-- MB");
+
+    public ReactiveProperty<long> CurrentFrame { get; } = new();
+
+    public ReactiveProperty<long> TotalFrames { get; } = new();
+
+    public ReactiveProperty<string> FrameProgressText { get; } = new("0 / 0");
+
+    public ReactiveProperty<bool> IsCompleted { get; } = new();
+
+    public ReactiveProperty<bool> WasCancelled { get; } = new();
+
     public IReadOnlyReactiveProperty<bool> IsIndeterminate => _isIndeterminate;
 
     public IReadOnlyReactiveProperty<bool> IsEncoding => _isEncoding;
@@ -171,14 +195,30 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
     public async Task StartEncode()
     {
+        var stopwatch = new Stopwatch();
+        bool succeeded = false;
         try
         {
             _logger.LogInformation("Starting encoding process.");
             LogEncodingSettings();
             _lastCts = new CancellationTokenSource();
             _isEncoding.Value = true;
+            IsCompleted.Value = false;
+            WasCancelled.Value = false;
             ProgressText.Value = "";
+            ProgressMain.Value = Strings.Encoding;
+            ProgressSub.Value = string.Empty;
+            Elapsed.Value = "00:00:00";
+            Eta.Value = "--:--:--";
+            CurrentSize.Value = "0 MB";
+            EstimatedSize.Value = "-- MB";
+            CurrentFrame.Value = 0;
+            TotalFrames.Value = 0;
+            FrameProgressText.Value = "0 / 0";
+            _activeDestination = DestinationFile.Value;
             Started?.Invoke(this, EventArgs.Empty);
+
+            stopwatch.Start();
 
             await Task.Run(async () =>
             {
@@ -195,6 +235,12 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
                 ProgressMax.Value = Model.Duration.TotalSeconds * 2;
 
+                double frameRate = videoSettings.FrameRate.ToDouble();
+                if (!double.IsFinite(frameRate) || frameRate <= 0) frameRate = 30;
+                long totalFrames = (long)Math.Round(Model.Duration.TotalSeconds * frameRate);
+                TotalFrames.Value = totalFrames;
+                FrameProgressText.Value = $"0 / {totalFrames}";
+
                 EncodingController? controller = Controller.Value;
                 if (controller == null)
                 {
@@ -206,30 +252,62 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                     _logger.LogInformation("Using encoding controller: {Controller}", controller);
                 }
 
-                // エンコード前にEditViewModelのレンダラーキャッシュを削除してメモリ解放
                 ClearEditViewModelCaches();
 
-                // エンコード専用のRendererを作成（キャッシュ無効、リソース共有無効）
                 using var renderer = new SceneRenderer(Model, disableResourceShare: true);
                 renderer.CacheOptions = RenderCacheOptions.Disabled;
                 var frameProgress = new Subject<TimeSpan>();
                 using var frameProvider = new FrameProviderImpl(Model, videoSettings.FrameRate, renderer, frameProgress);
-                // サンプルプロバイダー作成
                 using var composer = new SceneComposer(Model, disableResourceShare: true) { SampleRate = audioSettings.SampleRate };
-                // var composer = _editViewModel.Composer.Value;
                 var sampleProgress = new Subject<TimeSpan>();
                 using var sampleProvider = new SampleProviderImpl(
                     Model, composer, audioSettings.SampleRate, sampleProgress);
 
+                string? destinationPath = _activeDestination;
+
+                using (frameProgress
+                           .Subscribe(t =>
+                           {
+                               long frame = (long)Math.Round(t.TotalSeconds * frameRate);
+                               CurrentFrame.Value = frame;
+                               FrameProgressText.Value = totalFrames > 0
+                                   ? $"{frame} / {totalFrames}"
+                                   : $"{frame}";
+                           }))
                 using (frameProgress.CombineLatest(sampleProgress)
-                           .Subscribe(t => ProgressValue.Value = t.Item1.TotalSeconds + t.Item2.TotalSeconds))
+                           .Subscribe(t =>
+                           {
+                               double value = t.Item1.TotalSeconds + t.Item2.TotalSeconds;
+                               ProgressValue.Value = value;
+                               UpdateProgressIndicators(stopwatch.Elapsed, value, ProgressMax.Value, destinationPath);
+                           }))
                 {
                     await controller.Encode(frameProvider, sampleProvider, _lastCts.Token);
                 }
             });
 
+            succeeded = !(_lastCts?.IsCancellationRequested ?? true);
+            if (succeeded)
+            {
+                ProgressValue.Value = ProgressMax.Value;
+                CurrentFrame.Value = TotalFrames.Value;
+                FrameProgressText.Value = TotalFrames.Value > 0
+                    ? $"{TotalFrames.Value} / {TotalFrames.Value}"
+                    : FrameProgressText.Value;
+            }
             ProgressText.Value = Strings.Completed;
+            ProgressMain.Value = Strings.Completed;
+            ProgressSub.Value = string.Empty;
+            Eta.Value = "00:00:00";
             _logger.LogInformation("Encoding process completed successfully.");
+        }
+        catch (OperationCanceledException)
+        {
+            WasCancelled.Value = true;
+            ProgressText.Value = Strings.Cancel;
+            ProgressMain.Value = Strings.Cancel;
+            _logger.LogInformation("Encoding cancelled.");
+            TryDeletePartialFile(_activeDestination);
         }
         catch (Exception ex)
         {
@@ -238,14 +316,211 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
         }
         finally
         {
+            stopwatch.Stop();
+            Elapsed.Value = FormatDuration(stopwatch.Elapsed);
             _progress.Value = 0;
-            ProgressMax.Value = 0;
-            ProgressValue.Value = 0;
             _isIndeterminate.Value = false;
             _isEncoding.Value = false;
+            IsCompleted.Value = succeeded;
+            string? completedPath = _activeDestination;
+            _activeDestination = null;
             _lastCts = null;
             Finished?.Invoke(this, EventArgs.Empty);
             _logger.LogInformation("Encoding process finished.");
+
+            if (succeeded && completedPath != null)
+            {
+                ShowCompletionNotification(completedPath);
+            }
+        }
+    }
+
+    private void UpdateProgressIndicators(TimeSpan elapsed, double value, double max, string? destinationPath)
+    {
+        Elapsed.Value = FormatDuration(elapsed);
+
+        long currentBytes = 0;
+        if (destinationPath != null)
+        {
+            try
+            {
+                var info = new FileInfo(destinationPath);
+                if (info.Exists) currentBytes = info.Length;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read partial file size during encoding.");
+            }
+        }
+
+        CurrentSize.Value = FormatBytes(currentBytes);
+
+        if (max > 0 && value > 0)
+        {
+            double ratio = Math.Clamp(value / max, 0.0, 1.0);
+            if (ratio > 0 && ratio < 1)
+            {
+                double etaSeconds = elapsed.TotalSeconds * (1.0 / ratio - 1.0);
+                if (double.IsFinite(etaSeconds) && etaSeconds >= 0)
+                {
+                    Eta.Value = FormatDuration(TimeSpan.FromSeconds(etaSeconds));
+                }
+            }
+            else if (ratio >= 1)
+            {
+                Eta.Value = "00:00:00";
+            }
+
+            if (currentBytes > 0 && ratio > 0)
+            {
+                long estimatedTotal = (long)(currentBytes / ratio);
+                EstimatedSize.Value = FormatBytes(estimatedTotal);
+            }
+        }
+
+        ProgressSub.Value = $"{Elapsed.Value} / {Eta.Value}";
+    }
+
+    private static string FormatDuration(TimeSpan span)
+    {
+        if (span < TimeSpan.Zero) span = TimeSpan.Zero;
+        if (span.TotalHours >= 100) return @"99:59:59";
+        return span.ToString(@"hh\:mm\:ss");
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes <= 0) return "0 MB";
+        const double kb = 1024.0;
+        const double mb = kb * 1024.0;
+        const double gb = mb * 1024.0;
+        return bytes switch
+        {
+            < (long)mb => $"{bytes / kb:0.0} KB",
+            < (long)gb => $"{bytes / mb:0.0} MB",
+            _ => $"{bytes / gb:0.00} GB"
+        };
+    }
+
+    private void TryDeletePartialFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return;
+        if (!string.Equals(path, DestinationFile.Value, StringComparison.Ordinal))
+        {
+            _logger.LogDebug("Skip deleting partial file because destination changed.");
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                _logger.LogInformation("Deleted partial output file: {Path}", path);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete partial output file: {Path}", path);
+        }
+    }
+
+    private void ShowCompletionNotification(string path)
+    {
+        try
+        {
+            string fileName = Path.GetFileName(path);
+            NotificationService.ShowSuccess(
+                Strings.Completed,
+                string.Format(MessageStrings.ExportCompleted_File, fileName),
+                expiration: TimeSpan.FromSeconds(5),
+                onActionButtonClick: () => OpenContainingFolder(path),
+                actionButtonText: Strings.OpenFolder);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to show completion notification.");
+        }
+    }
+
+    public void OpenContainingFolder()
+    {
+        if (!string.IsNullOrEmpty(DestinationFile.Value))
+        {
+            OpenContainingFolder(DestinationFile.Value);
+        }
+    }
+
+    public void PlayOutput()
+    {
+        if (string.IsNullOrEmpty(DestinationFile.Value)) return;
+        OpenWithDefaultApp(DestinationFile.Value);
+    }
+
+    private void OpenContainingFolder(string filePath)
+    {
+        try
+        {
+            string? folder = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrEmpty(folder)) return;
+
+            if (OperatingSystem.IsWindows())
+            {
+                if (File.Exists(filePath))
+                {
+                    var psi = new ProcessStartInfo("explorer.exe") { UseShellExecute = true };
+                    psi.ArgumentList.Add($"/select,{filePath}");
+                    Process.Start(psi);
+                }
+                else
+                {
+                    Process.Start(new ProcessStartInfo(folder) { UseShellExecute = true });
+                }
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                var psi = new ProcessStartInfo("open") { UseShellExecute = false };
+                if (File.Exists(filePath))
+                {
+                    psi.ArgumentList.Add("-R");
+                    psi.ArgumentList.Add(filePath);
+                }
+                else
+                {
+                    psi.ArgumentList.Add(folder);
+                }
+                Process.Start(psi);
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo(folder) { UseShellExecute = true });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to open containing folder for {Path}", filePath);
+        }
+    }
+
+    private void OpenWithDefaultApp(string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath)) return;
+            if (OperatingSystem.IsMacOS())
+            {
+                var psi = new ProcessStartInfo("open") { UseShellExecute = false };
+                psi.ArgumentList.Add(filePath);
+                Process.Start(psi);
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true, Verb = "open" });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to open output file {Path}", filePath);
         }
     }
 

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
@@ -12,16 +12,79 @@
                   d:DesignWidth="800"
                   x:CompileBindings="True"
                   x:DataType="tools:OutputViewModel"
-                  CloseButtonText="{x:Static lang:Strings.Cancel}"
                   mc:Ignorable="d">
     <ui:ContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
     </ui:ContentDialog.Resources>
 
-    <StackPanel Spacing="8">
-        <TextBlock Text="{Binding ProgressText.Value}" />
+    <StackPanel MinWidth="380" Spacing="10">
+        <TextBlock FontWeight="SemiBold" Text="{Binding ProgressMain.Value}" />
+
         <ProgressBar IsIndeterminate="{Binding IsIndeterminate.Value}"
                      Maximum="{Binding ProgressMax.Value}"
                      Value="{Binding ProgressValue.Value}" />
+
+        <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto">
+            <TextBlock Grid.Row="0"
+                       Grid.Column="0"
+                       Margin="0,0,12,0"
+                       Opacity="0.7"
+                       Text="{x:Static lang:Strings.ElapsedTime}" />
+            <TextBlock Grid.Row="0"
+                       Grid.Column="1"
+                       Text="{Binding Elapsed.Value}" />
+            <TextBlock Grid.Row="0"
+                       Grid.Column="2"
+                       Margin="12,0,0,0"
+                       Opacity="0.7"
+                       Text="{x:Static lang:Strings.RemainingTime}" />
+
+            <TextBlock Grid.Row="1"
+                       Grid.Column="0"
+                       Margin="0,0,12,0"
+                       Opacity="0.7"
+                       Text="{x:Static lang:Strings.Frames}" />
+            <TextBlock Grid.Row="1"
+                       Grid.Column="1"
+                       Text="{Binding FrameProgressText.Value}" />
+            <TextBlock Grid.Row="1"
+                       Grid.Column="2"
+                       Margin="12,0,0,0"
+                       Text="{Binding Eta.Value}" />
+
+            <TextBlock Grid.Row="2"
+                       Grid.Column="0"
+                       Margin="0,0,12,0"
+                       Opacity="0.7"
+                       Text="{x:Static lang:Strings.FileSize}" />
+            <StackPanel Grid.Row="2"
+                        Grid.Column="1"
+                        Grid.ColumnSpan="2"
+                        Orientation="Horizontal"
+                        Spacing="6">
+                <TextBlock Text="{Binding CurrentSize.Value}" />
+                <TextBlock Opacity="0.5" Text="/" />
+                <TextBlock Text="{Binding EstimatedSize.Value}" />
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Margin="0,4,0,0"
+                    HorizontalAlignment="Right"
+                    Orientation="Horizontal"
+                    Spacing="8">
+            <Button Click="CancelClick"
+                    Content="{x:Static lang:Strings.Cancel}"
+                    IsVisible="{Binding IsEncoding.Value}" />
+            <Button Click="OpenFolderClick"
+                    Content="{x:Static lang:Strings.OpenFolder}"
+                    IsVisible="{Binding IsCompleted.Value}" />
+            <Button Click="PlayClick"
+                    Classes="accent"
+                    Content="{x:Static lang:Strings.Play}"
+                    IsVisible="{Binding IsCompleted.Value}" />
+            <Button Click="CloseClick"
+                    Content="{x:Static lang:Strings.Close}"
+                    IsVisible="{Binding !IsEncoding.Value}" />
+        </StackPanel>
     </StackPanel>
 </ui:ContentDialog>

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
@@ -6,60 +6,66 @@
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:tools="clr-namespace:Beutl.ViewModels.Tools"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"
-                  xmlns:vm="using:Beutl.ViewModels"
                   Title="{x:Static lang:Strings.Output}"
                   d:DesignHeight="450"
                   d:DesignWidth="800"
                   x:CompileBindings="True"
                   x:DataType="tools:OutputViewModel"
+                  CloseButtonClick="OnCloseButtonClick"
+                  CloseButtonText="{Binding CloseButtonText.Value}"
+                  DefaultButton="Primary"
+                  PrimaryButtonClick="OnPrimaryButtonClick"
+                  PrimaryButtonText="{Binding PrimaryButtonText.Value}"
+                  SecondaryButtonClick="OnSecondaryButtonClick"
+                  SecondaryButtonText="{Binding SecondaryButtonText.Value}"
                   mc:Ignorable="d">
     <ui:ContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
     </ui:ContentDialog.Resources>
 
-    <StackPanel MinWidth="380" Spacing="10">
-        <TextBlock FontWeight="SemiBold" Text="{Binding ProgressMain.Value}" />
+    <StackPanel Spacing="12">
+        <TextBlock FontWeight="SemiBold"
+                   Text="{Binding ProgressMain.Value}"
+                   TextWrapping="Wrap" />
 
         <ProgressBar IsIndeterminate="{Binding IsIndeterminate.Value}"
                      Maximum="{Binding ProgressMax.Value}"
                      Value="{Binding ProgressValue.Value}" />
 
-        <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto">
+        <Grid ColumnDefinitions="Auto,*"
+              ColumnSpacing="12"
+              RowDefinitions="Auto,Auto,Auto,Auto"
+              RowSpacing="6">
             <TextBlock Grid.Row="0"
                        Grid.Column="0"
-                       Margin="0,0,12,0"
                        Opacity="0.7"
                        Text="{x:Static lang:Strings.ElapsedTime}" />
             <TextBlock Grid.Row="0"
                        Grid.Column="1"
                        Text="{Binding Elapsed.Value}" />
-            <TextBlock Grid.Row="0"
-                       Grid.Column="2"
-                       Margin="12,0,0,0"
-                       Opacity="0.7"
-                       Text="{x:Static lang:Strings.RemainingTime}" />
 
             <TextBlock Grid.Row="1"
                        Grid.Column="0"
-                       Margin="0,0,12,0"
                        Opacity="0.7"
-                       Text="{x:Static lang:Strings.Frames}" />
+                       Text="{x:Static lang:Strings.RemainingTime}" />
             <TextBlock Grid.Row="1"
                        Grid.Column="1"
-                       Text="{Binding FrameProgressText.Value}" />
-            <TextBlock Grid.Row="1"
-                       Grid.Column="2"
-                       Margin="12,0,0,0"
                        Text="{Binding Eta.Value}" />
 
             <TextBlock Grid.Row="2"
                        Grid.Column="0"
-                       Margin="0,0,12,0"
+                       Opacity="0.7"
+                       Text="{x:Static lang:Strings.Frames}" />
+            <TextBlock Grid.Row="2"
+                       Grid.Column="1"
+                       Text="{Binding FrameProgressText.Value}" />
+
+            <TextBlock Grid.Row="3"
+                       Grid.Column="0"
                        Opacity="0.7"
                        Text="{x:Static lang:Strings.FileSize}" />
-            <StackPanel Grid.Row="2"
+            <StackPanel Grid.Row="3"
                         Grid.Column="1"
-                        Grid.ColumnSpan="2"
                         Orientation="Horizontal"
                         Spacing="6">
                 <TextBlock Text="{Binding CurrentSize.Value}" />
@@ -67,24 +73,5 @@
                 <TextBlock Text="{Binding EstimatedSize.Value}" />
             </StackPanel>
         </Grid>
-
-        <StackPanel Margin="0,4,0,0"
-                    HorizontalAlignment="Right"
-                    Orientation="Horizontal"
-                    Spacing="8">
-            <Button Click="CancelClick"
-                    Content="{x:Static lang:Strings.Cancel}"
-                    IsVisible="{Binding IsEncoding.Value}" />
-            <Button Click="OpenFolderClick"
-                    Content="{x:Static lang:Strings.OpenFolder}"
-                    IsVisible="{Binding IsCompleted.Value}" />
-            <Button Click="PlayClick"
-                    Classes="accent"
-                    Content="{x:Static lang:Strings.Play}"
-                    IsVisible="{Binding IsCompleted.Value}" />
-            <Button Click="CloseClick"
-                    Content="{x:Static lang:Strings.Close}"
-                    IsVisible="{Binding !IsEncoding.Value}" />
-        </StackPanel>
     </StackPanel>
 </ui:ContentDialog>

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
@@ -13,11 +13,6 @@
                   x:DataType="tools:OutputViewModel"
                   CloseButtonClick="OnCloseButtonClick"
                   CloseButtonText="{Binding CloseButtonText.Value}"
-                  DefaultButton="Primary"
-                  PrimaryButtonClick="OnPrimaryButtonClick"
-                  PrimaryButtonText="{Binding PrimaryButtonText.Value}"
-                  SecondaryButtonClick="OnSecondaryButtonClick"
-                  SecondaryButtonText="{Binding SecondaryButtonText.Value}"
                   mc:Ignorable="d">
     <ui:ContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
@@ -1,4 +1,3 @@
-using Avalonia.Interactivity;
 using Beutl.ViewModels.Tools;
 using FluentAvalonia.UI.Controls;
 
@@ -13,35 +12,29 @@ public partial class OutputProgressDialog : ContentDialog
 
     protected override Type StyleKeyOverride => typeof(ContentDialog);
 
-    private void CancelClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is OutputViewModel vm)
-        {
-            vm.CancelEncode();
-        }
-        Hide();
-    }
-
-    private void OpenFolderClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is OutputViewModel vm)
-        {
-            vm.OpenContainingFolder();
-        }
-    }
-
-    private void PlayClick(object? sender, RoutedEventArgs e)
+    private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
         if (DataContext is OutputViewModel vm)
         {
             vm.PlayOutput();
         }
-
-        Hide();
     }
 
-    private void CloseClick(object? sender, RoutedEventArgs e)
+    private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        Hide();
+        if (DataContext is OutputViewModel vm)
+        {
+            vm.OpenContainingFolder();
+        }
+
+        args.Cancel = true;
+    }
+
+    private void OnCloseButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        if (DataContext is OutputViewModel vm && vm.IsEncoding.Value)
+        {
+            vm.CancelEncode();
+        }
     }
 }

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.ViewModels.Tools;
+using Avalonia.Interactivity;
+using Beutl.ViewModels.Tools;
 using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
@@ -12,10 +13,35 @@ public partial class OutputProgressDialog : ContentDialog
 
     protected override Type StyleKeyOverride => typeof(ContentDialog);
 
-    protected override void OnCloseButtonClick(ContentDialogButtonClickEventArgs args)
+    private void CancelClick(object? sender, RoutedEventArgs e)
     {
-        base.OnCloseButtonClick(args);
-        if (DataContext is not OutputViewModel vm) return;
-        vm.CancelEncode();
+        if (DataContext is OutputViewModel vm)
+        {
+            vm.CancelEncode();
+        }
+        Hide();
+    }
+
+    private void OpenFolderClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OutputViewModel vm)
+        {
+            vm.OpenContainingFolder();
+        }
+    }
+
+    private void PlayClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OutputViewModel vm)
+        {
+            vm.PlayOutput();
+        }
+
+        Hide();
+    }
+
+    private void CloseClick(object? sender, RoutedEventArgs e)
+    {
+        Hide();
     }
 }

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
@@ -12,24 +12,6 @@ public partial class OutputProgressDialog : ContentDialog
 
     protected override Type StyleKeyOverride => typeof(ContentDialog);
 
-    private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-    {
-        if (DataContext is OutputViewModel vm)
-        {
-            vm.PlayOutput();
-        }
-    }
-
-    private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-    {
-        if (DataContext is OutputViewModel vm)
-        {
-            vm.OpenContainingFolder();
-        }
-
-        args.Cancel = true;
-    }
-
     private void OnCloseButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
         if (DataContext is OutputViewModel vm && vm.IsEncoding.Value)

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
@@ -1,4 +1,4 @@
-using Beutl.ViewModels.Tools;
+﻿using Beutl.ViewModels.Tools;
 using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;

--- a/src/Beutl/Views/Tools/OutputView.axaml
+++ b/src/Beutl/Views/Tools/OutputView.axaml
@@ -13,13 +13,21 @@
              mc:Ignorable="d">
     <StackPanel Spacing="4">
         <Grid Margin="4" ColumnDefinitions="*,Auto">
-            <StackPanel Spacing="8">
+            <StackPanel Spacing="6">
                 <TextBlock Margin="0,8,0,0" Text="{Binding ProgressText.Value}" />
-                <ProgressBar Grid.Row="2"
-                             Margin="0,0,8,0"
+                <ProgressBar Margin="0,0,8,0"
                              IsIndeterminate="{Binding IsIndeterminate.Value}"
                              Maximum="{Binding ProgressMax.Value}"
                              Value="{Binding ProgressValue.Value}" />
+                <StackPanel IsVisible="{Binding IsEncoding.Value}"
+                            Orientation="Horizontal"
+                            Spacing="12">
+                    <TextBlock Opacity="0.7" Text="{Binding Elapsed.Value, StringFormat={}{0}}" />
+                    <TextBlock Opacity="0.5" Text="/" />
+                    <TextBlock Text="{Binding Eta.Value}" />
+                    <TextBlock Opacity="0.5" Text="|" />
+                    <TextBlock Text="{Binding FrameProgressText.Value}" />
+                </StackPanel>
             </StackPanel>
             <Button Grid.Column="1"
                     VerticalAlignment="Bottom"

--- a/src/Beutl/Views/Tools/OutputView.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputView.axaml.cs
@@ -39,6 +39,9 @@ public partial class OutputView : UserControl
         var dialog = new OutputProgressDialog { DataContext = viewModel };
         _ = dialog.ShowAsync();
         await viewModel.StartEncode();
-        dialog.Hide();
+        if (viewModel.WasCancelled.Value)
+        {
+            dialog.Hide();
+        }
     }
 }


### PR DESCRIPTION
## Description
- Surface ETA, elapsed time, frame count, and current/estimated file size in both the export progress dialog and the inline output view so users can gauge encoding progress at a glance.
- Show a success toast with an "Open folder" action on completion, and automatically clean up the partial output file when the user cancels.
- Streamline the progress dialog by binding to the built-in ContentDialog Close button with a state-driven label (Cancel while encoding, Close once finished) instead of overriding handlers.

## Breaking changes
None

## Fixed issues
None