### PR TITLE
feat: Add false color and zebra scopes to color scopes tab

### DIFF
--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopeType.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopeType.cs
@@ -4,5 +4,7 @@ public enum ColorScopeType
 {
     Waveform,
     Histogram,
-    Vectorscope
+    Vectorscope,
+    FalseColor,
+    Zebra
 }

--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
@@ -55,6 +55,16 @@ public sealed class ColorScopesTabViewModel : IToolContext
 
     public ReactivePropertySlim<float> HistogramHdrRange { get; } = new(1.0f);
 
+    // False Color settings
+    public ReactivePropertySlim<float> FalseColorHdrRange { get; } = new(1.0f);
+
+    // Zebra settings
+    public ReactivePropertySlim<float> ZebraHighThreshold { get; } = new(0.95f);
+
+    public ReactivePropertySlim<float> ZebraLowThreshold { get; } = new(0.03f);
+
+    public ReactivePropertySlim<float> ZebraHdrRange { get; } = new(1.0f);
+
     // Shared settings
     public ReactivePropertySlim<ScopeColorSpace> ColorSpace { get; } = new(ScopeColorSpace.Gamma);
 
@@ -114,6 +124,40 @@ public sealed class ColorScopesTabViewModel : IToolContext
             }
         }
 
+        // False Color settings
+        if (json.TryGetPropertyValue("falseColorHdrRange", out var falseColorHdrNode) && falseColorHdrNode is JsonValue falseColorHdrValue)
+        {
+            if (falseColorHdrValue.TryGetValue(out float falseColorHdr) && falseColorHdr >= 0.01f)
+            {
+                FalseColorHdrRange.Value = falseColorHdr;
+            }
+        }
+
+        // Zebra settings
+        if (json.TryGetPropertyValue("zebraHighThreshold", out var zebraHighNode) && zebraHighNode is JsonValue zebraHighValue)
+        {
+            if (zebraHighValue.TryGetValue(out float zebraHigh))
+            {
+                ZebraHighThreshold.Value = Math.Clamp(zebraHigh, 0f, 1f);
+            }
+        }
+
+        if (json.TryGetPropertyValue("zebraLowThreshold", out var zebraLowNode) && zebraLowNode is JsonValue zebraLowValue)
+        {
+            if (zebraLowValue.TryGetValue(out float zebraLow))
+            {
+                ZebraLowThreshold.Value = Math.Clamp(zebraLow, 0f, 1f);
+            }
+        }
+
+        if (json.TryGetPropertyValue("zebraHdrRange", out var zebraHdrNode) && zebraHdrNode is JsonValue zebraHdrValue)
+        {
+            if (zebraHdrValue.TryGetValue(out float zebraHdr) && zebraHdr >= 0.01f)
+            {
+                ZebraHdrRange.Value = zebraHdr;
+            }
+        }
+
         // Shared settings
         if (json.TryGetPropertyValue("colorSpace", out var colorSpaceNode) && colorSpaceNode is JsonValue colorSpaceValue)
         {
@@ -135,6 +179,14 @@ public sealed class ColorScopesTabViewModel : IToolContext
         // Histogram settings
         json["histogramMode"] = (int)HistogramMode.Value;
         json["histogramHdrRange"] = HistogramHdrRange.Value;
+
+        // False Color settings
+        json["falseColorHdrRange"] = FalseColorHdrRange.Value;
+
+        // Zebra settings
+        json["zebraHighThreshold"] = ZebraHighThreshold.Value;
+        json["zebraLowThreshold"] = ZebraLowThreshold.Value;
+        json["zebraHdrRange"] = ZebraHdrRange.Value;
 
         // Shared settings
         json["colorSpace"] = (int)ColorSpace.Value;

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
@@ -2,6 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.FluentAvalonia"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:scopes="using:Beutl.Editor.Components.ColorScopesTab.Views.Scopes"
@@ -12,7 +13,7 @@
              x:DataType="viewModels:ColorScopesTabViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <Grid Height="32" ColumnDefinitions="Auto,Auto,Auto">
+        <Grid Height="32" ColumnDefinitions="Auto,Auto,Auto,Auto">
             <ComboBox Grid.Column="0"
                       Margin="8,0,0,0"
                       HorizontalAlignment="Stretch"
@@ -22,6 +23,8 @@
                 <ComboBoxItem Content="{x:Static lang:Strings.Waveform}" />
                 <ComboBoxItem Content="{x:Static lang:Strings.Histogram}" />
                 <ComboBoxItem Content="{x:Static lang:Strings.Vectorscope}" />
+                <ComboBoxItem Content="{x:Static lang:Strings.FalseColor}" />
+                <ComboBoxItem Content="{x:Static lang:Strings.Zebra}" />
             </ComboBox>
 
             <Grid Grid.Column="1"
@@ -49,7 +52,84 @@
                 </ComboBox>
             </Grid>
 
-            <ComboBox Grid.Column="2"
+            <Button Grid.Column="2"
+                    Margin="8,0,0,0"
+                    VerticalAlignment="Center"
+                    IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Zebra}"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="{x:Static lang:Strings.Settings}">
+                <icons:SymbolIcon Symbol="Settings" />
+                <Button.Flyout>
+                    <Flyout Placement="Bottom">
+                        <Flyout.FlyoutPresenterTheme>
+                            <ControlTheme BasedOn="{StaticResource {x:Type FlyoutPresenter}}"
+                                          TargetType="FlyoutPresenter">
+                                <Setter Property="Padding" Value="0" />
+                            </ControlTheme>
+                        </Flyout.FlyoutPresenterTheme>
+
+                        <StackPanel Width="288">
+                            <StackPanel.Styles>
+                                <Style Selector="TextBlock.section">
+                                    <Setter Property="Theme" Value="{StaticResource BodyStrongTextBlockStyle}" />
+                                    <Setter Property="FontSize" Value="13" />
+                                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                                    <Setter Property="Margin" Value="0,0,0,4" />
+                                </Style>
+                                <Style Selector="TextBlock.field">
+                                    <Setter Property="VerticalAlignment" Value="Center" />
+                                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+                                </Style>
+                            </StackPanel.Styles>
+
+                            <!--  Header  -->
+                            <Border Padding="16,12,16,12">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <icons:SymbolIcon VerticalAlignment="Center"
+                                                      FontSize="16"
+                                                      Symbol="Settings" />
+                                    <TextBlock VerticalAlignment="Center"
+                                               Text="{x:Static lang:Strings.Zebra}"
+                                               Theme="{StaticResource BodyStrongTextBlockStyle}" />
+                                </StackPanel>
+                            </Border>
+                            <Separator Height="1" Margin="0" />
+
+                            <StackPanel Margin="16,12,16,12" Spacing="10">
+                                <TextBlock Classes="section" Text="{x:Static lang:Strings.Threshold}" />
+
+                                <Grid ColumnDefinitions="92,*"
+                                      ColumnSpacing="12"
+                                      RowDefinitions="Auto,Auto"
+                                      RowSpacing="8">
+                                    <TextBlock Classes="field" Text="{x:Static lang:Strings.ZebraHighThreshold}" />
+                                    <NumericUpDown Grid.Column="1"
+                                                   HorizontalAlignment="Stretch"
+                                                   FormatString="F2"
+                                                   Increment="0.01"
+                                                   Maximum="1"
+                                                   Minimum="0"
+                                                   Value="{Binding ZebraHighThreshold.Value, Mode=TwoWay}" />
+
+                                    <TextBlock Grid.Row="1"
+                                               Classes="field"
+                                               Text="{x:Static lang:Strings.ZebraLowThreshold}" />
+                                    <NumericUpDown Grid.Row="1"
+                                                   Grid.Column="1"
+                                                   HorizontalAlignment="Stretch"
+                                                   FormatString="F2"
+                                                   Increment="0.01"
+                                                   Maximum="1"
+                                                   Minimum="0"
+                                                   Value="{Binding ZebraLowThreshold.Value, Mode=TwoWay}" />
+                                </Grid>
+                            </StackPanel>
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+
+            <ComboBox Grid.Column="3"
                       Margin="8,0,0,0"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Center"
@@ -88,6 +168,22 @@
                                        IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Vectorscope}"
                                        LabelBrush="{StaticResource ColorScopeLabelBrush}"
                                        SourceBitmap="{Binding SourceBitmap.Value}" />
+
+            <scopes:FalseColorControl x:Name="FalseColorControl"
+                                      BackgroundBrush="{StaticResource ColorScopeBackgroundBrush}"
+                                      ColorSpace="{Binding ColorSpace.Value}"
+                                      HdrRange="{Binding FalseColorHdrRange.Value, Mode=TwoWay}"
+                                      IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=FalseColor}"
+                                      SourceBitmap="{Binding SourceBitmap.Value}" />
+
+            <scopes:ZebraControl x:Name="ZebraControl"
+                                 BackgroundBrush="{StaticResource ColorScopeBackgroundBrush}"
+                                 ColorSpace="{Binding ColorSpace.Value}"
+                                 HdrRange="{Binding ZebraHdrRange.Value, Mode=TwoWay}"
+                                 HighThreshold="{Binding ZebraHighThreshold.Value}"
+                                 IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Zebra}"
+                                 LowThreshold="{Binding ZebraLowThreshold.Value}"
+                                 SourceBitmap="{Binding SourceBitmap.Value}" />
         </Panel>
     </Grid>
 </UserControl>

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml.cs
@@ -44,6 +44,12 @@ public partial class ColorScopesTabView : UserControl
             case ColorScopeType.Vectorscope:
                 VectorscopeControl?.Refresh();
                 break;
+            case ColorScopeType.FalseColor:
+                FalseColorControl?.Refresh();
+                break;
+            case ColorScopeType.Zebra:
+                ZebraControl?.Refresh();
+                break;
         }
     }
 }

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/FalseColorControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/FalseColorControl.cs
@@ -1,0 +1,121 @@
+﻿using Avalonia;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Beutl.Editor.Components.ColorScopesTab.ViewModels;
+using Beutl.Media;
+using Beutl.Media.Pixel;
+using BtlBitmap = Beutl.Media.Bitmap;
+using PixelSize = Avalonia.PixelSize;
+
+namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;
+
+/// <summary>
+/// Renders the source frame as a 9-band false-color (thermal) exposure map.
+/// </summary>
+public sealed class FalseColorControl : ImageOverlayScopeBase
+{
+    static FalseColorControl()
+    {
+    }
+
+    protected override Orientation DragAxis => Orientation.Vertical;
+
+    protected override unsafe WriteableBitmap? RenderImage(BtlBitmap source, WriteableBitmap? existing)
+    {
+        int sourceWidth = source.Width;
+        int sourceHeight = source.Height;
+        if (sourceWidth <= 0 || sourceHeight <= 0)
+            return existing;
+
+        WriteableBitmap result =
+            existing?.PixelSize.Width == sourceWidth && existing.PixelSize.Height == sourceHeight
+                ? existing
+                : new WriteableBitmap(
+                    new PixelSize(sourceWidth, sourceHeight),
+                    new Vector(96, 96),
+                    PixelFormat.Bgra8888,
+                    AlphaFormat.Premul);
+
+        bool linear = ColorSpace == ScopeColorSpace.Linear;
+        BitmapColorSpace targetColorSpace = linear ? BitmapColorSpace.LinearSrgb : BitmapColorSpace.Srgb;
+        float invHdr = 1f / MathF.Max(HdrRange, 1e-6f);
+
+        BtlBitmap rgbaF16;
+        bool requireDispose = false;
+        if (source.ColorType == BitmapColorType.RgbaF16 && source.ColorSpace == targetColorSpace)
+        {
+            rgbaF16 = source;
+        }
+        else
+        {
+            rgbaF16 = source.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, targetColorSpace);
+            requireDispose = true;
+        }
+
+        try
+        {
+            using ILockedFramebuffer fb = result.Lock();
+            byte* destPtr = (byte*)fb.Address;
+            int destRowBytes = fb.RowBytes;
+            byte* srcData = (byte*)rgbaF16.Data;
+            int srcRowBytes = rgbaF16.RowBytes;
+            bool premul = rgbaF16.AlphaType == BitmapAlphaType.Premul;
+
+            Parallel.For(0, sourceHeight, y =>
+            {
+                RgbaF16* srcRow = (RgbaF16*)(srcData + (long)y * srcRowBytes);
+                byte* destRow = destPtr + (long)y * destRowBytes;
+
+                for (int x = 0; x < sourceWidth; x++)
+                {
+                    RgbaF16 pixel = srcRow[x];
+                    float r = (float)pixel.R;
+                    float g = (float)pixel.G;
+                    float b = (float)pixel.B;
+                    float a = (float)pixel.A;
+
+                    if (premul && a > 0f && a < 1f)
+                    {
+                        float invA = 1f / a;
+                        r *= invA;
+                        g *= invA;
+                        b *= invA;
+                    }
+
+                    float luma = 0.2126f * r + 0.7152f * g + 0.0722f * b;
+                    float yNorm = Math.Clamp(luma * invHdr, 0f, 1f);
+
+                    (float fr, float fg, float fb) = FalseColorRamp(yNorm);
+
+                    int idx = x * 4;
+                    destRow[idx + 0] = (byte)(Math.Clamp(fb, 0f, 1f) * 255f);
+                    destRow[idx + 1] = (byte)(Math.Clamp(fg, 0f, 1f) * 255f);
+                    destRow[idx + 2] = (byte)(Math.Clamp(fr, 0f, 1f) * 255f);
+                    destRow[idx + 3] = 255;
+                }
+            });
+        }
+        finally
+        {
+            if (requireDispose)
+                rgbaF16.Dispose();
+        }
+
+        return result;
+    }
+
+    // Mirrors the GPU shader ramp in PlayerView (BitmapView/HdrBitmapView).
+    private static (float R, float G, float B) FalseColorRamp(float y)
+    {
+        if (y >= 0.999f) return (1.0f, 1.0f, 1.0f);
+        if (y >= 0.97f) return (1.0f, 0.0f, 0.0f);
+        if (y >= 0.84f) return (1.0f, 0.55f, 0.0f);
+        if (y >= 0.78f) return (1.0f, 1.0f, 0.0f);
+        if (y >= 0.56f) return (0.5f, 0.5f, 0.5f);
+        if (y >= 0.52f) return (1.0f, 0.6f, 0.7f);
+        if (y >= 0.38f) return (0.0f, 0.85f, 0.0f);
+        if (y >= 0.025f) return (0.0f, 0.3f, 1.0f);
+        return (0.4f, 0.0f, 0.6f);
+    }
+}

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HdrScopeControlBase.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/HdrScopeControlBase.cs
@@ -136,12 +136,15 @@ public abstract class HdrScopeControlBase : ScopeControlBase
     public override void Render(DrawingContext context)
     {
         base.Render(context);
+        RenderHdrOverlayText(context);
+    }
 
+    protected void RenderHdrOverlayText(DrawingContext context)
+    {
         if (_overlayText == null)
             return;
 
         var bounds = Bounds;
-        double axisMargin = AxisMargin;
 
         var formattedText = new FormattedText(
             _overlayText,

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ImageOverlayScopeBase.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ImageOverlayScopeBase.cs
@@ -1,0 +1,70 @@
+﻿using Avalonia;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using BtlBitmap = Beutl.Media.Bitmap;
+
+namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;
+
+/// <summary>
+/// Base for scopes that render an output image preserving the source aspect ratio,
+/// without axis labels (used by False Color and Zebra exposure visualizers).
+/// </summary>
+public abstract class ImageOverlayScopeBase : HdrScopeControlBase
+{
+    protected ImageOverlayScopeBase()
+    {
+        AxisMargin = 0;
+    }
+
+    protected sealed override string[]? VerticalAxisLabels => null;
+
+    protected sealed override string[]? HorizontalAxisLabels => null;
+
+    protected abstract WriteableBitmap? RenderImage(BtlBitmap source, WriteableBitmap? existing);
+
+    protected sealed override WriteableBitmap? RenderScope(
+        BtlBitmap sourceBitmap,
+        int targetWidth,
+        int targetHeight,
+        WriteableBitmap? existingBitmap)
+    {
+        // Render at the source's native resolution; the View applies Stretch.Uniform on draw.
+        return RenderImage(sourceBitmap, existingBitmap);
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        var bounds = Bounds;
+
+        var bgBrush = BackgroundBrush;
+        if (bgBrush != null)
+        {
+            context.FillRectangle(bgBrush, new Rect(0, 0, bounds.Width, bounds.Height));
+        }
+
+        var bitmap = RenderedBitmap;
+        if (bitmap != null && bounds.Width > 0 && bounds.Height > 0)
+        {
+            var pixelSize = bitmap.PixelSize;
+            if (pixelSize.Width > 0 && pixelSize.Height > 0)
+            {
+                var sourceSize = new Size(pixelSize.Width, pixelSize.Height);
+                double scale = Math.Min(bounds.Width / sourceSize.Width, bounds.Height / sourceSize.Height);
+                if (scale > 0)
+                {
+                    var scaledSize = sourceSize * scale;
+                    var destRect = new Rect(bounds.Size).CenterRect(new Rect(scaledSize));
+                    using (context.PushRenderOptions(new RenderOptions
+                    {
+                        BitmapInterpolationMode = BitmapInterpolationMode.HighQuality
+                    }))
+                    {
+                        context.DrawImage(bitmap, destRect);
+                    }
+                }
+            }
+        }
+
+        RenderHdrOverlayText(context);
+    }
+}

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ZebraControl.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/Scopes/ZebraControl.cs
@@ -1,0 +1,196 @@
+﻿using Avalonia;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Beutl.Editor.Components.ColorScopesTab.ViewModels;
+using Beutl.Media;
+using Beutl.Media.Pixel;
+using BtlBitmap = Beutl.Media.Bitmap;
+using PixelSize = Avalonia.PixelSize;
+
+namespace Beutl.Editor.Components.ColorScopesTab.Views.Scopes;
+
+/// <summary>
+/// Renders the source frame with diagonal zebra stripes drawn over pixels whose luma exceeds
+/// the high threshold or falls below the low threshold (exposure check).
+/// </summary>
+public sealed class ZebraControl : ImageOverlayScopeBase
+{
+    public static readonly DirectProperty<ZebraControl, float> HighThresholdProperty =
+        AvaloniaProperty.RegisterDirect<ZebraControl, float>(
+            nameof(HighThreshold), o => o.HighThreshold, (o, v) => o.HighThreshold = v, 0.95f);
+
+    public static readonly DirectProperty<ZebraControl, float> LowThresholdProperty =
+        AvaloniaProperty.RegisterDirect<ZebraControl, float>(
+            nameof(LowThreshold), o => o.LowThreshold, (o, v) => o.LowThreshold = v, 0.03f);
+
+    private float _highThreshold = 0.95f;
+    private float _lowThreshold = 0.03f;
+
+    private const int StripePeriod = 8;
+
+    static ZebraControl()
+    {
+        AffectsRender<ZebraControl>(HighThresholdProperty, LowThresholdProperty);
+        HighThresholdProperty.Changed.AddClassHandler<ZebraControl>((o, _) => o.Refresh());
+        LowThresholdProperty.Changed.AddClassHandler<ZebraControl>((o, _) => o.Refresh());
+    }
+
+    protected override Orientation DragAxis => Orientation.Vertical;
+
+    public float HighThreshold
+    {
+        get => _highThreshold;
+        set => SetAndRaise(HighThresholdProperty, ref _highThreshold, Math.Clamp(value, 0f, 1f));
+    }
+
+    public float LowThreshold
+    {
+        get => _lowThreshold;
+        set => SetAndRaise(LowThresholdProperty, ref _lowThreshold, Math.Clamp(value, 0f, 1f));
+    }
+
+    protected override unsafe WriteableBitmap? RenderImage(BtlBitmap source, WriteableBitmap? existing)
+    {
+        int sourceWidth = source.Width;
+        int sourceHeight = source.Height;
+        if (sourceWidth <= 0 || sourceHeight <= 0)
+            return existing;
+
+        WriteableBitmap result =
+            existing?.PixelSize.Width == sourceWidth && existing.PixelSize.Height == sourceHeight
+                ? existing
+                : new WriteableBitmap(
+                    new PixelSize(sourceWidth, sourceHeight),
+                    new Vector(96, 96),
+                    PixelFormat.Bgra8888,
+                    AlphaFormat.Premul);
+
+        bool linear = ColorSpace == ScopeColorSpace.Linear;
+        // Source for luma calculation (linear or gamma).
+        BitmapColorSpace lumaColorSpace = linear ? BitmapColorSpace.LinearSrgb : BitmapColorSpace.Srgb;
+        // Source for display output (always sRGB display).
+        BitmapColorSpace displayColorSpace = BitmapColorSpace.Srgb;
+        float invHdr = 1f / MathF.Max(HdrRange, 1e-6f);
+        float high = _highThreshold;
+        float low = _lowThreshold;
+
+        BtlBitmap lumaBitmap;
+        bool disposeLuma = false;
+        if (source.ColorType == BitmapColorType.RgbaF16 && source.ColorSpace == lumaColorSpace)
+        {
+            lumaBitmap = source;
+        }
+        else
+        {
+            lumaBitmap = source.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, lumaColorSpace);
+            disposeLuma = true;
+        }
+
+        BtlBitmap displayBitmap;
+        bool disposeDisplay = false;
+        if (source.ColorType == BitmapColorType.RgbaF16 && source.ColorSpace == displayColorSpace)
+        {
+            displayBitmap = source;
+        }
+        else if (lumaBitmap.ColorSpace == displayColorSpace && lumaBitmap.ColorType == BitmapColorType.RgbaF16)
+        {
+            displayBitmap = lumaBitmap;
+        }
+        else
+        {
+            displayBitmap = source.Convert(BitmapColorType.RgbaF16, BitmapAlphaType.Unpremul, displayColorSpace);
+            disposeDisplay = true;
+        }
+
+        try
+        {
+            using ILockedFramebuffer fb = result.Lock();
+            byte* destPtr = (byte*)fb.Address;
+            int destRowBytes = fb.RowBytes;
+
+            byte* lumaData = (byte*)lumaBitmap.Data;
+            int lumaRowBytes = lumaBitmap.RowBytes;
+            bool lumaPremul = lumaBitmap.AlphaType == BitmapAlphaType.Premul;
+
+            byte* displayData = (byte*)displayBitmap.Data;
+            int displayRowBytes = displayBitmap.RowBytes;
+            bool displayPremul = displayBitmap.AlphaType == BitmapAlphaType.Premul;
+
+            Parallel.For(0, sourceHeight, y =>
+            {
+                RgbaF16* lumaRow = (RgbaF16*)(lumaData + (long)y * lumaRowBytes);
+                RgbaF16* dispRow = (RgbaF16*)(displayData + (long)y * displayRowBytes);
+                byte* destRow = destPtr + (long)y * destRowBytes;
+
+                for (int x = 0; x < sourceWidth; x++)
+                {
+                    RgbaF16 lumaPixel = lumaRow[x];
+                    float lr = (float)lumaPixel.R;
+                    float lg = (float)lumaPixel.G;
+                    float lb = (float)lumaPixel.B;
+                    float la = (float)lumaPixel.A;
+                    if (lumaPremul && la > 0f && la < 1f)
+                    {
+                        float invA = 1f / la;
+                        lr *= invA;
+                        lg *= invA;
+                        lb *= invA;
+                    }
+                    float luma = 0.2126f * lr + 0.7152f * lg + 0.0722f * lb;
+                    float yNorm = Math.Clamp(luma * invHdr, 0f, 1f);
+
+                    RgbaF16 dispPixel = dispRow[x];
+                    float dr = (float)dispPixel.R;
+                    float dg = (float)dispPixel.G;
+                    float db = (float)dispPixel.B;
+                    float da = (float)dispPixel.A;
+                    if (displayPremul && da > 0f && da < 1f)
+                    {
+                        float invA = 1f / da;
+                        dr *= invA;
+                        dg *= invA;
+                        db *= invA;
+                    }
+
+                    bool over = yNorm >= high;
+                    bool under = yNorm <= low;
+                    if (over || under)
+                    {
+                        int phase = ((x + y) % StripePeriod) * 2 < StripePeriod ? 0 : 1;
+                        if (over)
+                        {
+                            // Black/white stripes for over-exposure.
+                            float v = phase;
+                            dr = v;
+                            dg = v;
+                            db = v;
+                        }
+                        else
+                        {
+                            // Red/black stripes for under-exposure.
+                            dr = phase;
+                            dg = 0f;
+                            db = 0f;
+                        }
+                    }
+
+                    int idx = x * 4;
+                    destRow[idx + 0] = (byte)(Math.Clamp(db, 0f, 1f) * 255f);
+                    destRow[idx + 1] = (byte)(Math.Clamp(dg, 0f, 1f) * 255f);
+                    destRow[idx + 2] = (byte)(Math.Clamp(dr, 0f, 1f) * 255f);
+                    destRow[idx + 3] = 255;
+                }
+            });
+        }
+        finally
+        {
+            if (disposeLuma)
+                lumaBitmap.Dispose();
+            if (disposeDisplay)
+                displayBitmap.Dispose();
+        }
+
+        return result;
+    }
+}

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -793,6 +793,21 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="Waveform" xml:space="preserve">
     <value>ウェーブフォーム</value>
   </data>
+  <data name="FalseColor" xml:space="preserve">
+    <value>フォルスカラー</value>
+  </data>
+  <data name="Zebra" xml:space="preserve">
+    <value>ゼブラ</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>閾値</value>
+  </data>
+  <data name="ZebraHighThreshold" xml:space="preserve">
+    <value>上限</value>
+  </data>
+  <data name="ZebraLowThreshold" xml:space="preserve">
+    <value>下限</value>
+  </data>
   <data name="Spectrum" xml:space="preserve">
     <value>スペクトラム</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -798,6 +798,21 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="Waveform" xml:space="preserve">
     <value>Waveform</value>
   </data>
+  <data name="FalseColor" xml:space="preserve">
+    <value>False Color</value>
+  </data>
+  <data name="Zebra" xml:space="preserve">
+    <value>Zebra</value>
+  </data>
+  <data name="Threshold" xml:space="preserve">
+    <value>Threshold</value>
+  </data>
+  <data name="ZebraHighThreshold" xml:space="preserve">
+    <value>High</value>
+  </data>
+  <data name="ZebraLowThreshold" xml:space="preserve">
+    <value>Low</value>
+  </data>
   <data name="Spectrum" xml:space="preserve">
     <value>Spectrum</value>
   </data>


### PR DESCRIPTION
## Description

- Add a False Color scope that overlays exposure-based colors on the preview to make under/over-exposed regions easy to spot.
- Add a Zebra scope with configurable high/low thresholds to highlight clipped highlights and crushed shadows.
- Both scopes support HDR range configuration so they remain useful when working with HDR sources.

## Breaking changes

None

## Fixed issues

None