### PR TITLE
feat: add razor tool for splitting clips on the timeline

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -75,6 +75,15 @@ public sealed class TimelineTabExtension : ToolTabExtension
             new ContextCommandKeyGesture("Ctrl+G"),
             new ContextCommandKeyGesture("Cmd+G", OSPlatform.OSX),
         ]),
+        new ContextCommandDefinition("ToggleRazorMode", Strings.RazorTool, Strings.RazorTool_Description,
+        [
+            new ContextCommandKeyGesture("C"),
+        ]),
+        new ContextCommandDefinition("ExitRazorMode", Strings.ExitRazorTool, Strings.ExitRazorTool_Description,
+        [
+            new ContextCommandKeyGesture("V"),
+            new ContextCommandKeyGesture("Escape"),
+        ]),
     ];
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -655,6 +655,11 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         SplitCore([this], timeSpan);
     }
 
+    internal void SplitAt(IReadOnlyList<ElementViewModel> targets, TimeSpan timeSpan)
+    {
+        SplitCore(targets, timeSpan);
+    }
+
     private void OnSplit(TimeSpan timeSpan)
     {
         IReadOnlyList<ElementViewModel> targets = GetGroupOrSelectedElements();

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -650,6 +650,11 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         }
     }
 
+    public void SplitAt(TimeSpan timeSpan)
+    {
+        SplitCore([this], timeSpan);
+    }
+
     private void OnSplit(TimeSpan timeSpan)
     {
         IReadOnlyList<ElementViewModel> targets = GetGroupOrSelectedElements();
@@ -658,6 +663,11 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             targets = [this];
         }
 
+        SplitCore(targets, timeSpan);
+    }
+
+    private void SplitCore(IReadOnlyList<ElementViewModel> targets, TimeSpan timeSpan)
+    {
         int rate = Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
         TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
         TimeSpan absTime = timeSpan.RoundToRate(rate);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
@@ -1099,7 +1100,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
                 }
 
                 break;
-            case "ToggleRazorMode":
+            case "ToggleRazorMode" when execution.KeyEventArgs?.Source is not TextBox:
                 IsRazorMode.Value = !IsRazorMode.Value;
                 if (execution.KeyEventArgs != null)
                 {
@@ -1107,7 +1108,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
                 }
 
                 break;
-            case "ExitRazorMode":
+            case "ExitRazorMode" when execution.KeyEventArgs?.Source is not TextBox:
                 if (IsRazorMode.Value)
                 {
                     IsRazorMode.Value = false;
@@ -1127,10 +1128,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
             ? Elements.Where(e => e.Model.Range.Contains(time)).ToArray()
             : Elements.Where(e => e.Model.Range.Contains(time) && e.Model.ZIndex == CalculateClickedLayer()).ToArray();
 
-        foreach (ElementViewModel target in targets)
+        if (targets.Count == 0)
         {
-            target.SplitAt(time);
+            return;
         }
+
+        targets[0].SplitAt(targets, time);
     }
 
     private sealed class TrackedLayerTopObservable(int layerNum, TimelineTabViewModel timeline)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -364,7 +364,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
 
     public HashSet<ElementViewModel> SelectedElements { get; } = [];
 
-
+    public ReactivePropertySlim<bool> IsRazorMode { get; } = new();
 
     public ToolTabExtension Extension => TimelineTabExtension.Instance;
 
@@ -1099,6 +1099,37 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
                 }
 
                 break;
+            case "ToggleRazorMode":
+                IsRazorMode.Value = !IsRazorMode.Value;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "ExitRazorMode":
+                if (IsRazorMode.Value)
+                {
+                    IsRazorMode.Value = false;
+                    if (execution.KeyEventArgs != null)
+                    {
+                        execution.KeyEventArgs.Handled = true;
+                    }
+                }
+
+                break;
+        }
+    }
+
+    public void RazorSplitAt(TimeSpan time, bool acrossAllLayers)
+    {
+        IReadOnlyList<ElementViewModel> targets = acrossAllLayers
+            ? Elements.Where(e => e.Model.Range.Contains(time)).ToArray()
+            : Elements.Where(e => e.Model.Range.Contains(time) && e.Model.ZIndex == CalculateClickedLayer()).ToArray();
+
+        foreach (ElementViewModel target in targets)
+        {
+            target.SplitAt(time);
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -59,6 +59,15 @@
                         </Style>
                     </ui:ToggleMenuFlyoutItem.Styles>
                 </ui:ToggleMenuFlyoutItem>
+                <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRazorMode.Value, Mode=TwoWay}"
+                                         InputGesture="{h:GetCommandGesture ToggleRazorMode,
+                                                                            ExtensionType={x:Type p:TimelineTabExtension}}"
+                                         Text="{x:Static lang:Strings.RazorTool}">
+                    <ui:ToggleMenuFlyoutItem.IconSource>
+                        <icons:SymbolIconSource Symbol="Cut" />
+                    </ui:ToggleMenuFlyoutItem.IconSource>
+                </ui:ToggleMenuFlyoutItem>
+                <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutItem Command="{Binding Split}" Text="{x:Static lang:Strings.Split}">
                     <ui:MenuFlyoutItem.IconSource>
                         <icons:SymbolIconSource Symbol="SplitVertical" />

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -391,6 +391,11 @@ public sealed partial class ElementView : UserControl
         {
             if (AssociatedObject is { _timeline: not null, ViewModel: { } viewModel } view)
             {
+                if (viewModel.Timeline.IsRazorMode.Value)
+                {
+                    return;
+                }
+
                 PointerPoint point = e.GetCurrentPoint(view.border);
                 if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
@@ -492,6 +497,13 @@ public sealed partial class ElementView : UserControl
         {
             if (AssociatedObject is { border: { } border, ViewModel: { } viewModel } view)
             {
+                if (viewModel.Timeline.IsRazorMode.Value)
+                {
+                    view.Cursor = Cursors.Cross;
+                    _resizeType = AlignmentX.Center;
+                    return;
+                }
+
                 if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Alt))
                 {
                     view.Cursor = null;
@@ -594,8 +606,13 @@ public sealed partial class ElementView : UserControl
 
         private void OnBorderPointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (AssociatedObject is { _timeline: { }, border: { } border } view)
+            if (AssociatedObject is { _timeline: { }, border: { }, ViewModel: { } viewModel } view)
             {
+                if (viewModel.Timeline.IsRazorMode.Value)
+                {
+                    return;
+                }
+
                 PointerPoint point = e.GetCurrentPoint(view.border);
                 if (point.Properties.IsLeftButtonPressed
                     && (view.Cursor == Cursors.Arrow || view.Cursor == null))
@@ -703,8 +720,22 @@ public sealed partial class ElementView : UserControl
 
         private void OnBorderPointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (AssociatedObject is { _timeline.ViewModel: not null } obj)
+            if (AssociatedObject is { _timeline.ViewModel: { } timelineVm } obj)
             {
+                if (timelineVm.IsRazorMode.Value && e.GetCurrentPoint(obj.border).Properties.IsLeftButtonPressed)
+                {
+                    if (obj.ViewModel is { } elementVm)
+                    {
+                        PointerPoint pt = e.GetCurrentPoint(obj.border);
+                        float scale = timelineVm.Options.Value.Scale;
+                        TimeSpan clickedTime = elementVm.Model.Start + pt.Position.X.PixelToTimeSpan(scale);
+                        elementVm.SplitAt(clickedTime);
+                    }
+
+                    e.Handled = true;
+                    return;
+                }
+
                 PointerPoint point = e.GetCurrentPoint(obj.border);
                 if (point.Properties.IsLeftButtonPressed)
                 {

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -8,6 +8,7 @@
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Editor.Components.TimelineTab.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:p="using:Beutl.Services.PrimitiveImpls"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:vm="using:Beutl.Editor.Components.TimelineTab.ViewModels"
              d:DesignHeight="450"
@@ -104,6 +105,37 @@
             </ItemsControl>
         </ScrollViewer>
 
+        <Border Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="2"
+                BorderBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                BorderThickness="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsRazorMode.Value}"
+                ZIndex="100" />
+
+        <Border Grid.Row="0"
+                Grid.Column="2"
+                Margin="8,4"
+                Padding="8,2"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{DynamicResource SystemFillColorCriticalBrush}"
+                CornerRadius="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsRazorMode.Value}"
+                ZIndex="100">
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <icons:SymbolIcon FontSize="14"
+                                  Foreground="White"
+                                  Symbol="Cut" />
+                <TextBlock FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="{x:Static lang:Strings.RazorTool}"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+        </Border>
 
         <ScrollViewer x:Name="ContentScroll"
                       Grid.Row="1"
@@ -123,6 +155,15 @@
                    PointerReleased="TimelinePanel_PointerReleased">
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
+                        <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRazorMode.Value, Mode=TwoWay}"
+                                                 InputGesture="{h:GetCommandGesture ToggleRazorMode,
+                                                                                    ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                 Text="{x:Static lang:Strings.RazorTool}">
+                            <ui:ToggleMenuFlyoutItem.IconSource>
+                                <icons:SymbolIconSource Symbol="Cut" />
+                            </ui:ToggleMenuFlyoutItem.IconSource>
+                        </ui:ToggleMenuFlyoutItem>
+                        <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
                         <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -122,6 +122,15 @@ public sealed partial class TimelineTabView : UserControl
                 }
             })
             .DisposeWith(_disposables);
+
+        vm.IsRazorMode
+            .ObserveOnUIDispatcher()
+            .Subscribe(isRazor =>
+            {
+                Cursor cursor = isRazor ? Cursors.Cross : Cursors.Arrow;
+                TimelinePanel.Cursor = cursor;
+            })
+            .DisposeWith(_disposables);
     }
 
     protected override void OnLoaded(RoutedEventArgs e)
@@ -407,6 +416,14 @@ public sealed partial class TimelineTabView : UserControl
 
         if (pointerPt.Properties.IsLeftButtonPressed)
         {
+            if (viewModel.IsRazorMode.Value)
+            {
+                viewModel.RazorSplitAt(viewModel.ClickedFrame, acrossAllLayers: true);
+                e.Handled = true;
+                _rightButtonPressed = false;
+                return;
+            }
+
             if (e.KeyModifiers == KeyGestureHelper.GetCommandModifier())
             {
                 _mouseFlag = MouseFlags.RangeSelectionPressed;

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -216,6 +216,18 @@
   <data name="Split" xml:space="preserve">
     <value>分割</value>
   </data>
+  <data name="RazorTool" xml:space="preserve">
+    <value>レーザーモード</value>
+  </data>
+  <data name="RazorTool_Description" xml:space="preserve">
+    <value>レーザー(分割)ツールを切り替えます。クリップ上をクリックして分割します。</value>
+  </data>
+  <data name="ExitRazorTool" xml:space="preserve">
+    <value>レーザーモードを終了</value>
+  </data>
+  <data name="ExitRazorTool_Description" xml:space="preserve">
+    <value>レーザーモードを終了し、選択ツールに戻ります。</value>
+  </data>
   <data name="SampleRate" xml:space="preserve">
     <value>サンプルレート</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -146,6 +146,18 @@
   <data name="Split" xml:space="preserve">
     <value>Split</value>
   </data>
+  <data name="RazorTool" xml:space="preserve">
+    <value>Razor Tool</value>
+  </data>
+  <data name="RazorTool_Description" xml:space="preserve">
+    <value>Toggle razor (split) tool. Click on a clip to split it.</value>
+  </data>
+  <data name="ExitRazorTool" xml:space="preserve">
+    <value>Exit Razor Tool</value>
+  </data>
+  <data name="ExitRazorTool_Description" xml:space="preserve">
+    <value>Exit razor mode and return to selection tool.</value>
+  </data>
   <data name="Delete" xml:space="preserve">
     <value>Delete</value>
   </data>


### PR DESCRIPTION
## Description
- Add a razor mode to the timeline that lets users split clips by clicking on them, providing a faster alternative to the existing context-menu split command.
- Toggle the mode with C and exit with V or Escape; show a red border and a labeled badge while active so the current tool is unmistakable.
- Surface the toggle in the element and timeline context menus, and switch the cursor to a crosshair to make the click-to-split affordance discoverable.

## Breaking changes
None

## Fixed issues
None