### PR TITLE
fix: prevent IpcSampleProvider from issuing non-sequential chunk requests

### DIFF
--- a/src/Beutl.FFmpegWorker/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcSampleProvider.cs
@@ -90,6 +90,12 @@ internal sealed class IpcSampleProvider : ISampleProvider
     {
         long chunkOffset = (offset / SampleRate) * SampleRate;
 
+        // 既にロード済みのチャンクが要求と一致する場合は何もしない
+        if (_currentChunk != null && _currentChunkOffset == chunkOffset)
+        {
+            return;
+        }
+
         // プリフェッチ済みのチャンクと一致する場合
         if (_prefetchTask != null && _prefetchChunkOffset == chunkOffset)
         {
@@ -103,8 +109,16 @@ internal sealed class IpcSampleProvider : ISampleProvider
             return;
         }
 
-        // プリフェッチと一致しない場合（初回 or シーク）
-        _prefetchTask = null;
+        // プリフェッチが進行中だが要求と一致しない場合は、完了を待ってから結果を破棄する。
+        // ホストへ非順次なリクエストが流出しないよう、参照を捨てるだけでなく必ず await する。
+        // キャンセルや通信エラーはそのまま上位へ伝播させる。
+        if (_prefetchTask != null)
+        {
+            Task<Pcm<Stereo32BitFloat>> staleTask = _prefetchTask;
+            _prefetchTask = null;
+            Pcm<Stereo32BitFloat> stalePcm = await staleTask;
+            stalePcm.Dispose();
+        }
 
         int bufferIndex = 0;
         _currentChunk?.Dispose();

--- a/src/Beutl/Models/SampleProviderImpl.cs
+++ b/src/Beutl/Models/SampleProviderImpl.cs
@@ -106,12 +106,16 @@ public sealed class SampleProviderImpl : ISampleProvider, IDisposable
                 }
 
                 item.Pcm.Dispose();
-                _logger.LogWarning("This chunk is misaligned. Requested chunk at offset {ChunkOffset}, Received chunk at offset {ReceivedOffset}", chunkOffset, item.Offset);
+                _logger.LogWarning(
+                    "Sample chunks are expected to be requested sequentially, but received offset {ReceivedOffset} while waiting for {ChunkOffset}. Falling back to on-demand composition.",
+                    item.Offset, chunkOffset);
                 return await ComposeChunk(chunkOffset, _cts.Token);
             }
         }
 
-        _logger.LogWarning("Requested chunk at offset {ChunkOffset} was not found in the channel.", chunkOffset);
+        _logger.LogWarning(
+            "Requested chunk at offset {ChunkOffset} is not available in the channel (producer already finished or skipped). Falling back to on-demand composition.",
+            chunkOffset);
         return await ComposeChunk(chunkOffset, _cts.Token);
     }
 


### PR DESCRIPTION
## Description

- The intermediate `IpcSampleProvider` running inside the FFmpeg worker process was leaking out-of-order `RequestSample` calls to the host's `SampleProviderImpl`, which assumes sequential chunk access. This produced large numbers of `misaligned chunk` and `chunk not found` warnings during encoding.
- `EnsureChunkLoaded` now early-returns when the requested chunk is already cached as the current chunk, so a redundant fetch is no longer issued for cross-chunk reads that resolve to the same offset.
- When an in-flight prefetch targets a different chunk than the new request, its task is now awaited and its `Pcm` result disposed before issuing the next fetch, so background prefetches can no longer race the host with stale requests (with cancellation/transport exceptions still propagating).
- The fallback warnings in `SampleProviderImpl` are reworded to clarify the sequential contract and that the provider is falling back to on-demand composition.

## Breaking changes

None

## Fixed issues

None