### PR TITLE
feat: Add crash recovery prompt to restore previous project

### DIFF
--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -17,6 +17,7 @@ public sealed class ViewConfig : ConfigurationBase
     public static readonly CoreProperty<bool> ShowExactBoundariesProperty;
     public static readonly CoreProperty<CoreList<string>> RecentFilesProperty;
     public static readonly CoreProperty<CoreList<string>> RecentProjectsProperty;
+    public static readonly CoreProperty<string?> LastOpenedProjectFileProperty;
     private readonly CoreList<string> _primaryProperties =
     [
         "AlignmentX",
@@ -69,6 +70,10 @@ public sealed class ViewConfig : ConfigurationBase
 
         RecentProjectsProperty = ConfigureProperty<CoreList<string>, ViewConfig>(nameof(RecentProjects))
             .Accessor(o => o.RecentProjects, (o, v) => o.RecentProjects = v)
+            .Register();
+
+        LastOpenedProjectFileProperty = ConfigureProperty<string?, ViewConfig>(nameof(LastOpenedProjectFile))
+            .DefaultValue(null)
             .Register();
     }
 
@@ -143,6 +148,12 @@ public sealed class ViewConfig : ConfigurationBase
         set => _recentProjects.Replace(value);
     }
 
+    public string? LastOpenedProjectFile
+    {
+        get => GetValue(LastOpenedProjectFileProperty);
+        set => SetValue(LastOpenedProjectFileProperty, value);
+    }
+
     public enum ViewTheme
     {
         Light,
@@ -204,7 +215,7 @@ public sealed class ViewConfig : ConfigurationBase
     protected override void OnPropertyChanged(PropertyChangedEventArgs args)
     {
         base.OnPropertyChanged(args);
-        if (args.PropertyName is nameof(Theme) or nameof(UICulture) or nameof(UseCustomAccentColor) or nameof(CustomAccentColor) or nameof(ShowExactBoundaries))
+        if (args.PropertyName is nameof(Theme) or nameof(UICulture) or nameof(UseCustomAccentColor) or nameof(CustomAccentColor) or nameof(ShowExactBoundaries) or nameof(LastOpenedProjectFile))
         {
             OnChanged();
         }

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -356,4 +356,10 @@
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>貼り付けできません: クリップボードに互換性のあるオブジェクトがありません。</value>
   </data>
+  <data name="RestoreLastProjectTitle" xml:space="preserve">
+    <value>前回のプロジェクトを開きますか？</value>
+  </data>
+  <data name="RestoreLastProjectPrompt" xml:space="preserve">
+    <value>前回「{0}」を編集中にBeutlが予期せず終了しました。このプロジェクトを再度開きますか？</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -107,14 +107,17 @@
   <data name="OutputException" xml:space="preserve">
     <value>出力中に例外が発生しました。</value>
   </data>
-  <data name="RestrictedModePrompt" xml:space="preserve">
-    <value>前回エラーが発生して終了したようです。
-原因か不明なため、制限モードで実行しますか。
-
-制限モードでは拡張機能を読み込みません。</value>
-  </data>
   <data name="PreviousSessionErrorTitle" xml:space="preserve">
     <value>前回エラーが発生して終了したようです。</value>
+  </data>
+  <data name="CrashRecoveryDescription" xml:space="preserve">
+    <value>前回 Beutl が予期せず終了しました。今回の起動方法を選択してください。</value>
+  </data>
+  <data name="CrashRecoveryRestoreOption" xml:space="preserve">
+    <value>前回開いていたプロジェクト「{0}」を復元する。</value>
+  </data>
+  <data name="CrashRecoveryRestrictedModeOption" xml:space="preserve">
+    <value>制限モード（拡張機能を読み込まない）で起動する。</value>
   </data>
   <data name="PackageChangesInProgress" xml:space="preserve">
     <value>パッケージが変更中です。</value>
@@ -355,11 +358,5 @@
   </data>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>貼り付けできません: クリップボードに互換性のあるオブジェクトがありません。</value>
-  </data>
-  <data name="RestoreLastProjectTitle" xml:space="preserve">
-    <value>前回のプロジェクトを開きますか？</value>
-  </data>
-  <data name="RestoreLastProjectPrompt" xml:space="preserve">
-    <value>前回「{0}」を編集中にBeutlが予期せず終了しました。このプロジェクトを再度開きますか？</value>
   </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -361,4 +361,10 @@ Do you want to restart the application?</value>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>Cannot paste: clipboard does not contain a compatible object.</value>
   </data>
+  <data name="RestoreLastProjectTitle" xml:space="preserve">
+    <value>Restore previous project?</value>
+  </data>
+  <data name="RestoreLastProjectPrompt" xml:space="preserve">
+    <value>Beutl was closed unexpectedly while editing "{0}". Do you want to reopen this project?</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -112,14 +112,17 @@ because the new name conflicts with an existing folder.</value>
   <data name="OutputException" xml:space="preserve">
     <value>An exception occurred during output.</value>
   </data>
-  <data name="RestrictedModePrompt" xml:space="preserve">
-    <value>It seems that an error occurred and the program terminated last time.
-Do you want to run in restricted mode because the cause is unknown?
-
-Restricted mode does not load extensions.</value>
-  </data>
   <data name="PreviousSessionErrorTitle" xml:space="preserve">
     <value>Looks like it ended with an error last time.</value>
+  </data>
+  <data name="CrashRecoveryDescription" xml:space="preserve">
+    <value>Beutl was closed unexpectedly last time. Choose how to start this session.</value>
+  </data>
+  <data name="CrashRecoveryRestoreOption" xml:space="preserve">
+    <value>Reopen the previous project "{0}".</value>
+  </data>
+  <data name="CrashRecoveryRestrictedModeOption" xml:space="preserve">
+    <value>Run in restricted mode (extensions are not loaded).</value>
   </data>
   <data name="PackageChangesInProgress" xml:space="preserve">
     <value>Changes to the package are in progress.</value>
@@ -360,11 +363,5 @@ Do you want to restart the application?</value>
   </data>
   <data name="CannotPasteFromClipboard" xml:space="preserve">
     <value>Cannot paste: clipboard does not contain a compatible object.</value>
-  </data>
-  <data name="RestoreLastProjectTitle" xml:space="preserve">
-    <value>Restore previous project?</value>
-  </data>
-  <data name="RestoreLastProjectPrompt" xml:space="preserve">
-    <value>Beutl was closed unexpectedly while editing "{0}". Do you want to reopen this project?</value>
   </data>
 </root>

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -98,6 +98,7 @@ public sealed class ProjectService
             // 値を発行
             _projectObservable.OnNext((New: null, project));
             _app.Project = null;
+            GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile = null;
             _logger.LogInformation("Closed project. Project: {Project}", project.Uri);
         }
     }
@@ -156,5 +157,6 @@ public sealed class ProjectService
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
         viewConfig.UpdateRecentProject(file);
         viewConfig.UpdateRecentFile(file);
+        viewConfig.LastOpenedProjectFile = file;
     }
 }

--- a/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
+++ b/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Beutl.Configuration;

--- a/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
+++ b/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
@@ -1,0 +1,102 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Beutl.Configuration;
+using Beutl.Logging;
+using FluentAvalonia.UI.Controls;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services.StartupTasks;
+
+public sealed class CrashRecoveryPromptTask : StartupTask
+{
+    private readonly ILogger<CrashRecoveryPromptTask> _logger = Log.CreateLogger<CrashRecoveryPromptTask>();
+
+    public CrashRecoveryPromptTask()
+    {
+        Task = Task.Run(async () =>
+        {
+            using Activity? activity = Telemetry.StartActivity("CrashRecoveryPromptTask");
+
+            if (!UnhandledExceptionHandler.LastExecutionExceptionWasThrown())
+            {
+                return;
+            }
+
+            string? lastProjectFile = GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile;
+            bool canRestoreProject = !string.IsNullOrEmpty(lastProjectFile) && File.Exists(lastProjectFile);
+            LastProjectFile = canRestoreProject ? lastProjectFile : null;
+
+            await App.WaitWindowOpened();
+
+            (bool restrictedMode, bool restoreProject) = await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var restrictedModeCheckBox = new CheckBox
+                {
+                    Content = MessageStrings.CrashRecoveryRestrictedModeOption,
+                    IsChecked = false,
+                };
+
+                CheckBox? restoreCheckBox = null;
+                var stack = new StackPanel
+                {
+                    Orientation = Orientation.Vertical,
+                    Spacing = 8,
+                };
+                stack.Children.Add(new TextBlock
+                {
+                    Text = MessageStrings.CrashRecoveryDescription,
+                    TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+                });
+
+                if (canRestoreProject)
+                {
+                    restoreCheckBox = new CheckBox
+                    {
+                        Content = string.Format(
+                            MessageStrings.CrashRecoveryRestoreOption,
+                            Path.GetFileName(lastProjectFile)),
+                        IsChecked = true,
+                    };
+                    stack.Children.Add(restoreCheckBox);
+                }
+
+                stack.Children.Add(restrictedModeCheckBox);
+
+                var dialog = new ContentDialog
+                {
+                    Title = MessageStrings.PreviousSessionErrorTitle,
+                    Content = stack,
+                    PrimaryButtonText = Strings.OK,
+                };
+
+                await dialog.ShowAsync();
+
+                return (
+                    restrictedModeCheckBox.IsChecked == true,
+                    restoreCheckBox?.IsChecked == true);
+            });
+
+            IsRestrictedMode = restrictedMode;
+            RestoreLastProject = restoreProject;
+
+            if (restrictedMode)
+            {
+                _logger.LogInformation("User opted to start in restricted mode.");
+            }
+
+            if (canRestoreProject && !restoreProject)
+            {
+                GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile = null;
+            }
+        });
+    }
+
+    public override Task Task { get; }
+
+    public bool IsRestrictedMode { get; private set; }
+
+    public bool RestoreLastProject { get; private set; }
+
+    public string? LastProjectFile { get; private set; }
+}

--- a/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
@@ -35,7 +35,8 @@ public sealed class LoadInstalledExtensionTask : StartupTask
                     StringComparer.OrdinalIgnoreCase);
 
                 // .beutl/packages/ 内のパッケージを読み込む
-                if (!await AsksRunInRestrictedMode())
+                IsRestrictedMode = await AsksRunInRestrictedMode();
+                if (!IsRestrictedMode)
                 {
                     IReadOnlyList<LocalPackage> packages = await _manager.GetPackages();
 
@@ -78,6 +79,8 @@ public sealed class LoadInstalledExtensionTask : StartupTask
     public override Task Task { get; }
 
     public ConcurrentBag<(LocalPackage, Exception)> Failures { get; } = [];
+
+    public bool IsRestrictedMode { get; private set; }
 
     // 最後に実行したとき、例外が発生して終了した場合、
     // 制限モード (拡張機能を読み込まない) で起動するかを尋ねる。

--- a/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
 using Beutl.Api.Services;
 using Beutl.Logging;

--- a/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadInstalledExtensionTask.cs
@@ -1,11 +1,7 @@
-﻿using System.Collections.Concurrent;
-
-using Avalonia.Threading;
+using System.Collections.Concurrent;
 
 using Beutl.Api.Services;
 using Beutl.Logging;
-
-using FluentAvalonia.UI.Controls;
 
 using Microsoft.Extensions.Logging;
 
@@ -34,8 +30,12 @@ public sealed class LoadInstalledExtensionTask : StartupTask
                     resolveTask.Failures.Select(f => f.Package.Id),
                     StringComparer.OrdinalIgnoreCase);
 
+                // クラッシュ復旧プロンプトの結果を待機し、制限モードか判定
+                CrashRecoveryPromptTask promptTask = startup.GetTask<CrashRecoveryPromptTask>();
+                await promptTask.Task;
+                IsRestrictedMode = promptTask.IsRestrictedMode;
+
                 // .beutl/packages/ 内のパッケージを読み込む
-                IsRestrictedMode = await AsksRunInRestrictedMode();
                 if (!IsRestrictedMode)
                 {
                     IReadOnlyList<LocalPackage> packages = await _manager.GetPackages();
@@ -81,30 +81,4 @@ public sealed class LoadInstalledExtensionTask : StartupTask
     public ConcurrentBag<(LocalPackage, Exception)> Failures { get; } = [];
 
     public bool IsRestrictedMode { get; private set; }
-
-    // 最後に実行したとき、例外が発生して終了した場合、
-    // 制限モード (拡張機能を読み込まない) で起動するかを尋ねる。
-    private static async ValueTask<bool> AsksRunInRestrictedMode()
-    {
-        if (UnhandledExceptionHandler.LastExecutionExceptionWasThrown())
-        {
-            await App.WaitWindowOpened();
-            return await Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                var dialog = new ContentDialog()
-                {
-                    Title = MessageStrings.PreviousSessionErrorTitle,
-                    Content = MessageStrings.RestrictedModePrompt,
-                    PrimaryButtonText = Strings.Yes,
-                    CloseButtonText = Strings.No
-                };
-
-                return await dialog.ShowAsync() == ContentDialogResult.Primary;
-            });
-        }
-        else
-        {
-            return false;
-        }
-    }
 }

--- a/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
+++ b/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
@@ -1,0 +1,78 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using Beutl.Configuration;
+using Beutl.Logging;
+using FluentAvalonia.UI.Controls;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services.StartupTasks;
+
+public sealed class RestoreLastProjectTask : StartupTask
+{
+    private readonly ILogger<RestoreLastProjectTask> _logger = Log.CreateLogger<RestoreLastProjectTask>();
+
+    public RestoreLastProjectTask(Startup startup)
+    {
+        Task = System.Threading.Tasks.Task.Run(async () =>
+        {
+            using Activity? activity = Telemetry.StartActivity("RestoreLastProjectTask");
+
+            LoadInstalledExtensionTask loadTask = startup.GetTask<LoadInstalledExtensionTask>();
+            await loadTask.Task;
+
+            if (!UnhandledExceptionHandler.LastExecutionExceptionWasThrown())
+            {
+                return;
+            }
+
+            if (loadTask.IsRestrictedMode)
+            {
+                _logger.LogInformation("Restricted mode: skipping project restore prompt.");
+                return;
+            }
+
+            string? file = GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile;
+            if (string.IsNullOrEmpty(file) || !File.Exists(file))
+            {
+                _logger.LogInformation("No last opened project to restore.");
+                return;
+            }
+
+            if (ProjectService.Current.CurrentProject.Value is not null)
+            {
+                return;
+            }
+
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime)
+            {
+                return;
+            }
+
+            await App.WaitWindowOpened();
+
+            bool yes = await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = MessageStrings.RestoreLastProjectTitle,
+                    Content = string.Format(MessageStrings.RestoreLastProjectPrompt, Path.GetFileName(file)),
+                    PrimaryButtonText = Strings.Yes,
+                    CloseButtonText = Strings.No,
+                };
+
+                return await dialog.ShowAsync() == ContentDialogResult.Primary;
+            });
+
+            if (!yes)
+            {
+                GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile = null;
+                return;
+            }
+
+            await ProjectService.Current.OpenProject(file);
+        });
+    }
+
+    public override Task Task { get; }
+}

--- a/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
+++ b/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using Beutl.Logging;

--- a/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
+++ b/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
@@ -1,9 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
-using Beutl.Configuration;
 using Beutl.Logging;
-using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.Logging;
 
 namespace Beutl.Services.StartupTasks;
@@ -14,28 +12,25 @@ public sealed class RestoreLastProjectTask : StartupTask
 
     public RestoreLastProjectTask(Startup startup)
     {
-        Task = System.Threading.Tasks.Task.Run(async () =>
+        Task = Task.Run(async () =>
         {
             using Activity? activity = Telemetry.StartActivity("RestoreLastProjectTask");
 
             LoadInstalledExtensionTask loadTask = startup.GetTask<LoadInstalledExtensionTask>();
             await loadTask.Task;
 
-            if (!UnhandledExceptionHandler.LastExecutionExceptionWasThrown())
+            CrashRecoveryPromptTask promptTask = startup.GetTask<CrashRecoveryPromptTask>();
+            await promptTask.Task;
+
+            if (!promptTask.RestoreLastProject)
             {
                 return;
             }
 
-            if (loadTask.IsRestrictedMode)
-            {
-                _logger.LogInformation("Restricted mode: skipping project restore prompt.");
-                return;
-            }
-
-            string? file = GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile;
+            string? file = promptTask.LastProjectFile;
             if (string.IsNullOrEmpty(file) || !File.Exists(file))
             {
-                _logger.LogInformation("No last opened project to restore.");
+                _logger.LogInformation("Skipping project restore: file is unavailable.");
                 return;
             }
 
@@ -46,27 +41,6 @@ public sealed class RestoreLastProjectTask : StartupTask
 
             if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime)
             {
-                return;
-            }
-
-            await App.WaitWindowOpened();
-
-            bool yes = await Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                var dialog = new ContentDialog
-                {
-                    Title = MessageStrings.RestoreLastProjectTitle,
-                    Content = string.Format(MessageStrings.RestoreLastProjectPrompt, Path.GetFileName(file)),
-                    PrimaryButtonText = Strings.Yes,
-                    CloseButtonText = Strings.No,
-                };
-
-                return await dialog.ShowAsync() == ContentDialogResult.Primary;
-            });
-
-            if (!yes)
-            {
-                GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile = null;
                 return;
             }
 

--- a/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
+++ b/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
@@ -70,7 +70,7 @@ public sealed class RestoreLastProjectTask : StartupTask
                 return;
             }
 
-            await ProjectService.Current.OpenProject(file);
+            await Dispatcher.UIThread.InvokeAsync(() => ProjectService.Current.OpenProject(file));
         });
     }
 

--- a/src/Beutl/Services/StartupTasks/Startup.cs
+++ b/src/Beutl/Services/StartupTasks/Startup.cs
@@ -61,6 +61,7 @@ public sealed class Startup
         Register(() => new ResolvePackageDependenciesTask(
             _apiApp.GetResource<InstalledPackageRepository>(),
             _apiApp.GetResource<PackageInstaller>()));
+        Register(() => new CrashRecoveryPromptTask());
         Register(() => new LoadInstalledExtensionTask(
             _apiApp.GetResource<PackageManager>(), this));
         Register(() => new LoadPrimitiveExtensionTask(_apiApp.GetResource<PackageManager>()));

--- a/src/Beutl/Services/StartupTasks/Startup.cs
+++ b/src/Beutl/Services/StartupTasks/Startup.cs
@@ -66,6 +66,7 @@ public sealed class Startup
         Register(() => new LoadPrimitiveExtensionTask(_apiApp.GetResource<PackageManager>()));
         Register(() => new LoadSideloadExtensionTask(_apiApp.GetResource<PackageManager>()));
         Register(() => new AfterLoadingExtensionsTask(this));
+        Register(() => new RestoreLastProjectTask(this));
         Register(() => new CheckForUpdatesTask(_apiApp));
         Register(() => new CheckForPackageUpdatesTask(this, _apiApp.GetResource<PackageManager>()));
     }


### PR DESCRIPTION
## Description

- Add a unified crash-recovery dialog that lets users reopen the previously open project and/or start in restricted mode after an unexpected exit
- Persist the last opened project path in `ViewConfig.LastOpenedProjectFile` so it can be restored on next launch
- Split the logic into dedicated `CrashRecoveryPromptTask` and `RestoreLastProjectTask` startup tasks; `LoadInstalledExtensionTask` now consults the prompt result instead of showing its own dialog

## Breaking changes

None.

## Fixed issues

None.