### PR TITLE
feat: Add JKL shuttle playback and loop toggle

### DIFF
--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 
 namespace Beutl.Controls;
 
@@ -22,6 +23,13 @@ public class Player : RangeBase
             nameof(IsPlaying),
             owner => owner.IsPlaying,
             (owner, obj) => owner.IsPlaying = obj);
+
+    public static readonly DirectProperty<Player, bool> IsLoopEnabledProperty =
+        AvaloniaProperty.RegisterDirect<Player, bool>(
+            nameof(IsLoopEnabled),
+            owner => owner.IsLoopEnabled,
+            (owner, obj) => owner.IsLoopEnabled = obj,
+            defaultBindingMode: BindingMode.TwoWay);
 
     public static readonly DirectProperty<Player, ICommand> PlayButtonCommandProperty =
         AvaloniaProperty.RegisterDirect<Player, ICommand>(
@@ -55,6 +63,7 @@ public class Player : RangeBase
 
     private string _currentTime = string.Empty;
     private bool _isPlaying;
+    private bool _isLoopEnabled;
     private ToggleButton _playButton;
     private RepeatButton _nextButton;
     private RepeatButton _previousButton;
@@ -103,6 +112,12 @@ public class Player : RangeBase
     {
         get => _isPlaying;
         set => SetAndRaise(IsPlayingProperty, ref _isPlaying, value);
+    }
+
+    public bool IsLoopEnabled
+    {
+        get => _isLoopEnabled;
+        set => SetAndRaise(IsLoopEnabledProperty, ref _isLoopEnabled, value);
     }
 
     public ICommand PlayButtonCommand

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -100,6 +100,14 @@
                                     Theme="{StaticResource TransparentButton}">
                                 <icons:SymbolIcon Symbol="Next" />
                             </Button>
+
+                            <ToggleButton Name="PART_LoopButton"
+                                          Grid.Column="6"
+                                          IsChecked="{TemplateBinding IsLoopEnabled, Mode=TwoWay}"
+                                          Theme="{StaticResource TransparentToggleButton}"
+                                          ToolTip.Tip="Loop">
+                                <icons:SymbolIcon Symbol="ArrowRepeat1" />
+                            </ToggleButton>
                         </StackPanel>
                     </Grid>
                 </Grid>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -750,6 +750,42 @@
   <data name="PreviousMarker_Description" xml:space="preserve">
     <value>前のマーカーへ移動します。</value>
   </data>
+  <data name="ShuttleForward" xml:space="preserve">
+    <value>シャトル早送り</value>
+  </data>
+  <data name="ShuttleForward_Description" xml:space="preserve">
+    <value>シャトル早送り（L）。連打で速度が上がります。</value>
+  </data>
+  <data name="ShuttleForwardFine" xml:space="preserve">
+    <value>シャトル早送り（低速）</value>
+  </data>
+  <data name="ShuttleForwardFine_Description" xml:space="preserve">
+    <value>半分の速度でシャトル早送りします。</value>
+  </data>
+  <data name="ShuttleBackward" xml:space="preserve">
+    <value>シャトル巻き戻し</value>
+  </data>
+  <data name="ShuttleBackward_Description" xml:space="preserve">
+    <value>シャトル巻き戻し（J）。連打で速度が上がります。</value>
+  </data>
+  <data name="ShuttleBackwardFine" xml:space="preserve">
+    <value>シャトル巻き戻し（低速）</value>
+  </data>
+  <data name="ShuttleBackwardFine_Description" xml:space="preserve">
+    <value>半分の速度でシャトル巻き戻しします。</value>
+  </data>
+  <data name="ShuttleStop" xml:space="preserve">
+    <value>シャトル停止</value>
+  </data>
+  <data name="ShuttleStop_Description" xml:space="preserve">
+    <value>シャトル再生を停止します。</value>
+  </data>
+  <data name="ToggleLoop" xml:space="preserve">
+    <value>ループ切替</value>
+  </data>
+  <data name="ToggleLoop_Description" xml:space="preserve">
+    <value>ループ再生のオン/オフを切り替えます。</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>コピーしたデータをペーストします。</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -755,6 +755,42 @@
   <data name="PreviousMarker_Description" xml:space="preserve">
     <value>Seek to the previous marker.</value>
   </data>
+  <data name="ShuttleForward" xml:space="preserve">
+    <value>Shuttle forward</value>
+  </data>
+  <data name="ShuttleForward_Description" xml:space="preserve">
+    <value>Shuttle forward (L). Press repeatedly to accelerate.</value>
+  </data>
+  <data name="ShuttleForwardFine" xml:space="preserve">
+    <value>Shuttle forward (fine)</value>
+  </data>
+  <data name="ShuttleForwardFine_Description" xml:space="preserve">
+    <value>Shuttle forward at half speed.</value>
+  </data>
+  <data name="ShuttleBackward" xml:space="preserve">
+    <value>Shuttle backward</value>
+  </data>
+  <data name="ShuttleBackward_Description" xml:space="preserve">
+    <value>Shuttle backward (J). Press repeatedly to accelerate.</value>
+  </data>
+  <data name="ShuttleBackwardFine" xml:space="preserve">
+    <value>Shuttle backward (fine)</value>
+  </data>
+  <data name="ShuttleBackwardFine_Description" xml:space="preserve">
+    <value>Shuttle backward at half speed.</value>
+  </data>
+  <data name="ShuttleStop" xml:space="preserve">
+    <value>Shuttle stop</value>
+  </data>
+  <data name="ShuttleStop_Description" xml:space="preserve">
+    <value>Stop shuttle playback.</value>
+  </data>
+  <data name="ToggleLoop" xml:space="preserve">
+    <value>Toggle loop</value>
+  </data>
+  <data name="ToggleLoop_Description" xml:space="preserve">
+    <value>Toggle loop playback.</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>Paste the copied data.</value>
   </data>

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -78,14 +78,6 @@ public sealed class SceneEditorExtension : EditorExtension
         [
             new ContextCommandKeyGesture("K")
         ]),
-        new("SetInPoint", "Set In point", "Set the In point at the current playhead position.",
-        [
-            new ContextCommandKeyGesture("I")
-        ]),
-        new("SetOutPoint", "Set Out point", "Set the Out point at the current playhead position.",
-        [
-            new ContextCommandKeyGesture("O")
-        ]),
         new("ToggleLoop", "Toggle loop", "Toggle loop playback.",
         [
             new ContextCommandKeyGesture("OemQuestion"),

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -1,9 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Platform.Storage;
-using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 using Beutl.Views;
@@ -59,6 +57,39 @@ public sealed class SceneEditorExtension : EditorExtension
         [
             new ContextCommandKeyGesture("Ctrl+Left"),
             new ContextCommandKeyGesture("Alt+Left", OSPlatform.OSX)
+        ]),
+        new("ShuttleForward", "Shuttle forward", "Shuttle forward (L). Press repeatedly to accelerate.",
+        [
+            new ContextCommandKeyGesture("L")
+        ]),
+        new("ShuttleForwardFine", "Shuttle forward (fine)", "Shuttle forward at half speed.",
+        [
+            new ContextCommandKeyGesture("Shift+L")
+        ]),
+        new("ShuttleBackward", "Shuttle backward", "Shuttle backward (J). Press repeatedly to accelerate.",
+        [
+            new ContextCommandKeyGesture("J")
+        ]),
+        new("ShuttleBackwardFine", "Shuttle backward (fine)", "Shuttle backward at half speed.",
+        [
+            new ContextCommandKeyGesture("Shift+J")
+        ]),
+        new("ShuttleStop", "Shuttle stop", "Stop shuttle playback.",
+        [
+            new ContextCommandKeyGesture("K")
+        ]),
+        new("SetInPoint", "Set In point", "Set the In point at the current playhead position.",
+        [
+            new ContextCommandKeyGesture("I")
+        ]),
+        new("SetOutPoint", "Set Out point", "Set the Out point at the current playhead position.",
+        [
+            new ContextCommandKeyGesture("O")
+        ]),
+        new("ToggleLoop", "Toggle loop", "Toggle loop playback.",
+        [
+            new ContextCommandKeyGesture("OemQuestion"),
+            new ContextCommandKeyGesture("OemSlash")
         ]),
     ];
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -58,30 +58,29 @@ public sealed class SceneEditorExtension : EditorExtension
             new ContextCommandKeyGesture("Ctrl+Left"),
             new ContextCommandKeyGesture("Alt+Left", OSPlatform.OSX)
         ]),
-        new("ShuttleForward", "Shuttle forward", "Shuttle forward (L). Press repeatedly to accelerate.",
+        new("ShuttleForward", Strings.ShuttleForward, Strings.ShuttleForward_Description,
         [
             new ContextCommandKeyGesture("L")
         ]),
-        new("ShuttleForwardFine", "Shuttle forward (fine)", "Shuttle forward at half speed.",
+        new("ShuttleForwardFine", Strings.ShuttleForwardFine, Strings.ShuttleForwardFine_Description,
         [
             new ContextCommandKeyGesture("Shift+L")
         ]),
-        new("ShuttleBackward", "Shuttle backward", "Shuttle backward (J). Press repeatedly to accelerate.",
+        new("ShuttleBackward", Strings.ShuttleBackward, Strings.ShuttleBackward_Description,
         [
             new ContextCommandKeyGesture("J")
         ]),
-        new("ShuttleBackwardFine", "Shuttle backward (fine)", "Shuttle backward at half speed.",
+        new("ShuttleBackwardFine", Strings.ShuttleBackwardFine, Strings.ShuttleBackwardFine_Description,
         [
             new ContextCommandKeyGesture("Shift+J")
         ]),
-        new("ShuttleStop", "Shuttle stop", "Stop shuttle playback.",
+        new("ShuttleStop", Strings.ShuttleStop, Strings.ShuttleStop_Description,
         [
             new ContextCommandKeyGesture("K")
         ]),
-        new("ToggleLoop", "Toggle loop", "Toggle loop playback.",
+        new("ToggleLoop", Strings.ToggleLoop, Strings.ToggleLoop_Description,
         [
-            new ContextCommandKeyGesture("OemQuestion"),
-            new ContextCommandKeyGesture("OemSlash")
+            new ContextCommandKeyGesture("OemQuestion")
         ]),
     ];
 

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -2,7 +2,6 @@
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Media;
 using Beutl.ProjectSystem;
-using ExCSS;
 using Microsoft.Extensions.Logging;
 
 namespace Beutl.ViewModels;
@@ -47,9 +46,10 @@ public partial class EditViewModel : IContextCommandHandler
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
+        bool isFromTextBox = execution.KeyEventArgs?.Source is TextBox;
         switch (execution.CommandName)
         {
-            case "PlayPause" when execution.KeyEventArgs?.Source is not TextBox:
+            case "PlayPause" when !isFromTextBox:
                 Player.PlayPause.Execute();
                 break;
             case "Next":
@@ -64,13 +64,37 @@ public partial class EditViewModel : IContextCommandHandler
             case "SeekEnd":
                 Player.End.Execute();
                 break;
-            case "ToggleMarker" when execution.KeyEventArgs?.Source is not TextBox:
+            case "ShuttleForward" when !isFromTextBox:
+                Player.ShuttleForward();
+                break;
+            case "ShuttleForwardFine" when !isFromTextBox:
+                Player.ShuttleForward(fineGrain: true);
+                break;
+            case "ShuttleBackward" when !isFromTextBox:
+                Player.ShuttleBackward();
+                break;
+            case "ShuttleBackwardFine" when !isFromTextBox:
+                Player.ShuttleBackward(fineGrain: true);
+                break;
+            case "ShuttleStop" when !isFromTextBox:
+                Player.ShuttleStop();
+                break;
+            case "SetInPoint" when !isFromTextBox:
+                Player.SetInPoint();
+                break;
+            case "SetOutPoint" when !isFromTextBox:
+                Player.SetOutPoint();
+                break;
+            case "ToggleLoop" when !isFromTextBox:
+                Player.ToggleLoop();
+                break;
+            case "ToggleMarker" when !isFromTextBox:
                 ToggleMarkerAtCurrentTime();
                 break;
-            case "NextMarker" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NextMarker" when !isFromTextBox:
                 SeekToAdjacentMarker(forward: true);
                 break;
-            case "PreviousMarker" when execution.KeyEventArgs?.Source is not TextBox:
+            case "PreviousMarker" when !isFromTextBox:
                 SeekToAdjacentMarker(forward: false);
                 break;
             default:

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -79,12 +79,6 @@ public partial class EditViewModel : IContextCommandHandler
             case "ShuttleStop" when !isFromTextBox:
                 Player.ShuttleStop();
                 break;
-            case "SetInPoint" when !isFromTextBox:
-                Player.SetInPoint();
-                break;
-            case "SetOutPoint" when !isFromTextBox:
-                Player.SetOutPoint();
-                break;
             case "ToggleLoop" when !isFromTextBox:
                 Player.ToggleLoop();
                 break;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -40,7 +40,6 @@ public enum LoopMode
 {
     None,
     All,
-    InOut,
     Selection,
 }
 
@@ -304,11 +303,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactivePropertySlim<bool> IsLoopEnabled { get; } = new(false);
 
-    public ReactivePropertySlim<LoopMode> LoopMode { get; } = new(ViewModels.LoopMode.InOut);
-
-    public ReactivePropertySlim<TimeSpan?> InPoint { get; } = new();
-
-    public ReactivePropertySlim<TimeSpan?> OutPoint { get; } = new();
+    public ReactivePropertySlim<LoopMode> LoopMode { get; } = new(ViewModels.LoopMode.All);
 
     public ReactiveProperty<TimeSpan> CurrentFrame { get; }
 
@@ -422,15 +417,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
         int sceneEndFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
         (TimeSpan loopStart, TimeSpan loopEnd) = GetLoopRange();
-        // 再生中のループ ON/OFF や In/Out 変更に追従するため、endFrame と loopActive、
-        // loopStart は再生中も IsLoopEnabled / LoopMode / InPoint / OutPoint の購読で更新する。
+        // 再生中のループ ON/OFF や LoopMode 変更に追従するため、endFrame / loopActive /
+        // loopStart は IsLoopEnabled / LoopMode の購読で更新する。
         int endFrame = ComputePlaybackEndFrame(IsLoopEnabled.Value, loopEnd, sceneEndFrame, rate);
         bool loopActive = IsLoopEnabled.Value;
         using var loopRangeSubscription = Observable.Merge(
                 IsLoopEnabled.Select(_ => Unit.Default),
-                LoopMode.Select(_ => Unit.Default),
-                InPoint.Select(_ => Unit.Default),
-                OutPoint.Select(_ => Unit.Default))
+                LoopMode.Select(_ => Unit.Default))
             .Subscribe(_ =>
             {
                 if (Scene == null) return;
@@ -594,14 +587,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             case ViewModels.LoopMode.All:
                 return (TimeSpan.Zero, sceneEnd);
 
-            case ViewModels.LoopMode.InOut:
-                {
-                    TimeSpan start = InPoint.Value ?? sceneStart;
-                    TimeSpan end = OutPoint.Value ?? sceneEnd;
-                    if (end <= start) end = sceneEnd;
-                    return (start, end);
-                }
-
             case ViewModels.LoopMode.Selection:
                 {
                     Element[] children = Scene.Children.Where(c => c.IsEnabled).ToArray();
@@ -619,27 +604,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
 
         return (TimeSpan.Zero, sceneEnd);
-    }
-
-    public void SetInPoint()
-    {
-        InPoint.Value = _editorClock.CurrentTime.Value;
-        // In >= Out になるとループ範囲が無効になるため反対側のマーカーを解除する
-        if (OutPoint.Value is { } o && o <= InPoint.Value)
-        {
-            OutPoint.Value = null;
-        }
-    }
-
-    public void SetOutPoint()
-    {
-        TimeSpan time = _editorClock.CurrentTime.Value;
-        // Out <= In になるとループ範囲が無効になるため反対側のマーカーを解除する
-        if (InPoint.Value is { } i && time <= i)
-        {
-            InPoint.Value = null;
-        }
-        OutPoint.Value = time;
     }
 
     public void ToggleLoop()
@@ -747,9 +711,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 TimeSpan cachedSceneEnd = Scene.Start + Scene.Duration;
                 using var loopRangeSubscription = Observable.Merge(
                         IsLoopEnabled.Select(_ => Unit.Default),
-                        LoopMode.Select(_ => Unit.Default),
-                        InPoint.Select(_ => Unit.Default),
-                        OutPoint.Select(_ => Unit.Default))
+                        LoopMode.Select(_ => Unit.Default))
                     .Subscribe(_ =>
                     {
                         if (Scene == null) return;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -36,13 +36,6 @@ public enum PlaybackDirection
     Backward,
 }
 
-public enum LoopMode
-{
-    None,
-    All,
-    Selection,
-}
-
 public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 {
     private static readonly TimeSpan s_second = TimeSpan.FromSeconds(1);
@@ -303,8 +296,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactivePropertySlim<bool> IsLoopEnabled { get; } = new(false);
 
-    public ReactivePropertySlim<LoopMode> LoopMode { get; } = new(ViewModels.LoopMode.All);
-
     public ReactiveProperty<TimeSpan> CurrentFrame { get; }
 
     public ReadOnlyReactiveProperty<TimeSpan> Duration { get; }
@@ -415,24 +406,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         TimeSpan durationTime = Scene.Duration;
         int startFrame = (int)startTime.ToFrameNumber(rate);
         int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
-        int sceneEndFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
-        (TimeSpan loopStart, TimeSpan loopEnd) = GetLoopRange();
-        // 再生中のループ ON/OFF や LoopMode 変更に追従するため、endFrame / loopActive /
-        // loopStart は IsLoopEnabled / LoopMode の購読で更新する。
-        int endFrame = ComputePlaybackEndFrame(IsLoopEnabled.Value, loopEnd, sceneEndFrame, rate);
-        bool loopActive = IsLoopEnabled.Value;
-        using var loopRangeSubscription = Observable.Merge(
-                IsLoopEnabled.Select(_ => Unit.Default),
-                LoopMode.Select(_ => Unit.Default))
-            .Subscribe(_ =>
-            {
-                if (Scene == null) return;
-                var range = GetLoopRange();
-                loopStart = range.Start;
-                loopEnd = range.End;
-                loopActive = IsLoopEnabled.Value;
-                endFrame = ComputePlaybackEndFrame(loopActive, loopEnd, sceneEndFrame, rate);
-            });
+        int endFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
         bufferStatus.StartTime.Value = startTime;
         bufferStatus.EndTime.Value = startTime;
         frameCacheManager.Options = frameCacheManager.Options with
@@ -479,7 +453,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 if (!IsPlaying.Value || expectFrame >= endFrame)
                 {
                     // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える
-                    if (loopActive && expectFrame >= endFrame)
+                    if (IsLoopEnabled.Value && expectFrame >= endFrame)
                     {
                         reachedNaturalEnd = true;
                         IsPlaying.Value = false;
@@ -545,20 +519,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         // loopStart は購読で最新化されているため、再生中の In/Out 変更にも追従する。
         if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
         {
-            _editorClock.CurrentTime.Value = loopStart;
+            _editorClock.CurrentTime.Value = Scene.Start;
             return true;
         }
 
         return false;
-    }
-
-    private static int ComputePlaybackEndFrame(bool loopEnabled, TimeSpan loopEnd, int sceneEndFrame, int rate)
-    {
-        if (!loopEnabled) return sceneEndFrame;
-        int loopEndFrame = (int)Math.Ceiling(loopEnd.ToFrameNumber(rate));
-        if (loopEndFrame > 0 && loopEndFrame < sceneEndFrame)
-            return loopEndFrame;
-        return sceneEndFrame;
     }
 
     public int GetFrameRate()
@@ -577,33 +542,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         if (Scene == null)
             return (TimeSpan.Zero, TimeSpan.Zero);
 
-        TimeSpan sceneStart = Scene.Start;
-        TimeSpan sceneEnd = sceneStart + Scene.Duration;
-
-        switch (LoopMode.Value)
-        {
-            // None / All いずれもシーン全体を範囲とする。実際のループ可否は IsLoopEnabled が決める。
-            case ViewModels.LoopMode.None:
-            case ViewModels.LoopMode.All:
-                return (TimeSpan.Zero, sceneEnd);
-
-            case ViewModels.LoopMode.Selection:
-                {
-                    Element[] children = Scene.Children.Where(c => c.IsEnabled).ToArray();
-                    if (_editorSelection.SelectedObject.Value is Element single)
-                    {
-                        return (single.Start, single.Range.End);
-                    }
-
-                    if (children.Length == 0)
-                        return (sceneStart, sceneEnd);
-                    TimeSpan minStart = children.Min(c => c.Start);
-                    TimeSpan maxEnd = children.Max(c => c.Range.End);
-                    return (minStart, maxEnd);
-                }
-        }
-
-        return (TimeSpan.Zero, sceneEnd);
+        return (Scene.Start, Scene.Start + Scene.Duration);
     }
 
     public void ToggleLoop()
@@ -705,20 +644,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 Scene.Edited -= OnSceneEdited;
                 // 既存の CurrentFrame 購読は維持して UpdateCurrentFrame 経由でレンダリングを行う
 
-                // ループ範囲とシーン終端は毎tick再計算するとSelectionモードで割り当てが嵩むため、
-                // 関係するプロパティを購読してキャッシュを更新する。
-                (TimeSpan loopStart, TimeSpan loopEnd) cachedLoop = GetLoopRange();
-                TimeSpan cachedSceneEnd = Scene.Start + Scene.Duration;
-                using var loopRangeSubscription = Observable.Merge(
-                        IsLoopEnabled.Select(_ => Unit.Default),
-                        LoopMode.Select(_ => Unit.Default))
-                    .Subscribe(_ =>
-                    {
-                        if (Scene == null) return;
-                        cachedLoop = GetLoopRange();
-                        cachedSceneEnd = Scene.Start + Scene.Duration;
-                    });
-
+                TimeSpan sceneStart = Scene.Start;
+                TimeSpan sceneEnd = sceneStart + Scene.Duration;
                 DateTime lastTime = DateTime.UtcNow;
                 while (_isShuttling && IsPlaying.Value && Scene != null)
                 {
@@ -733,28 +660,37 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     float speed = PlaybackSpeed.Value;
                     int sign = direction == ViewModels.PlaybackDirection.Forward ? 1 : -1;
                     TimeSpan delta = TimeSpan.FromTicks((long)(elapsed.Ticks * speed * sign));
-                    TimeSpan next = _editorClock.CurrentTime.Value + delta;
+                    TimeSpan currentTime = _editorClock.CurrentTime.Value;
+                    TimeSpan next = currentTime + delta;
 
-                    TimeSpan loopStart = cachedLoop.loopStart;
-                    TimeSpan loopEnd = cachedLoop.loopEnd;
-                    TimeSpan sceneEnd = cachedSceneEnd;
-                    TimeSpan minTime = TimeSpan.Zero;
-                    TimeSpan maxTime = sceneEnd - tick;
-                    if (IsLoopEnabled.Value && loopEnd > loopStart)
+                    // 範囲外から再生開始した場合はその位置から自然に再生する。
+                    // シーン範囲内に入った時点で通常のループ・境界判定に切り替わる。
+                    bool insideRange = currentTime >= sceneStart && currentTime < sceneEnd;
+                    if (insideRange)
                     {
-                        minTime = loopStart;
-                        maxTime = loopEnd - tick;
-                        if (next > loopEnd) next = loopStart;
-                        if (next < loopStart) next = loopEnd - tick;
+                        TimeSpan minTime = sceneStart;
+                        TimeSpan maxTime = sceneEnd - tick;
+                        if (IsLoopEnabled.Value)
+                        {
+                            if (next > sceneEnd) next = minTime;
+                            if (next < sceneStart) next = maxTime;
+                        }
+                        else
+                        {
+                            if (next >= sceneEnd) { next = maxTime; break; }
+                            if (next < sceneStart) { next = minTime; break; }
+                        }
+
+                        if (next < minTime) next = minTime;
+                        if (next > maxTime) next = maxTime;
                     }
                     else
                     {
-                        if (next >= sceneEnd) { next = maxTime; break; }
+                        // 範囲外: シーン範囲に向かう方向のみ進行を許可する。
+                        bool movingTowardRange = currentTime >= sceneEnd ? sign < 0 : sign > 0;
+                        if (!movingTowardRange) break;
                         if (next < TimeSpan.Zero) { next = TimeSpan.Zero; break; }
                     }
-
-                    if (next < minTime) next = minTime;
-                    if (next > maxTime) next = maxTime;
 
                     TimeSpan target = next;
                     Avalonia.Threading.Dispatcher.UIThread.Post(() =>

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -644,14 +644,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 Scene.Edited -= OnSceneEdited;
                 // 既存の CurrentFrame 購読は維持して UpdateCurrentFrame 経由でレンダリングを行う
 
-                TimeSpan sceneStart = Scene.Start;
-                TimeSpan sceneEnd = sceneStart + Scene.Duration;
                 DateTime lastTime = DateTime.UtcNow;
                 while (_isShuttling && IsPlaying.Value && Scene != null)
                 {
                     var direction = PlaybackDirection.Value;
                     if (direction == ViewModels.PlaybackDirection.Stopped)
                         break;
+
+                    // シャトル再生中に Scene.Start / Duration が変更されても追従できるよう毎回取得
+                    TimeSpan sceneStart = Scene.Start;
+                    TimeSpan sceneEnd = sceneStart + Scene.Duration;
 
                     DateTime now = DateTime.UtcNow;
                     TimeSpan elapsed = now - lastTime;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -422,16 +422,24 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
         int sceneEndFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
         (TimeSpan loopStart, TimeSpan loopEnd) = GetLoopRange();
-        int endFrame = sceneEndFrame;
+        // 再生中のループ ON/OFF や In/Out 変更に追従するため、endFrame と loopActive、
+        // loopStart は再生中も IsLoopEnabled / LoopMode / InPoint / OutPoint の購読で更新する。
+        int endFrame = ComputePlaybackEndFrame(IsLoopEnabled.Value, loopEnd, sceneEndFrame, rate);
         bool loopActive = IsLoopEnabled.Value;
-        if (loopActive)
-        {
-            int loopEndFrame = (int)Math.Ceiling(loopEnd.ToFrameNumber(rate));
-            if (loopEndFrame > 0 && loopEndFrame < endFrame)
+        using var loopRangeSubscription = Observable.Merge(
+                IsLoopEnabled.Select(_ => Unit.Default),
+                LoopMode.Select(_ => Unit.Default),
+                InPoint.Select(_ => Unit.Default),
+                OutPoint.Select(_ => Unit.Default))
+            .Subscribe(_ =>
             {
-                endFrame = loopEndFrame;
-            }
-        }
+                if (Scene == null) return;
+                var range = GetLoopRange();
+                loopStart = range.Start;
+                loopEnd = range.End;
+                loopActive = IsLoopEnabled.Value;
+                endFrame = ComputePlaybackEndFrame(loopActive, loopEnd, sceneEndFrame, rate);
+            });
         bufferStatus.StartTime.Value = startTime;
         bufferStatus.EndTime.Value = startTime;
         frameCacheManager.Options = frameCacheManager.Options with
@@ -540,14 +548,24 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         Scene.Edited += OnSceneEdited;
         _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
 
-        // ループが有効でユーザーによる停止ではない場合、ループ先頭に戻して再開を要求
-        if (loopActive && IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
+        // ループが有効でユーザーによる停止ではない場合、ループ先頭に戻して再開を要求。
+        // loopStart は購読で最新化されているため、再生中の In/Out 変更にも追従する。
+        if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
         {
             _editorClock.CurrentTime.Value = loopStart;
             return true;
         }
 
         return false;
+    }
+
+    private static int ComputePlaybackEndFrame(bool loopEnabled, TimeSpan loopEnd, int sceneEndFrame, int rate)
+    {
+        if (!loopEnabled) return sceneEndFrame;
+        int loopEndFrame = (int)Math.Ceiling(loopEnd.ToFrameNumber(rate));
+        if (loopEndFrame > 0 && loopEndFrame < sceneEndFrame)
+            return loopEndFrame;
+        return sceneEndFrame;
     }
 
     public int GetFrameRate()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -29,9 +29,26 @@ using AudioContext = Beutl.Audio.Platforms.OpenAL.AudioContext;
 
 namespace Beutl.ViewModels;
 
+public enum PlaybackDirection
+{
+    Stopped,
+    Forward,
+    Backward,
+}
+
+public enum LoopMode
+{
+    None,
+    All,
+    InOut,
+    Selection,
+}
+
 public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 {
     private static readonly TimeSpan s_second = TimeSpan.FromSeconds(1);
+    private static readonly float[] s_fastSpeeds = [1.0f, 2.0f, 4.0f, 8.0f, 16.0f, 32.0f];
+    private static readonly float[] s_slowSpeeds = [1.0f, 0.5f, 0.25f];
     private readonly ILogger _logger = Log.CreateLogger<PlayerViewModel>();
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<bool> _isEnabled;
@@ -42,6 +59,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private CancellationTokenSource? _cts;
     private Size _maxFrameSize;
     private Task _playbackTask = Task.CompletedTask;
+    private bool _isShuttling;
     // Published snapshots carry the start time of the buffer that was just *queued*
     // to the audio backend, which is ahead of the current playhead. Replay several
     // recent snapshots so a visualizer tab opened mid-playback also receives the
@@ -280,6 +298,18 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactivePropertySlim<bool> IsPlaying { get; } = new();
 
+    public ReactivePropertySlim<float> PlaybackSpeed { get; } = new(1.0f);
+
+    public ReactivePropertySlim<PlaybackDirection> PlaybackDirection { get; } = new(ViewModels.PlaybackDirection.Stopped);
+
+    public ReactivePropertySlim<bool> IsLoopEnabled { get; } = new(false);
+
+    public ReactivePropertySlim<LoopMode> LoopMode { get; } = new(ViewModels.LoopMode.InOut);
+
+    public ReactivePropertySlim<TimeSpan?> InPoint { get; } = new();
+
+    public ReactivePropertySlim<TimeSpan?> OutPoint { get; } = new();
+
     public ReactiveProperty<TimeSpan> CurrentFrame { get; }
 
     public ReadOnlyReactiveProperty<TimeSpan> Duration { get; }
@@ -356,126 +386,168 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         if (IsPlaying.Value) return;
 
+        PlaybackSpeed.Value = 1.0f;
+        PlaybackDirection.Value = ViewModels.PlaybackDirection.Forward;
+
         _playbackTask = Task.Run(async () =>
         {
-            if (!_isEnabled.Value || Scene == null)
-                return;
-
-            BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
-            FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
-            Scene.Edited -= OnSceneEdited;
-            _currentFrameSubscription?.Dispose();
-
-            IsPlaying.Value = true;
-            int rate = GetFrameRate();
-
-            TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
-            TimeSpan startTime = _editorClock.CurrentTime.Value;
-            TimeSpan durationTime = Scene.Duration;
-            int startFrame = (int)startTime.ToFrameNumber(rate);
-            int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
-            int endFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
-            bufferStatus.StartTime.Value = startTime;
-            bufferStatus.EndTime.Value = startTime;
-            frameCacheManager.Options = frameCacheManager.Options with
+            // ループ再生時は一度の Play() タスク内で再開する。
+            // Post で Play() を再帰呼び出しすると _playbackTask が新しいタスクで上書きされ、
+            // Pause() の `await _playbackTask;` が想定外のタスクを待ってしまうため避ける。
+            bool restart;
+            do
             {
-                DeletionStrategy = FrameCacheDeletionStrategy.BackwardBlock
-            };
-
-            frameCacheManager.CurrentFrame = startFrame;
-            using var playerImpl = new BufferedPlayer(EditViewModel, Scene, IsPlaying, rate);
-            _logger.LogInformation("Start the playback. ({SceneId}, {Rate}, {Start}, {Duration})",
-                _editViewModel.SceneId, rate, startFrame, durationFrame);
-            playerImpl.Start();
-
-            var clock = new AudioPlaybackClock();
-            var audioTask = PlayAudio(Scene, clock, startTime);
-
-            // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
-            // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
-            // 音声側が再生を開始（または音声なしと判明して終了）するまで待ってから
-            // ウォールクロックの基準点を取得する。
-            await clock.StartedTask;
-
-            DateTime startDateTime = DateTime.UtcNow;
-            var tcs = new TaskCompletionSource<bool>();
-            int nextExpectedFrame = startFrame + 1;
-            int processing = 0;
-
-            int ComputeExpectFrame()
-            {
-                TimeSpan elapsed = clock.GetTime() is { } audioTime
-                    ? audioTime - startTime
-                    : DateTime.UtcNow - startDateTime;
-                if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
-                return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
-            }
-
-            await using var timer = new Timer(_ =>
-            {
-                if (Interlocked.Exchange(ref processing, 1) != 0) return;
-                try
-                {
-                    var expectFrame = ComputeExpectFrame();
-                    if (!IsPlaying.Value || expectFrame >= endFrame)
-                    {
-                        tcs.TrySetResult(true);
-                        return;
-                    }
-
-                    if (expectFrame < nextExpectedFrame)
-                    {
-                        return;
-                    }
-
-                    while (playerImpl.TryDequeue(out IPlayer.Frame frame))
-                    {
-                        using (frame.Bitmap)
-                        {
-                            UpdateImage(frame.Bitmap.Clone());
-
-                            if (Scene != null)
-                            {
-                                _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
-                                EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
-                            }
-                        }
-
-                        // タイマーが正確じゃないから、だんだんとフレームがずれてくる
-                        // そのため、フレームを消費しすぎたら、そのフレーム番号とexpectFrameが一致するまでスキップする
-                        // 逆に、フレームを消費しすぎない場合は、そのまま次のフレームを取得する
-                        if (expectFrame <= frame.Time)
-                        {
-                            nextExpectedFrame = frame.Time + 1;
-                            break;
-                        }
-
-                        // 期待していたフレームよりも前のフレームが来た場合
-                    }
-
-                    playerImpl.Skipped(ComputeExpectFrame() + 1);
-                }
-                finally
-                {
-                    Interlocked.Exchange(ref processing, 0);
-                }
-            }, null, tick, tick);
-
-            await Task.WhenAll(tcs.Task, audioTask);
-
-            IsPlaying.Value = false;
-            frameCacheManager.UpdateBlocks();
-            bufferStatus.StartTime.Value = TimeSpan.Zero;
-            bufferStatus.EndTime.Value = TimeSpan.Zero;
-            frameCacheManager.Options = frameCacheManager.Options with
-            {
-                DeletionStrategy = FrameCacheDeletionStrategy.Old
-            };
-
-            _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
-            Scene.Edited += OnSceneEdited;
-            _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
+                restart = await PlayInternal();
+            } while (restart);
         });
+    }
+
+    private async Task<bool> PlayInternal()
+    {
+        if (!_isEnabled.Value || Scene == null)
+            return false;
+
+        BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
+        FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
+        Scene.Edited -= OnSceneEdited;
+        _currentFrameSubscription?.Dispose();
+
+        IsPlaying.Value = true;
+        int rate = GetFrameRate();
+
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+        TimeSpan startTime = _editorClock.CurrentTime.Value;
+        TimeSpan durationTime = Scene.Duration;
+        int startFrame = (int)startTime.ToFrameNumber(rate);
+        int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
+        int sceneEndFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
+        (TimeSpan loopStart, TimeSpan loopEnd) = GetLoopRange();
+        int endFrame = sceneEndFrame;
+        bool loopActive = IsLoopEnabled.Value;
+        if (loopActive)
+        {
+            int loopEndFrame = (int)Math.Ceiling(loopEnd.ToFrameNumber(rate));
+            if (loopEndFrame > 0 && loopEndFrame < endFrame)
+            {
+                endFrame = loopEndFrame;
+            }
+        }
+        bufferStatus.StartTime.Value = startTime;
+        bufferStatus.EndTime.Value = startTime;
+        frameCacheManager.Options = frameCacheManager.Options with
+        {
+            DeletionStrategy = FrameCacheDeletionStrategy.BackwardBlock
+        };
+
+        frameCacheManager.CurrentFrame = startFrame;
+        using var playerImpl = new BufferedPlayer(EditViewModel, Scene, IsPlaying, rate);
+        _logger.LogInformation("Start the playback. ({SceneId}, {Rate}, {Start}, {Duration})",
+            _editViewModel.SceneId, rate, startFrame, durationFrame);
+        playerImpl.Start();
+
+        var clock = new AudioPlaybackClock();
+        var audioTask = PlayAudio(Scene, clock, startTime);
+
+        // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
+        // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
+        // 音声側が再生を開始（または音声なしと判明して終了）するまで待ってから
+        // ウォールクロックの基準点を取得する。
+        await clock.StartedTask;
+
+        DateTime startDateTime = DateTime.UtcNow;
+        var tcs = new TaskCompletionSource<bool>();
+        int nextExpectedFrame = startFrame + 1;
+        int processing = 0;
+        bool reachedNaturalEnd = false;
+
+        int ComputeExpectFrame()
+        {
+            TimeSpan elapsed = clock.GetTime() is { } audioTime
+                ? audioTime - startTime
+                : DateTime.UtcNow - startDateTime;
+            if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+            return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
+        }
+
+        await using var timer = new Timer(_ =>
+        {
+            if (Interlocked.Exchange(ref processing, 1) != 0) return;
+            try
+            {
+                var expectFrame = ComputeExpectFrame();
+                if (!IsPlaying.Value || expectFrame >= endFrame)
+                {
+                    // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える
+                    if (loopActive && expectFrame >= endFrame)
+                    {
+                        reachedNaturalEnd = true;
+                        IsPlaying.Value = false;
+                    }
+                    tcs.TrySetResult(true);
+                    return;
+                }
+
+                if (expectFrame < nextExpectedFrame)
+                {
+                    return;
+                }
+
+                while (playerImpl.TryDequeue(out IPlayer.Frame frame))
+                {
+                    using (frame.Bitmap)
+                    {
+                        UpdateImage(frame.Bitmap.Clone());
+
+                        if (Scene != null)
+                        {
+                            _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
+                            EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
+                        }
+                    }
+
+                    // タイマーが正確じゃないから、だんだんとフレームがずれてくる
+                    // そのため、フレームを消費しすぎたら、そのフレーム番号とexpectFrameが一致するまでスキップする
+                    // 逆に、フレームを消費しすぎない場合は、そのまま次のフレームを取得する
+                    if (expectFrame <= frame.Time)
+                    {
+                        nextExpectedFrame = frame.Time + 1;
+                        break;
+                    }
+
+                    // 期待していたフレームよりも前のフレームが来た場合
+                }
+
+                playerImpl.Skipped(ComputeExpectFrame() + 1);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref processing, 0);
+            }
+        }, null, tick, tick);
+
+        await Task.WhenAll(tcs.Task, audioTask);
+
+        IsPlaying.Value = false;
+        frameCacheManager.UpdateBlocks();
+        bufferStatus.StartTime.Value = TimeSpan.Zero;
+        bufferStatus.EndTime.Value = TimeSpan.Zero;
+        frameCacheManager.Options = frameCacheManager.Options with
+        {
+            DeletionStrategy = FrameCacheDeletionStrategy.Old
+        };
+
+        _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
+        Scene.Edited += OnSceneEdited;
+        _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
+
+        // ループが有効でユーザーによる停止ではない場合、ループ先頭に戻して再開を要求
+        if (loopActive && IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
+        {
+            _editorClock.CurrentTime.Value = loopStart;
+            return true;
+        }
+
+        return false;
     }
 
     public int GetFrameRate()
@@ -487,6 +559,247 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
 
         return rate;
+    }
+
+    public (TimeSpan Start, TimeSpan End) GetLoopRange()
+    {
+        if (Scene == null)
+            return (TimeSpan.Zero, TimeSpan.Zero);
+
+        TimeSpan sceneStart = Scene.Start;
+        TimeSpan sceneEnd = sceneStart + Scene.Duration;
+
+        switch (LoopMode.Value)
+        {
+            // None / All いずれもシーン全体を範囲とする。実際のループ可否は IsLoopEnabled が決める。
+            case ViewModels.LoopMode.None:
+            case ViewModels.LoopMode.All:
+                return (TimeSpan.Zero, sceneEnd);
+
+            case ViewModels.LoopMode.InOut:
+                {
+                    TimeSpan start = InPoint.Value ?? sceneStart;
+                    TimeSpan end = OutPoint.Value ?? sceneEnd;
+                    if (end <= start) end = sceneEnd;
+                    return (start, end);
+                }
+
+            case ViewModels.LoopMode.Selection:
+                {
+                    Element[] children = Scene.Children.Where(c => c.IsEnabled).ToArray();
+                    if (_editorSelection.SelectedObject.Value is Element single)
+                    {
+                        return (single.Start, single.Range.End);
+                    }
+
+                    if (children.Length == 0)
+                        return (sceneStart, sceneEnd);
+                    TimeSpan minStart = children.Min(c => c.Start);
+                    TimeSpan maxEnd = children.Max(c => c.Range.End);
+                    return (minStart, maxEnd);
+                }
+        }
+
+        return (TimeSpan.Zero, sceneEnd);
+    }
+
+    public void SetInPoint()
+    {
+        InPoint.Value = _editorClock.CurrentTime.Value;
+        // In >= Out になるとループ範囲が無効になるため反対側のマーカーを解除する
+        if (OutPoint.Value is { } o && o <= InPoint.Value)
+        {
+            OutPoint.Value = null;
+        }
+    }
+
+    public void SetOutPoint()
+    {
+        TimeSpan time = _editorClock.CurrentTime.Value;
+        // Out <= In になるとループ範囲が無効になるため反対側のマーカーを解除する
+        if (InPoint.Value is { } i && time <= i)
+        {
+            InPoint.Value = null;
+        }
+        OutPoint.Value = time;
+    }
+
+    public void ToggleLoop()
+    {
+        IsLoopEnabled.Value = !IsLoopEnabled.Value;
+    }
+
+    public void ShuttleStop()
+    {
+        _isShuttling = false;
+        if (IsPlaying.Value)
+        {
+            _ = Pause();
+        }
+        else
+        {
+            PlaybackSpeed.Value = 1.0f;
+            PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
+        }
+    }
+
+    public void ShuttleForward(bool fineGrain = false)
+    {
+        _ = ShuttleAsync(forward: true, fineGrain);
+    }
+
+    public void ShuttleBackward(bool fineGrain = false)
+    {
+        _ = ShuttleAsync(forward: false, fineGrain);
+    }
+
+    private async Task ShuttleAsync(bool forward, bool fineGrain)
+    {
+        try
+        {
+            await ShuttleCore(forward, fineGrain);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred while starting shuttle playback.");
+        }
+    }
+
+    private async Task ShuttleCore(bool forward, bool fineGrain)
+    {
+        if (!_isEnabled.Value || Scene == null) return;
+        var newDirection = forward
+            ? ViewModels.PlaybackDirection.Forward
+            : ViewModels.PlaybackDirection.Backward;
+
+        // 通常再生中(L 押下時)はネイティブの再生を加速モードに切り替えるためまず停止
+        if (IsPlaying.Value && !_isShuttling)
+        {
+            await Pause();
+        }
+
+        if (PlaybackDirection.Value != newDirection)
+        {
+            PlaybackSpeed.Value = fineGrain ? s_slowSpeeds[1] : 1.0f;
+            PlaybackDirection.Value = newDirection;
+        }
+        else
+        {
+            // 同じ方向で連打されたら速度を倍々
+            float current = PlaybackSpeed.Value;
+            if (fineGrain)
+            {
+                int idx = Array.FindIndex(s_slowSpeeds, v => Math.Abs(v - current) < 0.001f);
+                int nextIdx = idx < 0 ? 1 : Math.Min(idx + 1, s_slowSpeeds.Length - 1);
+                PlaybackSpeed.Value = s_slowSpeeds[nextIdx];
+            }
+            else
+            {
+                int idx = Array.FindIndex(s_fastSpeeds, v => Math.Abs(v - current) < 0.001f);
+                int nextIdx = idx < 0 ? 1 : Math.Min(idx + 1, s_fastSpeeds.Length - 1);
+                PlaybackSpeed.Value = s_fastSpeeds[nextIdx];
+            }
+        }
+
+        if (!_isShuttling)
+        {
+            StartShuttle();
+        }
+    }
+
+    private void StartShuttle()
+    {
+        if (_isShuttling || Scene == null) return;
+        _isShuttling = true;
+        IsPlaying.Value = true;
+
+        _playbackTask = Task.Run(async () =>
+        {
+            try
+            {
+                int rate = GetFrameRate();
+                TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+                Scene.Edited -= OnSceneEdited;
+                // 既存の CurrentFrame 購読は維持して UpdateCurrentFrame 経由でレンダリングを行う
+
+                // ループ範囲とシーン終端は毎tick再計算するとSelectionモードで割り当てが嵩むため、
+                // 関係するプロパティを購読してキャッシュを更新する。
+                (TimeSpan loopStart, TimeSpan loopEnd) cachedLoop = GetLoopRange();
+                TimeSpan cachedSceneEnd = Scene.Start + Scene.Duration;
+                using var loopRangeSubscription = Observable.Merge(
+                        IsLoopEnabled.Select(_ => Unit.Default),
+                        LoopMode.Select(_ => Unit.Default),
+                        InPoint.Select(_ => Unit.Default),
+                        OutPoint.Select(_ => Unit.Default))
+                    .Subscribe(_ =>
+                    {
+                        if (Scene == null) return;
+                        cachedLoop = GetLoopRange();
+                        cachedSceneEnd = Scene.Start + Scene.Duration;
+                    });
+
+                DateTime lastTime = DateTime.UtcNow;
+                while (_isShuttling && IsPlaying.Value && Scene != null)
+                {
+                    var direction = PlaybackDirection.Value;
+                    if (direction == ViewModels.PlaybackDirection.Stopped)
+                        break;
+
+                    DateTime now = DateTime.UtcNow;
+                    TimeSpan elapsed = now - lastTime;
+                    lastTime = now;
+
+                    float speed = PlaybackSpeed.Value;
+                    int sign = direction == ViewModels.PlaybackDirection.Forward ? 1 : -1;
+                    TimeSpan delta = TimeSpan.FromTicks((long)(elapsed.Ticks * speed * sign));
+                    TimeSpan next = _editorClock.CurrentTime.Value + delta;
+
+                    TimeSpan loopStart = cachedLoop.loopStart;
+                    TimeSpan loopEnd = cachedLoop.loopEnd;
+                    TimeSpan sceneEnd = cachedSceneEnd;
+                    TimeSpan minTime = TimeSpan.Zero;
+                    TimeSpan maxTime = sceneEnd - tick;
+                    if (IsLoopEnabled.Value && loopEnd > loopStart)
+                    {
+                        minTime = loopStart;
+                        maxTime = loopEnd - tick;
+                        if (next > loopEnd) next = loopStart;
+                        if (next < loopStart) next = loopEnd - tick;
+                    }
+                    else
+                    {
+                        if (next >= sceneEnd) { next = maxTime; break; }
+                        if (next < TimeSpan.Zero) { next = TimeSpan.Zero; break; }
+                    }
+
+                    if (next < minTime) next = minTime;
+                    if (next > maxTime) next = maxTime;
+
+                    TimeSpan target = next;
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    {
+                        if (Scene != null)
+                        {
+                            _editorClock.CurrentTime.Value = target;
+                        }
+                    });
+
+                    await Task.Delay(tick).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _isShuttling = false;
+                IsPlaying.Value = false;
+                PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
+                PlaybackSpeed.Value = 1.0f;
+                if (Scene != null)
+                {
+                    Scene.Edited += OnSceneEdited;
+                }
+            }
+        });
     }
 
     private async Task PlayAudio(Scene scene, AudioPlaybackClock clock, TimeSpan startTime)
@@ -850,7 +1163,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         if (!IsPlaying.Value) return;
 
         _logger.LogInformation("Pause the playback. ({SceneId})", _editViewModel.SceneId);
+        _isShuttling = false;
         IsPlaying.Value = false;
+        PlaybackSpeed.Value = 1.0f;
+        PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
         await _playbackTask;
     }
 

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -19,6 +19,7 @@
             CurrentTime="{Binding CurrentFrame.Value, StringFormat={}{0:hh\\:mm\\:ss\\.ff}}"
             EndButtonCommand="{Binding End}"
             IsPlaying="{Binding IsPlaying.Value, Mode=OneWay}"
+            IsLoopEnabled="{Binding IsLoopEnabled.Value, Mode=TwoWay}"
             Maximum="{Binding Duration.Value, Converter={x:Static converters:TimeSpanToDoubleConverter.Instance}}"
             NextButtonCommand="{Binding Next}"
             PlayButtonCommand="{Binding PlayPause}"


### PR DESCRIPTION
## Description
- Adds JKL shuttle playback (J/L for backward/forward with progressive speed-up on repeat, K to stop) plus Shift+J/L for fine half-speed shuttling.
- Adds a loop toggle (default `?` key) and a loop ToggleButton in the player toolbar; the loop range is derived from `Scene.Start` and `Scene.Duration` and reacts live to changes during playback.
- Loop continuation is handled inside a single playback task so `Pause()` no longer awaits a stale task across loop iterations.

## Breaking changes
None.

## Fixed issues
None.