### PR TITLE
fix: Animate TextBlock properties and default stroke TrimEnd

### DIFF
--- a/src/Beutl.Engine/Graphics/Shapes/TextBlock.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextBlock.cs
@@ -22,7 +22,7 @@ public partial class TextBlock : Drawable
     [SuppressResourceClassGeneration]
     [Display(Name = nameof(GraphicsStrings.TextBlock_Size), ResourceType = typeof(GraphicsStrings))]
     [Range(0, float.MaxValue)]
-    public IProperty<float> Size { get; } = Property.Create<float>(12);
+    public IProperty<float> Size { get; } = Property.CreateAnimatable<float>(12);
 
     [SuppressResourceClassGeneration]
     [Display(Name = nameof(GraphicsStrings.TextBlock_FontFamily), ResourceType = typeof(GraphicsStrings))]
@@ -38,10 +38,10 @@ public partial class TextBlock : Drawable
 
     [SuppressResourceClassGeneration]
     [Display(Name = nameof(GraphicsStrings.TextBlock_Spacing), ResourceType = typeof(GraphicsStrings))]
-    public IProperty<float> Spacing { get; } = Property.Create<float>(0);
+    public IProperty<float> Spacing { get; } = Property.CreateAnimatable<float>(0);
 
     [Display(Name = nameof(GraphicsStrings.TextBlock_SplitByCharacters), ResourceType = typeof(GraphicsStrings))]
-    public IProperty<bool> SplitByCharacters { get; } = Property.Create<bool>(false);
+    public IProperty<bool> SplitByCharacters { get; } = Property.CreateAnimatable<bool>(false);
 
     [SuppressResourceClassGeneration]
     [Display(Name = nameof(GraphicsStrings.TextBlock_Text), ResourceType = typeof(GraphicsStrings))]

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedTextParser.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedTextParser.cs
@@ -311,7 +311,8 @@ public static class FormattedTextParser
                             MiterLimit = miterLimit,
                             StrokeCap = cap,
                             StrokeJoin = join,
-                            StrokeAlignment = align
+                            StrokeAlignment = align,
+                            TrimEnd = 100,
                         };
 
                         return true;


### PR DESCRIPTION
## Description
- Make `Size`, `Spacing`, and `SplitByCharacters` on `TextBlock` animatable so they can be keyframed like the other text properties
- Set the default `TrimEnd` to 100 in `FormattedTextParser` stroke formatting so strokes render fully by default instead of being trimmed away

## Breaking changes
None

## Fixed issues
None