### PR TITLE
fix: include Scene.Start in audio playback end time

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -880,7 +880,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
             // primaryBufferが終了、secondaryが開始
 
-            while (cur < scene.Duration)
+            TimeSpan endTime = scene.Start + scene.Duration;
+            while (cur < endTime)
             {
                 if (!IsPlaying.Value)
                 {
@@ -1042,7 +1043,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     AnchorClock();
 
                     await Task.Delay(100, cts.Token).ConfigureAwait(false);
-                    if (cur > scene.Duration)
+                    if (cur > scene.Start + scene.Duration)
                         break;
                 }
 


### PR DESCRIPTION
## Description
- The audio playback loop was comparing the current playback time `cur` against `scene.Duration` only, but `cur` is an absolute time that starts at `scene.Start`. When `Scene.Start` was non-zero, audio playback ended prematurely (or never reached the end of the scene).
- Compute the actual end time as `scene.Start + scene.Duration` and use it in both the primary buffer loop and the post-buffer wait loop in `PlayerViewModel`.

## Breaking changes
None

## Fixed issues
None