### PR TITLE
fix: update FrameCacheManager size when MaxFrameSize changes

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -334,30 +334,28 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         get => _maxFrameSize;
         set
         {
+            if (_maxFrameSize == value) return;
             _maxFrameSize = value;
 
-            if (_maxFrameSize != value)
+            FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
+            var frameSize = frameCacheManager.FrameSize.ToSize(1);
+            float scale = (float)Stretch.Uniform.CalculateScaling(_maxFrameSize, frameSize, StretchDirection.Both).X;
+            if (scale != 0)
             {
-                FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
-                var frameSize = frameCacheManager.FrameSize.ToSize(1);
-                float scale = (float)Stretch.Uniform.CalculateScaling(MaxFrameSize, frameSize, StretchDirection.Both).X;
-                if (scale != 0)
+                int den = (int)(1 / scale);
+                if (den % 2 == 1)
                 {
-                    int den = (int)(1 / scale);
-                    if (den % 2 == 1)
-                    {
-                        den++;
-                    }
+                    den++;
+                }
 
-                    frameCacheManager.Options = frameCacheManager.Options with
-                    {
-                        Size = PixelSize.FromSize(frameSize, 1f / den)
-                    };
-                }
-                else
+                frameCacheManager.Options = frameCacheManager.Options with
                 {
-                    frameCacheManager.Options = frameCacheManager.Options with { Size = null };
-                }
+                    Size = PixelSize.FromSize(frameSize, 1f / den)
+                };
+            }
+            else
+            {
+                frameCacheManager.Options = frameCacheManager.Options with { Size = null };
             }
         }
     }


### PR DESCRIPTION
## Description
- The `MaxFrameSize` setter assigned `_maxFrameSize = value` before checking `if (_maxFrameSize \!= value)`, so the comparison was always false and the body became dead code — `FrameCacheManager.Options` was never updated when `MaxFrameSize` changed.
- Reorder the setter to early-return when the value is unchanged, then run the cache-size recalculation so the frame cache actually re-scales.

## Breaking changes
None

## Fixed issues
None