### PR TITLE
fix: dedupe platform export presets across locale changes

### DIFF
--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -23,8 +23,9 @@ public class OutputPresetItem(OutputExtension extension, JsonObject json, string
 
     // ロケール非依存の安定キー。組み込みのプラットフォームプリセットに付与され、
     // ユーザーの言語切替後でも重複登録を防ぐために使う。ユーザーが UI から作成した
-    // プリセットは null。
-    public string? PresetKey { get; } = presetKey;
+    // プリセットは null。setter は PresetKey 未対応の保存データから読み込んだ
+    // 既存アイテムにキーをバックフィルする目的でのみ使用する。
+    public string? PresetKey { get; internal set; } = presetKey;
 
     public void Apply(ISupportOutputPreset context)
     {
@@ -364,7 +365,9 @@ public sealed class OutputPresetService
 
     private void AddPlatformPresets()
     {
-        AddH264Preset(
+        bool changed = false;
+
+        changed |= AddH264Preset(
             presetKey: "Platform.YouTube_1080p60",
             name: Strings.Preset_YouTube_1080p60,
             destinationSize: new PixelSize(1920, 1080),
@@ -376,7 +379,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "4.2");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.YouTube_4K60",
             name: Strings.Preset_YouTube_4K60,
             destinationSize: new PixelSize(3840, 2160),
@@ -388,7 +391,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "5.1");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.Twitter_1080p",
             name: Strings.Preset_Twitter_1080p,
             destinationSize: new PixelSize(1920, 1080),
@@ -400,7 +403,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "4.0");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.Instagram_Reels",
             name: Strings.Preset_Instagram_Reels,
             destinationSize: new PixelSize(1080, 1920),
@@ -412,7 +415,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "4.0");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.Instagram_Feed",
             name: Strings.Preset_Instagram_Feed,
             destinationSize: new PixelSize(1080, 1080),
@@ -424,7 +427,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "4.0");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.TikTok",
             name: Strings.Preset_TikTok,
             destinationSize: new PixelSize(1080, 1920),
@@ -436,7 +439,7 @@ public sealed class OutputPresetService
             profile: "high",
             level: "4.0");
 
-        AddH264Preset(
+        changed |= AddH264Preset(
             presetKey: "Platform.Discord_8MB",
             name: Strings.Preset_Discord_8MB,
             destinationSize: new PixelSize(720, 480),
@@ -448,9 +451,24 @@ public sealed class OutputPresetService
             profile: "main",
             level: "3.1",
             audioSampleRate: 44100);
+
+        if (changed)
+        {
+            // バックフィル / 新規追加を即時永続化しないと、ユーザーが何も操作せず
+            // 終了した後にロケールを切り替えて再起動した場合、前回のマイグレーションが
+            // 失われて重複登録が再発する。
+            try
+            {
+                SaveItems();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An exception has occurred while saving output presets after platform preset migration.");
+            }
+        }
     }
 
-    private void AddH264Preset(
+    private bool AddH264Preset(
         string presetKey,
         string name,
         PixelSize destinationSize,
@@ -464,11 +482,21 @@ public sealed class OutputPresetService
         int audioSampleRate = 48000)
     {
         // 既知のプラットフォームプリセットは PresetKey で照合し、ロケール変更で
-        // ローカライズ名が変わっても重複追加されないようにする。preview.2 から
-        // アップグレードしたユーザーは PresetKey が無いので名前で後方互換照合する。
-        if (_items.Any(i => i.PresetKey == presetKey || (i.PresetKey == null && i.Name.Value == name)))
+        // ローカライズ名が変わっても重複追加されないようにする。PresetKey 未対応の
+        // 保存データから復元したアイテムは PresetKey が null なので、名前一致で
+        // 後方互換照合した上でキーをバックフィルする。
+        OutputPresetItem? existing = _items.FirstOrDefault(
+            i => i.PresetKey == presetKey || (i.PresetKey == null && i.Name.Value == name));
+
+        if (existing != null)
         {
-            return;
+            if (existing.PresetKey == null)
+            {
+                existing.PresetKey = presetKey;
+                return true;
+            }
+
+            return false;
         }
 
         CodecRecord videoCodec = VideoCodecChoicesProvider.GetChoices()
@@ -480,7 +508,7 @@ public sealed class OutputPresetService
 
         if (videoCodec == CodecRecord.Default || audioCodec == CodecRecord.Default)
         {
-            return;
+            return false;
         }
 
         var vid = new FFmpegVideoEncoderSettings
@@ -519,5 +547,7 @@ public sealed class OutputPresetService
             },
             name,
             presetKey));
+
+        return true;
     }
 }

--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -13,13 +13,18 @@ using Reactive.Bindings;
 
 namespace Beutl.Services;
 
-public class OutputPresetItem(OutputExtension extension, JsonObject json, string name)
+public class OutputPresetItem(OutputExtension extension, JsonObject json, string name, string? presetKey = null)
 {
     public OutputExtension Extension { get; } = extension;
 
     public JsonObject Json { get; } = json;
 
     public ReactiveProperty<string> Name { get; } = new(name);
+
+    // ロケール非依存の安定キー。組み込みのプラットフォームプリセットに付与され、
+    // ユーザーの言語切替後でも重複登録を防ぐために使う。ユーザーが UI から作成した
+    // プリセットは null。
+    public string? PresetKey { get; } = presetKey;
 
     public void Apply(ISupportOutputPreset context)
     {
@@ -41,12 +46,19 @@ public class OutputPresetItem(OutputExtension extension, JsonObject json, string
 
     public static JsonNode ToJson(OutputPresetItem item)
     {
-        return new JsonObject
+        var jsonObject = new JsonObject
         {
             [nameof(Extension)] = TypeFormat.ToString(item.Extension.GetType()),
             [nameof(Json)] = item.Json.DeepClone(),
             [nameof(Name)] = item.Name.Value
         };
+
+        if (item.PresetKey != null)
+        {
+            jsonObject[nameof(PresetKey)] = item.PresetKey;
+        }
+
+        return jsonObject;
     }
 
     public static OutputPresetItem? FromJson(JsonNode json, ILogger logger)
@@ -85,7 +97,13 @@ public class OutputPresetItem(OutputExtension extension, JsonObject json, string
                 return null;
             }
 
-            return new OutputPresetItem(extension, jsonObject, name);
+            string? presetKey = null;
+            if (json[nameof(PresetKey)] is JsonValue keyValue && keyValue.TryGetValue(out string? key))
+            {
+                presetKey = key;
+            }
+
+            return new OutputPresetItem(extension, jsonObject, name, presetKey);
         }
         catch (Exception ex)
         {
@@ -347,9 +365,10 @@ public sealed class OutputPresetService
     private void AddPlatformPresets()
     {
         AddH264Preset(
-            Strings.Preset_YouTube_1080p60,
-            new PixelSize(1920, 1080),
-            new Rational(60, 1),
+            presetKey: "Platform.YouTube_1080p60",
+            name: Strings.Preset_YouTube_1080p60,
+            destinationSize: new PixelSize(1920, 1080),
+            frameRate: new Rational(60, 1),
             videoBitrate: 12_000_000,
             audioBitrate: 192_000,
             preset: "slow",
@@ -358,9 +377,10 @@ public sealed class OutputPresetService
             level: "4.2");
 
         AddH264Preset(
-            Strings.Preset_YouTube_4K60,
-            new PixelSize(3840, 2160),
-            new Rational(60, 1),
+            presetKey: "Platform.YouTube_4K60",
+            name: Strings.Preset_YouTube_4K60,
+            destinationSize: new PixelSize(3840, 2160),
+            frameRate: new Rational(60, 1),
             videoBitrate: 45_000_000,
             audioBitrate: 192_000,
             preset: "slow",
@@ -369,9 +389,10 @@ public sealed class OutputPresetService
             level: "5.1");
 
         AddH264Preset(
-            Strings.Preset_Twitter_1080p,
-            new PixelSize(1920, 1080),
-            new Rational(30, 1),
+            presetKey: "Platform.Twitter_1080p",
+            name: Strings.Preset_Twitter_1080p,
+            destinationSize: new PixelSize(1920, 1080),
+            frameRate: new Rational(30, 1),
             videoBitrate: 25_000_000,
             audioBitrate: 128_000,
             preset: "medium",
@@ -380,9 +401,10 @@ public sealed class OutputPresetService
             level: "4.0");
 
         AddH264Preset(
-            Strings.Preset_Instagram_Reels,
-            new PixelSize(1080, 1920),
-            new Rational(30, 1),
+            presetKey: "Platform.Instagram_Reels",
+            name: Strings.Preset_Instagram_Reels,
+            destinationSize: new PixelSize(1080, 1920),
+            frameRate: new Rational(30, 1),
             videoBitrate: 5_000_000,
             audioBitrate: 128_000,
             preset: "medium",
@@ -391,9 +413,10 @@ public sealed class OutputPresetService
             level: "4.0");
 
         AddH264Preset(
-            Strings.Preset_Instagram_Feed,
-            new PixelSize(1080, 1080),
-            new Rational(30, 1),
+            presetKey: "Platform.Instagram_Feed",
+            name: Strings.Preset_Instagram_Feed,
+            destinationSize: new PixelSize(1080, 1080),
+            frameRate: new Rational(30, 1),
             videoBitrate: 3_500_000,
             audioBitrate: 128_000,
             preset: "medium",
@@ -402,9 +425,10 @@ public sealed class OutputPresetService
             level: "4.0");
 
         AddH264Preset(
-            Strings.Preset_TikTok,
-            new PixelSize(1080, 1920),
-            new Rational(30, 1),
+            presetKey: "Platform.TikTok",
+            name: Strings.Preset_TikTok,
+            destinationSize: new PixelSize(1080, 1920),
+            frameRate: new Rational(30, 1),
             videoBitrate: 6_000_000,
             audioBitrate: 128_000,
             preset: "medium",
@@ -413,9 +437,10 @@ public sealed class OutputPresetService
             level: "4.0");
 
         AddH264Preset(
-            Strings.Preset_Discord_8MB,
-            new PixelSize(720, 480),
-            new Rational(30, 1),
+            presetKey: "Platform.Discord_8MB",
+            name: Strings.Preset_Discord_8MB,
+            destinationSize: new PixelSize(720, 480),
+            frameRate: new Rational(30, 1),
             videoBitrate: 800_000,
             audioBitrate: 64_000,
             preset: "medium",
@@ -426,6 +451,7 @@ public sealed class OutputPresetService
     }
 
     private void AddH264Preset(
+        string presetKey,
         string name,
         PixelSize destinationSize,
         Rational frameRate,
@@ -437,7 +463,10 @@ public sealed class OutputPresetService
         string level,
         int audioSampleRate = 48000)
     {
-        if (_items.Any(i => i.Name.Value == name))
+        // 既知のプラットフォームプリセットは PresetKey で照合し、ロケール変更で
+        // ローカライズ名が変わっても重複追加されないようにする。preview.2 から
+        // アップグレードしたユーザーは PresetKey が無いので名前で後方互換照合する。
+        if (_items.Any(i => i.PresetKey == presetKey || (i.PresetKey == null && i.Name.Value == name)))
         {
             return;
         }
@@ -488,6 +517,7 @@ public sealed class OutputPresetService
                 ["VideoSettings"] = CoreSerializer.SerializeToJsonObject(vid),
                 ["AudioSettings"] = CoreSerializer.SerializeToJsonObject(aud)
             },
-            name));
+            name,
+            presetKey));
     }
 }


### PR DESCRIPTION
## Description
- Add a locale-independent `PresetKey` to built-in platform export presets so changing the UI language no longer registers duplicate entries on next startup.
- Persist `PresetKey` in the preset JSON and match by it in `AddH264Preset`, falling back to the legacy name-based check for users upgrading from preview.2 (where presets have no key).

## Breaking changes
None.

## Fixed issues
None.