### PR TITLE
fix: address pre-release bugs in playback, cache, and export

### DIFF
--- a/src/Beutl.FFmpegWorker/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcSampleProvider.cs
@@ -159,11 +159,19 @@ internal sealed class IpcSampleProvider : ISampleProvider
             ?? throw new InvalidOperationException("Missing payload for ProvideSample");
 
         var pcm = new Pcm<Stereo32BitFloat>((int)SampleRate, sampleInfo.NumSamples);
-        unsafe
+        try
         {
-            _audioBuffers[bufferIndex].Read(new Span<byte>((void*)pcm.Data, sampleInfo.DataLength));
-        }
+            unsafe
+            {
+                _audioBuffers[bufferIndex].Read(new Span<byte>((void*)pcm.Data, sampleInfo.DataLength));
+            }
 
-        return pcm;
+            return pcm;
+        }
+        catch
+        {
+            pcm.Dispose();
+            throw;
+        }
     }
 }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -58,6 +58,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         FrameCacheManager = scene.GetObservable(Scene.FrameSizeProperty)
             .Select(v => new FrameCacheManager(v, CreateFrameCacheOptions()) { IsEnabled = config.IsFrameCacheEnabled })
+            .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables)!;
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -595,6 +595,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         if (IsPlaying.Value && !_isShuttling)
         {
             await Pause();
+
+            // await 中に別の ShuttleCore が先行して StartShuttle を完了している可能性がある。
+            // そのまま続行すると後続の PlaybackSpeed/Direction 設定で先行分を上書きしてしまうため、
+            // 状態が変化していたらこの呼び出しは何もせずに抜ける。
+            if (_isShuttling || IsPlaying.Value)
+            {
+                return;
+            }
         }
 
         if (PlaybackDirection.Value != newDirection)

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -55,7 +55,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                     var videoSettings = CoreSerializer.SerializeToJsonObject(Controller.Value.VideoSettings);
                     CoreSerializer.PopulateFromJsonObject(newController.VideoSettings, videoSettings);
                     var audioSettings = CoreSerializer.SerializeToJsonObject(Controller.Value.AudioSettings);
-                    CoreSerializer.PopulateFromJsonObject(Controller.Value.AudioSettings, audioSettings);
+                    CoreSerializer.PopulateFromJsonObject(newController.AudioSettings, audioSettings);
                     return newController;
                 }
 


### PR DESCRIPTION
## Description

Pre-release audit across the v2.0.0-preview.2 → HEAD range surfaced four issues, all fixed here:

- **Output audio settings reset on file rename** — `OutputViewModel` was populating audio settings back into the *old* controller after creating a new one, silently dropping bitrate/codec choices every time the destination file changed.
- **`FrameCacheManager` leak on scene resize** — the observable lacked `DisposePreviousValue`, leaking the cache (and its `ArrayPool` entries) every time `Scene.FrameSize` changed. `Renderer`/`Composer` already had this guard.
- **`Pcm` leak in `IpcSampleProvider.FetchChunk`** — if the shared-memory `Read` threw, the freshly allocated `Pcm` was leaked because the task faulted before any caller could dispose it.
- **JKL shuttle race during normal playback** — `await Pause()` yields the UI thread, letting a second JKL press complete `StartShuttle()` before the first call returns; the first call then overwrote the speed/direction the second had just set. Added a state re-check after the await.

## Breaking changes

None.

## Fixed issues

None.