### PR TITLE
fix: use physical pixels for MaxFrameSize

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -328,7 +328,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public event EventHandler? PreviewInvalidated;
 
-    // View側から設定
+    // View側から設定、物理ピクセル
     public Size MaxFrameSize
     {
         get => _maxFrameSize;
@@ -339,7 +339,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
             FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
             var frameSize = frameCacheManager.FrameSize.ToSize(1);
-            float scale = (float)Stretch.Uniform.CalculateScaling(_maxFrameSize, frameSize, StretchDirection.Both).X;
+            float scale = Stretch.Uniform.CalculateScaling(_maxFrameSize, frameSize).X;
             if (scale != 0)
             {
                 int den = (int)(1 / scale);

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -46,15 +46,7 @@ public partial class PlayerView : UserControl
         framePanel.KeyUp += OnFrameKeyUp;
 
         framePanel.GetObservable(BoundsProperty)
-            .Subscribe(s =>
-            {
-                if (DataContext is PlayerViewModel player && TopLevel.GetTopLevel(this) is { } topLevel)
-                {
-                    player.MaxFrameSize = new Beutl.Graphics.Size(
-                        (float)(s.Size.Width * topLevel.RenderScaling),
-                        (float)(s.Size.Height * topLevel.RenderScaling));
-                }
-            });
+            .Subscribe(_ => UpdateMaxFrameSize());
 
         // PlayerView.axaxml.DragAndDrop.cs
         DragDrop.SetAllowDrop(framePanel, true);
@@ -114,14 +106,44 @@ public partial class PlayerView : UserControl
             });
     }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        if (e.Root is TopLevel topLevel)
+        {
+            topLevel.ScalingChanged += OnTopLevelScalingChanged;
+        }
+        UpdateMaxFrameSize();
+    }
+
     protected override async void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
+        if (e.Root is TopLevel topLevel)
+        {
+            topLevel.ScalingChanged -= OnTopLevelScalingChanged;
+        }
         base.OnDetachedFromVisualTree(e);
         _imageConfigSubscription?.Dispose();
         _boundsSubscription?.Dispose();
         if (DataContext is PlayerViewModel viewModel && viewModel.IsPlaying.Value)
         {
             await viewModel.Pause();
+        }
+    }
+
+    private void OnTopLevelScalingChanged(object? sender, EventArgs e)
+    {
+        UpdateMaxFrameSize();
+    }
+
+    private void UpdateMaxFrameSize()
+    {
+        if (DataContext is PlayerViewModel player && TopLevel.GetTopLevel(this) is { } topLevel)
+        {
+            var size = framePanel.Bounds.Size;
+            player.MaxFrameSize = new Beutl.Graphics.Size(
+                (float)(size.Width * topLevel.RenderScaling),
+                (float)(size.Height * topLevel.RenderScaling));
         }
     }
 

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -48,9 +48,11 @@ public partial class PlayerView : UserControl
         framePanel.GetObservable(BoundsProperty)
             .Subscribe(s =>
             {
-                if (DataContext is PlayerViewModel player)
+                if (DataContext is PlayerViewModel player && TopLevel.GetTopLevel(this) is { } topLevel)
                 {
-                    player.MaxFrameSize = new((float)s.Size.Width, (float)s.Size.Height);
+                    player.MaxFrameSize = new Beutl.Graphics.Size(
+                        (float)(s.Size.Width * topLevel.RenderScaling),
+                        (float)(s.Size.Height * topLevel.RenderScaling));
                 }
             });
 


### PR DESCRIPTION
## Description
- `MaxFrameSize` was being set in logical (DIP) units, which on high-DPI displays caused the frame cache scale denominator to be miscalculated and produced a lower-than-intended cache resolution.
- Multiply the panel bounds by `TopLevel.RenderScaling` in `PlayerView` so `MaxFrameSize` is expressed in physical pixels, matching what `FrameCacheManager` expects.
- Simplify the scaling computation in `PlayerViewModel` by using the `CalculateScaling(Size, Size)` overload and dropping the redundant `(float)` cast.

## Breaking changes
None

## Fixed issues
None