### PR TITLE
fix: prevent cache size overflow when panel exceeds frame

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -340,7 +340,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
             var frameSize = frameCacheManager.FrameSize.ToSize(1);
             float scale = Stretch.Uniform.CalculateScaling(_maxFrameSize, frameSize).X;
-            if (scale != 0)
+            // パネルがフレーム以上のサイズなら縮小キャッシュは不要なので原寸を使う。
+            // ここで scale >= 1 を弾かないと (int)(1/scale) が 0 になり 1/den が +Infinity に発散して
+            // PixelSize.FromSize が int.MaxValue 級のサイズを生成してしまう。
+            if (scale > 0 && scale < 1)
             {
                 int den = (int)(1 / scale);
                 if (den % 2 == 1)


### PR DESCRIPTION
## Description
- Skip the reduced-size cache path in `PlayerViewModel` when the display panel is at least as large as the frame, falling back to the original frame size.
- When `scale >= 1`, `(int)(1 / scale)` evaluates to `0`, so the subsequent `1 / den` produces `+Infinity` and `PixelSize.FromSize` returns an `int.MaxValue`-class size, blowing up the cache budget.
- Tightens the guard from `scale \!= 0` to `scale > 0 && scale < 1` so the reduction only runs when a smaller cache actually makes sense.

## Breaking changes
None

## Fixed issues
None