### PR TITLE
fix: protect saved presets from overwrite on RestoreItems failure

### DIFF
--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -161,10 +161,10 @@ public sealed class OutputPresetService
     {
         try
         {
-            _isRestored = true;
             if (!File.Exists(_filePath))
             {
                 _logger.LogWarning("Output preset file not found: {FilePath}", _filePath);
+                _isRestored = true;
                 return;
             }
 
@@ -191,6 +191,11 @@ public sealed class OutputPresetService
                 }
             }
 
+            // 既存ファイルの読み込みに成功した場合のみ書き込みを許可する。
+            // try 冒頭で true にすると、IO 失敗や JSON 破損時に finally の
+            // CreateDefaultPresets/AddPlatformPresets 経由で SaveItems が走り、
+            // ユーザーの保存済みプリセットがデフォルトで上書きされてしまう。
+            _isRestored = true;
             _logger.LogInformation("Restored {Count} OutputPresetItem from file: {FilePath}", _items.Count, _filePath);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Description

- `OutputPresetService.RestoreItems` set `_isRestored = true` at the top of the `try` block. If `File.Open` failed (e.g. file locked by another process) or the JSON was malformed, the catch swallowed the error and the `finally` block ran `CreateDefaultPresets`/`AddPlatformPresets`, whose `SaveItems` then overwrote the user's saved presets with defaults.
- Move `_isRestored = true` to the file-not-found branch (where saving fresh defaults is intended) and to the end of the success path. On IO errors or invalid JSON the flag stays `false`, so `SaveItems` becomes a no-op and the existing on-disk file is preserved until the next start-up.

## Breaking changes

None

## Fixed issues

None