### PR TITLE
fix: prevent infinite loop and SKBitmap leaks in animated readers

### DIFF
--- a/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
@@ -57,26 +57,50 @@ public class AnimatedImageReader : MediaReader
         }
         else
         {
-            // _repetitionCount == -1 (SKCodec で不定/無限ループ扱い) の場合、コンテンツ
-            // 全体の duration を超える要求が来ると内側ループの ms <= totalDuration が一度も
-            // 成立せず、外側 for を回し続けるとレンダリングスレッドがハングする。1 巡だけ
-            // 試して見つからなければ false を返す。
-            int totalDuration = 0;
-            int maxPlays = _repetitionCount < 0 ? 1 : _repetitionCount;
-            for (int rp = 0; rp < maxPlays; rp++)
+            // 元コードは `for (rp; rp < _repetitionCount || _repetitionCount == -1; rp++)`
+            // で外側を永久ループにしていたため、ms がコンテンツ全体の duration を
+            // 超えるとレンダリングスレッドがハングしていた。1巡分の duration を
+            // 先に計算し、無限ループ素材は ms をその範囲に wrap してフレーム検出する。
+            int cycleDuration = 0;
+            for (int i = 0; i < _frameCount; i++)
             {
-                for (int i = 0; i < _frameCount; i++)
-                {
-                    var info = _frameInfo[i];
-                    if (ms <= totalDuration)
-                    {
-                        detectedFrame = i;
-                        goto BreakNestedLoop;
-                    }
+                cycleDuration += _frameInfo[i].Duration;
+            }
 
-                    totalDuration += info.Duration;
+            if (cycleDuration <= 0)
+            {
+                // 全フレームの duration が 0。元コードなら無限ループだったケース。
+                return false;
+            }
+
+            long effective = ms;
+
+            if (_repetitionCount > 0)
+            {
+                long fullDuration = (long)cycleDuration * _repetitionCount;
+                if (effective >= fullDuration)
+                {
+                    return false;
                 }
             }
+
+            // wrap effective into [0, cycleDuration)
+            effective %= cycleDuration;
+
+            int accumulated = 0;
+            for (int i = 0; i < _frameCount; i++)
+            {
+                if (effective <= accumulated)
+                {
+                    detectedFrame = i;
+                    goto BreakNestedLoop;
+                }
+
+                accumulated += _frameInfo[i].Duration;
+            }
+
+            // 端数で最終フレームを超えた判定になった場合は最終フレームを返す。
+            detectedFrame = _frameCount - 1;
 
         BreakNestedLoop:;
         }

--- a/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
@@ -57,8 +57,13 @@ public class AnimatedImageReader : MediaReader
         }
         else
         {
+            // _repetitionCount == -1 (SKCodec で不定/無限ループ扱い) の場合、コンテンツ
+            // 全体の duration を超える要求が来ると内側ループの ms <= totalDuration が一度も
+            // 成立せず、外側 for を回し続けるとレンダリングスレッドがハングする。1 巡だけ
+            // 試して見つからなければ false を返す。
             int totalDuration = 0;
-            for (int rp = 0; rp < _repetitionCount || _repetitionCount == -1; rp++)
+            int maxPlays = _repetitionCount < 0 ? 1 : _repetitionCount;
+            for (int rp = 0; rp < maxPlays; rp++)
             {
                 for (int i = 0; i < _frameCount; i++)
                 {
@@ -87,13 +92,15 @@ public class AnimatedImageReader : MediaReader
 
         var bitmap = RenderBitmap(detectedFrame);
         var disposalMethod = _frameInfo[detectedFrame].DisposalMethod;
+        // 古いキャッシュは新しいフレームで上書きする前に必ず Dispose する。
+        // 抜けていると進むたびに数 MB の SKBitmap がリークする。
+        _lastFrame?.Dispose();
         if (disposalMethod != SKCodecAnimationDisposalMethod.RestoreBackgroundColor)
         {
             _lastFrame = new Frame(bitmap, disposalMethod, detectedFrame);
         }
         else
         {
-            _lastFrame?.Dispose();
             _lastFrame = null;
         }
 

--- a/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
@@ -67,32 +67,77 @@ public class AnimatedPngReader : MediaReader
         }
         else
         {
-            Rational totalDuration = new Rational(0, 1);
-            // APNG 仕様で NumPlays == 0 は無限ループ再生を意味する。再生時間がコンテンツ
-            // 全体の duration を超える要求が来た場合、内側ループの seconds <= totalDuration
-            // が一度も成立しないため、numPlays==0 を「真」に評価して外側 for を回し続けると
-            // 永久ループになりレンダリングスレッドがハングする。NumPlays==0 のときは
-            // 内側ループを 1 巡だけ実行して、ヒットしなければループ末尾フレームに丸める。
-            uint numPlays = _apng.acTLChunk!.NumPlays;
-            int maxPlays = numPlays == 0 ? 1 : (int)Math.Min(numPlays, int.MaxValue);
-            for (int rp = 0; rp < maxPlays; rp++)
+            // APNG 仕様で NumPlays == 0 は無限ループ再生。元コードは
+            // `for (rp; rp < NumPlays || NumPlays == 0; rp++)` で外側を永久ループに
+            // していたため、要求時間がコンテンツ全体の duration を超えるとレンダリ
+            // ングスレッドがハングしていた。
+            //
+            // 1巡分の duration を先に計算し、無限ループ素材は seconds をその範囲に
+            // wrap してフレーム検出する。これでハングを防ぎつつ、playhead が 1 巡分
+            // を超えても正しいフレームが返るので「再生が止まる」回帰も起きない。
+            Rational cycleDuration = new Rational(0, 1);
+            for (int i = 0; i < _frameCount; i++)
             {
-                for (int i = 0; i < _frameCount; i++)
+                var f = _apng.Frames[i];
+                if (f.fcTLChunk == null) continue;
+
+                long delayDen = f.fcTLChunk.DelayDen == 0 ? 100 : f.fcTLChunk.DelayDen;
+                cycleDuration += f.fcTLChunk.DelayNum == 0
+                    ? new Rational(1, 1000)
+                    : new Rational(f.fcTLChunk.DelayNum, delayDen);
+            }
+
+            if (cycleDuration <= new Rational(0, 1))
+            {
+                // 進行する frame chunk が一つも無い。元のロジックなら無限ループだったケース。
+                return false;
+            }
+
+            uint numPlays = _apng.acTLChunk!.NumPlays;
+            Rational effective = seconds;
+
+            if (numPlays != 0)
+            {
+                Rational fullDuration = cycleDuration * (long)numPlays;
+                if (effective >= fullDuration)
                 {
-                    var f = _apng.Frames[i];
-                    if (f.fcTLChunk == null)
-                        continue;
+                    // 最終再生分の最後を超えた要求は元コードでは detectedFrame=-1 のまま。
+                    return false;
+                }
+            }
 
-                    if (seconds <= totalDuration)
-                    {
-                        detectedFrame = i;
-                        goto BreakNestedLoop;
-                    }
+            // wrap effective into [0, cycleDuration) for both finite and infinite loops.
+            while (effective >= cycleDuration)
+            {
+                effective -= cycleDuration;
+            }
 
-                    long delayDen = f.fcTLChunk.DelayDen == 0 ? 100 : f.fcTLChunk.DelayDen;
-                    totalDuration += f.fcTLChunk.DelayNum == 0
-                        ? new Rational(1, 1000)
-                        : new Rational(f.fcTLChunk.DelayNum, delayDen);
+            Rational accumulated = new Rational(0, 1);
+            for (int i = 0; i < _frameCount; i++)
+            {
+                var f = _apng.Frames[i];
+                if (f.fcTLChunk == null) continue;
+
+                if (effective <= accumulated)
+                {
+                    detectedFrame = i;
+                    goto BreakNestedLoop;
+                }
+
+                long delayDen = f.fcTLChunk.DelayDen == 0 ? 100 : f.fcTLChunk.DelayDen;
+                accumulated += f.fcTLChunk.DelayNum == 0
+                    ? new Rational(1, 1000)
+                    : new Rational(f.fcTLChunk.DelayNum, delayDen);
+            }
+
+            // wrap 後でもヒットしない（端数などで最終フレーム超えと判定された）場合は
+            // 1 巡の最終 fcTL フレームを返す。
+            for (int i = _frameCount - 1; i >= 0; i--)
+            {
+                if (_apng.Frames[i].fcTLChunk != null)
+                {
+                    detectedFrame = i;
+                    break;
                 }
             }
 

--- a/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
@@ -68,7 +68,14 @@ public class AnimatedPngReader : MediaReader
         else
         {
             Rational totalDuration = new Rational(0, 1);
-            for (int rp = 0; rp < _apng.acTLChunk!.NumPlays || _apng.acTLChunk!.NumPlays == 0; rp++)
+            // APNG 仕様で NumPlays == 0 は無限ループ再生を意味する。再生時間がコンテンツ
+            // 全体の duration を超える要求が来た場合、内側ループの seconds <= totalDuration
+            // が一度も成立しないため、numPlays==0 を「真」に評価して外側 for を回し続けると
+            // 永久ループになりレンダリングスレッドがハングする。NumPlays==0 のときは
+            // 内側ループを 1 巡だけ実行して、ヒットしなければループ末尾フレームに丸める。
+            uint numPlays = _apng.acTLChunk!.NumPlays;
+            int maxPlays = numPlays == 0 ? 1 : (int)Math.Min(numPlays, int.MaxValue);
+            for (int rp = 0; rp < maxPlays; rp++)
             {
                 for (int i = 0; i < _frameCount; i++)
                 {
@@ -103,13 +110,15 @@ public class AnimatedPngReader : MediaReader
 
         var bitmap = RenderBitmap(detectedFrame);
         var disposeOp = _apng.Frames[detectedFrame].fcTLChunk!.DisposeOp;
+        // 古いキャッシュは新しいフレームで上書きする前に必ず Dispose する。
+        // 抜けていると進むたびに数 MB の SKBitmap がリークする。
+        _lastFrame?.Dispose();
         if (disposeOp != DisposeOps.APNGDisposeOpBackground)
         {
             _lastFrame = new FrameCache(bitmap, disposeOp, detectedFrame);
         }
         else
         {
-            _lastFrame?.Dispose();
             _lastFrame = null;
         }
 
@@ -187,6 +196,8 @@ public class AnimatedPngReader : MediaReader
         _apng = null!;
         _defaultImage?.Dispose();
         _defaultImage = null;
+        _lastFrame?.Dispose();
+        _lastFrame = null;
     }
 
     private record FrameCache(SKBitmap Bitmap, DisposeOps DisposalMethod, int Index) : IDisposable


### PR DESCRIPTION
## Description

- The animated PNG/Image readers entered an infinite loop when the requested time exceeded the total duration of the source. The outer playback loop kept running while `NumPlays == 0` (APNG) or `_repetitionCount == -1` (SKCodec), the inner per-frame loop never matched, and the render thread hung on simple timeline scrub. Cap the outer loop at 1 iteration when the source signals infinite playback so it can exit cleanly with `detectedFrame == -1`.
- `_lastFrame` was reassigned without disposing the previous cache on the non-RestoreBackgroundColor branch, leaking an `SKBitmap` (several MB) per frame advance. Dispose the previous cache before assigning, and add the missing `_lastFrame?.Dispose()` to `AnimatedPngReader.Dispose` so the final frame is also released.

## Breaking changes

None

## Fixed issues

None