### PR TITLE
fix: balance pointer event handler subscriptions in ElementView

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -311,6 +311,7 @@ public sealed partial class ElementView : UserControl
             {
                 AssociatedObject.RemoveHandler(PointerMovedEvent, OnPointerMoved);
                 AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
+                AssociatedObject.border.RemoveHandler(PointerReleasedEvent, OnBorderPointerReleased);
                 AssociatedObject.border.RemoveHandler(PointerMovedEvent, OnBorderPointerMoved);
             }
         }
@@ -678,7 +679,7 @@ public sealed partial class ElementView : UserControl
             base.OnDetaching();
             if (AssociatedObject == null) return;
 
-            AssociatedObject.AddHandler(PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
+            AssociatedObject.RemoveHandler(PointerPressedEvent, OnPointerPressed);
             AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
             AssociatedObject.border.RemoveHandler(PointerReleasedEvent, OnBorderPointerReleased);
         }


### PR DESCRIPTION
## Description

- `_SelectBehavior.OnDetaching` called `AddHandler` instead of `RemoveHandler` on the tunnel-routed `PointerPressedEvent`, so every detach added a fresh handler and held the `AssociatedObject` alive. Handlers piled up across tab reopens and `OnPointerPressed` fired multiple times per click. Replace the `AddHandler` typo with `RemoveHandler`.
- `_ResizeBehavior.OnDetaching` forgot to release the `PointerReleasedEvent` handler attached in `OnAttached`, leaving the border with a dangling reference into a torn-down behavior. Add the matching `RemoveHandler` so the handler set is symmetric.

## Breaking changes

None

## Fixed issues

None