### PR TITLE
fix: skip layer move when LayerHeader is clicked without dragging

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
@@ -88,6 +88,11 @@ public sealed partial class LayerHeader : UserControl
 
     private void Border_PointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        // Border_PointerPressed で _pressed = true にされるのは左ボタンドラッグ開始時のみ。
+        // 右クリックや単発の左クリックで本ハンドラを通すと _newLayer = 0 のまま
+        // MoveLayerCommand が走り、レイヤーが ZIndex=0 に移動して履歴に commit される。
+        if (!_pressed) return;
+
         _pressed = false;
 
         int newLayerNum = _newLayer;
@@ -104,6 +109,7 @@ public sealed partial class LayerHeader : UserControl
         if (point.Properties.IsLeftButtonPressed && GetOrFindTimeline() is { } timeline)
         {
             _pressed = true;
+            _newLayer = ViewModel.Number.Value;
             _startRel = point.Position;
             _start = e.GetCurrentPoint(timeline.TimelinePanel).Position;
             _elements = ViewModel.Timeline.Elements


### PR DESCRIPTION
## Description

- `Border_PointerReleased` ran `MoveLayerCommand` and committed it to history unconditionally, even when no drag had started. `Border_PointerPressed` only sets `_pressed` for the left button, so a right-click or a single left-click without movement would still pass through release with `_newLayer = 0` (uninitialized field), forcing the clicked layer to `ZIndex=0` and recording a bogus "Move layer" entry in the undo history.
- Bail out of the release handler when `_pressed` is false, and seed `_newLayer` with the current layer number on press so a release-without-move drag is a no-op rather than a destructive move to layer 0.

## Breaking changes

None

## Fixed issues

None