### PR TITLE
fix: use directory path for relative element resolution in Scene

### DIFF
--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -416,7 +416,11 @@ public class Scene : ProjectItem, INotifyEdited
         ImmutableArray<TimeRange>.Builder affectedRange
             = ImmutableArray.CreateBuilder<TimeRange>(Math.Max(e.OldItems?.Count ?? 0, e.NewItems?.Count ?? 0));
 
-        string dirPath = Uri!.LocalPath;
+        // Path.GetRelativePath の基点はディレクトリでなければならない。Uri.LocalPath は
+        // .scene ファイル自身を指すため、そのまま使うと _excludeElements に "../foo.belm"
+        // のような不正パスが入り、Deserialize 側 (Path.GetDirectoryName を使用) と整合せず
+        // 除外パターンが効かない。結果として削除した Element が再読み込みで復活する。
+        string dirPath = Path.GetDirectoryName(Uri!.LocalPath)!;
         if (e.Action == NotifyCollectionChangedAction.Remove
             && e.OldItems != null)
         {


### PR DESCRIPTION
## Description

- `Children_CollectionChanged` used `Uri!.LocalPath` (the .scene file itself) as the base for `Path.GetRelativePath`, while every other code path (`Deserialize`, `UpdateInclude`, `SyncronizeFiles`) uses `Path.GetDirectoryName(Uri!.LocalPath)`. The mismatch caused entries written into `_excludeElements` to look like `../foo.belm`, which never matched the patterns recomputed on next load — a removed element returned after closing and reopening the scene.
- Compute `dirPath` consistently with the rest of the class so the add/remove bookkeeping survives a save/reload cycle.

## Breaking changes

None

## Fixed issues

None