### PR TITLE
fix: tolerate missing recent file/project entries in ViewConfig

### DIFF
--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -165,8 +165,19 @@ public sealed class ViewConfig : ConfigurationBase
     public override void Deserialize(ICoreSerializationContext context)
     {
         base.Deserialize(context);
-        RecentFiles = context.GetValue<CoreList<string>>(nameof(RecentFiles))!;
-        RecentProjects = context.GetValue<CoreList<string>>(nameof(RecentProjects))!;
+        // 古い settings.json や手動編集後のファイルでこれらのキーが欠落していると
+        // GetValue が null を返す。null! を素通りさせると _recentFiles.Replace(null) で
+        // ArgumentNullException が起き、後続の Editor/Graphics/Tutorial 設定の
+        // Deserialize もまとめて中断してしまう。null の場合は既存の空リストを保持する。
+        if (context.GetValue<CoreList<string>>(nameof(RecentFiles)) is { } recentFiles)
+        {
+            RecentFiles = recentFiles;
+        }
+
+        if (context.GetValue<CoreList<string>>(nameof(RecentProjects)) is { } recentProjects)
+        {
+            RecentProjects = recentProjects;
+        }
 
         WindowPosition = null;
         if (context.GetValue<WindowPositionRecord?>(nameof(WindowPosition)) is { } pos)


### PR DESCRIPTION
## Description

- `ViewConfig.Deserialize` assigned `context.GetValue<CoreList<string>>(...)` directly with the null-forgiving operator. Older `settings.json` files (or any hand-edited file) lacking `RecentFiles` or `RecentProjects` made the setter call `_recentFiles.Replace(null)`, which throws `ArgumentNullException`. `GlobalConfiguration.Restore` has no per-config try/catch so the exception aborted deserialization of every following config (`Editor`, `Graphics`, `Tutorial`), silently resetting them to defaults on the next launch.
- Pattern-match each lookup and only assign when the context provides a value, leaving the existing empty list intact when the key is missing.

## Breaking changes

None

## Fixed issues

None