### PR TITLE
fix: persist BackupConfig changes by hooking ConfigurationChanged

### DIFF
--- a/src/Beutl.Configuration/GlobalConfiguration.cs
+++ b/src/Beutl.Configuration/GlobalConfiguration.cs
@@ -149,6 +149,7 @@ public sealed class GlobalConfiguration
         FontConfig.ConfigurationChanged += OnConfigurationChanged;
         ViewConfig.ConfigurationChanged += OnConfigurationChanged;
         ExtensionConfig.ConfigurationChanged += OnConfigurationChanged;
+        BackupConfig.ConfigurationChanged += OnConfigurationChanged;
         TelemetryConfig.ConfigurationChanged += OnConfigurationChanged;
         EditorConfig.ConfigurationChanged += OnConfigurationChanged;
         TutorialConfig.ConfigurationChanged += OnConfigurationChanged;
@@ -160,6 +161,7 @@ public sealed class GlobalConfiguration
         FontConfig.ConfigurationChanged -= OnConfigurationChanged;
         ViewConfig.ConfigurationChanged -= OnConfigurationChanged;
         ExtensionConfig.ConfigurationChanged -= OnConfigurationChanged;
+        BackupConfig.ConfigurationChanged -= OnConfigurationChanged;
         TelemetryConfig.ConfigurationChanged -= OnConfigurationChanged;
         EditorConfig.ConfigurationChanged -= OnConfigurationChanged;
         TutorialConfig.ConfigurationChanged -= OnConfigurationChanged;


### PR DESCRIPTION
## Description

- `GlobalConfiguration.AddHandlers` / `RemoveHandlers` wired up the `ConfigurationChanged` event for every config except `BackupConfig`. `BackupConfig.OnPropertyChanged` invokes `OnChanged()` the same way the others do, but with no listener attached the global `Save` path was never triggered — toggling `BackupSettings` only persisted when an unrelated config changed in the same session.
- Add the missing subscription/unsubscription so `BackupConfig` participates in the same auto-save flow as the rest of the configuration objects.

## Breaking changes

None

## Fixed issues

None