### PR TITLE
fix: write JSON output atomically to avoid corrupting saved files

### DIFF
--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -100,10 +100,12 @@ public static class JsonHelper
         // ディスクフルでターゲットファイルがゼロバイトで残るのを防ぐ。
         // 既存ファイルは rename 成功時のみ置き換わるため、ユーザーのプロジェクトや
         // 設定ファイルが破損しない。
-        string tmp = filename + ".tmp";
+        // 固定の `.tmp` サフィックスだとユーザーや他ツールが既に持つ同名ファイルを
+        // 上書きしてしまうため、ランダムサフィックスを付与して衝突を避ける。
+        string tmp = $"{filename}.{Guid.NewGuid():N}.tmp";
         try
         {
-            using (var stream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var stream = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None))
             using (var writer = new Utf8JsonWriter(stream, WriterOptions))
             {
                 node.WriteTo(writer, SerializerOptions);

--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -96,10 +96,35 @@ public static class JsonHelper
 
     public static void JsonSave(this JsonNode node, string filename)
     {
-        using var stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Write);
-        using var writer = new Utf8JsonWriter(stream, WriterOptions);
+        // tmp に書いてから rename することで、書き込み中のクラッシュ・電源断・
+        // ディスクフルでターゲットファイルがゼロバイトで残るのを防ぐ。
+        // 既存ファイルは rename 成功時のみ置き換わるため、ユーザーのプロジェクトや
+        // 設定ファイルが破損しない。
+        string tmp = filename + ".tmp";
+        try
+        {
+            using (var stream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new Utf8JsonWriter(stream, WriterOptions))
+            {
+                node.WriteTo(writer, SerializerOptions);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
 
-        node.WriteTo(writer, SerializerOptions);
+            File.Move(tmp, filename, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+            catch
+            {
+                // 失敗しても元の例外は投げる
+            }
+            throw;
+        }
     }
 
     public static JsonNode? JsonRestore(string filename)

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -235,11 +235,13 @@ public static class CoreSerializer
             // tmp に書き出してから rename する。書き込み中のクラッシュや電源断で
             // 既存のプロジェクトファイル / Element ファイルがゼロバイト化したり
             // 中途半端な状態で残るのを防ぐ。
+            // 固定 `.tmp` サフィックスだとユーザーや他ツールが既に持つ同名ファイルを
+            // 上書きしてしまうため、ランダムサフィックスを付与して衝突を避ける。
             var options = new CoreSerializerOptions { BaseUri = uri, Mode = mode ?? CoreSerializationMode.Write | CoreSerializationMode.SaveReferencedObjects };
-            string tmp = path + ".tmp";
+            string tmp = $"{path}.{Guid.NewGuid():N}.tmp";
             try
             {
-                using (var stream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+                using (var stream = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None))
                 using (var writer = new Utf8JsonWriter(stream, JsonHelper.WriterOptions))
                 {
                     SerializeToJsonObject(obj, options)

--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -232,12 +232,36 @@ public static class CoreSerializer
                 Directory.CreateDirectory(directory);
             }
 
-            using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Write);
-            using var writer = new Utf8JsonWriter(stream, JsonHelper.WriterOptions);
-
+            // tmp に書き出してから rename する。書き込み中のクラッシュや電源断で
+            // 既存のプロジェクトファイル / Element ファイルがゼロバイト化したり
+            // 中途半端な状態で残るのを防ぐ。
             var options = new CoreSerializerOptions { BaseUri = uri, Mode = mode ?? CoreSerializationMode.Write | CoreSerializationMode.SaveReferencedObjects };
-            SerializeToJsonObject(obj, options)
-                .WriteTo(writer, JsonHelper.SerializerOptions);
+            string tmp = path + ".tmp";
+            try
+            {
+                using (var stream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+                using (var writer = new Utf8JsonWriter(stream, JsonHelper.WriterOptions))
+                {
+                    SerializeToJsonObject(obj, options)
+                        .WriteTo(writer, JsonHelper.SerializerOptions);
+                    writer.Flush();
+                    stream.Flush(flushToDisk: true);
+                }
+
+                File.Move(tmp, path, overwrite: true);
+            }
+            catch
+            {
+                try
+                {
+                    if (File.Exists(tmp)) File.Delete(tmp);
+                }
+                catch
+                {
+                    // 失敗しても元の例外は投げる
+                }
+                throw;
+            }
         }
         else
         {


### PR DESCRIPTION
## Description

- Both `JsonHelper.JsonSave` and `CoreSerializer.StoreToUri` opened the target path with `FileMode.Create`, truncating any existing contents before serialization began. A crash, power loss, disk-full, or any exception thrown during write left the original project / scene / element / settings file zero-bytes-or-half-written and unrecoverable. `EditViewModel.SaveAll` runs `StoreToUri` in parallel across every Element, so a single failure could leave several companion files in a half-written state.
- Write to `<path>.tmp` first, flush to disk, then `File.Move` with `overwrite: true` into place so the existing file only changes on success. On exceptions, clean up the partial tmp file before re-throwing.

## Breaking changes

None

## Fixed issues

None