### PR TITLE
ci: auto-format release notes and post Japanese translation comment

### DIFF
--- a/.github/workflows/japanese-release-notes.yml
+++ b/.github/workflows/japanese-release-notes.yml
@@ -59,18 +59,22 @@ jobs:
                - Translate the `**Full Changelog**` line label to `**フルチェンジログ**` but keep the URL.
                - Do not add or remove sections.
 
-            3. Before posting, check whether a Japanese-translation comment already exists on this discussion (to keep the workflow idempotent):
+            3. Check whether a Japanese-translation comment already exists on this discussion (to keep step 4 idempotent and to support repairing a previous half-completed run):
                ```
                gh api graphql -F number=${{ github.event.discussion.number }} -F owner='${{ github.repository_owner }}' -F repo='${{ github.event.repository.name }}' -f query='
                  query($owner: String!, $repo: String!, $number: Int!) {
                    repository(owner: $owner, name: $repo) {
-                     discussion(number: $number) { comments(first: 50) { nodes { id author { login } body } } }
+                     discussion(number: $number) { comments(first: 50) { nodes { id url body } } }
                    }
                  }'
                ```
-               If any existing comment already contains the marker line `<!-- japanese-release-notes -->`, exit without posting again.
+               Find the first comment whose body contains the marker line `<!-- japanese-release-notes -->`. Define `COMMENT_URL`:
+                 - If such a comment exists, set `COMMENT_URL` to its `url`. Skip step 4 — do NOT post another comment.
+                 - Otherwise, leave `COMMENT_URL` unset and proceed to step 4 to create the comment.
 
-            4. Post the translated body as a NEW comment on the discussion. Write the body to a temp file (it contains backticks, quotes, and newlines) and prepend the marker line `<!-- japanese-release-notes -->` followed by a blank line so future runs can detect it. Then:
+               In either case, ALWAYS continue to step 5 — a previous run may have posted the comment but failed to update the release body, and step 5 must be allowed to repair that.
+
+            4. (Only if `COMMENT_URL` was not set in step 3.) Post the translated body as a NEW comment on the discussion. Write the body to a temp file (it contains backticks, quotes, and newlines) and prepend the marker line `<!-- japanese-release-notes -->` followed by a blank line so future runs can detect it. Then:
                ```
                gh api graphql -F discussionId='${{ github.event.discussion.node_id }}' -F body=@"$comment_file" -f query='
                  mutation($discussionId: ID!, $body: String!) {
@@ -80,10 +84,10 @@ jobs:
                  }'
                ```
                (Use `-F body=@<file>` so the file contents are sent as the variable value.)
-               Capture the returned `comment.url` (e.g. `https://github.com/<owner>/<repo>/discussions/<n>#discussioncomment-<id>`) — you will use it in the next step.
+               Set `COMMENT_URL` to the returned `comment.url` (e.g. `https://github.com/<owner>/<repo>/discussions/<n>#discussioncomment-<id>`).
                Do NOT modify the discussion body itself — only add a comment.
 
-            5. If the release body does NOT already contain the substring `日本語のリリースノートは`, prepend exactly this paragraph (followed by one blank line) to the existing release body, using the comment URL captured in step 4 as `<COMMENT_URL>`:
+            5. If the release body does NOT already contain the substring `日本語のリリースノートは`, prepend exactly this paragraph (followed by one blank line) to the existing release body, using `COMMENT_URL` from step 3 or step 4:
                ```
                日本語のリリースノートは[こちら](<COMMENT_URL>)です。
                ```

--- a/.github/workflows/japanese-release-notes.yml
+++ b/.github/workflows/japanese-release-notes.yml
@@ -1,0 +1,100 @@
+name: Japanese Release Notes
+
+on:
+  discussion:
+    types: [created]
+
+jobs:
+  translate:
+    if: |
+      startsWith(github.event.discussion.title, 'v') &&
+      contains(github.event.discussion.title, '.')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Translate discussion and link from release
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.DISCUSSION_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.DISCUSSION_TOKEN }}
+          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(gh api graphql:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*),Bash(jq:*)"'
+          prompt: |
+            A new GitHub Discussion was just created in `${{ github.repository }}`. Treat its title as a release tag and:
+              1. translate the matching release body into Japanese and post it as a NEW COMMENT on the discussion (do not edit the discussion body itself), and
+              2. prepend a Japanese link to that release's body so users can find the translation.
+
+            ## Discussion context (from the event)
+            - number: `${{ github.event.discussion.number }}`
+            - node_id: `${{ github.event.discussion.node_id }}`
+            - title (use as release tag): `${{ github.event.discussion.title }}`
+            - url: `${{ github.event.discussion.html_url }}`
+            - category: `${{ github.event.discussion.category.name }}`
+
+            ## Steps
+
+            1. Use the discussion title verbatim as the release tag (e.g. `v2.0.0-preview.3`). Fetch the release body:
+               `gh release view "${{ github.event.discussion.title }}" -R ${{ github.repository }} --json body,tagName,isDraft,url`
+               If the release does not exist, exit cleanly with a message — do not modify anything.
+
+            2. Translate the release body into natural Japanese:
+               - Keep all markdown structure (headings, bullets, nesting, `<details>`/`<summary>`, code spans, links) intact.
+               - Translate human-readable text including section headings:
+                 - `## What's Changed` → `## 変更点`
+                 - `**New Features**` → `**新機能**`
+                 - `**Improvements & Refactoring**` → `**改善・リファクタリング**`
+                 - `**Bug Fixes**` → `**バグ修正**`
+                 - `**Other**` → `**その他**`
+                 - Download link labels: `Installer` → `インストーラー`, `Installer (.NET Runtime required)` → `インストーラー (.NET Runtime 必須)`, `Zip (arm64)` / `Zip (x64)` はそのまま、`Debian package` → `Debian パッケージ`, `Zip (.NET Runtime required)` → `Zip (.NET Runtime 必須)`.
+               - Inside the `<details><summary>Changelog</summary>` block, keep the auto-generated `* <prefix>: ... by @user in <PR-URL>` lines untranslated (they are PR titles).
+               - Translate the `**Full Changelog**` line label to `**フルチェンジログ**` but keep the URL.
+               - Do not add or remove sections.
+
+            3. Before posting, check whether a Japanese-translation comment already exists on this discussion (to keep the workflow idempotent):
+               ```
+               gh api graphql -F number=${{ github.event.discussion.number }} -F owner='${{ github.repository_owner }}' -F repo='${{ github.event.repository.name }}' -f query='
+                 query($owner: String!, $repo: String!, $number: Int!) {
+                   repository(owner: $owner, name: $repo) {
+                     discussion(number: $number) { comments(first: 50) { nodes { id author { login } body } } }
+                   }
+                 }'
+               ```
+               If any existing comment already contains the marker line `<!-- japanese-release-notes -->`, exit without posting again.
+
+            4. Post the translated body as a NEW comment on the discussion. Write the body to a temp file (it contains backticks, quotes, and newlines) and prepend the marker line `<!-- japanese-release-notes -->` followed by a blank line so future runs can detect it. Then:
+               ```
+               gh api graphql -F discussionId='${{ github.event.discussion.node_id }}' -F body=@"$comment_file" -f query='
+                 mutation($discussionId: ID!, $body: String!) {
+                   addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                     comment { id url }
+                   }
+                 }'
+               ```
+               (Use `-F body=@<file>` so the file contents are sent as the variable value.)
+               Capture the returned `comment.url` (e.g. `https://github.com/<owner>/<repo>/discussions/<n>#discussioncomment-<id>`) — you will use it in the next step.
+               Do NOT modify the discussion body itself — only add a comment.
+
+            5. If the release body does NOT already contain the substring `日本語のリリースノートは`, prepend exactly this paragraph (followed by one blank line) to the existing release body, using the comment URL captured in step 4 as `<COMMENT_URL>`:
+               ```
+               日本語のリリースノートは[こちら](<COMMENT_URL>)です。
+               ```
+               Then write the combined body back to a temp file and run:
+               `gh release edit "${{ github.event.discussion.title }}" -R ${{ github.repository }} --notes-file "$f"`
+               Preserve `--draft=true` if the release was a draft (use the `isDraft` value you fetched).
+               If the substring is already present, do not edit the release.
+
+            ## Constraints
+
+            - Do not edit the discussion body, title, or category — only ADD a comment.
+            - Do not publish the release, edit the tag, or touch assets.
+            - Do not modify any other discussion or release.
+            - If anything is ambiguous (release missing, translation refused, API error), exit without partial writes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,3 +114,79 @@ jobs:
           draft: true
           makeLatest: true
           generateReleaseNotes: true
+
+  format-release-notes:
+    if: ${{ github.event_name == 'push' || github.event.inputs['dry-run'] != 'true' }}
+    needs: [ determine-version, create-release ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Reformat release notes with Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*)"'
+          prompt: |
+            You are reformatting the body of the draft GitHub release `v${{ needs.determine-version.outputs.semVer }}` in `${{ github.repository }}` to match the style of https://github.com/b-editor/beutl/releases/tag/v2.0.0-preview.2.
+
+            ## Steps
+
+            1. Fetch the current auto-generated body:
+               `gh release view v${{ needs.determine-version.outputs.semVer }} -R ${{ github.repository }} --json body,tagName,isDraft`
+               Capture the body verbatim — you will both summarize it and embed it.
+
+            2. Build the new body in this exact order:
+
+               a. `## What's Changed`
+
+               b. Download links (use these exact URLs — the tag is `v${{ needs.determine-version.outputs.semVer }}`):
+                  - Windows
+                    - `[Installer](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/beutl-standalone-setup.exe)`
+                    - `[Installer (.NET Runtime required)](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/beutl-setup.exe)`
+                  - macOS
+                    - `[Zip (arm64)](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/Beutl.osx_arm64.app.zip)`
+                    - `[Zip (x64)](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/Beutl.osx_x64.app.zip)`
+                  - Linux
+                    - `[Debian package](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/beutl_${{ needs.determine-version.outputs.simpleVer }}-${{ needs.determine-version.outputs.revision }}ubuntu22.04_amd64.deb)`
+                    - `[Zip (.NET Runtime required)](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/Beutl-linux-x64-${{ needs.determine-version.outputs.semVer }}.zip)`
+                    - `[Zip](https://github.com/${{ github.repository }}/releases/download/v${{ needs.determine-version.outputs.semVer }}/Beutl-linux-x64-standalone-${{ needs.determine-version.outputs.semVer }}.zip)`
+
+               c. Categorized summary derived from the auto-generated `* <prefix>: ... by @user in <PR-URL>` list. Use these section headings only, and OMIT any heading that has zero entries:
+                  - `**New Features**` ← PR titles starting with `feat:` / `feature:`
+                  - `**Improvements & Refactoring**` ← `refactor:` / `perf:` / `improve:` / `chore(refactor):` style
+                  - `**Bug Fixes**` ← `fix:`
+                  - `**Other**` ← any other user-visible PR. Skip dependabot bumps and pure `chore:` / `ci:` / `build:` / `docs:` / `test:` PRs that have no end-user impact.
+
+                  Each bullet should describe the user-visible change in past tense, paraphrasing the PR title (do NOT copy `* feat: ... by @user in ...` verbatim into the summary). Group related PRs as a single bullet when natural. If multiple PRs touch one feature area, you may use a nested list as in the v2.0.0-preview.2 example (e.g. `- Audio` with sub-bullets).
+
+               d. Wrap the original auto-generated `* ... by @user in <PR-URL>` block exactly as captured (no edits, in the same order GitHub generated) inside:
+                  ```
+                  <details>
+                  <summary>Changelog</summary>
+
+                  ...original list...
+
+                  </details>
+                  ```
+
+               e. Preserve the trailing `**Full Changelog**: https://github.com/.../compare/...` line that the auto-generated body provides, on its own paragraph at the very end.
+
+            3. Write the new body to a temp file via `mktemp` + `printf` / `cat <<'EOF' > "$f"` (do not pass it inline because it has backticks and newlines), then run:
+               `gh release edit v${{ needs.determine-version.outputs.semVer }} -R ${{ github.repository }} --notes-file "$f" --draft=true`
+
+            ## Constraints
+
+            - The release MUST remain a draft (`--draft=true`).
+            - DO NOT add a "日本語のリリースノートはこちら" line — that is appended later by a separate workflow when the corresponding Discussion is created.
+            - DO NOT publish the release, edit the tag, modify assets, or open issues/PRs.
+            - DO NOT touch any other release.
+            - If the release body already looks reformatted (i.e., contains `## What's Changed` followed by the platform list), exit without changes.


### PR DESCRIPTION
## Description

- Add a `format-release-notes` job to `release.yml` that uses `anthropics/claude-code-action` to rewrite the auto-generated draft body into the v2.0.0-preview.2 style: per-OS download links (Windows / macOS / Linux), categorized summary (`**New Features**` / `**Improvements & Refactoring**` / `**Bug Fixes**` / `**Other**` with empty sections omitted), and the original auto-generated changelog folded into a `<details>` block.
- Add `japanese-release-notes.yml`: when a Discussion whose title matches a release tag is created, Claude translates that release body into Japanese and posts it as a discussion comment (marker-guarded with `<!-- japanese-release-notes -->` for idempotency), then prepends `日本語のリリースノートは[こちら](<comment-url>)です。` to the release body so users can jump to the translation.
- The release stays a draft throughout; no auto-publish, no asset edits.

> [!NOTE]
> `japanese-release-notes.yml` requires a new `secrets.DISCUSSION_TOKEN` (PAT with discussion write access) to be configured before this can run successfully.

## Breaking changes

None.

## Fixed issues

None.