### PR TITLE
fix: deserialize 1.x Element files missing $type discriminator

### DIFF
--- a/src/Beutl.Core/Serialization/CoreSerializer.cs
+++ b/src/Beutl.Core/Serialization/CoreSerializer.cs
@@ -156,9 +156,18 @@ public static class CoreSerializer
         if (node is not JsonObject jsonObject) throw new JsonException();
 
         // 互換性処理
-        if (type == typeof(ProjectItem) && !node.TryGetDiscriminator(out Type? _))
+        // 1.x で作成されたファイルでは一部のオブジェクトに $type が付与されないため、
+        // 期待される型に基づいてディスクリミネータを補完する。
+        if (!node.TryGetDiscriminator(out Type? _))
         {
-            node["$type"] = "[Beutl.ProjectSystem]:Scene";
+            if (type == typeof(ProjectItem))
+            {
+                node["$type"] = "[Beutl.ProjectSystem]:Scene";
+            }
+            else if (type.FullName == "Beutl.ProjectSystem.Element")
+            {
+                node["$type"] = "[Beutl.ProjectSystem]:Element";
+            }
         }
 
         Type? actualType = type.IsSealed ? type : jsonObject.GetDiscriminator(type);

--- a/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
+++ b/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
@@ -180,6 +180,28 @@ public class JsonSerializationTest
         Assert.That(elm1, Is.Not.Null);
     }
 
+    // 1.xで作成されたファイルではScene/Elementに$typeが付かないため、
+    // RestoreFromUriで補完されることを確認する。
+    [Test]
+    public void RestoreFromUri_FillsMissingDiscriminatorForLegacyFiles()
+    {
+        var basePath = Path.GetFullPath(ArtifactProvider.GetArtifactDirectory());
+        var scenePath = Path.Combine(basePath, "legacy.scene");
+        var layerPath = Path.Combine(basePath, "legacy.belm");
+        if (File.Exists(scenePath)) File.Delete(scenePath);
+        if (File.Exists(layerPath)) File.Delete(layerPath);
+
+        // $typeを持たない1.x形式のJSONを書き出す
+        File.WriteAllText(scenePath, "{\"Width\":1920,\"Height\":1080}");
+        File.WriteAllText(layerPath, "{\"Start\":\"00:00:00\",\"Length\":\"00:00:01\"}");
+
+        var scene = CoreSerializer.RestoreFromUri<ProjectItem>(UriHelper.CreateFromPath(scenePath));
+        Assert.That(scene, Is.InstanceOf<Scene>());
+
+        var element = CoreSerializer.RestoreFromUri<Element>(UriHelper.CreateFromPath(layerPath));
+        Assert.That(element, Is.InstanceOf<Element>());
+    }
+
     [Test]
     public void Resolve()
     {


### PR DESCRIPTION
## Description
- Projects created with Beutl 1.x omit the `$type` discriminator on Element (.belm) files, causing deserialization to fail when opened in 2.x.
- `CoreSerializer.RestoreFromUri` already patched the missing discriminator for `ProjectItem` (assumed to be `Scene`); extend the same compatibility shim to `Element` so legacy timelines load correctly.
- Added a unit test that restores legacy-style Scene/Element JSON without `$type` and asserts the correct concrete types are produced.

## Breaking changes
None.

## Fixed issues
Fixes #1768