### PR TITLE
fix: dispose audio resampler in FFmpeg encoding cleanup

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -263,29 +263,31 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
             var encoders = new List<(MediaEncoder, MediaStream)>();
             (MediaEncoder Encoder, MediaStream Stream)? audioRef = null;
             (MediaEncoder Encoder, MediaStream Stream)? videoRef = null;
-            if (outFormat.AudioCodec != AVCodecID.AV_CODEC_ID_NONE)
-            {
-                ConfigureAudioStream(outFormat, muxer, audioFrame, out var encoder, out var stream, out swr);
-                encoders.Add((encoder, stream));
-                audioRef = (encoder, stream);
-                encodeAudio = true;
-            }
-
-            if (outFormat.VideoCodec != AVCodecID.AV_CODEC_ID_NONE)
-            {
-                ConfigureVideoStream(outFormat, muxer, videoFrame, out var encoder, out var stream);
-                encoders.Add((encoder, stream));
-                videoRef = (encoder, stream);
-                encodeVideo = true;
-            }
-
-            muxer.DumpFormat();
-            muxer.WriteHeader();
-
-            var videoState = new EncodeState();
-            var audioState = new EncodeState();
+            bool headerWritten = false;
             try
             {
+                if (outFormat.AudioCodec != AVCodecID.AV_CODEC_ID_NONE)
+                {
+                    ConfigureAudioStream(outFormat, muxer, audioFrame, out var encoder, out var stream, out swr);
+                    encoders.Add((encoder, stream));
+                    audioRef = (encoder, stream);
+                    encodeAudio = true;
+                }
+
+                if (outFormat.VideoCodec != AVCodecID.AV_CODEC_ID_NONE)
+                {
+                    ConfigureVideoStream(outFormat, muxer, videoFrame, out var encoder, out var stream);
+                    encoders.Add((encoder, stream));
+                    videoRef = (encoder, stream);
+                    encodeVideo = true;
+                }
+
+                muxer.DumpFormat();
+                muxer.WriteHeader();
+                headerWritten = true;
+
+                var videoState = new EncodeState();
+                var audioState = new EncodeState();
                 while ((encodeVideo || encodeAudio) && !cancellationToken.IsCancellationRequested)
                 {
                     if (encodeVideo &&
@@ -305,8 +307,11 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
             }
             finally
             {
-                muxer.FlushCodecs(encoders.Select(i => i.Item1));
-                muxer.WriteTrailer();
+                if (headerWritten)
+                {
+                    muxer.FlushCodecs(encoders.Select(i => i.Item1));
+                    muxer.WriteTrailer();
+                }
                 encoders.ForEach(t => t.Item1.Dispose());
                 swr?.Dispose();
                 _filterGraph?.Dispose();

--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -308,6 +308,7 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
                 muxer.FlushCodecs(encoders.Select(i => i.Item1));
                 muxer.WriteTrailer();
                 encoders.ForEach(t => t.Item1.Dispose());
+                swr?.Dispose();
                 _filterGraph?.Dispose();
                 _filterGraph = null;
                 _bufferSrcCtx = null;


### PR DESCRIPTION
## Description

- Dispose the `SwrContext` audio resampler during the FFmpeg encoder cleanup path so its native buffers are released alongside the muxer, encoders, and filter graph.
- Prevents an unmanaged-memory leak that occurred whenever an export used an audio resampler, since `swr` was previously left undisposed at the end of `OnEncodeComplete`.

## Breaking changes

None

## Fixed issues

None