### PR TITLE
feat: Add Ctrl+Shift+P command palette for searchable commands

### DIFF
--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -233,10 +233,19 @@ public class ContextCommandManager(
                             continue;
                         }
 
-                        compiledHandler.Execute(new ContextCommandExecution(entry.Definition.Name)
+                        var execution = new ContextCommandExecution(entry.Definition.Name)
                         {
                             KeyEventArgs = args
-                        });
+                        };
+
+                        // ハンドラが CanExecute で false を返した場合は実行をスキップして
+                        // 同じジェスチャの後続バインディング（フォールバック）に処理を委ねる。
+                        if (!compiledHandler.CanExecute(execution))
+                        {
+                            continue;
+                        }
+
+                        compiledHandler.Execute(execution);
                         return;
                     }
                 }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1058,6 +1058,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
         return Elements.FirstOrDefault(x => x.Model == element);
     }
 
+    public bool CanExecute(ContextCommandExecution execution)
+    {
+        return execution.CommandName switch
+        {
+            "Copy" or "Cut" or "Delete" or "Exclude" or "ToggleGroup" => SelectedElements.Count > 0,
+            "ExitRazorMode" => IsRazorMode.Value,
+            _ => true,
+        };
+    }
+
     public void Execute(ContextCommandExecution execution)
     {
         _logger.LogDebug("Executing context command {CommandName}.", execution.CommandName);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -29,11 +29,12 @@ using Reactive.Bindings.Extensions;
 
 namespace Beutl.Editor.Components.TimelineTab.ViewModels;
 
-public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
+public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler, IContextCommandStateNotifier
 {
     private readonly ILogger _logger = Log.CreateLogger<TimelineTabViewModel>();
     private readonly CompositeDisposable _disposables = [];
     private readonly Subject<LayerHeaderViewModel> _layerHeightChanged = new();
+    private readonly Subject<System.Reactive.Unit> _canExecuteChangedSubject = new();
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
 
     public TimelineTabViewModel(IEditorContext editorContext)
@@ -206,6 +207,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
                 BufferStatus.UnlockCache(block.StartFrame, block.StartFrame + block.LengthFrame);
                 BufferStatus.UpdateBlocks();
             });
+
+        // CanExecute がレイザーモード切替に追従するよう変更通知へ流す。
+        IsRazorMode
+            .Subscribe(_ => _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default))
+            .AddTo(_disposables);
 
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
     }
@@ -385,6 +391,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
 
     public IObservable<LayerHeaderViewModel> LayerHeightChanged => _layerHeightChanged;
 
+    public IObservable<System.Reactive.Unit> CanExecuteChanged => _canExecuteChangedSubject;
+
     public string Header => Strings.Timeline;
 
     public void Dispose()
@@ -417,6 +425,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
         }
 
         _layerHeightChanged.Dispose();
+        _canExecuteChangedSubject.Dispose();
 
         Inlines.Clear();
         LayerHeaders.Clear();
@@ -1022,12 +1031,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
         }
 
         SelectedElements.Clear();
+        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
     }
 
     public void SelectElement(ElementViewModel item)
     {
         SelectedElements.Add(item);
         item.IsSelected.Value = true;
+        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
     }
 
     public void SwitchSelectedElement(ElementViewModel item)
@@ -1041,6 +1052,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler
         {
             SelectedElements.Remove(item);
         }
+
+        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
     }
 
     internal void RaiseLayerHeightChanged(LayerHeaderViewModel value)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -36,6 +36,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private readonly Subject<LayerHeaderViewModel> _layerHeightChanged = new();
     private readonly Subject<System.Reactive.Unit> _canExecuteChangedSubject = new();
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
+    private bool _isDisposed;
 
     public TimelineTabViewModel(IEditorContext editorContext)
     {
@@ -210,10 +211,18 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         // CanExecute がレイザーモード切替に追従するよう変更通知へ流す。
         IsRazorMode
-            .Subscribe(_ => _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default))
+            .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
 
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
+    }
+
+    private void RaiseCanExecuteChanged()
+    {
+        if (!_isDisposed)
+        {
+            _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
+        }
     }
 
     private void SetStartTimeCore(TimeSpan time)
@@ -398,6 +407,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public void Dispose()
     {
         _logger.LogInformation("Disposing TimelineViewModel.");
+        // 以降の OnNext を抑止してから内部 Subject を Dispose する。
+        _isDisposed = true;
         _disposables.Dispose();
         foreach (ElementViewModel? item in Elements.GetMarshal().Value)
         {
@@ -1031,14 +1042,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
 
         SelectedElements.Clear();
-        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
+        RaiseCanExecuteChanged();
     }
 
     public void SelectElement(ElementViewModel item)
     {
         SelectedElements.Add(item);
         item.IsSelected.Value = true;
-        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
+        RaiseCanExecuteChanged();
     }
 
     public void SwitchSelectedElement(ElementViewModel item)
@@ -1053,7 +1064,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             SelectedElements.Remove(item);
         }
 
-        _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
+        RaiseCanExecuteChanged();
     }
 
     internal void RaiseLayerHeightChanged(LayerHeaderViewModel value)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1086,7 +1086,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         return execution.CommandName switch
         {
-            "Copy" or "Cut" or "Delete" or "Exclude" or "ToggleGroup" => SelectedElements.Count > 0,
+            "Copy" or "Cut" or "Delete" or "Exclude" => SelectedElements.Count > 0,
+            "ToggleGroup" => SelectedElements.FirstOrDefault() is { } first
+                && (first.CanUngroupSelectedElements() || first.CanGroupSelectedElements()),
             "ExitRazorMode" => IsRazorMode.Value,
             _ => true,
         };

--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Reactive;
+using System.Runtime.InteropServices;
 using Avalonia.Input;
 
 namespace Beutl.Extensibility;
@@ -8,6 +9,14 @@ public interface IContextCommandHandler
     void Execute(ContextCommandExecution execution);
 
     bool CanExecute(ContextCommandExecution execution) => true;
+}
+
+// CanExecute の判定が状態変化に応じて変わる場合に実装する optional インターフェース。
+// CommandPalette はスナップショット中のハンドラーが提供する CanExecuteChanged を購読し、
+// 通知を受け取った時点でフィルタ結果を再評価する。
+public interface IContextCommandStateNotifier
+{
+    IObservable<Unit> CanExecuteChanged { get; }
 }
 
 public class ContextCommandExecution

--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -6,6 +6,8 @@ namespace Beutl.Extensibility;
 public interface IContextCommandHandler
 {
     void Execute(ContextCommandExecution execution);
+
+    bool CanExecute(ContextCommandExecution execution) => true;
 }
 
 public class ContextCommandExecution

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1108,4 +1108,19 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="EstimatedSize" xml:space="preserve">
     <value>推定サイズ</value>
   </data>
+  <data name="ShowCommandPalette" xml:space="preserve">
+    <value>コマンドパレットを開く</value>
+  </data>
+  <data name="ShowCommandPalette_Description" xml:space="preserve">
+    <value>検索可能なコマンド一覧を開きます</value>
+  </data>
+  <data name="CommandPalette_Placeholder" xml:space="preserve">
+    <value>コマンド名を入力…</value>
+  </data>
+  <data name="CommandPalette_NoResults" xml:space="preserve">
+    <value>一致するコマンドがありません</value>
+  </data>
+  <data name="CommandPalette_MenuCategory" xml:space="preserve">
+    <value>メニュー</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1114,4 +1114,19 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="EstimatedSize" xml:space="preserve">
     <value>Estimated</value>
   </data>
+  <data name="ShowCommandPalette" xml:space="preserve">
+    <value>Show command palette</value>
+  </data>
+  <data name="ShowCommandPalette_Description" xml:space="preserve">
+    <value>Open the searchable command list</value>
+  </data>
+  <data name="CommandPalette_Placeholder" xml:space="preserve">
+    <value>Type a command name…</value>
+  </data>
+  <data name="CommandPalette_NoResults" xml:space="preserve">
+    <value>No matching commands</value>
+  </data>
+  <data name="CommandPalette_MenuCategory" xml:space="preserve">
+    <value>Menu</value>
+  </data>
 </root>

--- a/src/Beutl/Services/CommandPaletteHandlerProvider.cs
+++ b/src/Beutl/Services/CommandPaletteHandlerProvider.cs
@@ -1,0 +1,34 @@
+using Beutl.Services.PrimitiveImpls;
+using Beutl.ViewModels;
+
+namespace Beutl.Services;
+
+public interface ICommandPaletteHandlerProvider
+{
+    IContextCommandHandler? Resolve(Type extensionType);
+}
+
+internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProvider
+{
+    private readonly Func<MainViewModel?> _mainViewModelAccessor;
+
+    public CommandPaletteHandlerProvider(Func<MainViewModel?> mainViewModelAccessor)
+    {
+        _mainViewModelAccessor = mainViewModelAccessor;
+    }
+
+    public IContextCommandHandler? Resolve(Type extensionType)
+    {
+        if (extensionType == typeof(MainViewExtension))
+        {
+            return _mainViewModelAccessor() as IContextCommandHandler;
+        }
+
+        if (typeof(EditorExtension).IsAssignableFrom(extensionType))
+        {
+            return EditorService.Current.SelectedTabItem.Value?.Context.Value as IContextCommandHandler;
+        }
+
+        return null;
+    }
+}

--- a/src/Beutl/Services/CommandPaletteHandlerProvider.cs
+++ b/src/Beutl/Services/CommandPaletteHandlerProvider.cs
@@ -1,4 +1,4 @@
-using Beutl.Services.PrimitiveImpls;
+﻿using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 
 namespace Beutl.Services;

--- a/src/Beutl/Services/CommandPaletteHandlerProvider.cs
+++ b/src/Beutl/Services/CommandPaletteHandlerProvider.cs
@@ -35,6 +35,17 @@ internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProv
             return null;
         }
 
+        if (typeof(ToolTabExtension).IsAssignableFrom(extensionType))
+        {
+            EditorTabItem? tab = EditorService.Current.SelectedTabItem.Value;
+            if (tab?.Context.Value is EditViewModel editor)
+            {
+                return editor.DockHost.FindToolContext(extensionType) as IContextCommandHandler;
+            }
+
+            return null;
+        }
+
         return null;
     }
 }

--- a/src/Beutl/Services/CommandPaletteHandlerProvider.cs
+++ b/src/Beutl/Services/CommandPaletteHandlerProvider.cs
@@ -26,7 +26,13 @@ internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProv
 
         if (typeof(EditorExtension).IsAssignableFrom(extensionType))
         {
-            return EditorService.Current.SelectedTabItem.Value?.Context.Value as IContextCommandHandler;
+            EditorTabItem? tab = EditorService.Current.SelectedTabItem.Value;
+            if (tab?.Extension.Value is { } extension && extension.GetType() == extensionType)
+            {
+                return tab.Context.Value as IContextCommandHandler;
+            }
+
+            return null;
         }
 
         return null;

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Avalonia.Input;
 using Beutl.Api.Services;
 using Beutl.Services.PrimitiveImpls;

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -67,6 +67,10 @@ public sealed class CommandPaletteService
                     .FirstOrDefault(i => i.Platform == s_currentPlatform)?.KeyGesture;
 
                 ContextCommandEntry capturedEntry = entry;
+                IContextCommandHandler? snapshotHandler = _handlerProvider.Resolve(entry.ExtensionType);
+                IObservable<System.Reactive.Unit>? stateChanged =
+                    (snapshotHandler as IContextCommandStateNotifier)?.CanExecuteChanged;
+
                 result.Add(new PaletteCommand(
                     Id: $"{entry.ExtensionType.FullName}.{entry.Definition.Name}",
                     DisplayName: displayName,
@@ -78,7 +82,10 @@ public sealed class CommandPaletteService
                     {
                         var handler = _handlerProvider.Resolve(capturedEntry.ExtensionType);
                         handler?.Execute(new ContextCommandExecution(capturedEntry.Definition.Name));
-                    }));
+                    })
+                {
+                    StateChanged = stateChanged
+                });
             }
         }
 

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -80,7 +80,21 @@ public sealed class CommandPaletteService
                     CategoryName: category,
                     KeyGesture: gesture,
                     CanExecute: () => snapshotHandler?.CanExecute(new ContextCommandExecution(capturedEntry.Definition.Name)) ?? false,
-                    Execute: () => snapshotHandler?.Execute(new ContextCommandExecution(capturedEntry.Definition.Name)))
+                    Execute: () =>
+                    {
+                        if (snapshotHandler is null)
+                        {
+                            return;
+                        }
+
+                        // スロットル窓や状態変化で表示と実行可否がずれる可能性があるため、
+                        // 実行直前にもう一度 CanExecute を確認してから Execute する。
+                        var execution = new ContextCommandExecution(capturedEntry.Definition.Name);
+                        if (snapshotHandler.CanExecute(execution))
+                        {
+                            snapshotHandler.Execute(execution);
+                        }
+                    })
                 {
                     StateChanged = stateChanged
                 });

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -67,6 +67,8 @@ public sealed class CommandPaletteService
                     .FirstOrDefault(i => i.Platform == s_currentPlatform)?.KeyGesture;
 
                 ContextCommandEntry capturedEntry = entry;
+                // スナップショット時に解決したハンドラーを Execute / CanExecute / StateChanged 全てで共有し、
+                // 列挙時と実行時で別インスタンスへ向くケースを防ぐ。タブ切替時は RebuildSnapshot で再列挙される。
                 IContextCommandHandler? snapshotHandler = _handlerProvider.Resolve(entry.ExtensionType);
                 IObservable<System.Reactive.Unit>? stateChanged =
                     (snapshotHandler as IContextCommandStateNotifier)?.CanExecuteChanged;
@@ -77,12 +79,8 @@ public sealed class CommandPaletteService
                     Description: entry.Definition.Description,
                     CategoryName: category,
                     KeyGesture: gesture,
-                    CanExecute: () => CanExecuteContextCommand(capturedEntry),
-                    Execute: () =>
-                    {
-                        var handler = _handlerProvider.Resolve(capturedEntry.ExtensionType);
-                        handler?.Execute(new ContextCommandExecution(capturedEntry.Definition.Name));
-                    })
+                    CanExecute: () => snapshotHandler?.CanExecute(new ContextCommandExecution(capturedEntry.Definition.Name)) ?? false,
+                    Execute: () => snapshotHandler?.Execute(new ContextCommandExecution(capturedEntry.Definition.Name)))
                 {
                     StateChanged = stateChanged
                 });
@@ -92,17 +90,6 @@ public sealed class CommandPaletteService
         AppendMenuCommands(result);
 
         return result;
-    }
-
-    private bool CanExecuteContextCommand(ContextCommandEntry entry)
-    {
-        IContextCommandHandler? handler = _handlerProvider.Resolve(entry.ExtensionType);
-        if (handler == null)
-        {
-            return false;
-        }
-
-        return handler.CanExecute(new ContextCommandExecution(entry.Definition.Name));
     }
 
     private string ResolveCategoryName(Type extensionType)

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -1,0 +1,154 @@
+using System.Runtime.InteropServices;
+using Avalonia.Input;
+using Beutl.Api.Services;
+using Beutl.Language;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.ViewModels;
+
+namespace Beutl.Services;
+
+public sealed class CommandPaletteService
+{
+    private static readonly OSPlatform s_currentPlatform =
+        OperatingSystem.IsWindows() ? OSPlatform.Windows :
+        OperatingSystem.IsLinux() ? OSPlatform.Linux :
+        OSPlatform.OSX;
+
+    private readonly ContextCommandManager? _commandManager;
+    private readonly ICommandPaletteHandlerProvider _handlerProvider;
+    private readonly Func<MenuBarViewModel?> _menuBarAccessor;
+    private readonly Dictionary<Type, string> _categoryNameCache = new();
+
+    public CommandPaletteService(
+        ContextCommandManager? commandManager,
+        ICommandPaletteHandlerProvider handlerProvider,
+        Func<MenuBarViewModel?> menuBarAccessor)
+    {
+        _commandManager = commandManager;
+        _handlerProvider = handlerProvider;
+        _menuBarAccessor = menuBarAccessor;
+    }
+
+    public IReadOnlyList<PaletteCommand> EnumerateCommands()
+    {
+        var result = new List<PaletteCommand>();
+
+        if (_commandManager != null)
+        {
+            foreach (ContextCommandEntry entry in _commandManager.GetDefinitions())
+            {
+                if (entry.Definition.Name == MainViewExtension.ShowCommandPaletteCommandName)
+                {
+                    continue;
+                }
+
+                string displayName = string.IsNullOrEmpty(entry.Definition.DisplayName)
+                    ? entry.Definition.Name
+                    : entry.Definition.DisplayName!;
+                string category = ResolveCategoryName(entry.ExtensionType);
+                KeyGesture? gesture = entry.KeyGestures
+                    .FirstOrDefault(i => i.Platform == s_currentPlatform)?.KeyGesture;
+
+                ContextCommandEntry capturedEntry = entry;
+                result.Add(new PaletteCommand(
+                    Id: $"{entry.ExtensionType.FullName}.{entry.Definition.Name}",
+                    DisplayName: displayName,
+                    Description: entry.Definition.Description,
+                    CategoryName: category,
+                    KeyGesture: gesture,
+                    CanExecute: () => CanExecuteContextCommand(capturedEntry),
+                    Execute: () =>
+                    {
+                        var handler = _handlerProvider.Resolve(capturedEntry.ExtensionType);
+                        handler?.Execute(new ContextCommandExecution(capturedEntry.Definition.Name));
+                    }));
+            }
+        }
+
+        AppendMenuCommands(result);
+
+        return result;
+    }
+
+    private bool CanExecuteContextCommand(ContextCommandEntry entry)
+    {
+        IContextCommandHandler? handler = _handlerProvider.Resolve(entry.ExtensionType);
+        if (handler == null)
+        {
+            return false;
+        }
+
+        if (entry.ExtensionType == typeof(MainViewExtension))
+        {
+            MenuBarViewModel? menuBar = _menuBarAccessor();
+            if (menuBar != null && TryGetMenuBarCommand(menuBar, entry.Definition.Name) is { } command)
+            {
+                return command.CanExecute(null);
+            }
+        }
+
+        return true;
+    }
+
+    private static System.Windows.Input.ICommand? TryGetMenuBarCommand(MenuBarViewModel menuBar, string name) => name switch
+    {
+        "CreateNewProject" => menuBar.CreateNewProject,
+        "CreateNewFile" => menuBar.CreateNew,
+        "OpenProject" => menuBar.OpenProject,
+        "OpenFile" => menuBar.OpenFile,
+        "Save" => menuBar.Save,
+        "SaveAll" => menuBar.SaveAll,
+        "CloseProject" => menuBar.CloseProject,
+        "Undo" => menuBar.Undo,
+        "Redo" => menuBar.Redo,
+        "Exit" => menuBar.Exit,
+        _ => null
+    };
+
+    private string ResolveCategoryName(Type extensionType)
+    {
+        if (_categoryNameCache.TryGetValue(extensionType, out string? cached))
+        {
+            return cached;
+        }
+
+        string name = extensionType.Name;
+        Extension? matched = ExtensionProvider.Current.AllExtensions
+            .FirstOrDefault(i => i.GetType() == extensionType);
+        if (matched != null && !string.IsNullOrEmpty(matched.DisplayName))
+        {
+            name = matched.DisplayName;
+        }
+
+        _categoryNameCache[extensionType] = name;
+        return name;
+    }
+
+    private void AppendMenuCommands(List<PaletteCommand> commands)
+    {
+        MenuBarViewModel? menuBar = _menuBarAccessor();
+        if (menuBar == null)
+        {
+            return;
+        }
+
+        string category = Strings.CommandPalette_MenuCategory;
+
+        foreach (MenuBarViewModel.PaletteMenuCommand menuCommand in menuBar.EnumeratePaletteCommands())
+        {
+            System.Windows.Input.ICommand command = menuCommand.Command;
+            commands.Add(new PaletteCommand(
+                Id: menuCommand.Id,
+                DisplayName: menuCommand.DisplayName,
+                Description: null,
+                CategoryName: category,
+                KeyGesture: null,
+                CanExecute: () => command.CanExecute(null),
+                Execute: () =>
+                {
+                    if (command.CanExecute(null))
+                        command.Execute(null);
+                }));
+        }
+    }
+}

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using Avalonia.Input;
 using Beutl.Api.Services;
-using Beutl.Language;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 
@@ -35,9 +34,18 @@ public sealed class CommandPaletteService
 
         if (_commandManager != null)
         {
+            Type? activeEditorExtensionType = EditorService.Current.SelectedTabItem.Value?.Extension.Value?.GetType();
+
             foreach (ContextCommandEntry entry in _commandManager.GetDefinitions())
             {
                 if (entry.Definition.Name == MainViewExtension.ShowCommandPaletteCommandName)
+                {
+                    continue;
+                }
+
+                // 編集中のタブと一致しないエディタ拡張のコマンドは表示しない。
+                if (typeof(EditorExtension).IsAssignableFrom(entry.ExtensionType)
+                    && entry.ExtensionType != activeEditorExtensionType)
                 {
                     continue;
                 }
@@ -78,32 +86,8 @@ public sealed class CommandPaletteService
             return false;
         }
 
-        if (entry.ExtensionType == typeof(MainViewExtension))
-        {
-            MenuBarViewModel? menuBar = _menuBarAccessor();
-            if (menuBar != null && TryGetMenuBarCommand(menuBar, entry.Definition.Name) is { } command)
-            {
-                return command.CanExecute(null);
-            }
-        }
-
-        return true;
+        return handler.CanExecute(new ContextCommandExecution(entry.Definition.Name));
     }
-
-    private static System.Windows.Input.ICommand? TryGetMenuBarCommand(MenuBarViewModel menuBar, string name) => name switch
-    {
-        "CreateNewProject" => menuBar.CreateNewProject,
-        "CreateNewFile" => menuBar.CreateNew,
-        "OpenProject" => menuBar.OpenProject,
-        "OpenFile" => menuBar.OpenFile,
-        "Save" => menuBar.Save,
-        "SaveAll" => menuBar.SaveAll,
-        "CloseProject" => menuBar.CloseProject,
-        "Undo" => menuBar.Undo,
-        "Redo" => menuBar.Redo,
-        "Exit" => menuBar.Exit,
-        _ => null
-    };
 
     private string ResolveCategoryName(Type extensionType)
     {

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -34,7 +34,9 @@ public sealed class CommandPaletteService
 
         if (_commandManager != null)
         {
-            Type? activeEditorExtensionType = EditorService.Current.SelectedTabItem.Value?.Extension.Value?.GetType();
+            EditorTabItem? activeTab = EditorService.Current.SelectedTabItem.Value;
+            Type? activeEditorExtensionType = activeTab?.Extension.Value?.GetType();
+            EditViewModel? activeEditor = activeTab?.Context.Value as EditViewModel;
 
             foreach (ContextCommandEntry entry in _commandManager.GetDefinitions())
             {
@@ -46,6 +48,13 @@ public sealed class CommandPaletteService
                 // 編集中のタブと一致しないエディタ拡張のコマンドは表示しない。
                 if (typeof(EditorExtension).IsAssignableFrom(entry.ExtensionType)
                     && entry.ExtensionType != activeEditorExtensionType)
+                {
+                    continue;
+                }
+
+                // 開いていない ToolTab のコマンドはハンドラーを解決できないため除外する。
+                if (typeof(ToolTabExtension).IsAssignableFrom(entry.ExtensionType)
+                    && (activeEditor is null || activeEditor.DockHost.FindToolContext(entry.ExtensionType) is null))
                 {
                     continue;
                 }

--- a/src/Beutl/Services/PaletteCommand.cs
+++ b/src/Beutl/Services/PaletteCommand.cs
@@ -1,0 +1,12 @@
+using Avalonia.Input;
+
+namespace Beutl.Services;
+
+public sealed record PaletteCommand(
+    string Id,
+    string DisplayName,
+    string? Description,
+    string CategoryName,
+    KeyGesture? KeyGesture,
+    Func<bool> CanExecute,
+    Action Execute);

--- a/src/Beutl/Services/PaletteCommand.cs
+++ b/src/Beutl/Services/PaletteCommand.cs
@@ -1,4 +1,4 @@
-using Avalonia.Input;
+﻿using Avalonia.Input;
 
 namespace Beutl.Services;
 

--- a/src/Beutl/Services/PaletteCommand.cs
+++ b/src/Beutl/Services/PaletteCommand.cs
@@ -9,4 +9,9 @@ public sealed record PaletteCommand(
     string CategoryName,
     KeyGesture? KeyGesture,
     Func<bool> CanExecute,
-    Action Execute);
+    Action Execute)
+{
+    // ハンドラーが状態変化を通知できる場合の observable。
+    // パレット側でこれを購読し、通知時に CanExecute を再評価する。
+    public IObservable<Unit>? StateChanged { get; init; }
+}

--- a/src/Beutl/Services/PrimitiveImpls/MainViewExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/MainViewExtension.cs
@@ -6,6 +6,8 @@ namespace Beutl.Services.PrimitiveImpls;
 [PrimitiveImpl]
 public class MainViewExtension : ViewExtension
 {
+    public const string ShowCommandPaletteCommandName = "ShowCommandPalette";
+
     public static readonly MainViewExtension Instance = new();
 
     public override string Name => "MainView";
@@ -63,6 +65,11 @@ public class MainViewExtension : ViewExtension
         [
             new ContextCommandKeyGesture("Alt+F4"),
             new ContextCommandKeyGesture("Cmd+Q", OSPlatform.OSX),
+        ]),
+        new(ShowCommandPaletteCommandName, Strings.ShowCommandPalette, Strings.ShowCommandPalette_Description,
+        [
+            new ContextCommandKeyGesture("Ctrl+Shift+P"),
+            new ContextCommandKeyGesture("Cmd+Shift+P", OSPlatform.OSX),
         ]),
     ];
 }

--- a/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
@@ -1,0 +1,38 @@
+using Avalonia.Input;
+using Beutl.Services;
+
+namespace Beutl.ViewModels;
+
+public sealed class CommandPaletteItemViewModel
+{
+    public CommandPaletteItemViewModel(PaletteCommand command, bool isEnabled, int relevance)
+    {
+        Command = command;
+        IsEnabled = isEnabled;
+        Relevance = relevance;
+    }
+
+    public PaletteCommand Command { get; }
+
+    public string DisplayName => Command.DisplayName;
+
+    public string? Description => Command.Description;
+
+    public string CategoryName => Command.CategoryName;
+
+    public KeyGesture? KeyGesture => Command.KeyGesture;
+
+    public string? KeyGestureText => Command.KeyGesture?.ToString();
+
+    public bool IsEnabled { get; }
+
+    internal int Relevance { get; }
+
+    public void Execute()
+    {
+        if (IsEnabled)
+        {
+            Command.Execute();
+        }
+    }
+}

--- a/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteItemViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Input;
+﻿using Avalonia.Input;
 using Beutl.Services;
 
 namespace Beutl.ViewModels;

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -1,0 +1,193 @@
+using System.Collections.ObjectModel;
+using Beutl.Services;
+using Beutl.ViewModels.ExtensionsPages;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels;
+
+public sealed class CommandPaletteViewModel : BaseViewModel
+{
+    private readonly CommandPaletteService _service;
+    private readonly ObservableCollection<CommandPaletteItemViewModel> _filteredCommands = [];
+    private IReadOnlyList<PaletteCommand> _snapshot = [];
+    private readonly IDisposable _querySubscription;
+
+    public CommandPaletteViewModel(CommandPaletteService service)
+    {
+        _service = service;
+        FilteredCommands = new ReadOnlyObservableCollection<CommandPaletteItemViewModel>(_filteredCommands);
+
+        _querySubscription = Query.Subscribe(_ => RefreshFiltered());
+    }
+
+    public ReactivePropertySlim<bool> IsOpen { get; } = new(false);
+
+    public ReactivePropertySlim<string> Query { get; } = new(string.Empty);
+
+    public ReadOnlyObservableCollection<CommandPaletteItemViewModel> FilteredCommands { get; }
+
+    public ReactivePropertySlim<CommandPaletteItemViewModel?> SelectedCommand { get; } = new();
+
+    public ReactivePropertySlim<bool> HasNoResults { get; } = new(false);
+
+    public void Toggle()
+    {
+        if (IsOpen.Value)
+        {
+            Close();
+        }
+        else
+        {
+            Open();
+        }
+    }
+
+    public void Open()
+    {
+        _snapshot = _service.EnumerateCommands();
+        if (Query.Value.Length == 0)
+        {
+            RefreshFiltered();
+        }
+        else
+        {
+            // Query.Value への代入で _querySubscription 経由で RefreshFiltered が走る
+            Query.Value = string.Empty;
+        }
+
+        IsOpen.Value = true;
+    }
+
+    public void Close()
+    {
+        IsOpen.Value = false;
+        SelectedCommand.Value = null;
+    }
+
+    public void ExecuteSelected()
+    {
+        CommandPaletteItemViewModel? item = SelectedCommand.Value;
+        if (item is { IsEnabled: true })
+        {
+            Close();
+            item.Execute();
+        }
+    }
+
+    public void MoveSelection(int delta)
+    {
+        if (_filteredCommands.Count == 0)
+        {
+            SelectedCommand.Value = null;
+            return;
+        }
+
+        int currentIndex = SelectedCommand.Value is { } current
+            ? _filteredCommands.IndexOf(current)
+            : -1;
+        int next = currentIndex + delta;
+        if (next < 0) next = 0;
+        if (next >= _filteredCommands.Count) next = _filteredCommands.Count - 1;
+        SelectedCommand.Value = _filteredCommands[next];
+    }
+
+    public void SelectFirst()
+    {
+        SelectedCommand.Value = _filteredCommands.FirstOrDefault();
+    }
+
+    public void SelectLast()
+    {
+        SelectedCommand.Value = _filteredCommands.LastOrDefault();
+    }
+
+    // CanExecute はパレットを開いた時点とクエリ変更時のスナップショットで評価する。
+    // 表示中に外部の状態が変化しても再評価しないが、コマンドパレットは短命 UI のため許容している。
+    private void RefreshFiltered()
+    {
+        string query = Query.Value?.Trim() ?? string.Empty;
+
+        var matches = new List<CommandPaletteItemViewModel>();
+        foreach (PaletteCommand command in _snapshot)
+        {
+            int relevance = ScoreMatch(command, query);
+            if (relevance < 0)
+            {
+                continue;
+            }
+
+            bool isEnabled;
+            try
+            {
+                isEnabled = command.CanExecute();
+            }
+            catch
+            {
+                isEnabled = false;
+            }
+
+            matches.Add(new CommandPaletteItemViewModel(command, isEnabled, relevance));
+        }
+
+        matches.Sort((a, b) =>
+        {
+            int byRelevance = b.Relevance.CompareTo(a.Relevance);
+            if (byRelevance != 0) return byRelevance;
+            int byEnabled = b.IsEnabled.CompareTo(a.IsEnabled);
+            if (byEnabled != 0) return byEnabled;
+            return string.Compare(a.DisplayName, b.DisplayName, StringComparison.CurrentCultureIgnoreCase);
+        });
+
+        _filteredCommands.Clear();
+        foreach (CommandPaletteItemViewModel item in matches)
+        {
+            _filteredCommands.Add(item);
+        }
+
+        SelectedCommand.Value = _filteredCommands.FirstOrDefault();
+        HasNoResults.Value = _filteredCommands.Count == 0 && !string.IsNullOrEmpty(query);
+    }
+
+    private static int ScoreMatch(PaletteCommand command, string query)
+    {
+        if (string.IsNullOrEmpty(query))
+        {
+            return 0;
+        }
+
+        int best = -1;
+        Update(ref best, command.DisplayName, query, baseScore: 100);
+        Update(ref best, command.Description, query, baseScore: 60);
+        Update(ref best, command.CategoryName, query, baseScore: 40);
+        return best;
+    }
+
+    private static void Update(ref int best, string? haystack, string needle, int baseScore)
+    {
+        if (string.IsNullOrEmpty(haystack)) return;
+
+        int idx = haystack.IndexOf(needle, StringComparison.CurrentCultureIgnoreCase);
+        if (idx < 0) return;
+
+        int score = baseScore;
+        if (idx == 0)
+        {
+            score += 30;
+        }
+        else if (idx > 0 && !char.IsLetterOrDigit(haystack[idx - 1]))
+        {
+            score += 15;
+        }
+
+        if (score > best) best = score;
+    }
+
+    public override void Dispose()
+    {
+        _querySubscription.Dispose();
+        IsOpen.Dispose();
+        Query.Dispose();
+        SelectedCommand.Dispose();
+        HasNoResults.Dispose();
+    }
+}

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -16,7 +16,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     private IReadOnlyList<PaletteCommand> _snapshot = [];
     private readonly IDisposable _querySubscription;
     private readonly IDisposable _activeTabSubscription;
-    private readonly CompositeDisposable _stateChangeSubscriptions = [];
+    private CompositeDisposable _stateChangeSubscriptions = [];
 
     public CommandPaletteViewModel(CommandPaletteService service)
     {
@@ -74,8 +74,11 @@ public sealed class CommandPaletteViewModel : BaseViewModel
 
     private void RebuildSnapshot()
     {
-        _stateChangeSubscriptions.Clear();
         _snapshot = _service.EnumerateCommands();
+
+        // 旧購読を Dispose する前に新購読を確立し、Clear→Subscribe の隙間で通知が落ちる窓を排除する。
+        // 重複期間は Throttle が吸収し、後で旧購読は破棄される。
+        var newSubscriptions = new CompositeDisposable();
 
         // 同じハンドラーから複数のコマンドが来る場合 StateChanged の observable は同一インスタンスになるため
         // Distinct で重複購読を避ける。通知時はバースト抑止のため軽くスロットリングして RefreshFiltered する。
@@ -94,8 +97,12 @@ public sealed class CommandPaletteViewModel : BaseViewModel
                         RefreshFiltered();
                     }
                 })
-                .AddTo(_stateChangeSubscriptions);
+                .AddTo(newSubscriptions);
         }
+
+        CompositeDisposable previous = _stateChangeSubscriptions;
+        _stateChangeSubscriptions = newSubscriptions;
+        previous.Dispose();
 
         // Throttle 経由ではなく即時に最新のスナップショットへ反映する
         RefreshFiltered();

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -164,8 +164,8 @@ public sealed class CommandPaletteViewModel : BaseViewModel
         SelectedCommand.Value = _filteredCommands.LastOrDefault();
     }
 
-    // CanExecute はパレットを開いた時点とクエリ変更時のスナップショットで評価する。
-    // 表示中に外部の状態が変化しても再評価しないが、コマンドパレットは短命 UI のため許容している。
+    // CanExecute はパレットを開いた時点とクエリ変更時に評価するほか、
+    // RebuildSnapshot で購読した StateChanged 通知 (s_stateChangeThrottle 経由) でも再評価される。
     private void RefreshFiltered()
     {
         string query = Query.Value?.Trim() ?? string.Empty;

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -9,12 +9,14 @@ namespace Beutl.ViewModels;
 public sealed class CommandPaletteViewModel : BaseViewModel
 {
     private static readonly TimeSpan s_queryThrottle = TimeSpan.FromMilliseconds(80);
+    private static readonly TimeSpan s_stateChangeThrottle = TimeSpan.FromMilliseconds(50);
 
     private readonly CommandPaletteService _service;
     private readonly ObservableCollection<CommandPaletteItemViewModel> _filteredCommands = [];
     private IReadOnlyList<PaletteCommand> _snapshot = [];
     private readonly IDisposable _querySubscription;
     private readonly IDisposable _activeTabSubscription;
+    private readonly CompositeDisposable _stateChangeSubscriptions = [];
 
     public CommandPaletteViewModel(CommandPaletteService service)
     {
@@ -72,7 +74,29 @@ public sealed class CommandPaletteViewModel : BaseViewModel
 
     private void RebuildSnapshot()
     {
+        _stateChangeSubscriptions.Clear();
         _snapshot = _service.EnumerateCommands();
+
+        // 同じハンドラーから複数のコマンドが来る場合 StateChanged の observable は同一インスタンスになるため
+        // Distinct で重複購読を避ける。通知時はバースト抑止のため軽くスロットリングして RefreshFiltered する。
+        foreach (IObservable<Unit> observable in _snapshot
+            .Select(c => c.StateChanged)
+            .OfType<IObservable<Unit>>()
+            .Distinct())
+        {
+            observable
+                .Throttle(s_stateChangeThrottle)
+                .ObserveOnUIDispatcher()
+                .Subscribe(_ =>
+                {
+                    if (IsOpen.Value)
+                    {
+                        RefreshFiltered();
+                    }
+                })
+                .AddTo(_stateChangeSubscriptions);
+        }
+
         // Throttle 経由ではなく即時に最新のスナップショットへ反映する
         RefreshFiltered();
     }
@@ -232,6 +256,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     {
         _querySubscription.Dispose();
         _activeTabSubscription.Dispose();
+        _stateChangeSubscriptions.Dispose();
         IsOpen.Dispose();
         Query.Dispose();
         SelectedCommand.Dispose();

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -2,11 +2,14 @@ using System.Collections.ObjectModel;
 using Beutl.Services;
 using Beutl.ViewModels.ExtensionsPages;
 using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 
 namespace Beutl.ViewModels;
 
 public sealed class CommandPaletteViewModel : BaseViewModel
 {
+    private static readonly TimeSpan s_queryThrottle = TimeSpan.FromMilliseconds(80);
+
     private readonly CommandPaletteService _service;
     private readonly ObservableCollection<CommandPaletteItemViewModel> _filteredCommands = [];
     private IReadOnlyList<PaletteCommand> _snapshot = [];
@@ -17,7 +20,11 @@ public sealed class CommandPaletteViewModel : BaseViewModel
         _service = service;
         FilteredCommands = new ReadOnlyObservableCollection<CommandPaletteItemViewModel>(_filteredCommands);
 
-        _querySubscription = Query.Subscribe(_ => RefreshFiltered());
+        _querySubscription = Query
+            .Skip(1)
+            .Throttle(s_queryThrottle)
+            .ObserveOnUIDispatcher()
+            .Subscribe(_ => RefreshFiltered());
     }
 
     public ReactivePropertySlim<bool> IsOpen { get; } = new(false);
@@ -45,16 +52,9 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     public void Open()
     {
         _snapshot = _service.EnumerateCommands();
-        if (Query.Value.Length == 0)
-        {
-            RefreshFiltered();
-        }
-        else
-        {
-            // Query.Value への代入で _querySubscription 経由で RefreshFiltered が走る
-            Query.Value = string.Empty;
-        }
-
+        Query.Value = string.Empty;
+        // Throttle 経由ではなく即時に最新のスナップショットへ反映する
+        RefreshFiltered();
         IsOpen.Value = true;
     }
 
@@ -138,14 +138,41 @@ public sealed class CommandPaletteViewModel : BaseViewModel
             return string.Compare(a.DisplayName, b.DisplayName, StringComparison.CurrentCultureIgnoreCase);
         });
 
-        _filteredCommands.Clear();
-        foreach (CommandPaletteItemViewModel item in matches)
+        ApplyFilteredCommands(matches);
+        HasNoResults.Value = _filteredCommands.Count == 0 && !string.IsNullOrEmpty(query);
+    }
+
+    // Clear+Add せず、同じ Id・IsEnabled の項目はそのまま再利用してリスト更新時のチラつきを抑える。
+    private void ApplyFilteredCommands(List<CommandPaletteItemViewModel> next)
+    {
+        string? previousSelectedId = SelectedCommand.Value?.Command.Id;
+
+        int common = Math.Min(_filteredCommands.Count, next.Count);
+        for (int i = 0; i < common; i++)
         {
-            _filteredCommands.Add(item);
+            CommandPaletteItemViewModel existing = _filteredCommands[i];
+            CommandPaletteItemViewModel candidate = next[i];
+            if (existing.Command.Id != candidate.Command.Id
+                || existing.IsEnabled != candidate.IsEnabled)
+            {
+                _filteredCommands[i] = candidate;
+            }
         }
 
-        SelectedCommand.Value = _filteredCommands.FirstOrDefault();
-        HasNoResults.Value = _filteredCommands.Count == 0 && !string.IsNullOrEmpty(query);
+        while (_filteredCommands.Count > next.Count)
+        {
+            _filteredCommands.RemoveAt(_filteredCommands.Count - 1);
+        }
+
+        for (int i = _filteredCommands.Count; i < next.Count; i++)
+        {
+            _filteredCommands.Add(next[i]);
+        }
+
+        CommandPaletteItemViewModel? preserved = previousSelectedId is null
+            ? null
+            : _filteredCommands.FirstOrDefault(i => i.Command.Id == previousSelectedId);
+        SelectedCommand.Value = preserved ?? _filteredCommands.FirstOrDefault();
     }
 
     private static int ScoreMatch(PaletteCommand command, string query)

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using Avalonia.Threading;
 using Beutl.Services;
 using Beutl.ViewModels.ExtensionsPages;
 using Reactive.Bindings;
@@ -74,6 +75,10 @@ public sealed class CommandPaletteViewModel : BaseViewModel
 
     private void RebuildSnapshot()
     {
+        // _snapshot / _stateChangeSubscriptions / _filteredCommands は同期化していないため、
+        // UI スレッドからのみ呼び出されることを明示的にチェックする。
+        Dispatcher.UIThread.VerifyAccess();
+
         _snapshot = _service.EnumerateCommands();
 
         // 旧購読を Dispose する前に新購読を確立し、Clear→Subscribe の隙間で通知が落ちる窓を排除する。
@@ -112,6 +117,14 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     {
         IsOpen.Value = false;
         SelectedCommand.Value = null;
+
+        // パレットを閉じた時点で snapshot 内の closure に閉じ込めたハンドラー参照と購読を解放し、
+        // 開いていない間にハンドラーや Subject を不必要に保持しないようにする。
+        _filteredCommands.Clear();
+        _snapshot = [];
+        CompositeDisposable previous = _stateChangeSubscriptions;
+        _stateChangeSubscriptions = [];
+        previous.Dispose();
     }
 
     public void ExecuteSelected()

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using Avalonia.Threading;
 using Beutl.Services;
 using Beutl.ViewModels.ExtensionsPages;

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -14,6 +14,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     private readonly ObservableCollection<CommandPaletteItemViewModel> _filteredCommands = [];
     private IReadOnlyList<PaletteCommand> _snapshot = [];
     private readonly IDisposable _querySubscription;
+    private readonly IDisposable _activeTabSubscription;
 
     public CommandPaletteViewModel(CommandPaletteService service)
     {
@@ -25,6 +26,19 @@ public sealed class CommandPaletteViewModel : BaseViewModel
             .Throttle(s_queryThrottle)
             .ObserveOnUIDispatcher()
             .Subscribe(_ => RefreshFiltered());
+
+        // パレット表示中にアクティブタブが切り替わったらスナップショットを取り直して
+        // コマンド一覧と CanExecute 結果を最新の状態に追従させる。
+        _activeTabSubscription = EditorService.Current.SelectedTabItem
+            .Skip(1)
+            .ObserveOnUIDispatcher()
+            .Subscribe(_ =>
+            {
+                if (IsOpen.Value)
+                {
+                    RebuildSnapshot();
+                }
+            });
     }
 
     public ReactivePropertySlim<bool> IsOpen { get; } = new(false);
@@ -51,11 +65,16 @@ public sealed class CommandPaletteViewModel : BaseViewModel
 
     public void Open()
     {
-        _snapshot = _service.EnumerateCommands();
         Query.Value = string.Empty;
+        RebuildSnapshot();
+        IsOpen.Value = true;
+    }
+
+    private void RebuildSnapshot()
+    {
+        _snapshot = _service.EnumerateCommands();
         // Throttle 経由ではなく即時に最新のスナップショットへ反映する
         RefreshFiltered();
-        IsOpen.Value = true;
     }
 
     public void Close()
@@ -212,6 +231,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     public override void Dispose()
     {
         _querySubscription.Dispose();
+        _activeTabSubscription.Dispose();
         IsOpen.Dispose();
         Query.Dispose();
         SelectedCommand.Dispose();

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -46,6 +46,13 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         return FindToolTab<T>(_ => true);
     }
 
+    public IToolContext? FindToolContext(Type extensionType)
+    {
+        return Factory.EnumerateTools()
+            .Select(t => t.ToolContext)
+            .FirstOrDefault(ctx => ctx.Extension.GetType() == extensionType);
+    }
+
     public bool OpenToolTab(IToolContext item)
     {
         return OpenToolTab(item, target: null);

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System.Reactive.Subjects;
+using Avalonia.Controls;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Media;
 using Beutl.ProjectSystem;
@@ -6,8 +7,47 @@ using Microsoft.Extensions.Logging;
 
 namespace Beutl.ViewModels;
 
-public partial class EditViewModel : IContextCommandHandler
+public partial class EditViewModel : IContextCommandHandler, IContextCommandStateNotifier
 {
+    private readonly Subject<System.Reactive.Unit> _commandStateChangedSubject = new();
+    private bool _commandStateNotifierDisposed;
+
+    public IObservable<System.Reactive.Unit> CanExecuteChanged => _commandStateChangedSubject;
+
+    // EditViewModel ctor で Player を初期化した直後に呼び、Player 系コマンドの ICommand.CanExecuteChanged を
+    // 通知 Subject へ流す。これによりパレット表示中の再生状態遷移にも CanExecute が追従する。
+    private void HookCommandStateNotifier()
+    {
+        ((System.Windows.Input.ICommand)Player.PlayPause).CanExecuteChanged += OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Next).CanExecuteChanged += OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Previous).CanExecuteChanged += OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Start).CanExecuteChanged += OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.End).CanExecuteChanged += OnPlayerCanExecuteChanged;
+    }
+
+    private void OnPlayerCanExecuteChanged(object? sender, EventArgs e)
+    {
+        if (!_commandStateNotifierDisposed)
+        {
+            _commandStateChangedSubject.OnNext(System.Reactive.Unit.Default);
+        }
+    }
+
+    private void DisposeCommandStateNotifier()
+    {
+        _commandStateNotifierDisposed = true;
+        if (Player is { } player)
+        {
+            ((System.Windows.Input.ICommand)player.PlayPause).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+            ((System.Windows.Input.ICommand)player.Next).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+            ((System.Windows.Input.ICommand)player.Previous).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+            ((System.Windows.Input.ICommand)player.Start).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+            ((System.Windows.Input.ICommand)player.End).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+        }
+
+        _commandStateChangedSubject.Dispose();
+    }
+
     // IContextCommandHandler を実装しない場合、以下のように ContextCommandAttribute を使用してコマンドを定義します。
     // [ContextCommand]
     // public void PlayPause(KeyEventArgs e)

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -36,15 +36,11 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     private void DisposeCommandStateNotifier()
     {
         _commandStateNotifierDisposed = true;
-        if (Player is { } player)
-        {
-            ((System.Windows.Input.ICommand)player.PlayPause).CanExecuteChanged -= OnPlayerCanExecuteChanged;
-            ((System.Windows.Input.ICommand)player.Next).CanExecuteChanged -= OnPlayerCanExecuteChanged;
-            ((System.Windows.Input.ICommand)player.Previous).CanExecuteChanged -= OnPlayerCanExecuteChanged;
-            ((System.Windows.Input.ICommand)player.Start).CanExecuteChanged -= OnPlayerCanExecuteChanged;
-            ((System.Windows.Input.ICommand)player.End).CanExecuteChanged -= OnPlayerCanExecuteChanged;
-        }
-
+        ((System.Windows.Input.ICommand)Player.PlayPause).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Next).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Previous).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.Start).CanExecuteChanged -= OnPlayerCanExecuteChanged;
+        ((System.Windows.Input.ICommand)Player.End).CanExecuteChanged -= OnPlayerCanExecuteChanged;
         _commandStateChangedSubject.Dispose();
     }
 

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -42,6 +42,19 @@ public partial class EditViewModel : IContextCommandHandler
     //     Player.End.Execute();
     // }
 
+    public bool CanExecute(ContextCommandExecution execution)
+    {
+        return execution.CommandName switch
+        {
+            "PlayPause" => ((System.Windows.Input.ICommand)Player.PlayPause).CanExecute(null),
+            "Next" => ((System.Windows.Input.ICommand)Player.Next).CanExecute(null),
+            "Previous" => ((System.Windows.Input.ICommand)Player.Previous).CanExecute(null),
+            "SeekStart" => ((System.Windows.Input.ICommand)Player.Start).CanExecute(null),
+            "SeekEnd" => ((System.Windows.Input.ICommand)Player.End).CanExecute(null),
+            _ => true,
+        };
+    }
+
     public void Execute(ContextCommandExecution execution)
     {
         if (execution.KeyEventArgs != null)

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -65,6 +65,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         config.PropertyChanged += OnEditorConfigPropertyChanged;
 
         Player = new PlayerViewModel(this);
+        HookCommandStateNotifier();
         Commands = new KnownCommandsImpl(scene, this);
         var sequenceGenerator = new OperationSequenceGenerator();
         var observer = new CoreObjectOperationObserver(null, Scene, sequenceGenerator)
@@ -324,6 +325,8 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
         SaveState();
         _editorSelection.SelectedObject.Value = null;
+        // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
+        DisposeCommandStateNotifier();
         await Player.DisposeAsync();
         _disposables.Dispose();
         IsEnabled.Dispose();

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -177,45 +177,29 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
-        switch (execution.CommandName)
+
+        if (execution.CommandName == "ShowCommandPalette")
         {
-            case "CreateNewProject":
-                MenuBar.CreateNewProject.Execute(null);
-                break;
-            case "CreateNewFile":
-                MenuBar.CreateNew.Execute(null);
-                break;
-            case "OpenProject":
-                MenuBar.OpenProject.Execute(null);
-                break;
-            case "OpenFile":
-                MenuBar.OpenFile.Execute(null);
-                break;
-            case "Save":
-                MenuBar.Save.Execute(null);
-                break;
-            case "SaveAll":
-                MenuBar.SaveAll.Execute(null);
-                break;
-            case "CloseProject":
-                MenuBar.CloseProject.Execute(null);
-                break;
-            case "Undo":
-                MenuBar.Undo.Execute(null);
-                break;
-            case "Redo":
-                MenuBar.Redo.Execute(null);
-                break;
-            case "Exit":
-                MenuBar.Exit.Execute(null);
-                break;
-            case "ShowCommandPalette":
-                CommandPalette.Toggle();
-                break;
-            default:
-                if (execution.KeyEventArgs != null)
-                    execution.KeyEventArgs.Handled = false;
-                break;
+            CommandPalette.Toggle();
+            return;
         }
+
+        if (MenuBar.FindContextCommand(execution.CommandName) is { } command)
+        {
+            if (command.CanExecute(null))
+                command.Execute(null);
+            return;
+        }
+
+        if (execution.KeyEventArgs != null)
+            execution.KeyEventArgs.Handled = false;
+    }
+
+    public bool CanExecute(ContextCommandExecution execution)
+    {
+        if (execution.CommandName == "ShowCommandPalette")
+            return true;
+
+        return MenuBar.FindContextCommand(execution.CommandName)?.CanExecute(null) ?? true;
     }
 }

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -200,6 +200,8 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         if (execution.CommandName == "ShowCommandPalette")
             return true;
 
-        return MenuBar.FindContextCommand(execution.CommandName)?.CanExecute(null) ?? true;
+        // 未知のコマンドは false を返し、ContextCommandManager のフォールバックバインディングや
+        // 他のハンドラーへキーイベントを委ねられるようにする。
+        return MenuBar.FindContextCommand(execution.CommandName)?.CanExecute(null) ?? false;
     }
 }

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -35,6 +35,12 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             .ToReadOnlyReactivePropertySlim("Beutl");
         TitleBreadcrumbBar = new TitleBreadcrumbBarViewModel(this, EditorService.Current);
 
+        var paletteService = new CommandPaletteService(
+            ContextCommandManager,
+            new CommandPaletteHandlerProvider(() => this),
+            () => MenuBar);
+        CommandPalette = new CommandPaletteViewModel(paletteService);
+
         ICoreReadOnlyList<Extension> allExtension = ExtensionProvider.Current.AllExtensions;
 
         var comparer = SortExpressionComparer<Extension>.Ascending(i => i.Name);
@@ -98,6 +104,8 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     public ContextCommandManager? ContextCommandManager { get; }
 
+    public CommandPaletteViewModel CommandPalette { get; }
+
     public SettingsDialogViewModel CreateSettingsDialog()
     {
         return new SettingsDialogViewModel(_beutlClients);
@@ -122,6 +130,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     public override void Dispose()
     {
+        CommandPalette.Dispose();
         ProjectService.Current.CloseProject();
         BeutlApplication.Current.Items.Clear();
     }
@@ -199,6 +208,9 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
                 break;
             case "Exit":
                 MenuBar.Exit.Execute(null);
+                break;
+            case "ShowCommandPalette":
+                CommandPalette.Toggle();
                 break;
             default:
                 if (execution.KeyEventArgs != null)

--- a/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
@@ -19,4 +19,21 @@ public partial class MenuBarViewModel
         yield return new("MenuBar.ResetDockLayout", Strings.ResetDockLayout, ResetDockLayout);
         yield return new("MenuBar.ShowSceneSettings", Strings.SceneSettings, ShowSceneSettings);
     }
+
+    // MainViewExtension の ContextCommand 名から MenuBar 上の ICommand への単一マッピング。
+    // MainViewModel.Execute / CanExecute と CommandPalette が共通で参照するためここに集約している。
+    public ICommand? FindContextCommand(string commandName) => commandName switch
+    {
+        "CreateNewProject" => CreateNewProject,
+        "CreateNewFile" => CreateNew,
+        "OpenProject" => OpenProject,
+        "OpenFile" => OpenFile,
+        "Save" => Save,
+        "SaveAll" => SaveAll,
+        "CloseProject" => CloseProject,
+        "Undo" => Undo,
+        "Redo" => Redo,
+        "Exit" => Exit,
+        _ => null
+    };
 }

--- a/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace Beutl.ViewModels;
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Palette.cs
@@ -1,0 +1,22 @@
+using System.Windows.Input;
+
+namespace Beutl.ViewModels;
+
+public partial class MenuBarViewModel
+{
+    public readonly record struct PaletteMenuCommand(string Id, string DisplayName, ICommand Command);
+
+    public IEnumerable<PaletteMenuCommand> EnumeratePaletteCommands()
+    {
+        yield return new("MenuBar.NewScene", Strings.CreateNewScene, NewScene);
+        yield return new("MenuBar.ExportProject", Strings.ExportProject, ExportProject);
+        yield return new("MenuBar.ImportProject", Strings.ImportProject, ImportProject);
+        yield return new("MenuBar.DeleteLayer", Strings.Delete, DeleteLayer);
+        yield return new("MenuBar.ExcludeLayer", Strings.Exclude, ExcludeLayer);
+        yield return new("MenuBar.CutLayer", Strings.Cut, CutLayer);
+        yield return new("MenuBar.CopyLayer", Strings.Copy, CopyLayer);
+        yield return new("MenuBar.PasteLayer", Strings.Paste, PasteLayer);
+        yield return new("MenuBar.ResetDockLayout", Strings.ResetDockLayout, ResetDockLayout);
+        yield return new("MenuBar.ShowSceneSettings", Strings.SceneSettings, ShowSceneSettings);
+    }
+}

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -21,9 +21,10 @@
 
         <!-- Palette container -->
         <Border x:Name="PaletteContainer"
-                Width="640"
+                MinWidth="320"
+                MaxWidth="640"
                 MaxHeight="480"
-                Margin="0,80,0,0"
+                Margin="16,80,16,16"
                 Padding="0"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
@@ -51,6 +52,7 @@
                          Margin="4,4,4,8"
                          Background="Transparent"
                          BorderThickness="0"
+                         DoubleTapped="OnResultsDoubleTapped"
                          IsVisible="{Binding !HasNoResults.Value}"
                          ItemsSource="{Binding FilteredCommands}"
                          SelectedItem="{Binding SelectedCommand.Value, Mode=TwoWay}">

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -1,0 +1,105 @@
+<UserControl x:Class="Beutl.Views.CommandPaletteView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="using:Beutl.ViewModels"
+             d:DesignHeight="480"
+             d:DesignWidth="800"
+             x:CompileBindings="True"
+             x:DataType="viewModels:CommandPaletteViewModel"
+             IsHitTestVisible="{Binding IsOpen.Value}"
+             IsVisible="{Binding IsOpen.Value}"
+             mc:Ignorable="d">
+    <Panel>
+        <!-- Light-dismiss backdrop -->
+        <Border x:Name="Backdrop"
+                Background="Transparent"
+                IsHitTestVisible="True"
+                PointerPressed="OnBackdropPointerPressed" />
+
+        <!-- Palette container -->
+        <Border x:Name="PaletteContainer"
+                Width="640"
+                MaxHeight="480"
+                Margin="0,80,0,0"
+                Padding="0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
+                BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                BoxShadow="0 8 32 0 #40000000"
+                CornerRadius="8">
+            <Grid RowDefinitions="Auto,Auto,*">
+                <TextBox x:Name="QueryTextBox"
+                         Margin="8,8,8,4"
+                         BorderThickness="0"
+                         FontSize="16"
+                         KeyDown="OnQueryKeyDown"
+                         Text="{Binding Query.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Watermark="{x:Static lang:Strings.CommandPalette_Placeholder}" />
+
+                <Border Grid.Row="1"
+                        Margin="8,0"
+                        BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                        BorderThickness="0,0,0,1" />
+
+                <ListBox x:Name="ResultsListBox"
+                         Grid.Row="2"
+                         Margin="4,4,4,8"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         IsVisible="{Binding !HasNoResults.Value}"
+                         ItemsSource="{Binding FilteredCommands}"
+                         SelectedItem="{Binding SelectedCommand.Value, Mode=TwoWay}">
+                    <ListBox.Styles>
+                        <Style Selector="ListBoxItem">
+                            <Setter Property="Padding" Value="8,6" />
+                        </Style>
+                    </ListBox.Styles>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:CommandPaletteItemViewModel">
+                            <Grid ColumnDefinitions="*,Auto"
+                                  IsEnabled="{Binding IsEnabled}">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock FontWeight="SemiBold"
+                                               Text="{Binding DisplayName}"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <TextBlock FontSize="11"
+                                                   Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                   Text="{Binding CategoryName}" />
+                                        <TextBlock FontSize="11"
+                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                   IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                   Text="{Binding Description}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </StackPanel>
+                                <Border Grid.Column="1"
+                                        Padding="6,2"
+                                        VerticalAlignment="Center"
+                                        Background="{DynamicResource ControlAltFillColorSecondaryBrush}"
+                                        CornerRadius="4"
+                                        IsVisible="{Binding KeyGestureText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                    <TextBlock FontSize="11"
+                                               Text="{Binding KeyGestureText}" />
+                                </Border>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <TextBlock Grid.Row="2"
+                           Margin="16"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           IsVisible="{Binding HasNoResults.Value}"
+                           Text="{x:Static lang:Strings.CommandPalette_NoResults}" />
+            </Grid>
+        </Border>
+    </Panel>
+</UserControl>

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -49,7 +49,9 @@ public partial class CommandPaletteView : UserControl
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        _disposables.Dispose();
+        // Dispose ではなく Clear を呼ぶことで、Avalonia により Detach→再 Attach された際の
+        // OnDataContextChanged 内 _disposables.Clear() が破棄済みインスタンスに対して呼ばれる事態を避ける。
+        _disposables.Clear();
         base.OnDetachedFromVisualTree(e);
     }
 

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Beutl.ViewModels;
 using Reactive.Bindings.Extensions;
 
@@ -10,11 +11,17 @@ namespace Beutl.Views;
 
 public partial class CommandPaletteView : UserControl
 {
+    private const int PageStep = 8;
+
     private readonly CompositeDisposable _disposables = [];
 
     public CommandPaletteView()
     {
         InitializeComponent();
+
+        // ListBox にフォーカスがある状態でも Escape / Enter を捕捉できるように、
+        // ルートで Bubble をフックする。矢印キーは ListBox の標準動作に任せる。
+        AddHandler(KeyDownEvent, OnRootKeyDown, RoutingStrategies.Bubble, handledEventsToo: false);
     }
 
     protected override void OnDataContextChanged(EventArgs e)
@@ -46,7 +53,7 @@ public partial class CommandPaletteView : UserControl
         base.OnDetachedFromVisualTree(e);
     }
 
-    private void OnBackdropPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+    private void OnBackdropPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is CommandPaletteViewModel viewModel)
         {
@@ -54,8 +61,6 @@ public partial class CommandPaletteView : UserControl
             e.Handled = true;
         }
     }
-
-    private const int PageStep = 8;
 
     private void OnQueryKeyDown(object? sender, KeyEventArgs e)
     {
@@ -66,10 +71,6 @@ public partial class CommandPaletteView : UserControl
 
         switch (e.Key)
         {
-            case Key.Escape:
-                viewModel.Close();
-                e.Handled = true;
-                break;
             case Key.Down:
                 viewModel.MoveSelection(1);
                 ScrollSelectionIntoView(viewModel);
@@ -100,10 +101,44 @@ public partial class CommandPaletteView : UserControl
                 ScrollSelectionIntoView(viewModel);
                 e.Handled = true;
                 break;
+        }
+    }
+
+    private void OnRootKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Handled || DataContext is not CommandPaletteViewModel viewModel)
+        {
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Escape:
+                viewModel.Close();
+                e.Handled = true;
+                break;
             case Key.Enter:
                 viewModel.ExecuteSelected();
                 e.Handled = true;
                 break;
+        }
+    }
+
+    private void OnResultsDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is not CommandPaletteViewModel viewModel)
+        {
+            return;
+        }
+
+        // 別アイテム上でダブルクリックされた場合に SelectedItem の更新が
+        // 反映される前に実行してしまわないよう、起点アイテムから VM を取り出す。
+        if (e.Source is Visual source
+            && source.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: CommandPaletteItemViewModel item })
+        {
+            viewModel.SelectedCommand.Value = item;
+            viewModel.ExecuteSelected();
+            e.Handled = true;
         }
     }
 

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -1,0 +1,115 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Beutl.ViewModels;
+using Reactive.Bindings.Extensions;
+
+namespace Beutl.Views;
+
+public partial class CommandPaletteView : UserControl
+{
+    private readonly CompositeDisposable _disposables = [];
+
+    public CommandPaletteView()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        _disposables.Clear();
+
+        if (DataContext is CommandPaletteViewModel viewModel)
+        {
+            viewModel.IsOpen
+                .Subscribe(open =>
+                {
+                    if (open)
+                    {
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            QueryTextBox.Focus();
+                            QueryTextBox.SelectAll();
+                        }, DispatcherPriority.Background);
+                    }
+                })
+                .AddTo(_disposables);
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        _disposables.Dispose();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void OnBackdropPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+    {
+        if (DataContext is CommandPaletteViewModel viewModel)
+        {
+            viewModel.Close();
+            e.Handled = true;
+        }
+    }
+
+    private const int PageStep = 8;
+
+    private void OnQueryKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is not CommandPaletteViewModel viewModel)
+        {
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Escape:
+                viewModel.Close();
+                e.Handled = true;
+                break;
+            case Key.Down:
+                viewModel.MoveSelection(1);
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.Up:
+                viewModel.MoveSelection(-1);
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.PageDown:
+                viewModel.MoveSelection(PageStep);
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.PageUp:
+                viewModel.MoveSelection(-PageStep);
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.Home:
+                viewModel.SelectFirst();
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.End:
+                viewModel.SelectLast();
+                ScrollSelectionIntoView(viewModel);
+                e.Handled = true;
+                break;
+            case Key.Enter:
+                viewModel.ExecuteSelected();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void ScrollSelectionIntoView(CommandPaletteViewModel viewModel)
+    {
+        if (viewModel.SelectedCommand.Value is { } selected)
+            ResultsListBox.ScrollIntoView(selected);
+    }
+}

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -337,6 +337,10 @@
         <tutorial:TutorialOverlay x:Name="TutorialOverlayPanel"
                                   Grid.RowSpan="3"
                                   IsVisible="False" />
+
+        <!-- コマンドパレット -->
+        <views:CommandPaletteView Grid.RowSpan="3"
+                                  DataContext="{Binding CommandPalette}" />
     </Grid>
 
 </UserControl>


### PR DESCRIPTION
## Description

- Introduce a Ctrl+Shift+P (Cmd+Shift+P on macOS) command palette overlay that lets users search and execute menu and editor commands without navigating nested menus, backed by `CommandPaletteService` and `ContextCommandManager`.
- Add `IContextCommandStateNotifier` so handlers (`EditViewModel` player commands, `TimelineTabViewModel`) can push live `CanExecute` updates to the open palette, and have `ContextCommandManager.Attach` honor `CanExecute` so disabled commands cannot be fired via their keyboard shortcut.
- Scope command resolution to the active editor tab and currently-open tool tabs (via `CommandPaletteHandlerProvider` / `DockHostViewModel.FindToolContext`) so commands from inactive editors and closed tool tabs no longer surface as dead entries; re-snapshot the palette when the active tab changes.

## Breaking changes

None

## Fixed issues

None