### PR TITLE
test: Expand unit-test coverage across Core, Engine, Utilities

### DIFF
--- a/src/Beutl.Engine/Beutl.Engine.csproj
+++ b/src/Beutl.Engine/Beutl.Engine.csproj
@@ -53,20 +53,29 @@
     Silk.NET 側のローダ (Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier) は
     Ubuntu などディストリ固有 RID (例: ubuntu.24.04-x64) を返し、リポジトリ内 fallback リストにも "ubuntu" が無いため
     runtimes/linux-x64/native/libshaderc_shared.so を解決できず libshaderc が読めなくなる。
-    回避策として、現在ビルドしているホスト OS/アーキに合わせたネイティブを bin 直下にもコピーし、
+    回避策として、ターゲット OS/アーキに合わせたネイティブを bin 直下にもコピーし、
     Silk.NET の BaseDirectoryResolver で拾えるようにする。
+
+    クロスターゲットビルド (例: x64 ホストから dotnet publish -r linux-arm64) では $(RuntimeIdentifier) が
+    指定されるので、それを優先して使う。未指定時のみホスト OS/アーキを検出してフォールバックする。
   -->
   <PropertyGroup>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">linux-x64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">linux-arm64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">osx-x64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">osx-arm64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">win-x64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">win-arm64</_ShadercNativeRid>
-    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X86'">win-x86</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_ShadercNativeRid>
+
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">linux-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">linux-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">osx-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">osx-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">win-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">win-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$(_ShadercNativeRid)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X86'">win-x86</_ShadercNativeRid>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(_ShadercNativeRid)' != '' And '$(PkgSilk_NET_Shaderc_Native)' != ''">
+  <!--
+    Exists() ガードで、パッケージに含まれていない RID (例: linux-musl-x64, osx.13-arm64 など) が
+    指定された場合に空 Content にフェイルし、ビルド失敗を回避する。
+  -->
+  <ItemGroup Condition="'$(_ShadercNativeRid)' != '' And '$(PkgSilk_NET_Shaderc_Native)' != '' And Exists('$(PkgSilk_NET_Shaderc_Native)\runtimes\$(_ShadercNativeRid)\native')">
     <Content Include="$(PkgSilk_NET_Shaderc_Native)\runtimes\$(_ShadercNativeRid)\native\*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Beutl.Engine/Beutl.Engine.csproj
+++ b/src/Beutl.Engine/Beutl.Engine.csproj
@@ -44,7 +44,33 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
     <PackageReference Include="Silk.NET.Shaderc" />
-    <PackageReference Include="Silk.NET.Shaderc.Native" />
+    <PackageReference Include="Silk.NET.Shaderc.Native" GeneratePathProperty="true" />
     <PackageReference Include="Silk.NET.Assimp" />
+  </ItemGroup>
+
+  <!--
+    Silk.NET.Shaderc.Native は runtimes/{rid}/native/ にしかネイティブライブラリを置かない。
+    Silk.NET 側のローダ (Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier) は
+    Ubuntu などディストリ固有 RID (例: ubuntu.24.04-x64) を返し、リポジトリ内 fallback リストにも "ubuntu" が無いため
+    runtimes/linux-x64/native/libshaderc_shared.so を解決できず libshaderc が読めなくなる。
+    回避策として、現在ビルドしているホスト OS/アーキに合わせたネイティブを bin 直下にもコピーし、
+    Silk.NET の BaseDirectoryResolver で拾えるようにする。
+  -->
+  <PropertyGroup>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">linux-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">linux-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">osx-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">osx-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">win-x64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">win-arm64</_ShadercNativeRid>
+    <_ShadercNativeRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X86'">win-x86</_ShadercNativeRid>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_ShadercNativeRid)' != '' And '$(PkgSilk_NET_Shaderc_Native)' != ''">
+    <Content Include="$(PkgSilk_NET_Shaderc_Native)\runtimes\$(_ShadercNativeRid)\native\*">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
 </Project>

--- a/tests/Beutl.UnitTests/Core/BeutlEnvironmentTests.cs
+++ b/tests/Beutl.UnitTests/Core/BeutlEnvironmentTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class BeutlEnvironmentTests
 {

--- a/tests/Beutl.UnitTests/Core/BeutlEnvironmentTests.cs
+++ b/tests/Beutl.UnitTests/Core/BeutlEnvironmentTests.cs
@@ -1,0 +1,75 @@
+namespace Beutl.UnitTests.Core;
+
+public class BeutlEnvironmentTests
+{
+    [Test]
+    public void GetHomeDirectoryPath_FallsBackToUserProfile_WhenEnvVarUnset()
+    {
+        string? original = Environment.GetEnvironmentVariable(BeutlEnvironment.HomeVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, null);
+            string expected = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".beutl");
+            Assert.That(BeutlEnvironment.GetHomeDirectoryPath(), Is.EqualTo(expected));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, original);
+        }
+    }
+
+    [Test]
+    public void GetHomeDirectoryPath_UsesEnvVar_WhenDirectoryExists()
+    {
+        string? original = Environment.GetEnvironmentVariable(BeutlEnvironment.HomeVariable);
+        string tempDir = Path.Combine(Path.GetTempPath(), $"beutl-env-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, tempDir);
+            Assert.That(BeutlEnvironment.GetHomeDirectoryPath(), Is.EqualTo(tempDir));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, original);
+            Directory.Delete(tempDir);
+        }
+    }
+
+    [Test]
+    public void GetHomeDirectoryPath_FallsBackWhenEnvVarPathDoesNotExist()
+    {
+        string? original = Environment.GetEnvironmentVariable(BeutlEnvironment.HomeVariable);
+        string nonExistent = Path.Combine(Path.GetTempPath(), $"beutl-missing-{Guid.NewGuid():N}");
+        try
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, nonExistent);
+            string expected = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".beutl");
+            Assert.That(BeutlEnvironment.GetHomeDirectoryPath(), Is.EqualTo(expected));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BeutlEnvironment.HomeVariable, original);
+        }
+    }
+
+    [Test]
+    public void GetPackagesDirectoryPath_IsHomeSlashPackages()
+    {
+        string home = BeutlEnvironment.GetHomeDirectoryPath();
+        Assert.That(BeutlEnvironment.GetPackagesDirectoryPath(),
+            Is.EqualTo(Path.Combine(home, "packages")));
+    }
+
+    [Test]
+    public void GetSideloadsDirectoryPath_IsHomeSlashSideloads()
+    {
+        string home = BeutlEnvironment.GetHomeDirectoryPath();
+        Assert.That(BeutlEnvironment.GetSideloadsDirectoryPath(),
+            Is.EqualTo(Path.Combine(home, "sideloads")));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/BlobFileSourceTests.cs
+++ b/tests/Beutl.UnitTests/Core/BlobFileSourceTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Beutl.IO;
 using Beutl.Serialization;
 

--- a/tests/Beutl.UnitTests/Core/BlobFileSourceTests.cs
+++ b/tests/Beutl.UnitTests/Core/BlobFileSourceTests.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using Beutl.IO;
+using Beutl.Serialization;
+
+namespace Beutl.UnitTests.Core;
+
+public class BlobFileSourceTests
+{
+    [Test]
+    public void Default_DataIsEmpty()
+    {
+        var source = new BlobFileSource();
+
+        Assert.That(source.Data, Is.Empty);
+    }
+
+    [Test]
+    public void Uri_BeforeReadFrom_Throws()
+    {
+        var source = new BlobFileSource();
+
+        Assert.That(() => _ = source.Uri, Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void ReadFrom_DataUri_PopulatesBytes()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("blob");
+        Uri uri = UriHelper.CreateBase64DataUri("application/octet-stream", payload);
+        var source = new BlobFileSource();
+
+        source.ReadFrom(uri);
+
+        Assert.That(source.Data, Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void ReadFrom_FileUri_ReadsContent()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            byte[] payload = Encoding.UTF8.GetBytes("file-blob");
+            File.WriteAllBytes(path, payload);
+            var source = new BlobFileSource();
+
+            source.ReadFrom(new Uri(path));
+
+            Assert.That(source.Data, Is.EqualTo(payload));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/ChoicesProviderAttributeTests.cs
+++ b/tests/Beutl.UnitTests/Core/ChoicesProviderAttributeTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class ChoicesProviderAttributeTests
 {

--- a/tests/Beutl.UnitTests/Core/ChoicesProviderAttributeTests.cs
+++ b/tests/Beutl.UnitTests/Core/ChoicesProviderAttributeTests.cs
@@ -1,0 +1,30 @@
+namespace Beutl.UnitTests.Core;
+
+public class ChoicesProviderAttributeTests
+{
+    private sealed class IntChoicesProvider : IChoicesProvider
+    {
+        public static IReadOnlyList<object> GetChoices() => [1, 2, 3];
+    }
+
+    private sealed class NotAProvider;
+
+    [Test]
+    public void Constructor_Stores_ProviderType()
+    {
+        var attr = new ChoicesProviderAttribute(typeof(IntChoicesProvider));
+        Assert.That(attr.ProviderType, Is.EqualTo(typeof(IntChoicesProvider)));
+    }
+
+    [Test]
+    public void Constructor_NonProvider_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new ChoicesProviderAttribute(typeof(NotAProvider)));
+    }
+
+    [Test]
+    public void Provider_GetChoices_ReturnsConfiguredOptions()
+    {
+        Assert.That(IntChoicesProvider.GetChoices(), Is.EqualTo(new object[] { 1, 2, 3 }));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CircularBufferTests.cs
+++ b/tests/Beutl.UnitTests/Core/CircularBufferTests.cs
@@ -1,0 +1,174 @@
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class CircularBufferTests
+{
+    [Test]
+    public void NewBuffer_IsEmptyAndNotFull()
+    {
+        var buf = new CircularBuffer<int>(3);
+        Assert.That(buf.IsEmpty, Is.True);
+        Assert.That(buf.IsFull, Is.False);
+        Assert.That(buf.Size, Is.EqualTo(0));
+        Assert.That(buf.Capacity, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Constructor_CapacityLessThanOne_Throws()
+    {
+        Assert.That(() => new CircularBuffer<int>(0), Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void Constructor_ItemsExceedCapacity_Throws()
+    {
+        Assert.That(() => new CircularBuffer<int>(2, [1, 2, 3]),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void Constructor_WithItems_PopulatesBuffer()
+    {
+        var buf = new CircularBuffer<int>(5, [1, 2, 3]);
+        Assert.That(buf.Size, Is.EqualTo(3));
+        Assert.That(buf.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void PushBack_BelowCapacity_AppendsAtEnd()
+    {
+        var buf = new CircularBuffer<int>(3);
+        buf.PushBack(1);
+        buf.PushBack(2);
+        Assert.That(buf.Front(), Is.EqualTo(1));
+        Assert.That(buf.Back(), Is.EqualTo(2));
+        Assert.That(buf.Size, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void PushBack_OverCapacity_OverwritesFront()
+    {
+        var buf = new CircularBuffer<int>(3);
+        buf.PushBack(1);
+        buf.PushBack(2);
+        buf.PushBack(3);
+        buf.PushBack(4);
+        Assert.That(buf.IsFull, Is.True);
+        Assert.That(buf.ToArray(), Is.EqualTo(new[] { 2, 3, 4 }));
+        Assert.That(buf.Front(), Is.EqualTo(2));
+        Assert.That(buf.Back(), Is.EqualTo(4));
+    }
+
+    [Test]
+    public void PushFront_BelowCapacity_PrependsAtStart()
+    {
+        var buf = new CircularBuffer<int>(3);
+        buf.PushFront(1);
+        buf.PushFront(2);
+        Assert.That(buf.Front(), Is.EqualTo(2));
+        Assert.That(buf.Back(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PushFront_OverCapacity_OverwritesBack()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2, 3]);
+        buf.PushFront(0);
+        Assert.That(buf.ToArray(), Is.EqualTo(new[] { 0, 1, 2 }));
+    }
+
+    [Test]
+    public void PopBack_ReducesSize_RemovesLastItem()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2, 3]);
+        buf.PopBack();
+        Assert.That(buf.Size, Is.EqualTo(2));
+        Assert.That(buf.Back(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void PopFront_ReducesSize_RemovesFirstItem()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2, 3]);
+        buf.PopFront();
+        Assert.That(buf.Size, Is.EqualTo(2));
+        Assert.That(buf.Front(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void PopFront_OnEmpty_Throws()
+    {
+        var buf = new CircularBuffer<int>(3);
+        Assert.That(() => buf.PopFront(), Throws.InvalidOperationException);
+        Assert.That(() => buf.PopBack(), Throws.InvalidOperationException);
+        Assert.That(() => buf.Front(), Throws.InvalidOperationException);
+        Assert.That(() => buf.Back(), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void Indexer_OnEmpty_Throws()
+    {
+        var buf = new CircularBuffer<int>(3);
+        Assert.That(() => _ = buf[0], Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => buf[0] = 1, Throws.TypeOf<IndexOutOfRangeException>());
+    }
+
+    [Test]
+    public void Indexer_OutOfRange_Throws()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2]);
+        Assert.That(() => _ = buf[2], Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => buf[2] = 0, Throws.TypeOf<IndexOutOfRangeException>());
+    }
+
+    [Test]
+    public void Indexer_GetAndSet_RoundTrips()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2, 3]);
+        Assert.That(buf[0], Is.EqualTo(1));
+        Assert.That(buf[1], Is.EqualTo(2));
+        Assert.That(buf[2], Is.EqualTo(3));
+        buf[1] = 9;
+        Assert.That(buf[1], Is.EqualTo(9));
+    }
+
+    [Test]
+    public void Clear_ResetsSize_KeepsCapacity()
+    {
+        var buf = new CircularBuffer<int>(3, [1, 2, 3]);
+        buf.Clear();
+        Assert.That(buf.IsEmpty, Is.True);
+        Assert.That(buf.Capacity, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Enumerator_AfterWrap_ReturnsLogicalOrder()
+    {
+        var buf = new CircularBuffer<int>(3);
+        buf.PushBack(1);
+        buf.PushBack(2);
+        buf.PushBack(3);
+        buf.PushBack(4); // wraps; expected [2, 3, 4]
+        Assert.That(buf.ToList(), Is.EqualTo(new[] { 2, 3, 4 }));
+    }
+
+    [Test]
+    public void ToArraySegments_HasTwoSegments()
+    {
+        var buf = new CircularBuffer<int>(3);
+        buf.PushBack(1);
+        buf.PushBack(2);
+        buf.PushBack(3);
+        buf.PushBack(4); // wraps internally
+
+        IList<ArraySegment<int>> segs = buf.ToArraySegments();
+        Assert.That(segs, Has.Count.EqualTo(2));
+        int total = 0;
+        foreach (ArraySegment<int> seg in segs)
+        {
+            total += seg.Count;
+        }
+        Assert.That(total, Is.EqualTo(buf.Size));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CircularBufferTests.cs
+++ b/tests/Beutl.UnitTests/Core/CircularBufferTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Collections;
+﻿using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/CoreDictionaryTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreDictionaryTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Specialized;
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class CoreDictionaryTests
+{
+    [Test]
+    public void Add_RaisesAddCollectionChanged_AndCountProperty()
+    {
+        var dict = new CoreDictionary<string, int>();
+        var actions = new List<NotifyCollectionChangedAction>();
+        var properties = new List<string?>();
+
+        dict.CollectionChanged += (_, e) => actions.Add(e.Action);
+        dict.PropertyChanged += (_, e) => properties.Add(e.PropertyName);
+
+        dict.Add("a", 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Add }));
+            Assert.That(properties, Does.Contain("Count"));
+            Assert.That(properties, Does.Contain("Item[a]"));
+        });
+    }
+
+    [Test]
+    public void Indexer_NewKey_AddsAndFiresAdd()
+    {
+        var dict = new CoreDictionary<string, int>();
+        var actions = new List<NotifyCollectionChangedAction>();
+        dict.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        dict["foo"] = 1;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict["foo"], Is.EqualTo(1));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Add }));
+        });
+    }
+
+    [Test]
+    public void Indexer_ExistingKey_FiresReplace()
+    {
+        var dict = new CoreDictionary<string, int> { ["foo"] = 1 };
+        var args = new List<NotifyCollectionChangedEventArgs>();
+        dict.CollectionChanged += (_, e) => args.Add(e);
+
+        dict["foo"] = 99;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict["foo"], Is.EqualTo(99));
+            Assert.That(args, Has.Count.EqualTo(1));
+            Assert.That(args[0].Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+        });
+    }
+
+    [Test]
+    public void Remove_ReturnsTrueAndRaisesRemove()
+    {
+        var dict = new CoreDictionary<string, int> { ["foo"] = 1, ["bar"] = 2 };
+        var actions = new List<NotifyCollectionChangedAction>();
+        dict.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict.Remove("foo"), Is.True);
+            Assert.That(dict.Remove("missing"), Is.False);
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Remove }));
+        });
+    }
+
+    [Test]
+    public void Clear_FiresRemoveAndPropertyChanges()
+    {
+        var dict = new CoreDictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var actions = new List<NotifyCollectionChangedAction>();
+        var properties = new List<string?>();
+        dict.CollectionChanged += (_, e) => actions.Add(e.Action);
+        dict.PropertyChanged += (_, e) => properties.Add(e.PropertyName);
+
+        dict.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict.Count, Is.EqualTo(0));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Remove }));
+            Assert.That(properties, Does.Contain("Count"));
+            Assert.That(properties, Does.Contain("Item"));
+        });
+    }
+
+    [Test]
+    public void TryGetValue_AndContainsKey()
+    {
+        var dict = new CoreDictionary<string, int> { ["foo"] = 1 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dict.TryGetValue("foo", out int value), Is.True);
+            Assert.That(value, Is.EqualTo(1));
+            Assert.That(dict.TryGetValue("bar", out _), Is.False);
+            Assert.That(dict.ContainsKey("foo"), Is.True);
+            Assert.That(dict.ContainsKey("bar"), Is.False);
+        });
+    }
+
+    [Test]
+    public void Enumerator_ReturnsAllPairs()
+    {
+        var dict = new CoreDictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var actual = dict.OrderBy(kv => kv.Key).ToArray();
+
+        Assert.That(actual, Is.EqualTo(new[]
+        {
+            new KeyValuePair<string, int>("a", 1),
+            new KeyValuePair<string, int>("b", 2),
+        }));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CoreDictionaryTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreDictionaryTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/CoreListExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListExtensionsTests.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel;
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class CoreListExtensionsTests
+{
+    [Test]
+    public void ForEachItem_AppliesAddedToInitialItems()
+    {
+        var list = new CoreList<int> { 1, 2, 3 };
+        var seen = new List<(int Index, int Value)>();
+        var removed = new List<int>();
+        bool resetCalled = false;
+
+        using var sub = list.ForEachItem(
+            (i, v) => seen.Add((i, v)),
+            (_, v) => removed.Add(v),
+            () => resetCalled = true);
+
+        Assert.That(seen, Is.EqualTo(new[] { (0, 1), (1, 2), (2, 3) }));
+        Assert.That(removed, Is.Empty);
+        Assert.That(resetCalled, Is.False);
+    }
+
+    [Test]
+    public void ForEachItem_ReceivesAddRemoveAndReplaceNotifications()
+    {
+        var list = new CoreList<string>();
+        var added = new List<(int Index, string Value)>();
+        var removed = new List<(int Index, string Value)>();
+
+        using var sub = list.ForEachItem<string>(
+            (i, v) => added.Add((i, v)),
+            (i, v) => removed.Add((i, v)),
+            () => { });
+
+        list.Add("a");
+        list.Add("b");
+        list[0] = "z";
+        list.RemoveAt(1);
+
+        Assert.That(added, Does.Contain((0, "a")));
+        Assert.That(added, Does.Contain((1, "b")));
+        Assert.That(added, Does.Contain((0, "z")));
+        Assert.That(removed, Does.Contain((0, "a")));
+        Assert.That(removed, Does.Contain((1, "b")));
+    }
+
+    [Test]
+    public void ForEachItem_OnReset_FiresResetAndReAdds()
+    {
+        var list = new CoreList<int> { 1, 2 };
+        var added = new List<int>();
+        bool reset = false;
+
+        using var sub = list.ForEachItem<int>(
+            (_, v) => added.Add(v),
+            (_, _) => { },
+            () => reset = true);
+
+        added.Clear();
+        list.Clear();
+
+        Assert.That(reset, Is.True);
+        Assert.That(added, Is.Empty);
+    }
+
+    [Test]
+    public void ForEachItem_DisposeStopsNotifications()
+    {
+        var list = new CoreList<int>();
+        var added = new List<int>();
+
+        var sub = list.ForEachItem<int>(
+            (_, v) => added.Add(v),
+            (_, _) => { },
+            () => { });
+
+        list.Add(1);
+        sub.Dispose();
+        list.Add(2);
+
+        Assert.That(added, Is.EqualTo(new[] { 1 }));
+    }
+
+    [Test]
+    public void TrackCollectionChanged_DoesNotEmitInitialItems()
+    {
+        var list = new CoreList<int> { 1, 2 };
+        var added = new List<int>();
+
+        using var sub = list.TrackCollectionChanged(
+            v => added.Add(v),
+            _ => { },
+            () => { });
+
+        Assert.That(added, Is.Empty);
+
+        list.Add(99);
+        Assert.That(added, Is.EqualTo(new[] { 99 }));
+    }
+
+    [Test]
+    public void TrackItemPropertyChanged_NotifiesWhenItemPropertyChanges()
+    {
+        var item = new TestNotify();
+        var list = new CoreList<TestNotify> { item };
+        Tuple<object?, PropertyChangedEventArgs>? captured = null;
+
+        using var sub = list.TrackItemPropertyChanged(t => captured = t);
+
+        item.Value = 42;
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Item1, Is.SameAs(item));
+        Assert.That(captured.Item2.PropertyName, Is.EqualTo(nameof(TestNotify.Value)));
+    }
+
+    [Test]
+    public void TrackItemPropertyChanged_StopsAfterDispose()
+    {
+        var item = new TestNotify();
+        var list = new CoreList<TestNotify> { item };
+        int count = 0;
+
+        var sub = list.TrackItemPropertyChanged(_ => count++);
+        item.Value = 1;
+        sub.Dispose();
+        item.Value = 2;
+
+        Assert.That(count, Is.EqualTo(1));
+    }
+
+    private sealed class TestNotify : INotifyPropertyChanged
+    {
+        private int _value;
+
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CoreListExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/CoreListTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListTests.cs
@@ -1,0 +1,233 @@
+using System.Collections.Specialized;
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class CoreListTests
+{
+    [Test]
+    public void Add_RaisesAddCollectionChangedAndCountProperty()
+    {
+        var list = new CoreList<int>();
+        var actions = new List<NotifyCollectionChangedAction>();
+        var properties = new List<string?>();
+
+        list.CollectionChanged += (_, e) => actions.Add(e.Action);
+        list.PropertyChanged += (_, e) => properties.Add(e.PropertyName);
+
+        list.Add(42);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list.Count, Is.EqualTo(1));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Add }));
+            Assert.That(properties, Does.Contain(nameof(CoreList<int>.Count)));
+            Assert.That(properties, Does.Contain("Item[]"));
+        });
+    }
+
+    [Test]
+    public void Add_FiresAttachedEvent()
+    {
+        var list = new CoreList<string>();
+        var attached = new List<string>();
+        list.Attached += attached.Add;
+
+        list.Add("hello");
+        list.AddRange(new[] { "a", "b" });
+
+        Assert.That(attached, Is.EqualTo(new[] { "hello", "a", "b" }));
+    }
+
+    [Test]
+    public void Indexer_SettingNewValue_FiresReplaceAndDetached()
+    {
+        var list = new CoreList<int>(new[] { 1, 2, 3 });
+        var actions = new List<NotifyCollectionChangedAction>();
+        var detached = new List<int>();
+        var attached = new List<int>();
+
+        list.CollectionChanged += (_, e) => actions.Add(e.Action);
+        list.Detached += detached.Add;
+        list.Attached += attached.Add;
+
+        list[1] = 99;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list[1], Is.EqualTo(99));
+            Assert.That(actions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Replace }));
+            Assert.That(detached, Is.EqualTo(new[] { 2 }));
+            Assert.That(attached, Is.EqualTo(new[] { 99 }));
+        });
+    }
+
+    [Test]
+    public void Indexer_SettingSameValue_DoesNotRaiseEvents()
+    {
+        var list = new CoreList<int>(new[] { 1, 2 });
+        var actions = new List<NotifyCollectionChangedAction>();
+        list.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        list[0] = 1;
+
+        Assert.That(actions, Is.Empty);
+    }
+
+    [Test]
+    public void Insert_AddsItemAtIndex()
+    {
+        var list = new CoreList<int>(new[] { 1, 3 });
+        var args = new List<NotifyCollectionChangedEventArgs>();
+        list.CollectionChanged += (_, e) => args.Add(e);
+
+        list.Insert(1, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list, Is.EqualTo(new[] { 1, 2, 3 }));
+            Assert.That(args, Has.Count.EqualTo(1));
+            Assert.That(args[0].Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(args[0].NewStartingIndex, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Remove_ReturnsTrueAndFiresRemove()
+    {
+        var list = new CoreList<int>(new[] { 1, 2, 3 });
+        var detached = new List<int>();
+        list.Detached += detached.Add;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list.Remove(2), Is.True);
+            Assert.That(list, Is.EqualTo(new[] { 1, 3 }));
+            Assert.That(detached, Is.EqualTo(new[] { 2 }));
+            Assert.That(list.Remove(99), Is.False);
+        });
+    }
+
+    [Test]
+    public void Move_ChangesPosition()
+    {
+        var list = new CoreList<int>(new[] { 1, 2, 3, 4 });
+        list.Move(0, 3);
+        Assert.That(list, Is.EqualTo(new[] { 2, 3, 4, 1 }));
+    }
+
+    [Test]
+    public void MoveRange_MovesContiguousItems()
+    {
+        var list = new CoreList<int>(new[] { 1, 2, 3, 4, 5 });
+        list.MoveRange(0, 2, 5);
+        Assert.That(list, Is.EqualTo(new[] { 3, 4, 5, 1, 2 }));
+    }
+
+    [Test]
+    public void RemoveAll_RemovesEveryListedItem()
+    {
+        var list = new CoreList<int>(new[] { 1, 2, 3, 2, 4, 2 });
+        list.RemoveAll(new[] { 2 });
+        Assert.That(list, Is.EqualTo(new[] { 1, 3, 4 }));
+    }
+
+    [Test]
+    public void Replace_DetachesAndAttachesItems()
+    {
+        var list = new CoreList<int>(new[] { 1, 2 });
+        var attached = new List<int>();
+        var detached = new List<int>();
+        list.Attached += attached.Add;
+        list.Detached += detached.Add;
+
+        list.Replace(new[] { 9, 8, 7 });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list, Is.EqualTo(new[] { 9, 8, 7 }));
+            Assert.That(detached, Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(attached, Is.EqualTo(new[] { 9, 8, 7 }));
+        });
+    }
+
+    [Test]
+    public void Clear_FiresRemoveOrResetBasedOnBehavior()
+    {
+        var removeList = new CoreList<int>(new[] { 1, 2 }) { ResetBehavior = ResetBehavior.Remove };
+        var resetList = new CoreList<int>(new[] { 1, 2 }) { ResetBehavior = ResetBehavior.Reset };
+
+        var removeActions = new List<NotifyCollectionChangedAction>();
+        var resetActions = new List<NotifyCollectionChangedAction>();
+        removeList.CollectionChanged += (_, e) => removeActions.Add(e.Action);
+        resetList.CollectionChanged += (_, e) => resetActions.Add(e.Action);
+
+        removeList.Clear();
+        resetList.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(removeList.Count, Is.EqualTo(0));
+            Assert.That(resetList.Count, Is.EqualTo(0));
+            Assert.That(removeActions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Remove }));
+            Assert.That(resetActions, Is.EqualTo(new[] { NotifyCollectionChangedAction.Reset }));
+        });
+    }
+
+    [Test]
+    public void Clear_OnEmpty_DoesNothing()
+    {
+        var list = new CoreList<int>();
+        var fired = false;
+        list.CollectionChanged += (_, _) => fired = true;
+        list.Clear();
+        Assert.That(fired, Is.False);
+    }
+
+    [Test]
+    public void GetMarshal_ProvidesCurrentSpan()
+    {
+        var list = new CoreList<int>(new[] { 10, 20, 30 });
+        CoreListMarshal<int> marshal = list.GetMarshal();
+        Assert.That(marshal.Value.ToArray(), Is.EqualTo(new[] { 10, 20, 30 }));
+    }
+
+    [Test]
+    public void GetMarshal_ThrowsAfterMutation()
+    {
+        var list = new CoreList<int>(new[] { 10 });
+        CoreListMarshal<int> marshal = list.GetMarshal();
+        list.Add(20);
+
+        bool threw = false;
+        try
+        {
+            _ = marshal.Value.Length;
+        }
+        catch (InvalidOperationException)
+        {
+            threw = true;
+        }
+
+        Assert.That(threw, Is.True);
+    }
+
+    [Test]
+    public void EnsureCapacity_GrowsBackingList()
+    {
+        var list = new CoreList<int>();
+        list.EnsureCapacity(32);
+        Assert.That(list.Capacity, Is.GreaterThanOrEqualTo(32));
+    }
+
+    [Test]
+    public void IList_IsFixedSize_AndIsReadOnly_AreFalse()
+    {
+        System.Collections.IList list = new CoreList<int>();
+        Assert.Multiple(() =>
+        {
+            Assert.That(list.IsFixedSize, Is.False);
+            Assert.That(list.IsReadOnly, Is.False);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CoreListTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/CoreObjectExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreObjectExtensionsTests.cs
@@ -1,0 +1,119 @@
+namespace Beutl.UnitTests.Core;
+
+public class CoreObjectExtensionsTests
+{
+    [Test]
+    public void GetPropertyChangedObservable_NullObj_Throws()
+    {
+        Assert.That(
+            () => CoreObjectExtensions.GetPropertyChangedObservable<string>(null!, CoreObject.NameProperty),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void GetPropertyChangedObservable_NullProperty_Throws()
+    {
+        var obj = new TestCoreObject();
+
+        Assert.That(
+            () => obj.GetPropertyChangedObservable<string>(null!),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void GetPropertyChangedObservable_FiresOnPropertyChange()
+    {
+        var obj = new TestCoreObject();
+        var values = new List<string?>();
+
+        using IDisposable sub = obj.GetPropertyChangedObservable(CoreObject.NameProperty)
+            .Subscribe(args => values.Add(args.NewValue));
+
+        obj.Name = "alpha";
+        obj.Name = "beta";
+
+        Assert.That(values, Is.EqualTo(new[] { "alpha", "beta" }));
+    }
+
+    [Test]
+    public void GetObservable_NullObj_Throws()
+    {
+        Assert.That(
+            () => CoreObjectExtensions.GetObservable<string>(null!, CoreObject.NameProperty),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void GetObservable_NullProperty_Throws()
+    {
+        var obj = new TestCoreObject();
+
+        Assert.That(
+            () => obj.GetObservable<string>(null!),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void GetObservable_EmitsCurrentValueImmediately()
+    {
+        var obj = new TestCoreObject { Name = "init" };
+        string? captured = null;
+
+        using IDisposable sub = obj.GetObservable(CoreObject.NameProperty).Subscribe(v => captured = v);
+
+        Assert.That(captured, Is.EqualTo("init"));
+
+        obj.Name = "next";
+        Assert.That(captured, Is.EqualTo("next"));
+    }
+
+    [Test]
+    public void Find_PredicateNull_Throws()
+    {
+        var obj = new TestCoreObject();
+
+        Assert.That(() => obj.Find(null!), Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void Find_IncludeSelfTrue_ReturnsObjectIfMatches()
+    {
+        var obj = new TestCoreObject();
+
+        object? result = obj.Find(o => ReferenceEquals(o, obj));
+
+        Assert.That(result, Is.SameAs(obj));
+    }
+
+    [Test]
+    public void Find_IncludeSelfFalse_DoesNotReturnSelf()
+    {
+        var obj = new TestCoreObject();
+
+        object? result = obj.Find(o => ReferenceEquals(o, obj), includeSelf: false);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void FindById_FindsSelf()
+    {
+        var obj = new TestCoreObject();
+
+        ICoreObject? result = obj.FindById(obj.Id);
+
+        Assert.That(result, Is.SameAs(obj));
+    }
+
+    [Test]
+    public void FindById_NotMatchingId_ReturnsNull()
+    {
+        var obj = new TestCoreObject();
+
+        ICoreObject? result = obj.FindById(Guid.NewGuid());
+
+        Assert.That(result, Is.Null);
+    }
+
+    private sealed class TestCoreObject : CoreObject;
+}

--- a/tests/Beutl.UnitTests/Core/CoreObjectExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreObjectExtensionsTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class CoreObjectExtensionsTests
 {

--- a/tests/Beutl.UnitTests/Core/CorePropertyJsonConverterTests.cs
+++ b/tests/Beutl.UnitTests/Core/CorePropertyJsonConverterTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/CorePropertyJsonConverterTests.cs
+++ b/tests/Beutl.UnitTests/Core/CorePropertyJsonConverterTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+
+namespace Beutl.UnitTests.Core;
+
+public class CorePropertyJsonConverterTests
+{
+    private sealed class JsonOwner : CoreObject
+    {
+        public static readonly CoreProperty<int> CountProperty
+            = ConfigureProperty<int, JsonOwner>(nameof(Count)).Register();
+
+        public int Count
+        {
+            get => GetValue(CountProperty);
+            set => SetValue(CountProperty, value);
+        }
+    }
+
+    private static readonly JsonSerializerOptions s_options = JsonHelper.SerializerOptions;
+
+    [Test]
+    public void Write_EmitsNameAndOwner()
+    {
+        // Touch the static field so the property is registered before serialization.
+        _ = JsonOwner.CountProperty;
+        string json = JsonSerializer.Serialize<CoreProperty>(JsonOwner.CountProperty, s_options);
+        using JsonDocument doc = JsonDocument.Parse(json);
+
+        Assert.That(doc.RootElement.GetProperty("Name").GetString(), Is.EqualTo("Count"));
+        Assert.That(doc.RootElement.GetProperty("Owner").GetString(),
+            Does.Contain(nameof(JsonOwner)));
+    }
+
+    [Test]
+    public void Read_ResolvesPropertyByOwnerAndName()
+    {
+        _ = JsonOwner.CountProperty;
+        string json = JsonSerializer.Serialize<CoreProperty>(JsonOwner.CountProperty, s_options);
+
+        CoreProperty? back = JsonSerializer.Deserialize<CoreProperty>(json, s_options);
+        Assert.That(back, Is.Not.Null);
+        Assert.That(back!.Name, Is.EqualTo("Count"));
+        Assert.That(back.OwnerType, Is.EqualTo(typeof(JsonOwner)));
+    }
+
+    [Test]
+    public void Read_NonObjectJson_Throws()
+    {
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<CoreProperty>("\"not-an-object\"", s_options));
+    }
+
+    [Test]
+    public void Read_MissingFields_Throws()
+    {
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<CoreProperty>("{\"Name\":\"Count\"}", s_options));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CultureNameValidationTests.cs
+++ b/tests/Beutl.UnitTests/Core/CultureNameValidationTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class CultureNameValidationTests
 {

--- a/tests/Beutl.UnitTests/Core/CultureNameValidationTests.cs
+++ b/tests/Beutl.UnitTests/Core/CultureNameValidationTests.cs
@@ -1,0 +1,22 @@
+namespace Beutl.UnitTests.Core;
+
+public class CultureNameValidationTests
+{
+    [Test]
+    [TestCase("en-US")]
+    [TestCase("ja-JP")]
+    [TestCase("en")]
+    [TestCase("")] // invariant culture
+    public void IsValid_KnownCultureNames_ReturnsTrue(string name)
+    {
+        Assert.That(CultureNameValidation.IsValid(name), Is.True);
+    }
+
+    [Test]
+    [TestCase("not-a-real-culture")]
+    [TestCase("xx-XX-fake")]
+    public void IsValid_UnknownCultureNames_ReturnsFalse(string name)
+    {
+        Assert.That(CultureNameValidation.IsValid(name), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Core/DisposableExtensionTests.cs
+++ b/tests/Beutl.UnitTests/Core/DisposableExtensionTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Disposables;
+﻿using System.Reactive.Disposables;
 using Beutl.Reactive;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/DisposableExtensionTests.cs
+++ b/tests/Beutl.UnitTests/Core/DisposableExtensionTests.cs
@@ -1,0 +1,124 @@
+using System.Reactive.Disposables;
+using Beutl.Reactive;
+
+namespace Beutl.UnitTests.Core;
+
+public class DisposableExtensionTests
+{
+    private sealed class CountedDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+        public void Dispose() => DisposeCount++;
+    }
+
+    [Test]
+    public void DisposeWith_AddsToCollectionAndReturnsSelf()
+    {
+        var list = new List<IDisposable>();
+        var disposable = new CountedDisposable();
+
+        CountedDisposable returned = disposable.DisposeWith(list);
+
+        Assert.That(returned, Is.SameAs(disposable));
+        Assert.That(list, Has.Count.EqualTo(1));
+        Assert.That(list[0], Is.SameAs(disposable));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple2_DisposesBothItems()
+    {
+        var a = new CountedDisposable();
+        var b = new CountedDisposable();
+
+        (a, b).DisposeAll();
+
+        Assert.That(a.DisposeCount, Is.EqualTo(1));
+        Assert.That(b.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple2_NullsAreSkipped()
+    {
+        ValueTuple<CountedDisposable?, CountedDisposable?> tuple = (null, null);
+
+        Assert.That(() => tuple.DisposeAll(), Throws.Nothing);
+    }
+
+    [Test]
+    public void DisposeAll_Tuple3_DisposesAll()
+    {
+        var a = new CountedDisposable();
+        var b = new CountedDisposable();
+        var c = new CountedDisposable();
+
+        ((a, b, c)!).DisposeAll();
+
+        Assert.That(a.DisposeCount, Is.EqualTo(1));
+        Assert.That(b.DisposeCount, Is.EqualTo(1));
+        Assert.That(c.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple4_DisposesAll()
+    {
+        var items = Enumerable.Range(0, 4).Select(_ => new CountedDisposable()).ToArray();
+
+        ValueTuple<CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?> tuple
+            = (items[0], items[1], items[2], items[3]);
+
+        tuple.DisposeAll();
+
+        Assert.That(items.Select(d => d.DisposeCount), Is.All.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple5_DisposesAll()
+    {
+        var items = Enumerable.Range(0, 5).Select(_ => new CountedDisposable()).ToArray();
+
+        ValueTuple<CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?> tuple
+            = (items[0], items[1], items[2], items[3], items[4]);
+
+        tuple.DisposeAll();
+
+        Assert.That(items.Select(d => d.DisposeCount), Is.All.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple6_DisposesAll()
+    {
+        var items = Enumerable.Range(0, 6).Select(_ => new CountedDisposable()).ToArray();
+
+        ValueTuple<CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?> tuple
+            = (items[0], items[1], items[2], items[3], items[4], items[5]);
+
+        tuple.DisposeAll();
+
+        Assert.That(items.Select(d => d.DisposeCount), Is.All.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeAll_Tuple7_DisposesAll()
+    {
+        var items = Enumerable.Range(0, 7).Select(_ => new CountedDisposable()).ToArray();
+
+        ValueTuple<CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?, CountedDisposable?> tuple
+            = (items[0], items[1], items[2], items[3], items[4], items[5], items[6]);
+
+        tuple.DisposeAll();
+
+        Assert.That(items.Select(d => d.DisposeCount), Is.All.EqualTo(1));
+    }
+
+    [Test]
+    public void DisposeWith_WithCompositeDisposable_DisposesWhenContainerDisposed()
+    {
+        var composite = new CompositeDisposable();
+        var disposable = new CountedDisposable();
+
+        disposable.DisposeWith((ICollection<IDisposable>)composite);
+        composite.Dispose();
+
+        Assert.That(disposable.DisposeCount, Is.EqualTo(1));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/EnumExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/EnumExtensionsTests.cs
@@ -1,0 +1,122 @@
+namespace Beutl.UnitTests.Core;
+
+public class EnumExtensionsTests
+{
+    [Flags]
+    private enum ByteFlags : byte
+    {
+        None = 0,
+        A = 1,
+        B = 2,
+        C = 4,
+    }
+
+    [Flags]
+    private enum ShortFlags : short
+    {
+        None = 0,
+        A = 1,
+        B = 2,
+        C = 4,
+    }
+
+    [Flags]
+    private enum IntFlags : int
+    {
+        None = 0,
+        A = 1 << 0,
+        B = 1 << 1,
+        C = 1 << 2,
+    }
+
+    [Flags]
+    private enum LongFlags : long
+    {
+        None = 0,
+        A = 1L,
+        B = 1L << 33,
+        C = 1L << 50,
+    }
+
+    [Test]
+    public void HasAllFlags_Byte_DetectsExpectedSubset()
+    {
+        ByteFlags value = ByteFlags.A | ByteFlags.B;
+        Assert.That(value.HasAllFlags(ByteFlags.A), Is.True);
+        Assert.That(value.HasAllFlags(ByteFlags.A | ByteFlags.B), Is.True);
+        Assert.That(value.HasAllFlags(ByteFlags.C), Is.False);
+        Assert.That(value.HasAllFlags(ByteFlags.A | ByteFlags.C), Is.False);
+    }
+
+    [Test]
+    public void HasAnyFlag_Byte_DetectsAtLeastOneOverlap()
+    {
+        ByteFlags value = ByteFlags.A;
+        Assert.That(value.HasAnyFlag(ByteFlags.A | ByteFlags.B), Is.True);
+        Assert.That(value.HasAnyFlag(ByteFlags.B | ByteFlags.C), Is.False);
+    }
+
+    [Test]
+    public void HasAllFlags_Short_DetectsExpectedSubset()
+    {
+        ShortFlags value = ShortFlags.A | ShortFlags.C;
+        Assert.That(value.HasAllFlags(ShortFlags.A | ShortFlags.C), Is.True);
+        Assert.That(value.HasAllFlags(ShortFlags.A | ShortFlags.B), Is.False);
+    }
+
+    [Test]
+    public void HasAnyFlag_Short_DetectsOverlap()
+    {
+        ShortFlags value = ShortFlags.B;
+        Assert.That(value.HasAnyFlag(ShortFlags.A | ShortFlags.B), Is.True);
+        Assert.That(value.HasAnyFlag(ShortFlags.A | ShortFlags.C), Is.False);
+    }
+
+    [Test]
+    public void HasAllFlags_Int_DetectsExpectedSubset()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+        Assert.That(value.HasAllFlags(IntFlags.A), Is.True);
+        Assert.That(value.HasAllFlags(IntFlags.C), Is.False);
+    }
+
+    [Test]
+    public void HasAnyFlag_Int_DetectsOverlap()
+    {
+        IntFlags value = IntFlags.A;
+        Assert.That(value.HasAnyFlag(IntFlags.A | IntFlags.B), Is.True);
+        Assert.That(value.HasAnyFlag(IntFlags.B | IntFlags.C), Is.False);
+    }
+
+    [Test]
+    public void HasAllFlags_Long_HandlesHighBits()
+    {
+        LongFlags value = LongFlags.B | LongFlags.C;
+        Assert.That(value.HasAllFlags(LongFlags.B), Is.True);
+        Assert.That(value.HasAllFlags(LongFlags.C), Is.True);
+        Assert.That(value.HasAllFlags(LongFlags.B | LongFlags.C), Is.True);
+        Assert.That(value.HasAllFlags(LongFlags.A | LongFlags.B), Is.False);
+    }
+
+    [Test]
+    public void HasAnyFlag_Long_HandlesHighBits()
+    {
+        LongFlags value = LongFlags.C;
+        Assert.That(value.HasAnyFlag(LongFlags.B | LongFlags.C), Is.True);
+        Assert.That(value.HasAnyFlag(LongFlags.A | LongFlags.B), Is.False);
+    }
+
+    [Test]
+    public void HasAllFlags_None_AlwaysTrue()
+    {
+        Assert.That(ByteFlags.A.HasAllFlags(ByteFlags.None), Is.True);
+        Assert.That(IntFlags.None.HasAllFlags(IntFlags.None), Is.True);
+    }
+
+    [Test]
+    public void HasAnyFlag_None_AlwaysFalse()
+    {
+        Assert.That(ByteFlags.A.HasAnyFlag(ByteFlags.None), Is.False);
+        Assert.That(LongFlags.A.HasAnyFlag(LongFlags.None), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Core/EnumExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/EnumExtensionsTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class EnumExtensionsTests
 {

--- a/tests/Beutl.UnitTests/Core/HierarchicalExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchicalExtensionsTests.cs
@@ -1,0 +1,165 @@
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class HierarchicalExtensionsTests
+{
+    private class TestNode : Hierarchical, IModifiableHierarchical
+    {
+        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
+    }
+
+    private sealed class SpecialNode : TestNode;
+
+    private sealed class TestRoot : Hierarchical, IHierarchicalRoot, IModifiableHierarchical
+    {
+        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
+
+        public event EventHandler<IHierarchical>? DescendantAttached;
+        public event EventHandler<IHierarchical>? DescendantDetached;
+
+        public void OnDescendantAttached(IHierarchical descendant) => DescendantAttached?.Invoke(this, descendant);
+        public void OnDescendantDetached(IHierarchical descendant) => DescendantDetached?.Invoke(this, descendant);
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Generic_FindsAncestor()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new SpecialNode();
+        root.HierarchicalChildren.Add(middle);
+        middle.HierarchicalChildren.Add(leaf);
+
+        TestRoot? found = ((IHierarchical)leaf).FindHierarchicalParent<TestRoot>();
+
+        Assert.That(found, Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Generic_IncludeSelfMatchesSelf()
+    {
+        var leaf = new SpecialNode();
+
+        SpecialNode? found = ((IHierarchical)leaf).FindHierarchicalParent<SpecialNode>(includeSelf: true);
+
+        Assert.That(found, Is.SameAs(leaf));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Generic_NoMatch_ReturnsDefault()
+    {
+        var root = new TestNode();
+
+        TestRoot? found = ((IHierarchical)root).FindHierarchicalParent<TestRoot>();
+
+        Assert.That(found, Is.Null);
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_Generic_NoMatch_Throws()
+    {
+        var root = new TestNode();
+
+        Assert.That(
+            () => ((IHierarchical)root).FindRequiredHierarchicalParent<TestRoot>(),
+            Throws.TypeOf<HierarchyException>());
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_Generic_ReturnsAncestor()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        TestRoot found = ((IHierarchical)leaf).FindRequiredHierarchicalParent<TestRoot>();
+
+        Assert.That(found, Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Type_FindsAncestor()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        IHierarchical? found = ((IHierarchical)leaf).FindHierarchicalParent(typeof(TestRoot));
+
+        Assert.That(found, Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Type_IncludeSelf_ReturnsSelfWhenMatching()
+    {
+        var leaf = new TestNode();
+
+        IHierarchical? found = ((IHierarchical)leaf).FindHierarchicalParent(typeof(TestNode), includeSelf: true);
+
+        Assert.That(found, Is.SameAs(leaf));
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_Type_NoMatch_Throws()
+    {
+        var root = new TestNode();
+
+        Assert.That(
+            () => ((IHierarchical)root).FindRequiredHierarchicalParent(typeof(TestRoot)),
+            Throws.TypeOf<HierarchyException>());
+    }
+
+    [Test]
+    public void FindHierarchicalRoot_FromLeaf_FindsRoot()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        IHierarchicalRoot? found = ((IHierarchical)leaf).FindHierarchicalRoot();
+
+        Assert.That(found, Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalRoot_NoRoot_ReturnsNull()
+    {
+        var node = new TestNode();
+
+        IHierarchicalRoot? found = ((IHierarchical)node).FindHierarchicalRoot();
+
+        Assert.That(found, Is.Null);
+    }
+
+    [Test]
+    public void EnumerateAllChildren_VisitsDescendantsRecursively()
+    {
+        var root = new TestNode();
+        var middle = new TestNode();
+        var leaf1 = new SpecialNode();
+        var leaf2 = new SpecialNode();
+        root.HierarchicalChildren.Add(middle);
+        middle.HierarchicalChildren.Add(leaf1);
+        middle.HierarchicalChildren.Add(leaf2);
+
+        SpecialNode[] specials = ((IHierarchical)root).EnumerateAllChildren<SpecialNode>().ToArray();
+
+        Assert.That(specials, Is.EquivalentTo(new[] { leaf1, leaf2 }));
+    }
+
+    [Test]
+    public void EnumerateAncestors_IteratesUpwardIncludingSelf()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new SpecialNode();
+        root.HierarchicalChildren.Add(middle);
+        middle.HierarchicalChildren.Add(leaf);
+
+        IHierarchical[] ancestors = ((IHierarchical)leaf).EnumerateAncestors<IHierarchical>().ToArray();
+
+        Assert.That(ancestors[0], Is.SameAs(leaf));
+        Assert.That(ancestors[^1], Is.SameAs(root));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/HierarchicalExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchicalExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Collections;
+﻿using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/HierarchicalTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchicalTests.cs
@@ -1,0 +1,279 @@
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+[TestFixture]
+public class HierarchicalTests
+{
+    private sealed class TestNode : Hierarchical, IModifiableHierarchical
+    {
+        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
+    }
+
+    private sealed class TestRoot : Hierarchical, IHierarchicalRoot, IModifiableHierarchical
+    {
+        public List<IHierarchical> AttachedDescendants { get; } = [];
+        public List<IHierarchical> DetachedDescendants { get; } = [];
+
+        public event EventHandler<IHierarchical>? DescendantAttached;
+        public event EventHandler<IHierarchical>? DescendantDetached;
+
+        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
+
+        public void OnDescendantAttached(IHierarchical descendant)
+        {
+            AttachedDescendants.Add(descendant);
+            DescendantAttached?.Invoke(this, descendant);
+        }
+
+        public void OnDescendantDetached(IHierarchical descendant)
+        {
+            DetachedDescendants.Add(descendant);
+            DescendantDetached?.Invoke(this, descendant);
+        }
+    }
+
+    [Test]
+    public void AddChild_SetsParent()
+    {
+        var parent = new TestNode();
+        var child = new TestNode();
+
+        parent.HierarchicalChildren.Add(child);
+
+        Assert.That(((IHierarchical)child).HierarchicalParent, Is.SameAs(parent));
+    }
+
+    [Test]
+    public void RemoveChild_ClearsParent()
+    {
+        var parent = new TestNode();
+        var child = new TestNode();
+
+        parent.HierarchicalChildren.Add(child);
+        parent.HierarchicalChildren.Remove(child);
+
+        Assert.That(((IHierarchical)child).HierarchicalParent, Is.Null);
+    }
+
+    [Test]
+    public void AttachToRoot_RaisesAttachedEvents()
+    {
+        var root = new TestRoot();
+        var child = new TestNode();
+        var attachedFired = false;
+        child.AttachedToHierarchy += (_, _) => attachedFired = true;
+
+        root.HierarchicalChildren.Add(child);
+
+        Assert.That(attachedFired, Is.True);
+        Assert.That(root.AttachedDescendants, Does.Contain(child));
+        Assert.That(((IHierarchical)child).HierarchicalRoot, Is.SameAs(root));
+    }
+
+    [Test]
+    public void DetachFromRoot_RaisesDetachedEvents()
+    {
+        var root = new TestRoot();
+        var child = new TestNode();
+        root.HierarchicalChildren.Add(child);
+
+        var detachedFired = false;
+        child.DetachedFromHierarchy += (_, _) => detachedFired = true;
+
+        root.HierarchicalChildren.Remove(child);
+
+        Assert.That(detachedFired, Is.True);
+        Assert.That(root.DetachedDescendants, Does.Contain(child));
+        Assert.That(((IHierarchical)child).HierarchicalRoot, Is.Null);
+    }
+
+    [Test]
+    public void NestedAttach_PropagatesToDescendants()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new TestNode();
+        middle.HierarchicalChildren.Add(leaf);
+
+        root.HierarchicalChildren.Add(middle);
+
+        Assert.That(((IHierarchical)leaf).HierarchicalRoot, Is.SameAs(root));
+        Assert.That(root.AttachedDescendants, Does.Contain(leaf));
+    }
+
+    [Test]
+    public void NestedDetach_PropagatesToDescendants()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new TestNode();
+        middle.HierarchicalChildren.Add(leaf);
+        root.HierarchicalChildren.Add(middle);
+
+        root.HierarchicalChildren.Remove(middle);
+
+        Assert.That(((IHierarchical)leaf).HierarchicalRoot, Is.Null);
+        Assert.That(root.DetachedDescendants, Does.Contain(leaf));
+    }
+
+    [Test]
+    public void DoubleParent_ThrowsInvalidOperation()
+    {
+        var parent1 = new TestNode();
+        var parent2 = new TestNode();
+        var child = new TestNode();
+        parent1.HierarchicalChildren.Add(child);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ((IModifiableHierarchical)child).SetParent(parent2));
+    }
+
+    [Test]
+    public void HierarchyAttachmentEventArgs_StoresValues()
+    {
+        var root = new TestRoot();
+        IHierarchical parent = root;
+        var args = new HierarchyAttachmentEventArgs(root, parent);
+
+        Assert.That(args.Root, Is.SameAs(root));
+        Assert.That(args.Parent, Is.SameAs(parent));
+    }
+
+    [Test]
+    public void HierarchyException_DefaultCtor()
+    {
+        var ex = new HierarchyException();
+        Assert.That(ex.Message, Is.Not.Null);
+    }
+
+    [Test]
+    public void HierarchyException_MessageCtor()
+    {
+        var ex = new HierarchyException("oops");
+        Assert.That(ex.Message, Is.EqualTo("oops"));
+    }
+
+    [Test]
+    public void HierarchyException_InnerCtor()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new HierarchyException("outer", inner);
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_Generic_FindsAncestor()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new TestNode();
+        middle.HierarchicalChildren.Add(leaf);
+        root.HierarchicalChildren.Add(middle);
+
+        Assert.That(leaf.FindHierarchicalParent<TestRoot>(), Is.SameAs(root));
+        Assert.That(leaf.FindHierarchicalParent<TestNode>(), Is.SameAs(middle));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_IncludeSelf_ReturnsSelf()
+    {
+        var node = new TestNode();
+        Assert.That(node.FindHierarchicalParent<TestNode>(includeSelf: true), Is.SameAs(node));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_NotFound_ReturnsDefault()
+    {
+        var node = new TestNode();
+        Assert.That(node.FindHierarchicalParent<TestRoot>(), Is.Null);
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_NotFound_Throws()
+    {
+        var node = new TestNode();
+        Assert.Throws<HierarchyException>(() => node.FindRequiredHierarchicalParent<TestRoot>());
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_Found_Returns()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        Assert.That(leaf.FindRequiredHierarchicalParent<TestRoot>(), Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalParent_TypeOverload_Works()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        Assert.That(leaf.FindHierarchicalParent(typeof(TestRoot)), Is.SameAs(root));
+        Assert.That(leaf.FindHierarchicalParent(typeof(IHierarchicalRoot)), Is.SameAs(root));
+        Assert.That(leaf.FindHierarchicalParent(typeof(string)), Is.Null);
+    }
+
+    [Test]
+    public void FindRequiredHierarchicalParent_TypeOverload_Throws()
+    {
+        var node = new TestNode();
+        Assert.Throws<HierarchyException>(() => node.FindRequiredHierarchicalParent(typeof(TestRoot)));
+    }
+
+    [Test]
+    public void FindHierarchicalRoot_ReturnsRoot()
+    {
+        var root = new TestRoot();
+        var leaf = new TestNode();
+        root.HierarchicalChildren.Add(leaf);
+
+        Assert.That(leaf.FindHierarchicalRoot(), Is.SameAs(root));
+    }
+
+    [Test]
+    public void FindHierarchicalRoot_OrphanReturnsNull()
+    {
+        var node = new TestNode();
+        Assert.That(node.FindHierarchicalRoot(), Is.Null);
+    }
+
+    [Test]
+    public void EnumerateAllChildren_ReturnsDescendants()
+    {
+        var root = new TestNode();
+        var middle = new TestNode();
+        var leaf1 = new TestNode();
+        var leaf2 = new TestNode();
+        middle.HierarchicalChildren.Add(leaf1);
+        middle.HierarchicalChildren.Add(leaf2);
+        root.HierarchicalChildren.Add(middle);
+
+        var results = ((IHierarchical)root).EnumerateAllChildren<TestNode>().ToList();
+
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results, Does.Contain(middle));
+        Assert.That(results, Does.Contain(leaf1));
+        Assert.That(results, Does.Contain(leaf2));
+    }
+
+    [Test]
+    public void EnumerateAncestors_StartsFromSelf()
+    {
+        var root = new TestRoot();
+        var middle = new TestNode();
+        var leaf = new TestNode();
+        middle.HierarchicalChildren.Add(leaf);
+        root.HierarchicalChildren.Add(middle);
+
+        var ancestors = ((IHierarchical)leaf).EnumerateAncestors<IHierarchical>().ToList();
+
+        Assert.That(ancestors[0], Is.SameAs(leaf));
+        Assert.That(ancestors[1], Is.SameAs(middle));
+        Assert.That(ancestors[2], Is.SameAs(root));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/HierarchicalTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchicalTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Collections;
+﻿using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/HierarchyExceptionTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchyExceptionTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class HierarchyExceptionTests
 {

--- a/tests/Beutl.UnitTests/Core/HierarchyExceptionTests.cs
+++ b/tests/Beutl.UnitTests/Core/HierarchyExceptionTests.cs
@@ -1,0 +1,28 @@
+namespace Beutl.UnitTests.Core;
+
+public class HierarchyExceptionTests
+{
+    [Test]
+    public void Default_HasNoMessage()
+    {
+        var ex = new HierarchyException();
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void WithMessage_PreservesMessage()
+    {
+        var ex = new HierarchyException("hierarchy mismatch");
+        Assert.That(ex.Message, Is.EqualTo("hierarchy mismatch"));
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void WithInner_PreservesBoth()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new HierarchyException("outer", inner);
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/JsonConvertersExtraTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonConvertersExtraTests.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+
+namespace Beutl.UnitTests.Core;
+
+public class JsonConvertersExtraTests
+{
+    private static readonly JsonSerializerOptions s_options = JsonHelper.SerializerOptions;
+
+    [Test]
+    public void CultureInfo_InvariantCulture_RoundTrips()
+    {
+        string json = JsonSerializer.Serialize(CultureInfo.InvariantCulture, s_options);
+        CultureInfo? back = JsonSerializer.Deserialize<CultureInfo>(json, s_options);
+        Assert.That(back, Is.EqualTo(CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void CultureInfo_NullJsonValue_ReturnsNull()
+    {
+        Assert.That(JsonSerializer.Deserialize<CultureInfo>("null", s_options), Is.Null);
+    }
+
+    [Test]
+    public void Vector3_InvalidString_Throws()
+    {
+        Assert.Throws<FormatException>(() => JsonSerializer.Deserialize<Vector3>("\"not-a-vector\"", s_options));
+    }
+
+    [Test]
+    public void Vector3_NullValue_Throws()
+    {
+        Exception? ex = Assert.Catch(() => JsonSerializer.Deserialize<Vector3>("null", s_options));
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex!.Message, Does.Contain("Vector3"));
+    }
+
+    [Test]
+    public void Quaternion_TooFewComponents_Throws()
+    {
+        Assert.Throws<FormatException>(() => JsonSerializer.Deserialize<Quaternion>("\"1,2,3\"", s_options));
+    }
+
+    [Test]
+    public void DirectoryInfo_RelativePath_RoundTrips()
+    {
+        var dir = new DirectoryInfo("relative/path");
+        string json = JsonSerializer.Serialize(dir, s_options);
+        DirectoryInfo? back = JsonSerializer.Deserialize<DirectoryInfo>(json, s_options);
+        Assert.That(back, Is.Not.Null);
+        Assert.That(back!.FullName, Is.EqualTo(dir.FullName));
+    }
+
+    [Test]
+    public void FileInfo_NullValue_ReturnsNull()
+    {
+        Assert.That(JsonSerializer.Deserialize<FileInfo>("null", s_options), Is.Null);
+    }
+
+    [Test]
+    public void Rational_InvalidString_Throws()
+    {
+        Assert.Throws<FormatException>(() => JsonSerializer.Deserialize<Rational>("\"3:4\"", s_options));
+    }
+
+    [Test]
+    public void Reference_RoundTripsViaConverter()
+    {
+        var reference = new Reference<JsonReferenceTestObject>(Guid.NewGuid());
+        string json = JsonSerializer.Serialize(reference, s_options);
+        Assert.That(json, Is.EqualTo($"\"{reference.Id}\""));
+
+        Reference<JsonReferenceTestObject> back = JsonSerializer.Deserialize<Reference<JsonReferenceTestObject>>(json, s_options);
+        Assert.That(back.Id, Is.EqualTo(reference.Id));
+    }
+
+    private sealed class JsonReferenceTestObject : CoreObject;
+}

--- a/tests/Beutl.UnitTests/Core/JsonConvertersExtraTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonConvertersExtraTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using System.Text.Json;
 

--- a/tests/Beutl.UnitTests/Core/JsonConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonConvertersTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Numerics;
 using System.Text.Json;
 

--- a/tests/Beutl.UnitTests/Core/JsonConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonConvertersTests.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+
+namespace Beutl.UnitTests.Core;
+
+public class JsonConvertersTests
+{
+    private static readonly JsonSerializerOptions s_options = JsonHelper.SerializerOptions;
+
+    [Test]
+    public void CultureInfo_RoundTrip()
+    {
+        var ja = CultureInfo.GetCultureInfo("ja-JP");
+        string json = JsonSerializer.Serialize(ja, s_options);
+        Assert.That(json, Is.EqualTo("\"ja-JP\""));
+
+        CultureInfo? back = JsonSerializer.Deserialize<CultureInfo>(json, s_options);
+        Assert.That(back, Is.EqualTo(ja));
+    }
+
+    [Test]
+    public void DirectoryInfo_RoundTrip()
+    {
+        string path = Path.GetTempPath();
+        var dir = new DirectoryInfo(path);
+        string json = JsonSerializer.Serialize(dir, s_options);
+
+        DirectoryInfo? back = JsonSerializer.Deserialize<DirectoryInfo>(json, s_options);
+        Assert.That(back, Is.Not.Null);
+        Assert.That(back!.FullName, Is.EqualTo(dir.FullName));
+    }
+
+    [Test]
+    public void FileInfo_RoundTrip()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "beutl-test-file.txt");
+        var file = new FileInfo(path);
+        string json = JsonSerializer.Serialize(file, s_options);
+
+        FileInfo? back = JsonSerializer.Deserialize<FileInfo>(json, s_options);
+        Assert.That(back, Is.Not.Null);
+        Assert.That(back!.FullName, Is.EqualTo(file.FullName));
+    }
+
+    [Test]
+    public void Vector3_RoundTrip()
+    {
+        var v = new Vector3(1.5f, -2.5f, 3.5f);
+        string json = JsonSerializer.Serialize(v, s_options);
+        Assert.That(json, Is.EqualTo("\"1.5,-2.5,3.5\""));
+
+        Vector3 back = JsonSerializer.Deserialize<Vector3>(json, s_options);
+        Assert.That(back, Is.EqualTo(v));
+    }
+
+    [Test]
+    public void Quaternion_RoundTrip()
+    {
+        var q = new Quaternion(0.1f, 0.2f, 0.3f, 1f);
+        string json = JsonSerializer.Serialize(q, s_options);
+        Assert.That(json, Is.EqualTo("\"0.1,0.2,0.3,1\""));
+
+        Quaternion back = JsonSerializer.Deserialize<Quaternion>(json, s_options);
+        Assert.That(back, Is.EqualTo(q));
+    }
+
+    [Test]
+    public void Rational_FromString_Reads()
+    {
+        Rational r = JsonSerializer.Deserialize<Rational>("\"3/4\"", s_options);
+        Assert.That(r, Is.EqualTo(new Rational(3, 4)));
+    }
+
+    [Test]
+    public void Rational_FromObject_ReadsNumeratorDenominator()
+    {
+        const string json = "{\"Numerator\":7,\"Denominator\":2}";
+        Rational r = JsonSerializer.Deserialize<Rational>(json, s_options);
+        Assert.That(r, Is.EqualTo(new Rational(7, 2)));
+    }
+
+    [Test]
+    public void Rational_Write_AsString()
+    {
+        var r = new Rational(5, 6);
+        string json = JsonSerializer.Serialize(r, s_options);
+        Assert.That(json, Is.EqualTo("\"5/6\""));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json.Nodes;
+using Beutl.Serialization;
+
+namespace Beutl.UnitTests.Core;
+
+public class JsonHelperTests
+{
+    [Test]
+    public void JsonSave_AndRestore_RoundTripsContent()
+    {
+        var json = new JsonObject { ["x"] = 1, ["s"] = "hello" };
+        string path = Path.GetTempFileName();
+        try
+        {
+            json.JsonSave(path);
+
+            JsonNode? restored = JsonHelper.JsonRestore(path);
+            Assert.That(restored, Is.Not.Null);
+            Assert.That((int)restored!["x"]!, Is.EqualTo(1));
+            Assert.That((string?)restored["s"], Is.EqualTo("hello"));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void JsonSave_DoesNotLeaveTempFile()
+    {
+        var json = new JsonObject { ["v"] = 1 };
+        string path = Path.GetTempFileName();
+        string dir = Path.GetDirectoryName(path)!;
+        string baseName = Path.GetFileName(path);
+        try
+        {
+            json.JsonSave(path);
+
+            string[] tmps = Directory.GetFiles(dir, $"{baseName}.*.tmp");
+            Assert.That(tmps, Is.Empty);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void JsonRestore_FileNotFound_ReturnsNull()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        JsonNode? result = JsonHelper.JsonRestore(path);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void TryGetDiscriminator_Type_ReturnsTypeForKnownEntries()
+    {
+        var node = new JsonObject { ["$type"] = TypeFormat.ToString(typeof(Optional<int>)) };
+
+        bool ok = node.TryGetDiscriminator(out Type? type);
+
+        Assert.That(ok, Is.True);
+        Assert.That(type, Is.EqualTo(typeof(Optional<int>)));
+    }
+
+    [Test]
+    public void TryGetDiscriminator_String_ReturnsRawValue()
+    {
+        var node = new JsonObject { ["@type"] = "[Some.Asm]:Some.Type" };
+
+        bool ok = node.TryGetDiscriminator(out string? text);
+
+        Assert.That(ok, Is.True);
+        Assert.That(text, Is.EqualTo("[Some.Asm]:Some.Type"));
+    }
+
+    [Test]
+    public void TryGetDiscriminator_NoTypeProperty_ReturnsFalse()
+    {
+        var node = new JsonObject { ["foo"] = 1 };
+
+        bool ok = node.TryGetDiscriminator(out Type? type);
+
+        Assert.That(ok, Is.False);
+        Assert.That(type, Is.Null);
+    }
+
+    [Test]
+    public void GetDiscriminator_FallsBackToFallbackTypeAttribute()
+    {
+        // No discriminator on node, BaseType has FallbackTypeAttribute -> uses fallback.
+        var node = new JsonObject();
+
+        Type? type = node.GetDiscriminator(typeof(BaseWithFallback));
+
+        Assert.That(type, Is.EqualTo(typeof(FallbackImpl)));
+    }
+
+    [Test]
+    public void GetDiscriminator_PrefersExplicitTypeOverFallback()
+    {
+        var node = new JsonObject { ["$type"] = TypeFormat.ToString(typeof(Optional<int>)) };
+
+        Type? type = node.GetDiscriminator(typeof(BaseWithFallback));
+
+        Assert.That(type, Is.EqualTo(typeof(Optional<int>)));
+    }
+
+    [Test]
+    public void WriteDiscriminator_WritesTypeFormatString()
+    {
+        var node = new JsonObject();
+
+        node.WriteDiscriminator(typeof(Optional<int>));
+
+        Assert.That((string?)node["$type"], Is.EqualTo(TypeFormat.ToString(typeof(Optional<int>))));
+    }
+
+    [Test]
+    public void TryGetPropertyValueAsJsonValue_TypedAccessSucceeds()
+    {
+        var node = new JsonObject { ["v"] = 42 };
+
+        bool ok = node.TryGetPropertyValueAsJsonValue<int>("v", out int value);
+
+        Assert.That(ok, Is.True);
+        Assert.That(value, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void TryGetPropertyValueAsJsonValue_MissingProperty_ReturnsFalse()
+    {
+        var node = new JsonObject();
+
+        bool ok = node.TryGetPropertyValueAsJsonValue<int>("v", out int value);
+
+        Assert.That(ok, Is.False);
+        Assert.That(value, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ToDictionary_FlattensJsonStructure()
+    {
+        var node = new JsonObject
+        {
+            ["i"] = 1,
+            ["s"] = "x",
+            ["b"] = true,
+            ["arr"] = new JsonArray(1, 2, 3),
+            ["nested"] = new JsonObject { ["a"] = 1 },
+        };
+
+        Dictionary<string, object> dict = node.ToDictionary();
+
+        Assert.That(dict["s"], Is.EqualTo("x"));
+        Assert.That(dict["b"], Is.EqualTo(true));
+        Assert.That(dict["arr"], Is.InstanceOf<object[]>());
+        Assert.That(dict["nested"], Is.InstanceOf<Dictionary<string, object>>());
+    }
+
+    [Test]
+    public void GetOrCreateConverterInstance_ReturnsSameInstanceForSameType()
+    {
+        var c1 = JsonHelper.GetOrCreateConverterInstance(typeof(OptionalJsonConverter));
+        var c2 = JsonHelper.GetOrCreateConverterInstance(typeof(OptionalJsonConverter));
+
+        Assert.That(c1, Is.SameAs(c2));
+        Assert.That(c1, Is.InstanceOf<OptionalJsonConverter>());
+    }
+
+    [FallbackType(typeof(FallbackImpl))]
+    private abstract class BaseWithFallback
+    {
+    }
+
+    private sealed class FallbackImpl : BaseWithFallback
+    {
+    }
+}

--- a/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Serialization;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/LightweightObservableBaseTests.cs
+++ b/tests/Beutl.UnitTests/Core/LightweightObservableBaseTests.cs
@@ -1,0 +1,166 @@
+using Beutl.Reactive;
+
+namespace Beutl.UnitTests.Core;
+
+public class LightweightObservableBaseTests
+{
+    private sealed class TestObservable : LightweightObservableBase<int>
+    {
+        public int InitializeCount;
+        public int DeinitializeCount;
+
+        protected override void Initialize() => InitializeCount++;
+
+        protected override void Deinitialize() => DeinitializeCount++;
+
+        public void EmitNext(int value) => PublishNext(value);
+
+        public void EmitCompleted() => PublishCompleted();
+
+        public void EmitError(Exception error) => PublishError(error);
+    }
+
+    private sealed class RecordingObserver : IObserver<int>
+    {
+        public List<int> Values { get; } = [];
+        public Exception? Error;
+        public int CompletedCount;
+
+        public void OnCompleted() => CompletedCount++;
+        public void OnError(Exception error) => Error = error;
+        public void OnNext(int value) => Values.Add(value);
+    }
+
+    [Test]
+    public void Subscribe_FirstObserver_TriggersInitialize()
+    {
+        var obs = new TestObservable();
+        var sub = obs.Subscribe(new RecordingObserver());
+
+        Assert.That(obs.InitializeCount, Is.EqualTo(1));
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(0));
+
+        sub.Dispose();
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Subscribe_SecondObserver_DoesNotReinitialize()
+    {
+        var obs = new TestObservable();
+        var s1 = obs.Subscribe(new RecordingObserver());
+        var s2 = obs.Subscribe(new RecordingObserver());
+
+        Assert.That(obs.InitializeCount, Is.EqualTo(1));
+
+        s1.Dispose();
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(0));
+
+        s2.Dispose();
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Subscribe_Null_Throws()
+    {
+        var obs = new TestObservable();
+        Assert.That(() => obs.Subscribe(null!), Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void OnNext_DispatchesToSingleObserver()
+    {
+        var obs = new TestObservable();
+        var observer = new RecordingObserver();
+        using var _ = obs.Subscribe(observer);
+
+        obs.EmitNext(1);
+        obs.EmitNext(2);
+
+        Assert.That(observer.Values, Is.EqualTo(new[] { 1, 2 }));
+    }
+
+    [Test]
+    public void OnNext_DispatchesToMultipleObservers()
+    {
+        var obs = new TestObservable();
+        var a = new RecordingObserver();
+        var b = new RecordingObserver();
+        using var _ = obs.Subscribe(a);
+        using var __ = obs.Subscribe(b);
+
+        obs.EmitNext(7);
+
+        Assert.That(a.Values, Is.EqualTo(new[] { 7 }));
+        Assert.That(b.Values, Is.EqualTo(new[] { 7 }));
+    }
+
+    [Test]
+    public void OnCompleted_NotifiesAllObserversAndDeinitializes()
+    {
+        var obs = new TestObservable();
+        var observer = new RecordingObserver();
+        using var _ = obs.Subscribe(observer);
+
+        obs.EmitCompleted();
+
+        Assert.That(observer.CompletedCount, Is.EqualTo(1));
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void OnError_NotifiesAllObservers()
+    {
+        var obs = new TestObservable();
+        var observer = new RecordingObserver();
+        using var _ = obs.Subscribe(observer);
+
+        var error = new InvalidOperationException("boom");
+        obs.EmitError(error);
+
+        Assert.That(observer.Error, Is.SameAs(error));
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Subscribe_AfterCompleted_OnCompletedImmediately()
+    {
+        var obs = new TestObservable();
+        using (obs.Subscribe(new RecordingObserver()))
+        {
+            obs.EmitCompleted();
+        }
+
+        var observer = new RecordingObserver();
+        var sub = obs.Subscribe(observer);
+        Assert.That(observer.CompletedCount, Is.EqualTo(1));
+        Assert.That(sub, Is.Not.Null);
+    }
+
+    [Test]
+    public void Subscribe_AfterError_OnErrorImmediately()
+    {
+        var obs = new TestObservable();
+        var firstObserver = new RecordingObserver();
+        using (obs.Subscribe(firstObserver))
+        {
+            obs.EmitError(new InvalidOperationException("done"));
+        }
+
+        var observer = new RecordingObserver();
+        obs.Subscribe(observer);
+
+        Assert.That(observer.Error, Is.Not.Null);
+    }
+
+    [Test]
+    public void Dispose_TwiceIsNoop()
+    {
+        var obs = new TestObservable();
+        var sub = obs.Subscribe(new RecordingObserver());
+        sub.Dispose();
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+        sub.Dispose();
+        Assert.That(obs.DeinitializeCount, Is.EqualTo(1));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/LightweightObservableBaseTests.cs
+++ b/tests/Beutl.UnitTests/Core/LightweightObservableBaseTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Reactive;
+﻿using Beutl.Reactive;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/NotifyCollectionChangedExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/NotifyCollectionChangedExtensionsTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Specialized;
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class NotifyCollectionChangedExtensionsTests
+{
+    [Test]
+    public void GetWeakCollectionChangedObservable_NullCollection_Throws()
+    {
+        Assert.That(() => NotifyCollectionChangedExtensions.GetWeakCollectionChangedObservable(null!),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void WeakSubscribe_Handler_NullCollection_Throws()
+    {
+        Assert.That(() => ((INotifyCollectionChanged)null!).WeakSubscribe((NotifyCollectionChangedEventHandler)((_, _) => { })),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void WeakSubscribe_Action_NullCollection_Throws()
+    {
+        Assert.That(() => ((INotifyCollectionChanged)null!).WeakSubscribe((Action<NotifyCollectionChangedEventArgs>)(_ => { })),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void WeakSubscribe_Handler_NullHandler_Throws()
+    {
+        var list = new CoreList<int>();
+
+        Assert.That(() => list.WeakSubscribe((NotifyCollectionChangedEventHandler)null!),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void WeakSubscribe_Action_NullHandler_Throws()
+    {
+        var list = new CoreList<int>();
+
+        Assert.That(() => list.WeakSubscribe((Action<NotifyCollectionChangedEventArgs>)null!),
+            Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void WeakSubscribe_Handler_ReceivesNotifications()
+    {
+        var list = new CoreList<int>();
+        var actions = new List<NotifyCollectionChangedAction>();
+
+        using IDisposable sub = list.WeakSubscribe((sender, args) => actions.Add(args.Action));
+
+        list.Add(1);
+        list.Add(2);
+        list.RemoveAt(0);
+
+        Assert.That(actions, Is.EqualTo(new[]
+        {
+            NotifyCollectionChangedAction.Add,
+            NotifyCollectionChangedAction.Add,
+            NotifyCollectionChangedAction.Remove,
+        }));
+    }
+
+    [Test]
+    public void WeakSubscribe_Action_ReceivesNotifications()
+    {
+        var list = new CoreList<int>();
+        int count = 0;
+
+        using IDisposable sub = list.WeakSubscribe(_ => count++);
+
+        list.Add(99);
+
+        Assert.That(count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void WeakSubscribe_Dispose_StopsNotifications()
+    {
+        var list = new CoreList<int>();
+        int count = 0;
+
+        IDisposable sub = list.WeakSubscribe(_ => count++);
+        list.Add(1);
+        sub.Dispose();
+        list.Add(2);
+
+        Assert.That(count, Is.EqualTo(1));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/NotifyCollectionChangedExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/NotifyCollectionChangedExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/ObservableExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/ObservableExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+﻿using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Beutl.Reactive;
 

--- a/tests/Beutl.UnitTests/Core/ObservableExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Core/ObservableExtensionsTests.cs
@@ -1,0 +1,70 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Beutl.Reactive;
+
+namespace Beutl.UnitTests.Core;
+
+public class ObservableExtensionsTests
+{
+    [Test]
+    public void ReturnThenNever_PublishesValueOnceAndStaysSubscribed()
+    {
+        IObservable<int> obs = Observable.ReturnThenNever(42);
+        var values = new List<int>();
+        bool completed = false;
+
+        using IDisposable sub = obs.Subscribe(values.Add, () => completed = true);
+
+        Assert.That(values, Is.EqualTo(new[] { 42 }));
+        Assert.That(completed, Is.False);
+    }
+
+    [Test]
+    public void CombineWithPrevious_EmitsTuplePerValue()
+    {
+        var source = new Subject<int>();
+        var pairs = new List<(int? Old, int? New)>();
+
+        using IDisposable sub = source.CombineWithPrevious().Subscribe(p => pairs.Add(p));
+
+        source.OnNext(1);
+        source.OnNext(2);
+        source.OnNext(3);
+
+        Assert.That(pairs[0], Is.EqualTo(((int?)0, (int?)1)));
+        Assert.That(pairs[1], Is.EqualTo(((int?)1, (int?)2)));
+        Assert.That(pairs[2], Is.EqualTo(((int?)2, (int?)3)));
+    }
+
+    [Test]
+    public void CombineWithPrevious_WithSelector_PassesPreviousAndCurrent()
+    {
+        var source = new Subject<int>();
+        var diffs = new List<int>();
+
+        using IDisposable sub = source
+            .CombineWithPrevious((prev, curr) => curr - prev)
+            .Subscribe(diffs.Add);
+
+        source.OnNext(10);
+        source.OnNext(15);
+        source.OnNext(7);
+
+        Assert.That(diffs, Is.EqualTo(new[] { 10, 5, -8 }));
+    }
+
+    [Test]
+    public void CombineWithPrevious_FirstValueHasDefaultPrevious()
+    {
+        var source = new Subject<string>();
+        var pairs = new List<(string? Old, string? New)>();
+
+        using IDisposable sub = source.CombineWithPrevious().Subscribe(p => pairs.Add(p));
+
+        source.OnNext("first");
+
+        Assert.That(pairs, Has.Count.EqualTo(1));
+        Assert.That(pairs[0].Old, Is.Null);
+        Assert.That(pairs[0].New, Is.EqualTo("first"));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
+++ b/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
+++ b/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
@@ -9,6 +9,10 @@ public class OptionalJsonConverterTests
     [Test]
     public void Serialize_EmptyOptional_WritesNothing()
     {
+        // The Optional<T> JSON converter intentionally writes nothing when HasValue is false.
+        // This relies on the parent serializer skipping the property entirely (Optional<T> is
+        // never the root of a serialized payload), so the standalone output here is not a
+        // valid JSON document by design.
         Optional<int> empty = default;
         string json = JsonSerializer.Serialize(empty, Options);
         Assert.That(json, Is.Empty);

--- a/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
+++ b/tests/Beutl.UnitTests/Core/OptionalJsonConverterTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace Beutl.UnitTests.Core;
+
+public class OptionalJsonConverterTests
+{
+    private static JsonSerializerOptions Options => JsonHelper.SerializerOptions;
+
+    [Test]
+    public void Serialize_EmptyOptional_WritesNothing()
+    {
+        Optional<int> empty = default;
+        string json = JsonSerializer.Serialize(empty, Options);
+        Assert.That(json, Is.Empty);
+    }
+
+    [Test]
+    public void Serialize_OptionalInt_WritesNumber()
+    {
+        var opt = new Optional<int>(42);
+        string json = JsonSerializer.Serialize(opt, Options);
+        Assert.That(json, Is.EqualTo("42"));
+    }
+
+    [Test]
+    public void Serialize_OptionalString_WritesQuotedString()
+    {
+        var opt = new Optional<string>("hello");
+        string json = JsonSerializer.Serialize(opt, Options);
+        Assert.That(json.Trim(), Is.EqualTo("\"hello\""));
+    }
+
+    [Test]
+    public void Deserialize_Number_FromInsideOptionalProperty_ReturnsOptional()
+    {
+        var result = JsonSerializer.Deserialize<Optional<int>>("123", Options);
+        Assert.That(result.HasValue, Is.True);
+        Assert.That(result.Value, Is.EqualTo(123));
+    }
+
+    [Test]
+    public void Deserialize_Number_ReturnsOptional()
+    {
+        var result = JsonSerializer.Deserialize<Optional<int>>("42", Options);
+        Assert.That(result.HasValue, Is.True);
+        Assert.That(result.Value, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Deserialize_String_ReturnsOptional()
+    {
+        var result = JsonSerializer.Deserialize<Optional<string>>("\"hello\"", Options);
+        Assert.That(result.HasValue, Is.True);
+        Assert.That(result.Value, Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void RoundTrip_OptionalDouble_PreservesValue()
+    {
+        var opt = new Optional<double>(3.14);
+        string json = JsonSerializer.Serialize(opt, Options);
+        var parsed = JsonSerializer.Deserialize<Optional<double>>(json, Options);
+        Assert.That(parsed.HasValue, Is.True);
+        Assert.That(parsed.Value, Is.EqualTo(3.14));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/OptionalTests.cs
+++ b/tests/Beutl.UnitTests/Core/OptionalTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class OptionalTests
 {

--- a/tests/Beutl.UnitTests/Core/OptionalTests.cs
+++ b/tests/Beutl.UnitTests/Core/OptionalTests.cs
@@ -1,0 +1,138 @@
+namespace Beutl.UnitTests.Core;
+
+public class OptionalTests
+{
+    [Test]
+    public void Default_HasValue_IsFalse()
+    {
+        Optional<int> empty = default;
+        Assert.That(empty.HasValue, Is.False);
+        Assert.That(Optional<int>.Empty.HasValue, Is.False);
+    }
+
+    [Test]
+    public void Construct_WithValue_HasValueIsTrue()
+    {
+        var opt = new Optional<int>(42);
+        Assert.That(opt.HasValue, Is.True);
+        Assert.That(opt.Value, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Value_OnEmpty_Throws()
+    {
+        Optional<int> empty = default;
+        Assert.That(() => empty.Value, Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void GetValueOrDefault_NoArgs_ReturnsDefault()
+    {
+        Optional<int> empty = default;
+        Assert.That(empty.GetValueOrDefault(), Is.EqualTo(0));
+
+        var opt = new Optional<int>(7);
+        Assert.That(opt.GetValueOrDefault(), Is.EqualTo(7));
+    }
+
+    [Test]
+    public void GetValueOrDefault_WithFallback_ReturnsFallbackWhenEmpty()
+    {
+        Optional<int> empty = default;
+        Assert.That(empty.GetValueOrDefault(99), Is.EqualTo(99));
+
+        var opt = new Optional<int>(7);
+        Assert.That(opt.GetValueOrDefault(99), Is.EqualTo(7));
+    }
+
+    [Test]
+    public void GetValueOrDefault_TypedCast_WorksForCompatibleType()
+    {
+        var opt = new Optional<object>("text");
+        Assert.That(opt.GetValueOrDefault<string>(), Is.EqualTo("text"));
+
+        var optInt = new Optional<object>(123);
+        Assert.That(optInt.GetValueOrDefault<string>(), Is.Null);
+    }
+
+    [Test]
+    public void GetValueOrDefault_TypedCastWithFallback_UsesFallbackWhenEmpty()
+    {
+        // Type mismatch when HasValue still returns default(TResult) by current implementation.
+        var opt = new Optional<object>(123);
+        Assert.That(opt.GetValueOrDefault<string>("fallback"), Is.Null);
+
+        Optional<object> empty = default;
+        Assert.That(empty.GetValueOrDefault<string>("fallback"), Is.EqualTo("fallback"));
+    }
+
+    [Test]
+    public void Equality_TwoEmpty_AreEqual()
+    {
+        Optional<int> a = default;
+        Optional<int> b = default;
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a == b, Is.True);
+        Assert.That(a != b, Is.False);
+    }
+
+    [Test]
+    public void Equality_EmptyVsValue_AreNotEqual()
+    {
+        Optional<int> empty = default;
+        var withValue = new Optional<int>(0);
+        Assert.That(empty == withValue, Is.False);
+        Assert.That(empty != withValue, Is.True);
+    }
+
+    [Test]
+    public void Equality_SameValues_AreEqual()
+    {
+        var a = new Optional<string>("hi");
+        var b = new Optional<string>("hi");
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)42), Is.False);
+    }
+
+    [Test]
+    public void GetHashCode_EmptyIsZero_WithValueIsValueHash()
+    {
+        Assert.That(Optional<int>.Empty.GetHashCode(), Is.EqualTo(0));
+        Assert.That(new Optional<int>(7).GetHashCode(), Is.EqualTo(7.GetHashCode()));
+        Assert.That(new Optional<string?>(null).GetHashCode(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ToString_RepresentsState()
+    {
+        Assert.That(Optional<int>.Empty.ToString(), Is.EqualTo("(empty)"));
+        Assert.That(new Optional<string?>(null).ToString(), Is.EqualTo("(null)"));
+        Assert.That(new Optional<int>(5).ToString(), Is.EqualTo("5"));
+    }
+
+    [Test]
+    public void ToObject_PreservesEmptiness()
+    {
+        Assert.That(Optional<int>.Empty.ToObject().HasValue, Is.False);
+
+        Optional<object?> obj = new Optional<int>(3).ToObject();
+        Assert.That(obj.HasValue, Is.True);
+        Assert.That(obj.Value, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ImplicitConversion_FromValue_HasValueIsTrue()
+    {
+        Optional<int> opt = 5;
+        Assert.That(opt.HasValue, Is.True);
+        Assert.That(opt.Value, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void IOptional_GetValueType_ReturnsT()
+    {
+        IOptional opt = new Optional<long>(1);
+        Assert.That(opt.GetValueType(), Is.EqualTo(typeof(long)));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/PooledArrayTests.cs
+++ b/tests/Beutl.UnitTests/Core/PooledArrayTests.cs
@@ -1,0 +1,104 @@
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+public class PooledArrayTests
+{
+    [Test]
+    public void Constructor_AllocatesPooledLength()
+    {
+        using var array = new PooledArray<int>(8);
+        Assert.Multiple(() =>
+        {
+            Assert.That(array.Length, Is.EqualTo(8));
+            Assert.That(array.IsDisposed, Is.False);
+            Assert.That(array.Span.Length, Is.EqualTo(8));
+            Assert.That(array.Array.Length, Is.GreaterThanOrEqualTo(8));
+        });
+    }
+
+    [Test]
+    public void Indexer_AllowsReadAndWrite()
+    {
+        using var array = new PooledArray<int>(3);
+        for (int i = 0; i < array.Length; i++)
+        {
+            array[i] = i + 1;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(array[0], Is.EqualTo(1));
+            Assert.That(array[1], Is.EqualTo(2));
+            Assert.That(array[2], Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void Indexer_OutOfRange_Throws()
+    {
+        using var array = new PooledArray<int>(2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = array[-1]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = array[2]);
+    }
+
+    [Test]
+    public void Enumerator_IteratesAllElements()
+    {
+        using var array = new PooledArray<int>(3);
+        array[0] = 10;
+        array[1] = 20;
+        array[2] = 30;
+
+        var collected = new List<int>();
+        foreach (int item in array)
+        {
+            collected.Add(item);
+        }
+
+        Assert.That(collected, Is.EqualTo(new[] { 10, 20, 30 }));
+    }
+
+    [Test]
+    public void Dispose_TwiceIsSafe_AndBlocksAccess()
+    {
+        var array = new PooledArray<int>(4);
+        array.Dispose();
+        Assert.That(array.IsDisposed, Is.True);
+
+        // Calling Dispose again must not throw.
+        array.Dispose();
+        Assert.That(array.IsDisposed, Is.True);
+
+        Assert.Throws<ObjectDisposedException>(() => _ = array.Span.Length);
+        Assert.Throws<ObjectDisposedException>(() => _ = array.Array);
+    }
+
+    [Test]
+    public void ToPooledArray_FromIList_CopiesElements()
+    {
+        var source = new List<int> { 1, 2, 3 };
+        using PooledArray<int> array = source.ToPooledArray();
+
+        Assert.That(array.Length, Is.EqualTo(3));
+        Assert.That(array.Span.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void ToPooledArray_FromEnumerable_CopiesElements()
+    {
+        IEnumerable<int> source = NumbersOneToFive();
+        using PooledArray<int> array = source.ToPooledArray();
+
+        Assert.That(array.Length, Is.EqualTo(5));
+        Assert.That(array.Span.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+
+        static IEnumerable<int> NumbersOneToFive()
+        {
+            for (int i = 1; i <= 5; i++)
+            {
+                yield return i;
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/PooledArrayTests.cs
+++ b/tests/Beutl.UnitTests/Core/PooledArrayTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Collections;
+﻿using Beutl.Collections;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/RationalArithmeticTests.cs
+++ b/tests/Beutl.UnitTests/Core/RationalArithmeticTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/RationalArithmeticTests.cs
+++ b/tests/Beutl.UnitTests/Core/RationalArithmeticTests.cs
@@ -1,0 +1,272 @@
+using System.Globalization;
+
+namespace Beutl.UnitTests.Core;
+
+public class RationalArithmeticTests
+{
+    [Test]
+    public void Constants_HaveExpectedValues()
+    {
+        Assert.That(Rational.Zero, Is.EqualTo(new Rational(0, 1)));
+        Assert.That(Rational.One, Is.EqualTo(new Rational(1, 1)));
+        Assert.That(Rational.AdditiveIdentity, Is.EqualTo(Rational.Zero));
+        Assert.That(Rational.MultiplicativeIdentity, Is.EqualTo(Rational.One));
+        Assert.That(Rational.MaxValue.Numerator, Is.EqualTo(long.MaxValue));
+        Assert.That(Rational.MinValue.Numerator, Is.EqualTo(long.MinValue));
+        Assert.That(Rational.Radix, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void IsNaN_ReturnsTrue_OnlyFor0Over0()
+    {
+        Assert.That(Rational.IsNaN(Rational.NaN), Is.True);
+        Assert.That(Rational.IsNaN(new Rational(1, 0)), Is.False);
+        Assert.That(Rational.IsNaN(new Rational(0, 1)), Is.False);
+    }
+
+    [Test]
+    public void IsInfinity_DetectsBothSigns()
+    {
+        Assert.That(Rational.IsInfinity(Rational.PositiveInfinity), Is.True);
+        Assert.That(Rational.IsInfinity(Rational.NegativeInfinity), Is.True);
+        Assert.That(Rational.IsInfinity(Rational.One), Is.False);
+        Assert.That(Rational.IsPositiveInfinity(Rational.PositiveInfinity), Is.True);
+        Assert.That(Rational.IsNegativeInfinity(Rational.NegativeInfinity), Is.True);
+        Assert.That(Rational.IsFinite(Rational.One), Is.True);
+        Assert.That(Rational.IsFinite(Rational.PositiveInfinity), Is.False);
+    }
+
+    [Test]
+    public void IsInteger_TrueForWholeNumbersOnly()
+    {
+        Assert.That(Rational.IsInteger(new Rational(5, 1)), Is.True);
+        Assert.That(Rational.IsInteger(new Rational(6, 3)), Is.True);
+        Assert.That(Rational.IsInteger(new Rational(1, 2)), Is.False);
+        Assert.That(Rational.IsInteger(Rational.PositiveInfinity), Is.False);
+    }
+
+    [Test]
+    public void IsZero_OnlyTrueForCanonicalZero()
+    {
+        Assert.That(Rational.IsZero(Rational.Zero), Is.True);
+        Assert.That(Rational.IsZero(new Rational(0, 5)), Is.False);
+    }
+
+    [Test]
+    public void IsEvenInteger_AndIsOddInteger()
+    {
+        Assert.That(Rational.IsEvenInteger(new Rational(4, 1)), Is.True);
+        Assert.That(Rational.IsEvenInteger(new Rational(3, 1)), Is.False);
+        Assert.That(Rational.IsOddInteger(new Rational(3, 1)), Is.True);
+        Assert.That(Rational.IsOddInteger(new Rational(4, 1)), Is.False);
+    }
+
+    [Test]
+    public void IsNegative_RespectsSignOfNumeratorAndDenominator()
+    {
+        Assert.That(Rational.IsNegative(new Rational(-1, 2)), Is.True);
+        Assert.That(Rational.IsNegative(new Rational(1, -2)), Is.True);
+        Assert.That(Rational.IsNegative(new Rational(-1, -2)), Is.False);
+        Assert.That(Rational.IsNegative(new Rational(1, 2)), Is.False);
+    }
+
+    [Test]
+    public void IsPositive_ReflectsCurrentImplementation()
+    {
+        // Implementation uses XOR of long.IsPositive(num) and long.IsPositive(den);
+        // i.e. exactly one of them is non-negative.
+        Assert.That(Rational.IsPositive(new Rational(-1, 2)), Is.True);
+        Assert.That(Rational.IsPositive(new Rational(1, -2)), Is.True);
+        Assert.That(Rational.IsPositive(new Rational(-1, -2)), Is.False);
+        Assert.That(Rational.IsPositive(new Rational(1, 2)), Is.False);
+    }
+
+    [Test]
+    public void Abs_ReturnsAbsoluteValue()
+    {
+        Assert.That(Rational.Abs(new Rational(-3, 4)), Is.EqualTo(new Rational(3, 4)));
+        Assert.That(Rational.Abs(new Rational(3, -4)), Is.EqualTo(new Rational(3, 4)));
+    }
+
+    [Test]
+    public void Addition_CombinesWithCommonDenominator()
+    {
+        Rational result = new Rational(1, 2) + new Rational(1, 3);
+        Assert.That(result.Simplify(), Is.EqualTo(new Rational(5, 6)));
+    }
+
+    [Test]
+    public void Subtraction_CombinesWithCommonDenominator()
+    {
+        Rational result = new Rational(1, 2) - new Rational(1, 3);
+        Assert.That(result.Simplify(), Is.EqualTo(new Rational(1, 6)));
+    }
+
+    [Test]
+    public void Multiplication_RationalAndScalar()
+    {
+        Assert.That(new Rational(1, 2) * new Rational(2, 3), Is.EqualTo(new Rational(2, 6)));
+        Assert.That(new Rational(1, 2) * 3, Is.EqualTo(new Rational(3, 2)));
+        Assert.That(new Rational(1, 2) * 4L, Is.EqualTo(new Rational(4, 2)));
+    }
+
+    [Test]
+    public void Division_RegularCase_DividesCorrectly()
+    {
+        Rational result = new Rational(1, 2) / new Rational(1, 4);
+        Assert.That(result.Simplify(), Is.EqualTo(new Rational(2, 1)));
+    }
+
+    [Test]
+    public void Division_ByZero_Throws()
+    {
+        Assert.That(() => new Rational(1, 2) / Rational.Zero,
+            Throws.TypeOf<DivideByZeroException>());
+    }
+
+    [Test]
+    public void Negation_FlipsNumeratorSign()
+    {
+        Assert.That(-new Rational(1, 2), Is.EqualTo(new Rational(-1, 2)));
+    }
+
+    [Test]
+    public void IncrementAndDecrement_AddOrSubtractOne()
+    {
+        var v = new Rational(3, 2);
+        Assert.That(++v, Is.EqualTo(new Rational(5, 2)));
+        v = new Rational(3, 2);
+        Assert.That(--v, Is.EqualTo(new Rational(1, 2)));
+    }
+
+    [Test]
+    public void Modulo_RationalAndInt()
+    {
+        Rational result = new Rational(7, 2) % new Rational(3, 2);
+        Assert.That(result, Is.EqualTo(new Rational(1, 2)));
+
+        Rational intResult = new Rational(7, 2) % 2;
+        Assert.That(intResult, Is.EqualTo(new Rational(1, 2)));
+    }
+
+    [Test]
+    public void Comparison_HandlesNaN_NeverGreaterOrLess()
+    {
+        Assert.That(Rational.NaN < Rational.One, Is.False);
+        Assert.That(Rational.NaN > Rational.One, Is.False);
+        Assert.That(Rational.NaN <= Rational.One, Is.False);
+        Assert.That(Rational.NaN >= Rational.One, Is.False);
+    }
+
+    [Test]
+    public void Comparison_OfIntegerRationals()
+    {
+        var two = new Rational(2);
+        var three = new Rational(3);
+        var twoCopy = new Rational(2);
+        var threeCopy = new Rational(3);
+        Assert.That(two < three, Is.True);
+        Assert.That(three > two, Is.True);
+        Assert.That(two <= twoCopy, Is.True);
+        Assert.That(three >= threeCopy, Is.True);
+    }
+
+    [Test]
+    public void CompareTo_OrdersByValue_HandlesNullAndNaN()
+    {
+        var two = new Rational(2);
+        Assert.That(two.CompareTo(null), Is.EqualTo(1));
+        Assert.That(two.CompareTo((object)new Rational(3)), Is.EqualTo(-1));
+        Assert.That(two.CompareTo(new Rational(2)), Is.EqualTo(0));
+        Assert.That(Rational.NaN.CompareTo(Rational.NaN), Is.EqualTo(0));
+        Assert.That(Rational.NaN.CompareTo(Rational.One), Is.EqualTo(-1));
+        Assert.That(Rational.One.CompareTo(Rational.NaN), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CompareTo_NonRational_Throws()
+    {
+        Assert.That(() => new Rational(1).CompareTo("not a rational"),
+            Throws.ArgumentException);
+    }
+
+    [Test]
+    public void ToString_NaN_ProducesIndeterminateLabel()
+    {
+        Assert.That(Rational.NaN.ToString(), Is.EqualTo("[ Indeterminate ]"));
+        Assert.That(Rational.PositiveInfinity.ToString(), Is.EqualTo("[ PositiveInfinity ]"));
+        Assert.That(Rational.NegativeInfinity.ToString(), Is.EqualTo("[ NegativeInfinity ]"));
+        Assert.That(Rational.Zero.ToString(), Is.EqualTo("0"));
+        Assert.That(new Rational(5).ToString(), Is.EqualTo("5"));
+        Assert.That(new Rational(1, 2).ToString(), Is.EqualTo("1/2"));
+    }
+
+    [Test]
+    public void TryFormat_WritesExpectedRepresentation()
+    {
+        Span<char> buf = stackalloc char[32];
+        Assert.That(Rational.NaN.TryFormat(buf, out int w, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(buf[..w].ToString(), Is.EqualTo("[ Indeterminate ]"));
+
+        Assert.That(Rational.PositiveInfinity.TryFormat(buf, out w, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(buf[..w].ToString(), Is.EqualTo("[ PositiveInfinity ]"));
+
+        Assert.That(new Rational(0, 1).TryFormat(buf, out w, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(buf[..w].ToString(), Is.EqualTo("0"));
+
+        Assert.That(new Rational(7, 2).TryFormat(buf, out w, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(buf[..w].ToString(), Is.EqualTo("7/2"));
+    }
+
+    [Test]
+    public void Conversions_ToDecimalDoubleSingle()
+    {
+        var r = new Rational(1, 2);
+        Assert.That(r.ToDouble(), Is.EqualTo(0.5));
+        Assert.That(r.ToSingle(), Is.EqualTo(0.5f));
+        Assert.That(r.ToDecimal(), Is.EqualTo(0.5m));
+    }
+
+    [Test]
+    public void Simplify_HandlesEdgeCases()
+    {
+        Assert.That(Rational.NaN.Simplify(), Is.EqualTo(Rational.NaN));
+        Assert.That(Rational.PositiveInfinity.Simplify(), Is.EqualTo(Rational.PositiveInfinity));
+        Assert.That(Rational.NegativeInfinity.Simplify(), Is.EqualTo(Rational.NegativeInfinity));
+        Assert.That(new Rational(5, 5).Simplify(), Is.EqualTo(new Rational(1, 1)));
+        Assert.That(Rational.Zero.Simplify(), Is.EqualTo(Rational.Zero));
+        Assert.That(new Rational(6, 8).Simplify(), Is.EqualTo(new Rational(3, 4)));
+    }
+
+    [Test]
+    public void TryParse_ValidAndInvalidStrings()
+    {
+        Assert.That(Rational.TryParse("3/4", out Rational r1), Is.True);
+        Assert.That(r1, Is.EqualTo(new Rational(3, 4)));
+
+        Assert.That(Rational.TryParse("5", out Rational r2), Is.True);
+        Assert.That(r2, Is.EqualTo(new Rational(5)));
+
+        Assert.That(Rational.TryParse("1.5", out _), Is.False);
+        Assert.That(Rational.TryParse("/2", out _), Is.False);
+        Assert.That(Rational.TryParse("a/b", out _), Is.False);
+    }
+
+    [Test]
+    public void MaxMagnitude_ReturnsLargerByAbsoluteValue()
+    {
+        Assert.That(Rational.MaxMagnitude(new Rational(-3, 1), new Rational(2, 1)),
+            Is.EqualTo(new Rational(-3, 1)));
+        Assert.That(Rational.MaxMagnitude(Rational.NaN, new Rational(2)),
+            Is.EqualTo(Rational.NaN));
+    }
+
+    [Test]
+    public void MinMagnitude_ReturnsSmallerByAbsoluteValue()
+    {
+        Assert.That(Rational.MinMagnitude(new Rational(-3, 1), new Rational(2, 1)),
+            Is.EqualTo(new Rational(2, 1)));
+        Assert.That(Rational.MinMagnitude(Rational.NaN, new Rational(2)),
+            Is.EqualTo(Rational.NaN));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/RationalFormattingTests.cs
+++ b/tests/Beutl.UnitTests/Core/RationalFormattingTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/RationalFormattingTests.cs
+++ b/tests/Beutl.UnitTests/Core/RationalFormattingTests.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+
+namespace Beutl.UnitTests.Core;
+
+public class RationalFormattingTests
+{
+    [Test]
+    public void ToString_NaN_ReturnsIndeterminate()
+    {
+        Assert.That(Rational.NaN.ToString(), Is.EqualTo("[ Indeterminate ]"));
+    }
+
+    [Test]
+    public void ToString_PositiveInfinity_ReturnsLabel()
+    {
+        Assert.That(Rational.PositiveInfinity.ToString(), Is.EqualTo("[ PositiveInfinity ]"));
+    }
+
+    [Test]
+    public void ToString_NegativeInfinity_ReturnsLabel()
+    {
+        Assert.That(Rational.NegativeInfinity.ToString(), Is.EqualTo("[ NegativeInfinity ]"));
+    }
+
+    [Test]
+    public void ToString_Zero_ReturnsZero()
+    {
+        Assert.That(Rational.Zero.ToString(), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void ToString_Integer_ReturnsNumeratorOnly()
+    {
+        Assert.That(new Rational(5, 1).ToString(), Is.EqualTo("5"));
+        Assert.That(new Rational(-3, 1).ToString(), Is.EqualTo("-3"));
+    }
+
+    [Test]
+    public void ToString_Fraction_ReturnsSlashFormat()
+    {
+        Assert.That(new Rational(1, 2).ToString(), Is.EqualTo("1/2"));
+        Assert.That(new Rational(7, 12).ToString(), Is.EqualTo("7/12"));
+    }
+
+    [Test]
+    public void ToString_WithFormatSpecifier_DelegatesToFormatProvider()
+    {
+        var r = new Rational(3, 4);
+        Assert.That(r.ToString("X", CultureInfo.InvariantCulture), Is.EqualTo("3/4"));
+    }
+
+    [Test]
+    public void TryFormat_NaN_ReturnsLabel()
+    {
+        Span<char> buffer = stackalloc char[32];
+        Assert.That(Rational.NaN.TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("[ Indeterminate ]"));
+    }
+
+    [Test]
+    public void TryFormat_PositiveInfinity_ReturnsLabel()
+    {
+        Span<char> buffer = stackalloc char[32];
+        Assert.That(Rational.PositiveInfinity.TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("[ PositiveInfinity ]"));
+    }
+
+    [Test]
+    public void TryFormat_NegativeInfinity_ReturnsLabel()
+    {
+        Span<char> buffer = stackalloc char[32];
+        Assert.That(Rational.NegativeInfinity.TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("[ NegativeInfinity ]"));
+    }
+
+    [Test]
+    public void TryFormat_Zero_WritesZero()
+    {
+        Span<char> buffer = stackalloc char[8];
+        Assert.That(Rational.Zero.TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void TryFormat_Integer_WritesNumerator()
+    {
+        Span<char> buffer = stackalloc char[8];
+        Assert.That(new Rational(7, 1).TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("7"));
+    }
+
+    [Test]
+    public void TryFormat_Fraction_WritesSlashForm()
+    {
+        Span<char> buffer = stackalloc char[16];
+        Assert.That(new Rational(3, 4).TryFormat(buffer, out int written, default, null), Is.True);
+        Assert.That(buffer[..written].ToString(), Is.EqualTo("3/4"));
+    }
+
+    [Test]
+    public void ToDecimal_ReturnsExactRatio()
+    {
+        Assert.That(new Rational(1, 4).ToDecimal(), Is.EqualTo(0.25m));
+        Assert.That(new Rational(-3, 2).ToDecimal(), Is.EqualTo(-1.5m));
+    }
+
+    [Test]
+    public void ToDouble_ReturnsRatio()
+    {
+        Assert.That(new Rational(1, 2).ToDouble(), Is.EqualTo(0.5));
+    }
+
+    [Test]
+    public void ToSingle_ReturnsRatio()
+    {
+        Assert.That(new Rational(1, 4).ToSingle(), Is.EqualTo(0.25f));
+    }
+
+    [Test]
+    public void EqualityOperators_BehaveAsExpected()
+    {
+        Assert.That(new Rational(1, 2) == new Rational(2, 4), Is.True);
+        Assert.That(new Rational(1, 2) != new Rational(3, 4), Is.True);
+    }
+
+    [Test]
+    public void Equals_NullObject_ReturnsFalse()
+    {
+        Assert.That(new Rational(1, 2).Equals((object?)null), Is.False);
+    }
+
+    [Test]
+    public void GetHashCode_SameNumeratorDenominator_AreEqual()
+    {
+        Assert.That(new Rational(2, 4).GetHashCode(), Is.EqualTo(new Rational(2, 4).GetHashCode()));
+    }
+
+    [Test]
+    public void Negation_FlipsSignOfNumerator()
+    {
+        var r = new Rational(3, 4);
+        Assert.That(-r, Is.EqualTo(new Rational(-3, 4)));
+    }
+
+    [Test]
+    public void MultiplicationByInt_ScalesNumerator()
+    {
+        var r = new Rational(1, 4);
+        Assert.That(r * 3, Is.EqualTo(new Rational(3, 4)));
+    }
+
+    [Test]
+    public void MultiplicationByLong_ScalesNumerator()
+    {
+        var r = new Rational(1, 4);
+        Assert.That(r * 5L, Is.EqualTo(new Rational(5, 4)));
+    }
+
+    [Test]
+    public void Simplify_NaN_ReturnsNaN()
+    {
+        Assert.That(Rational.NaN.Simplify(), Is.EqualTo(Rational.NaN));
+    }
+
+    [Test]
+    public void Simplify_PositiveInfinity_ReturnsItself()
+    {
+        Assert.That(Rational.PositiveInfinity.Simplify(), Is.EqualTo(Rational.PositiveInfinity));
+    }
+
+    [Test]
+    public void Simplify_Zero_ReturnsItself()
+    {
+        Assert.That(Rational.Zero.Simplify(), Is.EqualTo(Rational.Zero));
+    }
+
+    [Test]
+    public void Simplify_EqualNumeratorDenominator_ReturnsOne()
+    {
+        Assert.That(new Rational(7, 7).Simplify(), Is.EqualTo(Rational.One));
+    }
+
+    [Test]
+    public void Simplify_ZeroNumerator_TreatedAsIntegerAndReturnsItself()
+    {
+        // 0/5 は IsInteger を満たすので Simplify はそのまま返す
+        Assert.That(new Rational(0, 5).Simplify(), Is.EqualTo(new Rational(0, 5)));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/ReferenceTests.cs
+++ b/tests/Beutl.UnitTests/Core/ReferenceTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class ReferenceTests
 {

--- a/tests/Beutl.UnitTests/Core/ReferenceTests.cs
+++ b/tests/Beutl.UnitTests/Core/ReferenceTests.cs
@@ -1,0 +1,104 @@
+namespace Beutl.UnitTests.Core;
+
+public class ReferenceTests
+{
+    private sealed class TestObject : CoreObject;
+
+    [Test]
+    public void DefaultReference_IsNull()
+    {
+        Reference<TestObject> reference = default;
+        Assert.That(reference.IsNull, Is.True);
+        Assert.That(reference.Value, Is.Null);
+        Assert.That(reference.Id, Is.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public void Constructor_WithGuid_StoresId()
+    {
+        var id = Guid.NewGuid();
+        var reference = new Reference<TestObject>(id);
+        Assert.That(reference.Id, Is.EqualTo(id));
+        Assert.That(reference.Value, Is.Null);
+        Assert.That(reference.IsNull, Is.False);
+    }
+
+    [Test]
+    public void Constructor_WithObject_PullsIdFromObject()
+    {
+        var obj = new TestObject();
+        var reference = new Reference<TestObject>(obj);
+        Assert.That(reference.Id, Is.EqualTo(obj.Id));
+        Assert.That(reference.Value, Is.SameAs(obj));
+    }
+
+    [Test]
+    public void Resolved_AttachesObject_KeepsIdConsistent()
+    {
+        var obj = new TestObject();
+        var reference = new Reference<TestObject>(obj.Id);
+
+        Reference<TestObject> resolved = reference.Resolved(obj);
+
+        Assert.That(resolved.Value, Is.SameAs(obj));
+        Assert.That(resolved.Id, Is.EqualTo(obj.Id));
+    }
+
+    [Test]
+    public void IReferenceResolved_DelegatesToTyped()
+    {
+        var obj = new TestObject();
+        IReference reference = new Reference<TestObject>(obj.Id);
+        IReference resolved = reference.Resolved(obj);
+        Assert.That(resolved.Value, Is.SameAs(obj));
+        Assert.That(resolved.ObjectType, Is.EqualTo(typeof(TestObject)));
+    }
+
+    [Test]
+    public void Equals_TwoReferencesWithSameIdAndValue_AreEqual()
+    {
+        var obj = new TestObject();
+        var a = new Reference<TestObject>(obj);
+        var b = new Reference<TestObject>(obj);
+        Assert.That(a == b, Is.True);
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Equals_DifferentIds_AreNotEqual()
+    {
+        var a = new Reference<TestObject>(Guid.NewGuid());
+        var b = new Reference<TestObject>(Guid.NewGuid());
+        Assert.That(a != b, Is.True);
+    }
+
+    [Test]
+    public void Deconstruct_ExposesIdAndValue()
+    {
+        var obj = new TestObject();
+        var reference = new Reference<TestObject>(obj);
+        var (id, value) = reference;
+        Assert.That(id, Is.EqualTo(obj.Id));
+        Assert.That(value, Is.SameAs(obj));
+    }
+
+    [Test]
+    public void ImplicitConversion_FromGuid_AndToGuid_AreSymmetric()
+    {
+        var id = Guid.NewGuid();
+        Reference<TestObject> reference = id;
+        Guid back = reference;
+        Assert.That(back, Is.EqualTo(id));
+    }
+
+    [Test]
+    public void ImplicitConversion_FromObject_PreservesId()
+    {
+        var obj = new TestObject();
+        Reference<TestObject> reference = obj;
+        TestObject? back = reference;
+        Assert.That(back, Is.SameAs(obj));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/SuppressionTests.cs
+++ b/tests/Beutl.UnitTests/Core/SuppressionTests.cs
@@ -84,15 +84,15 @@ public class SuppressionTests
     }
 
     [Test]
-    public async Task PublishingSuppression_AsyncLocal_NotLeakedAcrossThreads()
+    public async Task PublishingSuppression_AsyncLocal_FlowsIntoChildTaskAndPreservesParent()
     {
         using IDisposable scope = PublishingSuppression.Enter();
         Assert.That(PublishingSuppression.IsSuppressed, Is.True);
 
         bool seenInOtherTask = await Task.Run(() => PublishingSuppression.IsSuppressed);
 
-        // AsyncLocal flows into Task.Run, but the captured snapshot remains true.
-        // After we explore a child task and return, parent state must still be true.
+        // AsyncLocal flows the suppression flag into Task.Run, and parent state is preserved
+        // after the child task completes.
         Assert.That(seenInOtherTask, Is.True);
         Assert.That(PublishingSuppression.IsSuppressed, Is.True);
     }

--- a/tests/Beutl.UnitTests/Core/SuppressionTests.cs
+++ b/tests/Beutl.UnitTests/Core/SuppressionTests.cs
@@ -1,0 +1,99 @@
+using Beutl.Editor;
+
+namespace Beutl.UnitTests.Core;
+
+public class SuppressionTests
+{
+    [Test]
+    public void PublishingSuppression_NotSuppressedByDefault()
+    {
+        Assert.That(PublishingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void PublishingSuppression_EnterSetsFlagAndDisposeRestores()
+    {
+        Assert.That(PublishingSuppression.IsSuppressed, Is.False);
+
+        IDisposable scope = PublishingSuppression.Enter();
+        try
+        {
+            Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+        }
+        finally
+        {
+            scope.Dispose();
+        }
+
+        Assert.That(PublishingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void PublishingSuppression_NestedScopesRequireMatchingDisposes()
+    {
+        IDisposable outer = PublishingSuppression.Enter();
+        IDisposable inner = PublishingSuppression.Enter();
+
+        Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+
+        inner.Dispose();
+        Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+
+        outer.Dispose();
+        Assert.That(PublishingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void PublishingSuppression_DoubleDisposeIsIdempotent()
+    {
+        IDisposable scope = PublishingSuppression.Enter();
+        Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+
+        scope.Dispose();
+        scope.Dispose(); // double-dispose must not decrement again
+
+        Assert.That(PublishingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void RecordingSuppression_NotSuppressedByDefault()
+    {
+        Assert.That(RecordingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void RecordingSuppression_EnterSetsFlagAndDisposeRestores()
+    {
+        IDisposable scope = RecordingSuppression.Enter();
+
+        Assert.That(RecordingSuppression.IsSuppressed, Is.True);
+
+        scope.Dispose();
+        Assert.That(RecordingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public void RecordingSuppression_DoubleDisposeIsIdempotent()
+    {
+        IDisposable scope = RecordingSuppression.Enter();
+
+        scope.Dispose();
+        scope.Dispose();
+
+        Assert.That(RecordingSuppression.IsSuppressed, Is.False);
+    }
+
+    [Test]
+    public async Task PublishingSuppression_AsyncLocal_NotLeakedAcrossThreads()
+    {
+        using IDisposable scope = PublishingSuppression.Enter();
+        Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+
+        bool seenInOtherTask = await Task.Run(() => PublishingSuppression.IsSuppressed);
+
+        // AsyncLocal flows into Task.Run, but the captured snapshot remains true.
+        // After we explore a child task and return, parent state must still be true.
+        Assert.That(seenInOtherTask, Is.True);
+        Assert.That(PublishingSuppression.IsSuppressed, Is.True);
+    }
+}

--- a/tests/Beutl.UnitTests/Core/SuppressionTests.cs
+++ b/tests/Beutl.UnitTests/Core/SuppressionTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor;
+﻿using Beutl.Editor;
 
 namespace Beutl.UnitTests.Core;
 

--- a/tests/Beutl.UnitTests/Core/TupleRangeDataAnnotationValidaterTests.cs
+++ b/tests/Beutl.UnitTests/Core/TupleRangeDataAnnotationValidaterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Validation;
 using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
 using ValidationContext = Beutl.Validation.ValidationContext;

--- a/tests/Beutl.UnitTests/Core/TupleRangeDataAnnotationValidaterTests.cs
+++ b/tests/Beutl.UnitTests/Core/TupleRangeDataAnnotationValidaterTests.cs
@@ -1,0 +1,77 @@
+using Beutl.Graphics;
+using Beutl.Validation;
+using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
+using ValidationContext = Beutl.Validation.ValidationContext;
+
+namespace Beutl.UnitTests.Core;
+
+public class TupleRangeDataAnnotationValidaterTests
+{
+    private static ValidationContext EmptyContext => default;
+
+    [Test]
+    public void Constructor_StoresAttribute_AndParsesBounds()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10");
+        var validator = new TupleRangeDataAnnotationValidater<Vector, float>(attr);
+
+        Assert.That(validator.Attribute, Is.SameAs(attr));
+        Assert.That(validator.Minimum, Is.EqualTo(new Vector(0, 0)));
+        Assert.That(validator.Maximum, Is.EqualTo(new Vector(10, 10)));
+    }
+
+    [Test]
+    public void Constructor_RejectsExclusiveBounds()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10")
+        {
+            MaximumIsExclusive = true
+        };
+
+        Assert.Throws<NotSupportedException>(
+            () => new TupleRangeDataAnnotationValidater<Vector, float>(attr));
+    }
+
+    [Test]
+    public void Constructor_RejectsExclusiveMinimum()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10")
+        {
+            MinimumIsExclusive = true
+        };
+
+        Assert.Throws<NotSupportedException>(
+            () => new TupleRangeDataAnnotationValidater<Vector, float>(attr));
+    }
+
+    [Test]
+    public void TryCoerce_ClampsEachComponent()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10");
+        var validator = new TupleRangeDataAnnotationValidater<Vector, float>(attr);
+
+        Vector value = new(-3f, 25f);
+        Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.True);
+        Assert.That(value, Is.EqualTo(new Vector(0f, 10f)));
+    }
+
+    [Test]
+    public void TryCoerce_InsideRange_RetainsValue()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10");
+        var validator = new TupleRangeDataAnnotationValidater<Vector, float>(attr);
+
+        Vector value = new(4f, 6f);
+        Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.True);
+        Assert.That(value, Is.EqualTo(new Vector(4f, 6f)));
+    }
+
+    [Test]
+    public void Validate_ReturnsNull_NoMatterTheValue()
+    {
+        var attr = new RangeAttribute(typeof(Vector), "0,0", "10,10");
+        var validator = new TupleRangeDataAnnotationValidater<Vector, float>(attr);
+
+        Assert.That(validator.Validate(EmptyContext, new Vector(50f, 50f)), Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Core/TypeDisplayHelpersTests.cs
+++ b/tests/Beutl.UnitTests/Core/TypeDisplayHelpersTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/TypeDisplayHelpersTests.cs
+++ b/tests/Beutl.UnitTests/Core/TypeDisplayHelpersTests.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Beutl.UnitTests.Core;
+
+public class TypeDisplayHelpersTests
+{
+    [Display(Name = "Cool Type", Description = "A cool type for testing.")]
+    private sealed class TypeWithDisplay
+    {
+        [Display(Name = "Cool Member", Description = "A cool member.")]
+        public int MemberWithDisplay { get; set; }
+
+        public int PlainMember { get; set; }
+    }
+
+    private sealed class TypeWithoutDisplay
+    {
+        public int PlainMember { get; set; }
+    }
+
+    [Test]
+    public void GetLocalizedName_Type_ReturnsDisplayName()
+    {
+        Assert.That(TypeDisplayHelpers.GetLocalizedName(typeof(TypeWithDisplay)),
+            Is.EqualTo("Cool Type"));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_Type_ReturnsDisplayDescription()
+    {
+        Assert.That(TypeDisplayHelpers.GetLocalizedDescription(typeof(TypeWithDisplay)),
+            Is.EqualTo("A cool type for testing."));
+    }
+
+    [Test]
+    public void GetLocalizedName_Type_FallsBackToTypeName()
+    {
+        Assert.That(TypeDisplayHelpers.GetLocalizedName(typeof(TypeWithoutDisplay)),
+            Is.EqualTo(nameof(TypeWithoutDisplay)));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_Type_NoAttribute_ReturnsNull()
+    {
+        Assert.That(TypeDisplayHelpers.GetLocalizedDescription(typeof(TypeWithoutDisplay)),
+            Is.Null);
+    }
+
+    [Test]
+    public void GetLocalizedName_Member_ReturnsDisplayName()
+    {
+        MemberInfo member = typeof(TypeWithDisplay).GetProperty(nameof(TypeWithDisplay.MemberWithDisplay))!;
+        Assert.That(TypeDisplayHelpers.GetLocalizedName(member),
+            Is.EqualTo("Cool Member"));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_Member_ReturnsDisplayDescription()
+    {
+        MemberInfo member = typeof(TypeWithDisplay).GetProperty(nameof(TypeWithDisplay.MemberWithDisplay))!;
+        Assert.That(TypeDisplayHelpers.GetLocalizedDescription(member),
+            Is.EqualTo("A cool member."));
+    }
+
+    [Test]
+    public void GetLocalizedName_Member_NoAttribute_FallsBackToMemberName()
+    {
+        MemberInfo member = typeof(TypeWithDisplay).GetProperty(nameof(TypeWithDisplay.PlainMember))!;
+        Assert.That(TypeDisplayHelpers.GetLocalizedName(member),
+            Is.EqualTo("PlainMember"));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_Member_NoAttribute_ReturnsNull()
+    {
+        MemberInfo member = typeof(TypeWithDisplay).GetProperty(nameof(TypeWithDisplay.PlainMember))!;
+        Assert.That(TypeDisplayHelpers.GetLocalizedDescription(member),
+            Is.Null);
+    }
+
+    [Test]
+    public void GetLocalizedName_NullType_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => TypeDisplayHelpers.GetLocalizedName((Type)null!));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_NullType_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => TypeDisplayHelpers.GetLocalizedDescription((Type)null!));
+    }
+
+    [Test]
+    public void GetLocalizedName_NullMember_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => TypeDisplayHelpers.GetLocalizedName((MemberInfo)null!));
+    }
+
+    [Test]
+    public void GetLocalizedDescription_NullMember_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => TypeDisplayHelpers.GetLocalizedDescription((MemberInfo)null!));
+    }
+
+    [Test]
+    public void GetLocalizedName_Type_CachesResult()
+    {
+        // Calling twice should return identical (cached) string instance.
+        string a = TypeDisplayHelpers.GetLocalizedName(typeof(TypeWithDisplay));
+        string b = TypeDisplayHelpers.GetLocalizedName(typeof(TypeWithDisplay));
+        Assert.That(a, Is.SameAs(b));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/TypeFormatTests.cs
+++ b/tests/Beutl.UnitTests/Core/TypeFormatTests.cs
@@ -1,0 +1,88 @@
+namespace Beutl.UnitTests.Core;
+
+public class TypeFormatTests
+{
+    [Test]
+    public void RoundTrip_CommonRuntimeTypes()
+    {
+        AssertRoundTrip(typeof(int));
+        AssertRoundTrip(typeof(string));
+        AssertRoundTrip(typeof(double));
+    }
+
+    [Test]
+    public void RoundTrip_BeutlOptional()
+    {
+        // Optional<T> lives in the Beutl namespace inside Beutl.Core,
+        // exercising the namespace==assembly shortened encoding path.
+        AssertRoundTrip(typeof(Optional<int>));
+    }
+
+    [Test]
+    public void RoundTrip_NestedType()
+    {
+        AssertRoundTrip(typeof(NestedHost.Nested));
+    }
+
+    [Test]
+    public void RoundTrip_NestedGenericType()
+    {
+        AssertRoundTrip(typeof(NestedHost.NestedGeneric<int>));
+    }
+
+    [Test]
+    public void ToString_AssemblyAndNamespacePrefix()
+    {
+        // The format encodes assembly in [...] and uses ':' before the type name.
+        string formatted = TypeFormat.ToString(typeof(int));
+
+        Assert.That(formatted, Does.StartWith("["));
+        Assert.That(formatted, Does.Contain("]"));
+        Assert.That(formatted, Does.Contain(":Int32"));
+    }
+
+    [Test]
+    public void ToType_UnknownAssembly_ReturnsNull()
+    {
+        // Make a syntactically valid string referencing an unknown assembly.
+        string formatted = "[NoSuchAssembly.Foo]:NoSuchType";
+
+        Type? result = TypeFormat.ToType(formatted);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ToType_LegacyFFmpegEmbeddingNamespaceIsRemapped()
+    {
+        // The TypeFormat.ToType replaces "Beutl.Embedding.FFmpeg" with
+        // "Beutl.Extensions.FFmpeg" before parsing. We can verify the rewrite
+        // path is taken by passing a synthetic assembly name and confirming
+        // the logic doesn't throw and falls through to a null result.
+        string legacy = "[Beutl.Embedding.FFmpeg]:NotARealType";
+
+        Type? result = TypeFormat.ToType(legacy);
+
+        Assert.That(result, Is.Null);
+    }
+
+    private static void AssertRoundTrip(Type type)
+    {
+        string formatted = TypeFormat.ToString(type);
+        Type? parsed = TypeFormat.ToType(formatted);
+
+        Assert.That(parsed, Is.Not.Null, $"failed to parse {formatted}");
+        Assert.That(parsed, Is.EqualTo(type));
+    }
+
+    public class NestedHost
+    {
+        public class Nested
+        {
+        }
+
+        public class NestedGeneric<T>
+        {
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/TypeFormatTests.cs
+++ b/tests/Beutl.UnitTests/Core/TypeFormatTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.Core;
+﻿namespace Beutl.UnitTests.Core;
 
 public class TypeFormatTests
 {

--- a/tests/Beutl.UnitTests/Core/UriHelperTests.cs
+++ b/tests/Beutl.UnitTests/Core/UriHelperTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Beutl.Serialization;
 
 namespace Beutl.UnitTests.Core;

--- a/tests/Beutl.UnitTests/Core/UriHelperTests.cs
+++ b/tests/Beutl.UnitTests/Core/UriHelperTests.cs
@@ -1,0 +1,152 @@
+using System.Text;
+using Beutl.Serialization;
+
+namespace Beutl.UnitTests.Core;
+
+public class UriHelperTests
+{
+    [Test]
+    public void ParseDataUri_PlainText_DecodesAsUtf8()
+    {
+        var uri = new Uri("data:text/plain,Hello%20World");
+
+        var (data, metadata) = UriHelper.ParseDataUri(uri);
+
+        Assert.That(Encoding.UTF8.GetString(data), Is.EqualTo("Hello World"));
+        Assert.That(metadata, Is.EqualTo("text/plain"));
+    }
+
+    [Test]
+    public void ParseDataUri_Base64_DecodesBytes()
+    {
+        byte[] payload = [1, 2, 3, 4, 5];
+        string base64 = Convert.ToBase64String(payload);
+        var uri = new Uri($"data:application/octet-stream;base64,{base64}");
+
+        var (data, metadata) = UriHelper.ParseDataUri(uri);
+
+        Assert.That(data, Is.EqualTo(payload));
+        Assert.That(metadata, Is.EqualTo("application/octet-stream;base64"));
+    }
+
+    [Test]
+    public void ParseDataUri_MissingComma_Throws()
+    {
+        // Constructed without going through Uri parsing of the data scheme,
+        // so an invalid data URI without a comma raises FormatException.
+        var uri = new Uri("data:text/plain", UriKind.Absolute);
+
+        Assert.That(() => UriHelper.ParseDataUri(uri), Throws.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void CreateBase64DataUri_RoundTrip()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes("Beutl");
+
+        Uri uri = UriHelper.CreateBase64DataUri("text/plain", payload);
+
+        var (data, metadata) = UriHelper.ParseDataUri(uri);
+        Assert.That(uri.Scheme, Is.EqualTo("data"));
+        Assert.That(metadata.EndsWith(";base64"), Is.True);
+        Assert.That(data, Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void ResolveByteArray_File_ReturnsContent()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            byte[] payload = Encoding.UTF8.GetBytes("payload");
+            File.WriteAllBytes(path, payload);
+            var uri = new Uri(path);
+
+            byte[] result = UriHelper.ResolveByteArray(uri);
+
+            Assert.That(result, Is.EqualTo(payload));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void ResolveByteArray_DataUri_ReturnsContent()
+    {
+        byte[] payload = [9, 8, 7];
+        Uri uri = UriHelper.CreateBase64DataUri("application/octet-stream", payload);
+
+        byte[] result = UriHelper.ResolveByteArray(uri);
+
+        Assert.That(result, Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void ResolveByteArray_UnsupportedScheme_Throws()
+    {
+        var uri = new Uri("https://example.com/foo");
+
+        Assert.That(() => UriHelper.ResolveByteArray(uri), Throws.TypeOf<NotSupportedException>());
+    }
+
+    [Test]
+    public void ResolveStream_DataUri_ReturnsReadableStream()
+    {
+        byte[] payload = [1, 2, 3];
+        Uri uri = UriHelper.CreateBase64DataUri("application/octet-stream", payload);
+
+        using Stream stream = UriHelper.ResolveStream(uri);
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+
+        Assert.That(ms.ToArray(), Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void ResolveStream_File_ReturnsReadableStream()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            byte[] payload = Encoding.UTF8.GetBytes("hello-stream");
+            File.WriteAllBytes(path, payload);
+            var uri = new Uri(path);
+
+            using Stream stream = UriHelper.ResolveStream(uri);
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+
+            Assert.That(ms.ToArray(), Is.EqualTo(payload));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void ResolveStream_UnsupportedScheme_Throws()
+    {
+        var uri = new Uri("ftp://example.com/foo");
+
+        Assert.That(() => UriHelper.ResolveStream(uri), Throws.TypeOf<NotSupportedException>());
+    }
+
+    [Test]
+    public void CreateFromPath_BuildsAbsoluteUri()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            Uri uri = UriHelper.CreateFromPath(path);
+            Assert.That(uri.IsFile, Is.True);
+            Assert.That(uri.LocalPath, Is.EqualTo(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/ValidationTests.cs
+++ b/tests/Beutl.UnitTests/Core/ValidationTests.cs
@@ -1,0 +1,224 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Validation;
+using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
+using ValidationContext = Beutl.Validation.ValidationContext;
+
+namespace Beutl.UnitTests.Core;
+
+public class ValidationTests
+{
+    private static ValidationContext EmptyContext => default;
+
+    [Test]
+    public void DataAnnotation_NullAttribute_ReturnsNull()
+    {
+        var validator = new DataAnnotationValidater<int>(null);
+        Assert.That(validator.Validate(EmptyContext, 5), Is.Null);
+    }
+
+    [Test]
+    public void DataAnnotation_RangeAttribute_ValidValueReturnsNull()
+    {
+        var validator = new DataAnnotationValidater<int>(new RangeAttribute(0, 100));
+        Assert.That(validator.Validate(EmptyContext, 50), Is.Null);
+    }
+
+    [Test]
+    public void DataAnnotation_RangeAttribute_InvalidValueReturnsErrorMessage()
+    {
+        var validator = new DataAnnotationValidater<int>(new RangeAttribute(0, 100));
+        string? message = validator.Validate(EmptyContext, 500);
+        Assert.That(message, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void DataAnnotation_TryCoerce_AlwaysReturnsFalse()
+    {
+        var validator = new DataAnnotationValidater<int>(new RangeAttribute(0, 100));
+        int value = 500;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.False);
+            Assert.That(value, Is.EqualTo(500));
+        });
+    }
+
+    [Test]
+    public void RangeDataAnnotation_TryCoerce_ClampsToRange()
+    {
+        var validator = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100));
+
+        int low = -10;
+        int high = 200;
+        int inside = 50;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.TryCoerce(EmptyContext, ref low), Is.True);
+            Assert.That(low, Is.EqualTo(0));
+            Assert.That(validator.TryCoerce(EmptyContext, ref high), Is.True);
+            Assert.That(high, Is.EqualTo(100));
+            Assert.That(validator.TryCoerce(EmptyContext, ref inside), Is.True);
+            Assert.That(inside, Is.EqualTo(50));
+        });
+    }
+
+    [Test]
+    public void RangeDataAnnotation_NullAttribute_ValidateReturnsNull_AndCoerceReturnsFalse()
+    {
+        var validator = new RangeDataAnnotationValidater<int> { Attribute = null };
+        int value = 50;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.Validate(EmptyContext, 50), Is.Null);
+            Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.False);
+        });
+    }
+
+    [Test]
+    public void RangeDataAnnotation_DoubleAttribute_ProducesTypedBounds()
+    {
+        var validator = new RangeDataAnnotationValidater<float>(new RangeAttribute(-1.5, 1.5));
+
+        float low = -10f;
+        float high = 10f;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.Minimum, Is.EqualTo(-1.5f));
+            Assert.That(validator.Maximum, Is.EqualTo(1.5f));
+            validator.TryCoerce(EmptyContext, ref low);
+            validator.TryCoerce(EmptyContext, ref high);
+            Assert.That(low, Is.EqualTo(-1.5f));
+            Assert.That(high, Is.EqualTo(1.5f));
+        });
+    }
+
+    [Test]
+    public void RangeDataAnnotation_Validate_OutOfRangeReturnsMessage()
+    {
+        var validator = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100));
+        string? message = validator.Validate(EmptyContext, 500);
+        Assert.That(message, Is.Not.Null.And.Not.Empty);
+        Assert.That(validator.Validate(EmptyContext, 50), Is.Null);
+    }
+
+    [Test]
+    public void Multiple_TryCoerce_RunsAllInOrder()
+    {
+        var first = new RangeDataAnnotationValidater<int>(new RangeAttribute(-5, 5));
+        var second = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100));
+        var validator = new MultipleValidator<int>([first, second]);
+
+        int value = 200;
+        Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.True);
+        Assert.That(value, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Multiple_TryCoerce_StopsOnFailure()
+    {
+        var failing = new FailingCoerceValidator();
+        var succeeding = new SuccessValidator();
+        var validator = new MultipleValidator<int>([failing, succeeding]);
+
+        int value = 5;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.False);
+            Assert.That(succeeding.CoerceCount, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Multiple_Validate_ConcatenatesAllMessages()
+    {
+        var first = new MessageValidator("err-1");
+        var second = new MessageValidator("err-2");
+        var validator = new MultipleValidator<int>([first, second]);
+
+        string? combined = validator.Validate(EmptyContext, 0);
+        Assert.That(combined, Does.Contain("err-1"));
+        Assert.That(combined, Does.Contain("err-2"));
+    }
+
+    [Test]
+    public void Multiple_Validate_NoErrorsReturnsNull()
+    {
+        var validator = new MultipleValidator<int>([new SuccessValidator(), new SuccessValidator()]);
+        Assert.That(validator.Validate(EmptyContext, 0), Is.Null);
+    }
+
+    [Test]
+    public void RangeDataAnnotation_BothExclusive_TryCoerceReturnsFalse()
+    {
+        var validator = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100)
+        {
+            MinimumIsExclusive = true,
+            MaximumIsExclusive = true,
+        });
+
+        int value = 50;
+        Assert.That(validator.TryCoerce(EmptyContext, ref value), Is.False);
+    }
+
+    [Test]
+    public void RangeDataAnnotation_MaxExclusiveOnly_OnlyClampsToMinimum()
+    {
+        var validator = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100)
+        {
+            MaximumIsExclusive = true,
+        });
+
+        int low = -10;
+        int high = 200;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.TryCoerce(EmptyContext, ref low), Is.True);
+            Assert.That(low, Is.EqualTo(0));
+            Assert.That(validator.TryCoerce(EmptyContext, ref high), Is.True);
+            Assert.That(high, Is.EqualTo(200));
+        });
+    }
+
+    [Test]
+    public void RangeDataAnnotation_MinExclusiveOnly_OnlyClampsToMaximum()
+    {
+        var validator = new RangeDataAnnotationValidater<int>(new RangeAttribute(0, 100)
+        {
+            MinimumIsExclusive = true,
+        });
+
+        int low = -10;
+        int high = 200;
+        Assert.Multiple(() =>
+        {
+            Assert.That(validator.TryCoerce(EmptyContext, ref low), Is.True);
+            Assert.That(low, Is.EqualTo(-10));
+            Assert.That(validator.TryCoerce(EmptyContext, ref high), Is.True);
+            Assert.That(high, Is.EqualTo(100));
+        });
+    }
+
+    private sealed class FailingCoerceValidator : IValidator<int>
+    {
+        public bool TryCoerce(ValidationContext context, ref int value) => false;
+        public string? Validate(ValidationContext context, int value) => null;
+    }
+
+    private sealed class SuccessValidator : IValidator<int>
+    {
+        public int CoerceCount { get; private set; }
+        public bool TryCoerce(ValidationContext context, ref int value)
+        {
+            CoerceCount++;
+            return true;
+        }
+        public string? Validate(ValidationContext context, int value) => null;
+    }
+
+    private sealed class MessageValidator(string message) : IValidator<int>
+    {
+        public bool TryCoerce(ValidationContext context, ref int value) => true;
+        public string? Validate(ValidationContext context, int value) => message;
+    }
+}

--- a/tests/Beutl.UnitTests/Core/ValidationTests.cs
+++ b/tests/Beutl.UnitTests/Core/ValidationTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Validation;
 using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
 using ValidationContext = Beutl.Validation.ValidationContext;

--- a/tests/Beutl.UnitTests/Editor/AudioFrameSnapshotTests.cs
+++ b/tests/Beutl.UnitTests/Editor/AudioFrameSnapshotTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor.Services;
+﻿using Beutl.Editor.Services;
 
 namespace Beutl.UnitTests.Editor;
 

--- a/tests/Beutl.UnitTests/Editor/AudioFrameSnapshotTests.cs
+++ b/tests/Beutl.UnitTests/Editor/AudioFrameSnapshotTests.cs
@@ -1,0 +1,44 @@
+using Beutl.Editor.Services;
+
+namespace Beutl.UnitTests.Editor;
+
+public class AudioFrameSnapshotTests
+{
+    [Test]
+    public void SampleCount_DerivedFromInterleavedLength()
+    {
+        // 4 frames * 2 channels = 8 samples interleaved
+        var snapshot = new AudioFrameSnapshot(new float[8], 48000, 2, TimeSpan.Zero);
+        Assert.That(snapshot.SampleCount, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void SampleCount_ZeroChannels_ReturnsZero()
+    {
+        var snapshot = new AudioFrameSnapshot([], 48000, 0, TimeSpan.Zero);
+        Assert.That(snapshot.SampleCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Duration_FromSampleCountAndRate()
+    {
+        // 48000 samples per channel @ 48000 Hz = 1s
+        var snapshot = new AudioFrameSnapshot(new float[48000 * 2], 48000, 2, TimeSpan.Zero);
+        Assert.That(snapshot.Duration, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void Duration_ZeroSampleRate_ReturnsZero()
+    {
+        var snapshot = new AudioFrameSnapshot(new float[8], 0, 2, TimeSpan.FromSeconds(5));
+        Assert.That(snapshot.Duration, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void StartTime_PreservedFromConstruction()
+    {
+        var t = TimeSpan.FromSeconds(2.5);
+        var snapshot = new AudioFrameSnapshot(new float[4], 44100, 2, t);
+        Assert.That(snapshot.StartTime, Is.EqualTo(t));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/CacheBlockTests.cs
+++ b/tests/Beutl.UnitTests/Editor/CacheBlockTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor.Services;
+﻿using Beutl.Editor.Services;
 
 namespace Beutl.UnitTests.Editor;
 

--- a/tests/Beutl.UnitTests/Editor/CacheBlockTests.cs
+++ b/tests/Beutl.UnitTests/Editor/CacheBlockTests.cs
@@ -1,0 +1,33 @@
+using Beutl.Editor.Services;
+
+namespace Beutl.UnitTests.Editor;
+
+public class CacheBlockTests
+{
+    [Test]
+    public void Constructor_StoresFrameValues()
+    {
+        var block = new CacheBlock(rate: 60, start: 30, length: 90, isLocked: true);
+        Assert.That(block.StartFrame, Is.EqualTo(30));
+        Assert.That(block.LengthFrame, Is.EqualTo(90));
+        Assert.That(block.IsLocked, Is.True);
+    }
+
+    [Test]
+    public void Constructor_ConvertsFrameToTimeSpan()
+    {
+        // 60fps, start=30 frames -> 0.5s, length=120 frames -> 2.0s
+        var block = new CacheBlock(rate: 60, start: 30, length: 120, isLocked: false);
+        Assert.That(block.Start, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+        Assert.That(block.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void IsLocked_DefaultsToConstructorValue()
+    {
+        var unlocked = new CacheBlock(60, 0, 60, false);
+        var locked = new CacheBlock(60, 0, 60, true);
+        Assert.That(unlocked.IsLocked, Is.False);
+        Assert.That(locked.IsLocked, Is.True);
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/ContextCommandTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ContextCommandTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Beutl.Extensibility;
 
 namespace Beutl.UnitTests.Editor;

--- a/tests/Beutl.UnitTests/Editor/ContextCommandTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ContextCommandTests.cs
@@ -1,0 +1,88 @@
+using System.Runtime.InteropServices;
+using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Editor;
+
+public class ContextCommandTests
+{
+    [Test]
+    public void ContextCommandExecution_StoresName()
+    {
+        var exec = new ContextCommandExecution("Save");
+        Assert.That(exec.CommandName, Is.EqualTo("Save"));
+        Assert.That(exec.KeyEventArgs, Is.Null);
+    }
+
+    [Test]
+    public void ContextCommandAttribute_NameIsSettable()
+    {
+        var attr = new ContextCommandAttribute { Name = "MyCmd" };
+        Assert.That(attr.Name, Is.EqualTo("MyCmd"));
+    }
+
+    [Test]
+    public void ContextCommandKeyGesture_StoresValues()
+    {
+        var g = new ContextCommandKeyGesture("Ctrl+S", OSPlatform.Windows);
+        Assert.That(g.KeyGesture, Is.EqualTo("Ctrl+S"));
+        Assert.That(g.Platform, Is.EqualTo(OSPlatform.Windows));
+    }
+
+    [Test]
+    public void ContextCommandDefinition_StoresAllFields()
+    {
+        var win = new ContextCommandKeyGesture("Ctrl+S", OSPlatform.Windows);
+        var def = new ContextCommandDefinition("Save", "Save File", "Saves current document", [win]);
+
+        Assert.That(def.Name, Is.EqualTo("Save"));
+        Assert.That(def.DisplayName, Is.EqualTo("Save File"));
+        Assert.That(def.Description, Is.EqualTo("Saves current document"));
+        Assert.That(def.KeyGestures, Is.Not.Null);
+        Assert.That(def.KeyGestures, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void ContextCommandDefinition_NullGestures_StaysNull()
+    {
+        var def = new ContextCommandDefinition("Cmd");
+        Assert.That(def.KeyGestures, Is.Null);
+    }
+
+    [Test]
+    public void ContextCommandDefinition_FallbackGesture_FillsAllPlatforms()
+    {
+        var fallback = new ContextCommandKeyGesture("Ctrl+S");
+        var def = new ContextCommandDefinition("Save", keyGestures: [fallback]);
+
+        Assert.That(def.KeyGestures, Is.Not.Null);
+        Assert.That(def.KeyGestures, Has.Length.EqualTo(3));
+
+        var platforms = def.KeyGestures!.Select(g => g.Platform).ToArray();
+        Assert.That(platforms, Does.Contain(OSPlatform.Windows));
+        Assert.That(platforms, Does.Contain(OSPlatform.Linux));
+        Assert.That(platforms, Does.Contain(OSPlatform.OSX));
+    }
+
+    [Test]
+    public void ContextCommandDefinition_PerPlatformGestures_PreserveValues()
+    {
+        var win = new ContextCommandKeyGesture("Ctrl+S", OSPlatform.Windows);
+        var mac = new ContextCommandKeyGesture("Cmd+S", OSPlatform.OSX);
+        var def = new ContextCommandDefinition("Save", keyGestures: [win, mac]);
+
+        Assert.That(def.KeyGestures, Has.Length.EqualTo(2));
+        Assert.That(def.KeyGestures!.Any(g => g.Platform == OSPlatform.Windows && g.KeyGesture == "Ctrl+S"));
+        Assert.That(def.KeyGestures!.Any(g => g.Platform == OSPlatform.OSX && g.KeyGesture == "Cmd+S"));
+    }
+
+    [Test]
+    public void ContextCommandDefinition_FallbackPlusOverride_OverrideWins()
+    {
+        var fallback = new ContextCommandKeyGesture("Ctrl+S");
+        var mac = new ContextCommandKeyGesture("Cmd+S", OSPlatform.OSX);
+        var def = new ContextCommandDefinition("Save", keyGestures: [fallback, mac]);
+
+        var macGesture = def.KeyGestures!.Single(g => g.Platform == OSPlatform.OSX);
+        Assert.That(macGesture.KeyGesture, Is.EqualTo("Cmd+S"));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor.Services;
+﻿using Beutl.Editor.Services;
 using Beutl.Graphics;
 
 namespace Beutl.UnitTests.Editor;

--- a/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
@@ -1,0 +1,49 @@
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Editor;
+
+public class ElementDescriptionTests
+{
+    [Test]
+    public void Default_HasExpectedDefaults()
+    {
+        var desc = new ElementDescription(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 3);
+        Assert.That(desc.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(desc.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(desc.Layer, Is.EqualTo(3));
+        Assert.That(desc.Name, Is.EqualTo(string.Empty));
+        Assert.That(desc.InitialObject, Is.Null);
+        Assert.That(desc.FileName, Is.Null);
+        Assert.That(desc.Position, Is.EqualTo(default(Point)));
+    }
+
+    [Test]
+    public void With_AllProperties()
+    {
+        var desc = new ElementDescription(
+            TimeSpan.FromSeconds(0),
+            TimeSpan.FromSeconds(5),
+            Layer: 2,
+            Name: "title",
+            InitialObject: typeof(string),
+            FileName: "/tmp/x.mp4",
+            Position: new Point(10, 20));
+
+        Assert.That(desc.Name, Is.EqualTo("title"));
+        Assert.That(desc.InitialObject, Is.EqualTo(typeof(string)));
+        Assert.That(desc.FileName, Is.EqualTo("/tmp/x.mp4"));
+        Assert.That(desc.Position, Is.EqualTo(new Point(10, 20)));
+    }
+
+    [Test]
+    public void Equality_BasedOnAllFields()
+    {
+        var a = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "x");
+        var b = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "x");
+        Assert.That(a, Is.EqualTo(b));
+
+        var c = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, "y");
+        Assert.That(a, Is.Not.EqualTo(c));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
@@ -1,0 +1,208 @@
+using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Engine.Expressions;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class AnimatablePropertyTests
+{
+    private static AnimatableProperty<T> Make<T>(T defaultValue, string name = "Value")
+    {
+        var property = new AnimatableProperty<T>(defaultValue);
+        property.SetAttributes(name, []);
+        return property;
+    }
+
+    private static KeyFrameAnimation<int> CreateLinearAnimation(int from, int to, double seconds)
+    {
+        var animation = new KeyFrameAnimation<int>();
+        animation.KeyFrames.Add(new KeyFrame<int>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = from,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<int>
+        {
+            KeyTime = TimeSpan.FromSeconds(seconds),
+            Value = to,
+            Easing = new LinearEasing()
+        });
+        return animation;
+    }
+
+    [Test]
+    public void Defaults_AreReportedCorrectly()
+    {
+        var property = Make(7);
+
+        Assert.That(property.IsAnimatable, Is.True);
+        Assert.That(property.SupportsExpression, Is.True);
+        Assert.That(property.DefaultValue, Is.EqualTo(7));
+        Assert.That(property.CurrentValue, Is.EqualTo(7));
+        Assert.That(property.HasLocalValue, Is.False);
+        Assert.That(property.HasExpression, Is.False);
+        Assert.That(property.Animation, Is.Null);
+    }
+
+    [Test]
+    public void CurrentValue_NewValue_RaisesValueChangedAndEdited()
+    {
+        var property = Make(0);
+        PropertyValueChangedEventArgs<int>? args = null;
+        int edited = 0;
+        property.ValueChanged += (_, e) => args = e;
+        property.Edited += (_, _) => edited++;
+
+        property.CurrentValue = 100;
+
+        Assert.That(args, Is.Not.Null);
+        Assert.That(args!.NewValue, Is.EqualTo(100));
+        Assert.That(args.OldValue, Is.EqualTo(0));
+        Assert.That(edited, Is.EqualTo(1));
+        Assert.That(property.HasLocalValue, Is.True);
+    }
+
+    [Test]
+    public void CurrentValue_SameValue_DoesNotRaiseEvents()
+    {
+        var property = Make(10);
+        int edited = 0;
+        property.Edited += (_, _) => edited++;
+
+        property.CurrentValue = 10;
+
+        Assert.That(edited, Is.Zero);
+    }
+
+    [Test]
+    public void Animation_AssigningRaisesEdited()
+    {
+        var property = Make(0);
+        IAnimation<int>? captured = null;
+        int edited = 0;
+        property.AnimationChanged += a => captured = a;
+        property.Edited += (_, _) => edited++;
+
+        var animation = CreateLinearAnimation(0, 10, 1);
+        property.Animation = animation;
+
+        Assert.That(captured, Is.SameAs(animation));
+        Assert.That(edited, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Animation_AssigningSameValue_NoEvent()
+    {
+        var property = Make(0);
+        var animation = CreateLinearAnimation(0, 10, 1);
+        property.Animation = animation;
+        int edited = 0;
+        property.Edited += (_, _) => edited++;
+
+        property.Animation = animation;
+
+        Assert.That(edited, Is.Zero);
+    }
+
+    [Test]
+    public void Animation_ClearingToNull_RaisesEdited()
+    {
+        var property = Make(0);
+        property.Animation = CreateLinearAnimation(0, 10, 1);
+        int edited = 0;
+        property.Edited += (_, _) => edited++;
+
+        property.Animation = null;
+
+        Assert.That(edited, Is.EqualTo(1));
+        Assert.That(property.Animation, Is.Null);
+    }
+
+    [Test]
+    public void GetValue_WithAnimation_ReturnsInterpolatedValue()
+    {
+        var property = Make(0);
+        property.Animation = CreateLinearAnimation(0, 100, 1.0);
+
+        var midpoint = property.GetValue(new CompositionContext(TimeSpan.FromSeconds(0.5)));
+
+        Assert.That(midpoint, Is.InRange(40, 60));
+    }
+
+    [Test]
+    public void GetValue_WithoutAnimationOrExpression_ReturnsCurrentValue()
+    {
+        var property = Make(0);
+        property.CurrentValue = 7;
+
+        var value = property.GetValue(CompositionContext.Default);
+
+        Assert.That(value, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Expression_AssigningRaisesExpressionChangedAndEdited()
+    {
+        var property = Make(0.0);
+        IExpression<double>? captured = null;
+        int edited = 0;
+        property.ExpressionChanged += e => captured = e;
+        property.Edited += (_, _) => edited++;
+
+        var expression = Expression.Create<double>("1+2");
+        property.Expression = expression;
+
+        Assert.That(captured, Is.SameAs(expression));
+        Assert.That(edited, Is.EqualTo(1));
+        Assert.That(property.HasExpression, Is.True);
+    }
+
+    [Test]
+    public void ResetToDefault_ClearsValueAnimationAndExpression()
+    {
+        var property = Make(7);
+        property.CurrentValue = 99;
+        property.Animation = CreateLinearAnimation(0, 10, 1);
+        property.Expression = Expression.Create<int>("1+2");
+
+        property.ResetToDefault();
+
+        Assert.That(property.CurrentValue, Is.EqualTo(7));
+        Assert.That(property.HasLocalValue, Is.False);
+        Assert.That(property.Animation, Is.Null);
+        Assert.That(property.HasExpression, Is.False);
+    }
+
+    [Test]
+    public void CompoundAssign_SetsCurrentValue()
+    {
+        var property = Make(0);
+
+        property <<= 99;
+
+        Assert.That(property.CurrentValue, Is.EqualTo(99));
+    }
+
+    [Test]
+    public void Name_BeforeInitialization_Throws()
+    {
+        var property = new AnimatableProperty<int>(0);
+
+        Assert.Throws<InvalidOperationException>(() => _ = property.Name);
+    }
+
+    [Test]
+    public void GetOwnerObject_AfterSet_ReturnsAssignedOwner()
+    {
+        var property = Make(0);
+        var owner = new TestEngineObjectForProperty();
+
+        property.SetOwnerObject(owner);
+
+        Assert.That(property.GetOwnerObject(), Is.SameAs(owner));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
 using Beutl.Composition;
 using Beutl.Engine;

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 
 using Beutl.Animation.Animators;
 using Beutl.Graphics;

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -1,0 +1,350 @@
+using System.Numerics;
+
+using Beutl.Animation.Animators;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Animation;
+
+[TestFixture]
+public class AnimatorInterpolateTests
+{
+    [Test]
+    [TestCase(0f, 1f, 0f, 0f)]
+    [TestCase(0f, 1f, 1f, 1f)]
+    [TestCase(0f, 1f, 0.5f, 0.5f)]
+    [TestCase(2f, 4f, 0.25f, 2.5f)]
+    public void FloatAnimator_Linear(float oldVal, float newVal, float progress, float expected)
+    {
+        var animator = new FloatAnimator();
+        Assert.That(animator.Interpolate(progress, oldVal, newVal), Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    [TestCase(0d, 10d, 0.5f, 5d)]
+    [TestCase(-1d, 1d, 0.5f, 0d)]
+    public void DoubleAnimator_Linear(double oldVal, double newVal, float progress, double expected)
+    {
+        var animator = new DoubleAnimator();
+        Assert.That(animator.Interpolate(progress, oldVal, newVal), Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    public void DecimalAnimator_Midpoint()
+    {
+        var animator = new DecimalAnimator();
+        Assert.That(animator.Interpolate(0.5f, 0m, 10m), Is.EqualTo(5m));
+    }
+
+    [Test]
+    [TestCase(0, 100, 0f, 0)]
+    [TestCase(0, 100, 0.5f, 50)]
+    [TestCase(0, 100, 1f, 100)]
+    public void Int32Animator_Linear(int oldVal, int newVal, float progress, int expected)
+    {
+        var animator = new Int32Animator();
+        Assert.That(animator.Interpolate(progress, oldVal, newVal), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Int16Animator_Midpoint()
+    {
+        var animator = new Int16Animator();
+        Assert.That(animator.Interpolate(0.5f, (short)0, (short)100), Is.EqualTo((short)50));
+    }
+
+    [Test]
+    public void Int64Animator_Midpoint()
+    {
+        var animator = new Int64Animator();
+        Assert.That(animator.Interpolate(0.5f, 0L, 1000L), Is.EqualTo(500L));
+    }
+
+    [Test]
+    public void ByteAnimator_Midpoint()
+    {
+        var animator = new ByteAnimator();
+        Assert.That(animator.Interpolate(0.5f, (byte)0, (byte)200), Is.EqualTo((byte)100));
+    }
+
+    [Test]
+    public void SByteAnimator_Midpoint()
+    {
+        var animator = new SByteAnimator();
+        Assert.That(animator.Interpolate(0.5f, (sbyte)-100, (sbyte)100), Is.EqualTo((sbyte)0));
+    }
+
+    [Test]
+    public void UInt16Animator_Midpoint()
+    {
+        var animator = new UInt16Animator();
+        Assert.That(animator.Interpolate(0.5f, (ushort)0, (ushort)200), Is.EqualTo((ushort)100));
+    }
+
+    [Test]
+    public void UInt32Animator_Midpoint()
+    {
+        var animator = new UInt32Animator();
+        Assert.That(animator.Interpolate(0.5f, 0u, 200u), Is.EqualTo(100u));
+    }
+
+    [Test]
+    public void UInt64Animator_Midpoint()
+    {
+        var animator = new UInt64Animator();
+        Assert.That(animator.Interpolate(0.5f, 0ul, 200ul), Is.EqualTo(100ul));
+    }
+
+    [Test]
+    [TestCase(0f, false, false, false)]
+    [TestCase(0.49f, false, true, false)]
+    [TestCase(0.5f, false, true, false)]
+    [TestCase(0.99f, false, true, false)]
+    [TestCase(1f, false, true, true)]
+    public void BoolAnimator_StepAtEnd(float progress, bool oldVal, bool newVal, bool expected)
+    {
+        var animator = new BoolAnimator();
+        Assert.That(animator.Interpolate(progress, oldVal, newVal), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ColorAnimator_BoundaryReturnsEndpoints()
+    {
+        var animator = new ColorAnimator();
+        var c1 = Color.FromArgb(0, 0, 0, 0);
+        var c2 = Color.FromArgb(255, 255, 255, 255);
+
+        Assert.That(animator.Interpolate(0f, c1, c2), Is.EqualTo(c1));
+        Assert.That(animator.Interpolate(1f, c1, c2), Is.EqualTo(c2));
+    }
+
+    [Test]
+    public void ColorAnimator_AlphaInterpolation()
+    {
+        var animator = new ColorAnimator();
+        var c1 = Color.FromArgb(0, 0, 0, 0);
+        var c2 = Color.FromArgb(200, 0, 0, 0);
+
+        var mid = animator.Interpolate(0.5f, c1, c2);
+        Assert.That(mid.A, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void PointAnimator_Linear()
+    {
+        var animator = new PointAnimator();
+        var result = animator.Interpolate(0.5f, new Point(0, 0), new Point(10, 20));
+        Assert.That(result.X, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Y, Is.EqualTo(10f).Within(1e-6));
+    }
+
+    [Test]
+    public void SizeAnimator_Linear()
+    {
+        var animator = new SizeAnimator();
+        var result = animator.Interpolate(0.25f, new Size(0, 0), new Size(40, 80));
+        Assert.That(result.Width, Is.EqualTo(10f).Within(1e-6));
+        Assert.That(result.Height, Is.EqualTo(20f).Within(1e-6));
+    }
+
+    [Test]
+    public void VectorAnimator_Linear()
+    {
+        var animator = new VectorAnimator();
+        var result = animator.Interpolate(0.5f, new Beutl.Graphics.Vector(0, 0), new Beutl.Graphics.Vector(10, 10));
+        Assert.That(result.X, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Y, Is.EqualTo(5f).Within(1e-6));
+    }
+
+    [Test]
+    public void RectAnimator_Linear()
+    {
+        var animator = new RectAnimator();
+        var result = animator.Interpolate(0.5f, new Rect(0, 0, 0, 0), new Rect(10, 20, 30, 40));
+        Assert.That(result.X, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Y, Is.EqualTo(10f).Within(1e-6));
+        Assert.That(result.Width, Is.EqualTo(15f).Within(1e-6));
+        Assert.That(result.Height, Is.EqualTo(20f).Within(1e-6));
+    }
+
+    [Test]
+    public void ThicknessAnimator_Linear()
+    {
+        var animator = new ThicknessAnimator();
+        var result = animator.Interpolate(0.5f, new Thickness(0), new Thickness(10, 20, 30, 40));
+        Assert.That(result.Left, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Top, Is.EqualTo(10f).Within(1e-6));
+        Assert.That(result.Right, Is.EqualTo(15f).Within(1e-6));
+        Assert.That(result.Bottom, Is.EqualTo(20f).Within(1e-6));
+    }
+
+    [Test]
+    public void CornerRadiusAnimator_Linear()
+    {
+        var animator = new CornerRadiusAnimator();
+        var result = animator.Interpolate(0.5f, new CornerRadius(0), new CornerRadius(10, 20, 30, 40));
+        Assert.That(result.TopLeft, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.TopRight, Is.EqualTo(10f).Within(1e-6));
+        Assert.That(result.BottomRight, Is.EqualTo(15f).Within(1e-6));
+        Assert.That(result.BottomLeft, Is.EqualTo(20f).Within(1e-6));
+    }
+
+    [Test]
+    public void PixelPointAnimator_LinearIntegerInterpolation()
+    {
+        var animator = new PixelPointAnimator();
+        var result = animator.Interpolate(0.5f, new PixelPoint(0, 0), new PixelPoint(10, 20));
+        Assert.That(result.X, Is.EqualTo(5));
+        Assert.That(result.Y, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void PixelSizeAnimator_LinearIntegerInterpolation()
+    {
+        var animator = new PixelSizeAnimator();
+        var result = animator.Interpolate(0.5f, new PixelSize(0, 0), new PixelSize(10, 20));
+        Assert.That(result.Width, Is.EqualTo(5));
+        Assert.That(result.Height, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void PixelRectAnimator_LinearIntegerInterpolation()
+    {
+        var animator = new PixelRectAnimator();
+        var result = animator.Interpolate(0.5f, new PixelRect(0, 0, 0, 0), new PixelRect(10, 20, 30, 40));
+        Assert.That(result.X, Is.EqualTo(5));
+        Assert.That(result.Y, Is.EqualTo(10));
+        Assert.That(result.Width, Is.EqualTo(15));
+        Assert.That(result.Height, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void RelativePointAnimator_SameUnitInterpolates()
+    {
+        var animator = new RelativePointAnimator();
+        var result = animator.Interpolate(
+            0.5f,
+            new RelativePoint(0f, 0f, RelativeUnit.Relative),
+            new RelativePoint(1f, 1f, RelativeUnit.Relative));
+        Assert.That(result.Unit, Is.EqualTo(RelativeUnit.Relative));
+        Assert.That(result.Point.X, Is.EqualTo(0.5f).Within(1e-6));
+        Assert.That(result.Point.Y, Is.EqualTo(0.5f).Within(1e-6));
+    }
+
+    [Test]
+    public void RelativePointAnimator_DifferentUnit_StepAtHalf()
+    {
+        var animator = new RelativePointAnimator();
+        var oldP = new RelativePoint(0f, 0f, RelativeUnit.Absolute);
+        var newP = new RelativePoint(1f, 1f, RelativeUnit.Relative);
+
+        Assert.That(animator.Interpolate(0.4f, oldP, newP), Is.EqualTo(oldP));
+        Assert.That(animator.Interpolate(0.5f, oldP, newP), Is.EqualTo(newP));
+        Assert.That(animator.Interpolate(0.6f, oldP, newP), Is.EqualTo(newP));
+    }
+
+    [Test]
+    public void RelativeRectAnimator_SameUnitInterpolates()
+    {
+        var animator = new RelativeRectAnimator();
+        var result = animator.Interpolate(
+            0.5f,
+            new RelativeRect(0, 0, 0, 0, RelativeUnit.Relative),
+            new RelativeRect(1, 1, 1, 1, RelativeUnit.Relative));
+        Assert.That(result.Unit, Is.EqualTo(RelativeUnit.Relative));
+        Assert.That(result.Rect.X, Is.EqualTo(0.5f).Within(1e-6));
+        Assert.That(result.Rect.Width, Is.EqualTo(0.5f).Within(1e-6));
+    }
+
+    [Test]
+    public void RelativeRectAnimator_DifferentUnit_StepAtHalf()
+    {
+        var animator = new RelativeRectAnimator();
+        var oldR = new RelativeRect(0, 0, 0, 0, RelativeUnit.Absolute);
+        var newR = new RelativeRect(1, 1, 1, 1, RelativeUnit.Relative);
+
+        Assert.That(animator.Interpolate(0.49f, oldR, newR), Is.EqualTo(oldR));
+        Assert.That(animator.Interpolate(0.5f, oldR, newR), Is.EqualTo(newR));
+    }
+
+    [Test]
+    public void Vector2Animator_Linear()
+    {
+        var animator = new Vector2Animator();
+        var result = animator.Interpolate(0.5f, new Vector2(0, 0), new Vector2(10, 20));
+        Assert.That(result.X, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Y, Is.EqualTo(10f).Within(1e-6));
+    }
+
+    [Test]
+    public void Vector3Animator_Linear()
+    {
+        var animator = new Vector3Animator();
+        var result = animator.Interpolate(0.5f, new Vector3(0, 0, 0), new Vector3(10, 20, 30));
+        Assert.That(result.X, Is.EqualTo(5f).Within(1e-6));
+        Assert.That(result.Z, Is.EqualTo(15f).Within(1e-6));
+    }
+
+    [Test]
+    public void Vector4Animator_Linear()
+    {
+        var animator = new Vector4Animator();
+        var result = animator.Interpolate(0.5f, new Vector4(0, 0, 0, 0), new Vector4(2, 4, 6, 8));
+        Assert.That(result.W, Is.EqualTo(4f).Within(1e-6));
+    }
+
+    [Test]
+    public void Matrix3x2Animator_Linear()
+    {
+        var animator = new Matrix3x2Animator();
+        var oldM = Matrix3x2.Identity;
+        var newM = new Matrix3x2(2, 0, 0, 2, 10, 20);
+        var result = animator.Interpolate(0.5f, oldM, newM);
+        Assert.That(result.M11, Is.EqualTo(1.5f).Within(1e-6));
+        Assert.That(result.M31, Is.EqualTo(5f).Within(1e-6));
+    }
+
+    [Test]
+    public void Matrix4x4Animator_Linear()
+    {
+        var animator = new Matrix4x4Animator();
+        var oldM = Matrix4x4.Identity;
+        var newM = Matrix4x4.Identity;
+        newM.M11 = 2;
+        var result = animator.Interpolate(0.5f, oldM, newM);
+        Assert.That(result.M11, Is.EqualTo(1.5f).Within(1e-6));
+    }
+
+    [Test]
+    public void MatrixAnimator_Linear()
+    {
+        var animator = new MatrixAnimator();
+        var oldM = Matrix.Identity;
+        var newM = new Matrix(2, 0, 0, 2, 10, 20);
+        var result = animator.Interpolate(0.5f, oldM, newM);
+        Assert.That(result.M11, Is.EqualTo(1.5f).Within(1e-6));
+        Assert.That(result.M31, Is.EqualTo(5f).Within(1e-6));
+    }
+
+    [Test]
+    public void GradingColorAnimator_Linear()
+    {
+        var animator = new GradingColorAnimator();
+        var oldC = new GradingColor(0, 0, 0);
+        var newC = new GradingColor(2, 4, 6);
+        var result = animator.Interpolate(0.5f, oldC, newC);
+        Assert.That(result.R, Is.EqualTo(1f).Within(1e-6));
+        Assert.That(result.G, Is.EqualTo(2f).Within(1e-6));
+        Assert.That(result.B, Is.EqualTo(3f).Within(1e-6));
+    }
+
+    [Test]
+    public void Animator_DefaultValueReturnsDefault()
+    {
+        var animator = new FloatAnimator();
+        Assert.That(animator.DefaultValue(), Is.EqualTo(0f));
+
+        var colorAnim = new ColorAnimator();
+        Assert.That(colorAnim.DefaultValue(), Is.EqualTo(default(Color)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Animation/EasingsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/EasingsTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
 
 namespace Beutl.UnitTests.Engine.Animation;

--- a/tests/Beutl.UnitTests/Engine/Animation/EasingsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/EasingsTests.cs
@@ -1,0 +1,115 @@
+using Beutl.Animation;
+using Beutl.Animation.Easings;
+
+namespace Beutl.UnitTests.Engine.Animation;
+
+public class EasingsTests
+{
+    [Test]
+    [TestCase(0f, 0f)]
+    [TestCase(0.25f, 0.25f)]
+    [TestCase(0.5f, 0.5f)]
+    [TestCase(0.75f, 0.75f)]
+    [TestCase(1f, 1f)]
+    public void LinearEasing_IsIdentity(float progress, float expected)
+    {
+        var easing = new LinearEasing();
+        Assert.That(easing.Ease(progress), Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    [TestCase(0f, 0f)]
+    [TestCase(0.99f, 0f)]
+    [TestCase(1f, 1f)]
+    public void HoldEasing_StaysAtZeroUntilEnd(float progress, float expected)
+    {
+        var easing = new HoldEasing();
+        Assert.That(easing.Ease(progress), Is.EqualTo(expected));
+    }
+
+    private static readonly Easing[] s_easings =
+    [
+        new LinearEasing(),
+        new HoldEasing(),
+        new BackEaseIn(),
+        new BackEaseInOut(),
+        new BackEaseOut(),
+        new BounceEaseIn(),
+        new BounceEaseInOut(),
+        new BounceEaseOut(),
+        new CircularEaseIn(),
+        new CircularEaseInOut(),
+        new CircularEaseOut(),
+        new CubicEaseIn(),
+        new CubicEaseInOut(),
+        new CubicEaseOut(),
+        new ElasticEaseIn(),
+        new ElasticEaseInOut(),
+        new ElasticEaseOut(),
+        new ExponentialEaseIn(),
+        new ExponentialEaseInOut(),
+        new ExponentialEaseOut(),
+        new QuadraticEaseIn(),
+        new QuadraticEaseInOut(),
+        new QuadraticEaseOut(),
+        new QuarticEaseIn(),
+        new QuarticEaseInOut(),
+        new QuarticEaseOut(),
+        new QuinticEaseIn(),
+        new QuinticEaseInOut(),
+        new QuinticEaseOut(),
+        new SineEaseIn(),
+        new SineEaseInOut(),
+        new SineEaseOut(),
+    ];
+
+    [Test, TestCaseSource(nameof(s_easings))]
+    public void Easing_AtZero_IsZero(Easing easing)
+    {
+        Assert.That(easing.Ease(0f), Is.EqualTo(0f).Within(1e-3));
+    }
+
+    [Test, TestCaseSource(nameof(s_easings))]
+    public void Easing_AtOne_IsOne(Easing easing)
+    {
+        Assert.That(easing.Ease(1f), Is.EqualTo(1f).Within(1e-3));
+    }
+
+    [Test]
+    public void SplineEasing_DefaultsToLinear()
+    {
+        var easing = new SplineEasing();
+        Assert.That(easing.Ease(0.5f), Is.EqualTo(0.5f).Within(1e-3));
+    }
+
+    [Test]
+    public void SplineEasing_FiresChangedOnControlPointChange()
+    {
+        var easing = new SplineEasing();
+        int count = 0;
+        easing.Changed += (_, _) => count++;
+
+        easing.X1 = 0.25f;
+        easing.Y1 = 0.5f;
+        easing.X2 = 0.75f;
+        easing.Y2 = 0.5f;
+
+        Assert.That(count, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void SplineEasing_FromKeySplineUsesProvidedSpline()
+    {
+        var keySpline = new KeySpline(0.25f, 0.1f, 0.25f, 1f);
+        var easing = new SplineEasing(keySpline);
+
+        Assert.That(easing.Ease(0.5f), Is.EqualTo(keySpline.GetSplineProgress(0.5f)).Within(1e-5));
+    }
+
+    [Test]
+    public void SplineEasing_InvalidX1_Throws()
+    {
+        var easing = new SplineEasing();
+        Assert.Throws<ArgumentException>(() => easing.X1 = -0.1f);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Animation/KeySplineTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/KeySplineTests.cs
@@ -90,4 +90,44 @@ public class KeySplineTests
 
         Assert.That(isValid, Is.False);
     }
+
+    [Test]
+    public void GetSplineProgress_AtZero_IsZero()
+    {
+        var keySpline = new KeySpline(0.42f, 0f, 0.58f, 1f);
+        Assert.That(keySpline.GetSplineProgress(0f), Is.EqualTo(0f).Within(1e-6));
+    }
+
+    [Test]
+    public void GetSplineProgress_AtOne_IsOne()
+    {
+        var keySpline = new KeySpline(0.42f, 0f, 0.58f, 1f);
+        Assert.That(keySpline.GetSplineProgress(1f), Is.EqualTo(1f).Within(1e-3));
+    }
+
+    [Test]
+    public void TryParse_NullProvider_StillSucceeds()
+    {
+        Assert.That(KeySpline.TryParse("0.5,0.0,0.5,1.0".AsSpan(), out var ks, provider: null), Is.True);
+        Assert.That(ks!.ControlPointX1, Is.EqualTo(0.5f));
+    }
+
+    [Test]
+    public void Parse_FromSpan_RoundTrips()
+    {
+        var ks = KeySpline.Parse("0.5,0.0,0.5,1.0".AsSpan());
+        Assert.That(ks.ControlPointX1, Is.EqualTo(0.5f));
+        Assert.That(ks.ControlPointY2, Is.EqualTo(1.0f));
+    }
+
+    [Test]
+    public void ControlPoints_Y_AnyValue_Allowed()
+    {
+        var keySpline = new KeySpline();
+        // Y values are not range-restricted.
+        Assert.DoesNotThrow(() => keySpline.ControlPointY1 = -1f);
+        Assert.DoesNotThrow(() => keySpline.ControlPointY2 = 5f);
+        Assert.That(keySpline.ControlPointY1, Is.EqualTo(-1f));
+        Assert.That(keySpline.ControlPointY2, Is.EqualTo(5f));
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Animation/SplineEasingHelperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/SplineEasingHelperTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
 
 namespace Beutl.UnitTests.Engine.Animation;

--- a/tests/Beutl.UnitTests/Engine/Animation/SplineEasingHelperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/SplineEasingHelperTests.cs
@@ -1,0 +1,71 @@
+using Beutl.Animation;
+using Beutl.Animation.Easings;
+
+namespace Beutl.UnitTests.Engine.Animation;
+
+[TestFixture]
+public class SplineEasingHelperTests
+{
+    [Test]
+    public void SplitByT_ReturnsTwoEasings()
+    {
+        var src = new SplineEasing(0.25f, 0.1f, 0.25f, 1f);
+
+        var (left, right) = SplineEasingHelper.SplitByT(src, 0.5f);
+
+        Assert.That(left, Is.Not.Null);
+        Assert.That(right, Is.Not.Null);
+    }
+
+    [Test]
+    public void SplitByT_ClampsBelowZero()
+    {
+        var src = new SplineEasing();
+        Assert.DoesNotThrow(() => SplineEasingHelper.SplitByT(src, -1f));
+    }
+
+    [Test]
+    public void SplitByT_ClampsAboveOne()
+    {
+        var src = new SplineEasing();
+        Assert.DoesNotThrow(() => SplineEasingHelper.SplitByT(src, 2f));
+    }
+
+    [Test]
+    public void SplitByT_LeftAndRightControlPointsValid()
+    {
+        var src = new SplineEasing(0.42f, 0f, 0.58f, 1f);
+
+        var (left, right) = SplineEasingHelper.SplitByT(src, 0.5f);
+
+        Assert.That(left.X1, Is.InRange(0f, 1f));
+        Assert.That(left.X2, Is.InRange(0f, 1f));
+        Assert.That(right.X1, Is.InRange(0f, 1f));
+        Assert.That(right.X2, Is.InRange(0f, 1f));
+    }
+
+    [Test]
+    public void Remove_NonNumberType_FallsBackToRemoveAt()
+    {
+        var animation = new KeyFrameAnimation<bool>();
+        animation.KeyFrames.Add(new KeyFrame<bool> { KeyTime = TimeSpan.FromSeconds(0), Value = false });
+        animation.KeyFrames.Add(new KeyFrame<bool> { KeyTime = TimeSpan.FromSeconds(1), Value = true });
+
+        SplineEasingHelper.Remove(animation, 1);
+
+        Assert.That(animation.KeyFrames, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Move_NonNumberType_OnlyAdjustsKeyTime()
+    {
+        var animation = new KeyFrameAnimation<bool>();
+        var kf = new KeyFrame<bool> { KeyTime = TimeSpan.FromSeconds(1), Value = true };
+        animation.KeyFrames.Add(new KeyFrame<bool> { KeyTime = TimeSpan.FromSeconds(0), Value = false });
+        animation.KeyFrames.Add(kf);
+
+        SplineEasingHelper.Move(animation, kf, TimeSpan.FromSeconds(2));
+
+        Assert.That(kf.KeyTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/AnimationSamplerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimationSamplerTests.cs
@@ -1,0 +1,104 @@
+using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class AnimationSamplerTests
+{
+    private static IProperty<float> AnimatedFloat(float from, float to, double durationSeconds)
+    {
+        var property = Property.CreateAnimatable(from);
+        property.SetAttributes("Value", []);
+
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = from,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromSeconds(durationSeconds),
+            Value = to,
+            Easing = new LinearEasing()
+        });
+        property.Animation = animation;
+        return property;
+    }
+
+    [Test]
+    public void SampleBuffer_NullProperty_Throws()
+    {
+        var sampler = new AnimationSampler();
+        Span<float> buffer = stackalloc float[8];
+
+        // Need to use an indirect call because of stackalloc + lambda issue
+        Assert.Throws<ArgumentNullException>(() => Invoke(sampler));
+
+        static void Invoke(AnimationSampler sampler)
+        {
+            Span<float> b = stackalloc float[8];
+            sampler.SampleBuffer<float>(null!, new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), 8, b);
+        }
+    }
+
+    [Test]
+    public void SampleBuffer_NoAnimation_FillsWithCurrentValue()
+    {
+        var sampler = new AnimationSampler();
+        var property = Property.CreateAnimatable(3.5f);
+        property.SetAttributes("Value", []);
+        property.CurrentValue = 9.5f;
+
+        Span<float> buffer = stackalloc float[4];
+        sampler.SampleBuffer(property, new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), 4, buffer);
+
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            Assert.That(buffer[i], Is.EqualTo(9.5f));
+        }
+    }
+
+    [Test]
+    public void SampleBuffer_KeyFrameAnimation_ProducesIncreasingSamples()
+    {
+        var sampler = new AnimationSampler();
+        var property = AnimatedFloat(0f, 10f, 1.0);
+
+        Span<float> buffer = stackalloc float[10];
+        sampler.SampleBuffer(property, new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), 10, buffer);
+
+        Assert.That(buffer[0], Is.EqualTo(0f).Within(1e-3));
+        // Linearly interpolated => values should monotonically increase.
+        for (int i = 1; i < buffer.Length; i++)
+        {
+            Assert.That(buffer[i], Is.GreaterThanOrEqualTo(buffer[i - 1]));
+        }
+    }
+
+    [Test]
+    public void SampleBuffer_RangeOffsetMovesStartingValue()
+    {
+        var sampler = new AnimationSampler();
+        var property = AnimatedFloat(0f, 100f, 1.0);
+
+        Span<float> buffer = stackalloc float[1];
+        sampler.SampleBuffer(property, new TimeRange(TimeSpan.FromSeconds(0.5), TimeSpan.FromSeconds(0.5)), 4, buffer);
+
+        Assert.That(buffer[0], Is.EqualTo(50f).Within(1f));
+    }
+
+    [Test]
+    public void SampleBuffer_EmptyOutput_DoesNothing()
+    {
+        var sampler = new AnimationSampler();
+        var property = AnimatedFloat(0f, 10f, 1.0);
+
+        Assert.DoesNotThrow(() => sampler.SampleBuffer(
+            property, new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), 4, Span<float>.Empty));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/AnimationSamplerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimationSamplerTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
 using Beutl.Engine;
 using Beutl.Media;

--- a/tests/Beutl.UnitTests/Engine/BitmapColorSpaceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapColorSpaceTests.cs
@@ -1,0 +1,104 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class BitmapColorSpaceTests
+{
+    [Test]
+    public void Srgb_IsSrgb_True()
+    {
+        Assert.That(BitmapColorSpace.Srgb.IsSrgb, Is.True);
+    }
+
+    [Test]
+    public void LinearSrgb_GammaIsLinear()
+    {
+        Assert.That(BitmapColorSpace.LinearSrgb.GammaIsLinear, Is.True);
+    }
+
+    [Test]
+    public void Equality_TwoSrgbInstances_AreEqual()
+    {
+        Assert.That(BitmapColorSpace.Srgb, Is.EqualTo(BitmapColorSpace.Srgb));
+        Assert.That(BitmapColorSpace.Srgb == BitmapColorSpace.Srgb, Is.True);
+    }
+
+    [Test]
+    public void Equality_SrgbVsLinear_AreNotEqual()
+    {
+        Assert.That(BitmapColorSpace.Srgb, Is.Not.EqualTo(BitmapColorSpace.LinearSrgb));
+        Assert.That(BitmapColorSpace.Srgb != BitmapColorSpace.LinearSrgb, Is.True);
+    }
+
+    [Test]
+    public void Equals_AgainstNull_ReturnsFalse()
+    {
+        BitmapColorSpace srgb = BitmapColorSpace.Srgb;
+        Assert.That(srgb!.Equals((BitmapColorSpace?)null), Is.False);
+        Assert.That(srgb!.Equals((object?)null), Is.False);
+    }
+
+    [Test]
+    public void GetHashCode_StableForSameInstance()
+    {
+        Assert.That(BitmapColorSpace.Srgb.GetHashCode(),
+            Is.EqualTo(BitmapColorSpace.Srgb.GetHashCode()));
+    }
+
+    [Test]
+    public void ToLinearGamma_IsEquivalentToLinearSrgb()
+    {
+        var converted = BitmapColorSpace.Srgb.ToLinearGamma();
+        Assert.That(converted.GammaIsLinear, Is.True);
+    }
+
+    [Test]
+    public void ToSrgbGamma_IsEquivalentToSrgb()
+    {
+        var converted = BitmapColorSpace.LinearSrgb.ToSrgbGamma();
+        Assert.That(converted.IsSrgb, Is.True);
+    }
+
+    [Test]
+    public void ToString_ReturnsNonEmpty()
+    {
+        Assert.That(BitmapColorSpace.Srgb.ToString(), Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void OperatorEquality_BothNull_True()
+    {
+        BitmapColorSpace? a = null;
+        BitmapColorSpace? b = null;
+        Assert.That(a == b, Is.True);
+        Assert.That(a != b, Is.False);
+    }
+
+    [Test]
+    public void OperatorEquality_LeftNull_RightNotNull_False()
+    {
+        BitmapColorSpace? a = null;
+        Assert.That(a == BitmapColorSpace.Srgb, Is.False);
+    }
+
+    [Test]
+    public void GetNumericalTransferFunction_NotEmpty()
+    {
+        var fn = BitmapColorSpace.Srgb.GetNumericalTransferFunction();
+        // sRGB transfer function has known constants
+        Assert.That(fn, Is.Not.Null);
+    }
+
+    [Test]
+    public void ToColorSpaceXyz_ReturnsValue()
+    {
+        var xyz = BitmapColorSpace.Srgb.ToColorSpaceXyz();
+        Assert.That(xyz, Is.Not.Null);
+    }
+
+    [Test]
+    public void CreateIcc_InvalidData_ReturnsNull()
+    {
+        Assert.That(BitmapColorSpace.CreateIcc([0x00, 0x01, 0x02]), Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/BitmapColorSpaceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapColorSpaceTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/BitmapColorTypeExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapColorTypeExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/BitmapColorTypeExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapColorTypeExtensionsTests.cs
@@ -1,0 +1,68 @@
+using Beutl.Media;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine;
+
+public class BitmapColorTypeExtensionsTests
+{
+    private static readonly (BitmapColorType Beutl, SKColorType Sk)[] s_pairs =
+    [
+        (BitmapColorType.Alpha8, SKColorType.Alpha8),
+        (BitmapColorType.Rgb565, SKColorType.Rgb565),
+        (BitmapColorType.Argb4444, SKColorType.Argb4444),
+        (BitmapColorType.Rgba8888, SKColorType.Rgba8888),
+        (BitmapColorType.Rgb888x, SKColorType.Rgb888x),
+        (BitmapColorType.Bgra8888, SKColorType.Bgra8888),
+        (BitmapColorType.Rgba1010102, SKColorType.Rgba1010102),
+        (BitmapColorType.Bgra1010102, SKColorType.Bgra1010102),
+        (BitmapColorType.Rgb101010x, SKColorType.Rgb101010x),
+        (BitmapColorType.Bgr101010x, SKColorType.Bgr101010x),
+        (BitmapColorType.Bgr101010xXR, SKColorType.Bgr101010xXR),
+        (BitmapColorType.Gray8, SKColorType.Gray8),
+        (BitmapColorType.RgbaF16, SKColorType.RgbaF16),
+        (BitmapColorType.RgbaF16Clamped, SKColorType.RgbaF16Clamped),
+        (BitmapColorType.RgbaF32, SKColorType.RgbaF32),
+        (BitmapColorType.Rg88, SKColorType.Rg88),
+        (BitmapColorType.AlphaF16, SKColorType.AlphaF16),
+        (BitmapColorType.RgF16, SKColorType.RgF16),
+        (BitmapColorType.Alpha16, SKColorType.Alpha16),
+        (BitmapColorType.Rg1616, SKColorType.Rg1616),
+        (BitmapColorType.Rgba16161616, SKColorType.Rgba16161616),
+        (BitmapColorType.Srgba8888, SKColorType.Srgba8888),
+        (BitmapColorType.R8Unorm, SKColorType.R8Unorm),
+    ];
+
+    [TestCaseSource(nameof(s_pairs))]
+    public void RoundTrip_BetweenBeutlAndSkia((BitmapColorType beutl, SKColorType sk) pair)
+    {
+        Assert.That(pair.beutl.ToSKColorType(), Is.EqualTo(pair.sk));
+        Assert.That(BitmapColorTypeExtensions.FromSKColorType(pair.sk), Is.EqualTo(pair.beutl));
+    }
+
+    [Test]
+    public void Unknown_To_Sk_ReturnsUnknown()
+    {
+        Assert.That(BitmapColorType.Unknown.ToSKColorType(), Is.EqualTo(SKColorType.Unknown));
+    }
+
+    [Test]
+    public void Unknown_From_Sk_ReturnsUnknown()
+    {
+        Assert.That(BitmapColorTypeExtensions.FromSKColorType(SKColorType.Unknown),
+            Is.EqualTo(BitmapColorType.Unknown));
+    }
+
+    [Test]
+    public void OutOfRange_BeutlValue_ReturnsSkUnknown()
+    {
+        Assert.That(((BitmapColorType)int.MaxValue).ToSKColorType(),
+            Is.EqualTo(SKColorType.Unknown));
+    }
+
+    [Test]
+    public void OutOfRange_SkValue_ReturnsBeutlUnknown()
+    {
+        Assert.That(BitmapColorTypeExtensions.FromSKColorType((SKColorType)int.MaxValue),
+            Is.EqualTo(BitmapColorType.Unknown));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/BitmapTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapTests.cs
@@ -1,0 +1,143 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class BitmapTests
+{
+    [Test]
+    public void Constructor_BasicSize_PropertiesAreInitialized()
+    {
+        using var bitmap = new Bitmap(10, 20);
+        Assert.That(bitmap.Width, Is.EqualTo(10));
+        Assert.That(bitmap.Height, Is.EqualTo(20));
+        Assert.That(bitmap.IsDisposed, Is.False);
+        Assert.That(bitmap.ByteCount, Is.GreaterThan(0));
+        Assert.That(bitmap.BytesPerPixel, Is.GreaterThan(0));
+        Assert.That(bitmap.RowBytes, Is.GreaterThanOrEqualTo(bitmap.Width * bitmap.BytesPerPixel));
+    }
+
+    [Test]
+    public void Constructor_NegativeSize_Throws()
+    {
+        Assert.That(() => new Bitmap(-1, 10), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        Assert.That(() => new Bitmap(10, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void Info_ContainsAllProperties()
+    {
+        using var bitmap = new Bitmap(5, 6);
+        BitmapInfo info = bitmap.Info;
+        Assert.That(info.Width, Is.EqualTo(5));
+        Assert.That(info.Height, Is.EqualTo(6));
+        Assert.That(info.ByteCount, Is.EqualTo(bitmap.ByteCount));
+    }
+
+    [Test]
+    public void GetPixelSpan_HasCorrectLength()
+    {
+        using var bitmap = new Bitmap(3, 4);
+        Assert.That(bitmap.GetPixelSpan().Length, Is.EqualTo(bitmap.ByteCount));
+    }
+
+    [Test]
+    public void GetPixelSpan_Generic_HasExpectedLength()
+    {
+        using var bitmap = new Bitmap(4, 5);
+        var span = bitmap.GetPixelSpan<int>();
+        Assert.That(span.Length * sizeof(int), Is.EqualTo(bitmap.ByteCount));
+    }
+
+    [Test]
+    public void GetRow_ReturnsExpectedSize()
+    {
+        using var bitmap = new Bitmap(8, 4);
+        Assert.That(bitmap.GetRow(0).Length, Is.EqualTo(bitmap.Width * bitmap.BytesPerPixel));
+        Assert.That(bitmap.GetRow(3).Length, Is.EqualTo(bitmap.Width * bitmap.BytesPerPixel));
+    }
+
+    [Test]
+    public void GetRow_Negative_Throws()
+    {
+        using var bitmap = new Bitmap(4, 4);
+        Assert.That(() => bitmap.GetRow(-1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        Assert.That(() => bitmap.GetRow(4), Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void Clone_MakesIndependentCopy()
+    {
+        using var bitmap = new Bitmap(4, 4);
+        using var copy = bitmap.Clone();
+        Assert.That(copy.Width, Is.EqualTo(bitmap.Width));
+        Assert.That(copy.Height, Is.EqualTo(bitmap.Height));
+        Assert.That(copy, Is.Not.SameAs(bitmap));
+    }
+
+    [Test]
+    public void Clear_DoesNotThrow()
+    {
+        using var bitmap = new Bitmap(4, 4);
+        Assert.That(() => bitmap.Clear(), Throws.Nothing);
+    }
+
+    [Test]
+    public void Dispose_SetsIsDisposed()
+    {
+        var bitmap = new Bitmap(4, 4);
+        bitmap.Dispose();
+        Assert.That(bitmap.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void Operations_AfterDispose_Throw()
+    {
+        var bitmap = new Bitmap(4, 4);
+        bitmap.Dispose();
+        Assert.That(() => bitmap.GetPixelSpan(), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.That(() => bitmap.Clear(), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.That(() => bitmap.Clone(), Throws.InstanceOf<ObjectDisposedException>());
+    }
+
+    [Test]
+    public void ICloneable_Clone_ReturnsBitmap()
+    {
+        using var bitmap = new Bitmap(2, 2);
+        ICloneable cloneable = bitmap;
+        using var copy = (Bitmap)cloneable.Clone();
+        Assert.That(copy.Width, Is.EqualTo(bitmap.Width));
+    }
+
+    [Test]
+    public void ExtractSubset_ReturnsCorrectSize()
+    {
+        using var bitmap = new Bitmap(10, 10);
+        using var sub = bitmap.ExtractSubset(new PixelRect(2, 2, 4, 4));
+        Assert.That(sub.Width, Is.EqualTo(4));
+        Assert.That(sub.Height, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void ExtractSubset_OutOfRange_Throws()
+    {
+        using var bitmap = new Bitmap(4, 4);
+        Assert.That(() => bitmap.ExtractSubset(new PixelRect(0, 0, 10, 10)),
+            Throws.InstanceOf<ArgumentException>().Or.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void ColorType_Default_IsBgra8888()
+    {
+        using var bitmap = new Bitmap(2, 2);
+        Assert.That(bitmap.ColorType, Is.EqualTo(BitmapColorType.Bgra8888));
+    }
+
+    [Test]
+    public void Convert_ToDifferentColorType_Succeeds()
+    {
+        using var bitmap = new Bitmap(2, 2);
+        using var converted = bitmap.Convert(BitmapColorType.Rgba8888);
+        Assert.That(converted.ColorType, Is.EqualTo(BitmapColorType.Rgba8888));
+        Assert.That(converted.Width, Is.EqualTo(bitmap.Width));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/BitmapTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/CmykHsvTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CmykHsvTests.cs
@@ -1,0 +1,167 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class CmykHsvTests
+{
+    [Test]
+    public void Cmyk_Constructor_StoresComponents()
+    {
+        var c = new Cmyk(0.1f, 0.2f, 0.3f, 0.4f, 0.5f);
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.C, Is.EqualTo(0.1f));
+            Assert.That(c.M, Is.EqualTo(0.2f));
+            Assert.That(c.Y, Is.EqualTo(0.3f));
+            Assert.That(c.K, Is.EqualTo(0.4f));
+            Assert.That(c.A, Is.EqualTo(0.5f));
+        });
+    }
+
+    [Test]
+    public void Cmyk_Equality_AndHashCode()
+    {
+        var a = new Cmyk(0.1f, 0.2f, 0.3f, 0.4f, 0.5f);
+        var b = new Cmyk(0.1f, 0.2f, 0.3f, 0.4f, 0.5f);
+        var different = new Cmyk(0.1f, 0.2f, 0.3f, 0.4f, 1f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != different, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)42), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void Cmyk_FromColor_RoundTripsThroughColor()
+    {
+        var color = Color.FromArgb(0x40, 0x20, 0x80, 0xC0);
+        var cmyk = new Cmyk(color);
+        Assert.That(cmyk.ToColor(), Is.EqualTo(color));
+    }
+
+    [Test]
+    public void Cmyk_FromHsv_MatchesColorRouting()
+    {
+        var color = Color.FromArgb(0xff, 0x12, 0x34, 0x56);
+        Hsv hsv = color.ToHsv();
+        Cmyk fromHsvCtor = new Cmyk(hsv);
+        Cmyk viaToCmyk = hsv.ToCmyk();
+        Assert.That(fromHsvCtor, Is.EqualTo(viaToCmyk));
+    }
+
+    [Test]
+    public void Cmyk_ToColor_PureBlackAndWhite()
+    {
+        var black = new Cmyk(0, 0, 0, 1, 1).ToColor();
+        var white = new Cmyk(0, 0, 0, 0, 1).ToColor();
+        Assert.Multiple(() =>
+        {
+            Assert.That(black, Is.EqualTo(Color.FromArgb(255, 0, 0, 0)));
+            Assert.That(white, Is.EqualTo(Color.FromArgb(255, 255, 255, 255)));
+        });
+    }
+
+    [Test]
+    public void Cmyk_ToHsv_RoundTripsBackToColor()
+    {
+        var color = Color.FromArgb(0xff, 0x80, 0x40, 0xC0);
+        Cmyk cmyk = color.ToCmyk();
+        Hsv hsv = cmyk.ToHsv();
+        Assert.That(hsv.ToColor(), Is.EqualTo(color));
+    }
+
+    [Test]
+    public void Hsv_Constructor_StoresComponents()
+    {
+        var h = new Hsv(120f, 50f, 75f, 1f);
+        Assert.Multiple(() =>
+        {
+            Assert.That(h.H, Is.EqualTo(120f));
+            Assert.That(h.S, Is.EqualTo(50f));
+            Assert.That(h.V, Is.EqualTo(75f));
+            Assert.That(h.A, Is.EqualTo(1f));
+        });
+    }
+
+    [Test]
+    public void Hsv_Equality_AndHashCode()
+    {
+        var a = new Hsv(120f, 50f, 75f, 1f);
+        var b = new Hsv(120f, 50f, 75f, 1f);
+        var differentHue = new Hsv(180f, 50f, 75f, 1f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != differentHue, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)"foo"), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void Hsv_ToColor_ZeroSaturationProducesGray()
+    {
+        var hsv = new Hsv(180f, 0f, 50f, 1f);
+        Color color = hsv.ToColor();
+        Assert.Multiple(() =>
+        {
+            Assert.That(color.R, Is.EqualTo(color.G));
+            Assert.That(color.G, Is.EqualTo(color.B));
+            Assert.That(color.A, Is.EqualTo(0xff));
+            Assert.That(color.R, Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void Hsv_ToColor_HueWrapsAt360()
+    {
+        var atZero = new Hsv(0f, 100f, 100f, 1f).ToColor();
+        var atThreeSixty = new Hsv(360f, 100f, 100f, 1f).ToColor();
+        Assert.That(atZero, Is.EqualTo(atThreeSixty));
+    }
+
+    [Test]
+    [TestCase(0f, 255, 0, 0)]
+    [TestCase(60f, 255, 255, 0)]
+    [TestCase(120f, 0, 255, 0)]
+    [TestCase(180f, 0, 255, 255)]
+    [TestCase(240f, 0, 0, 255)]
+    [TestCase(300f, 255, 0, 255)]
+    public void Hsv_ToColor_PrimaryHues(float hue, int r, int g, int b)
+    {
+        var hsv = new Hsv(hue, 100f, 100f, 1f);
+        var color = hsv.ToColor();
+        Assert.Multiple(() =>
+        {
+            Assert.That(color.R, Is.EqualTo(r));
+            Assert.That(color.G, Is.EqualTo(g));
+            Assert.That(color.B, Is.EqualTo(b));
+            Assert.That(color.A, Is.EqualTo(0xff));
+        });
+    }
+
+    [Test]
+    public void Hsv_FromCmyk_MatchesColorRouting()
+    {
+        var color = Color.FromArgb(0xff, 0x40, 0xA0, 0x60);
+        Cmyk cmyk = color.ToCmyk();
+        Hsv direct = cmyk.ToHsv();
+        Hsv viaCtor = new Hsv(cmyk);
+        Assert.That(direct, Is.EqualTo(viaCtor));
+    }
+
+    [Test]
+    public void Hsv_ToCmyk_RoundTripsBackToColor()
+    {
+        var color = Color.FromArgb(0xff, 0x60, 0x90, 0x10);
+        Hsv hsv = color.ToHsv();
+        Cmyk cmyk = hsv.ToCmyk();
+        Assert.That(cmyk.ToColor(), Is.EqualTo(color));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/CmykHsvTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CmykHsvTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/ColorExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ColorExtraTests.cs
@@ -1,0 +1,226 @@
+using System.Numerics;
+
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class ColorExtraTests
+{
+    [Test]
+    public void FromArgb_StoresComponents()
+    {
+        var c = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+        Assert.That(c.A, Is.EqualTo(0x12));
+        Assert.That(c.R, Is.EqualTo(0x34));
+        Assert.That(c.G, Is.EqualTo(0x56));
+        Assert.That(c.B, Is.EqualTo(0x78));
+    }
+
+    [Test]
+    public void FromRgb_DefaultsAlphaToFull()
+    {
+        var c = Color.FromRgb(1, 2, 3);
+        Assert.That(c.A, Is.EqualTo(0xff));
+        Assert.That(c.R, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FromUInt32_RoundTripsToUInt32()
+    {
+        uint value = 0x12345678;
+        var color = Color.FromUInt32(value);
+        Assert.That(color.ToUint32(), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void FromInt32_RoundTripsToInt32()
+    {
+        int value = 0x12345678;
+        var color = Color.FromInt32(value);
+        Assert.That(color.ToInt32(), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Parse_KnownName()
+    {
+        var c = Color.Parse("Red");
+        Assert.That(c.R, Is.EqualTo(0xff));
+        Assert.That(c.G, Is.EqualTo(0));
+        Assert.That(c.B, Is.EqualTo(0));
+        Assert.That(c.A, Is.EqualTo(0xff));
+    }
+
+    [Test]
+    public void Parse_KnownNameLooksUpExactName()
+    {
+        // KnownColors stores enum field names like "Red".
+        Assert.That(Color.Parse("Red"), Is.EqualTo(Color.FromUInt32(0xffff0000)));
+    }
+
+    [Test]
+    public void Parse_NullThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => Color.Parse((string)null!));
+    }
+
+    [Test]
+    public void Parse_UnknownThrows()
+    {
+        Assert.Throws<FormatException>(() => Color.Parse("NotAColor"));
+    }
+
+    [Test]
+    public void TryParse_NullReturnsFalse()
+    {
+        Assert.That(Color.TryParse((string)null!, out _), Is.False);
+    }
+
+    [Test]
+    public void TryParse_EmptyReturnsFalse()
+    {
+        Assert.That(Color.TryParse("", out _), Is.False);
+        Assert.That(Color.TryParse(ReadOnlySpan<char>.Empty, out _), Is.False);
+    }
+
+    [Test]
+    public void TryParse_InvalidName()
+    {
+        Assert.That(Color.TryParse("Foobar", out _), Is.False);
+    }
+
+    [Test]
+    public void ToString_KnownReturnsName()
+    {
+        Assert.That(Color.Parse("Red").ToString(), Is.EqualTo("Red"));
+    }
+
+    [Test]
+    public void ToString_UnknownReturnsHex()
+    {
+        var c = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+        Assert.That(c.ToString(), Is.EqualTo("#12345678"));
+    }
+
+    [Test]
+    public void Equals_AndHashCode()
+    {
+        var a = Color.FromArgb(255, 100, 100, 100);
+        var b = Color.FromArgb(255, 100, 100, 100);
+        var c = Color.FromArgb(255, 100, 100, 200);
+
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"not a color"), Is.False);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void ToLinear_BlackIsZero()
+    {
+        var v = Color.FromArgb(255, 0, 0, 0).ToLinear();
+        Assert.That(v.X, Is.EqualTo(0f).Within(1e-6));
+        Assert.That(v.Y, Is.EqualTo(0f).Within(1e-6));
+        Assert.That(v.Z, Is.EqualTo(0f).Within(1e-6));
+        Assert.That(v.W, Is.EqualTo(1f).Within(1e-6));
+    }
+
+    [Test]
+    public void ToLinear_WhiteIsOne()
+    {
+        var v = Color.FromArgb(255, 255, 255, 255).ToLinear();
+        Assert.That(v.X, Is.EqualTo(1f).Within(1e-3));
+        Assert.That(v.Y, Is.EqualTo(1f).Within(1e-3));
+        Assert.That(v.Z, Is.EqualTo(1f).Within(1e-3));
+        Assert.That(v.W, Is.EqualTo(1f).Within(1e-6));
+    }
+
+    [Test]
+    public void ToLinearPremultiplied_AlphaScalesRgb()
+    {
+        var color = Color.FromArgb(127, 255, 255, 255);
+        var v = color.ToLinearPremultiplied();
+        var alpha = 127f / 255f;
+
+        Assert.That(v.W, Is.EqualTo(alpha).Within(1e-6));
+        Assert.That(v.X, Is.EqualTo(alpha).Within(1e-3));
+    }
+
+    [Test]
+    public void FromLinear_RoundTrip()
+    {
+        var input = Color.FromArgb(255, 100, 150, 200);
+        var linear = input.ToLinear();
+        var result = Color.FromLinear(linear);
+
+        Assert.That(result.R, Is.EqualTo(input.R).Within(1));
+        Assert.That(result.G, Is.EqualTo(input.G).Within(1));
+        Assert.That(result.B, Is.EqualTo(input.B).Within(1));
+        Assert.That(result.A, Is.EqualTo(input.A));
+    }
+
+    [Test]
+    public void FromLinear_ClampsOutOfRange()
+    {
+        var clamped = Color.FromLinear(new Vector4(2f, -1f, 0.5f, 2f));
+        Assert.That(clamped.A, Is.EqualTo(255));
+    }
+
+    [Test]
+    public void IParsable_Parse()
+    {
+        var color = ParseViaInterface<Color>("Red");
+        Assert.That(color, Is.EqualTo(Color.Parse("Red")));
+    }
+
+    [Test]
+    public void IParsable_TryParse()
+    {
+        Assert.That(TryParseViaInterface<Color>("Red", out var color), Is.True);
+        Assert.That(color, Is.EqualTo(Color.Parse("Red")));
+
+        Assert.That(TryParseViaInterface<Color>(null, out _), Is.False);
+    }
+
+    [Test]
+    public void ISpanParsable_Parse()
+    {
+        var color = SpanParseViaInterface<Color>("Red".AsSpan());
+        Assert.That(color, Is.EqualTo(Color.Parse("Red")));
+    }
+
+    private static T ParseViaInterface<T>(string s) where T : IParsable<T>
+        => T.Parse(s, null);
+
+    private static bool TryParseViaInterface<T>(string? s, out T? result) where T : IParsable<T>
+        => T.TryParse(s, null, out result);
+
+    private static T SpanParseViaInterface<T>(ReadOnlySpan<char> s) where T : ISpanParsable<T>
+        => T.Parse(s, null);
+
+    [Test]
+    public void ToBrushExtension_CreatesBrush()
+    {
+        var brush = Color.Parse("Red").ToBrush();
+        Assert.That(brush.Color.CurrentValue, Is.EqualTo(Color.Parse("Red")));
+    }
+
+    [Test]
+    public void ToBrushResourceExtension_CreatesResource()
+    {
+        var res = Color.Parse("Red").ToBrushResource();
+        Assert.That(res, Is.Not.Null);
+    }
+
+    [Test]
+    public void Colors_WellKnownConstants()
+    {
+        Assert.That(Colors.Black.ToUint32(), Is.EqualTo(0xff000000));
+        Assert.That(Colors.White.ToUint32(), Is.EqualTo(0xffffffff));
+        Assert.That(Colors.Red.ToUint32(), Is.EqualTo(0xffff0000));
+        Assert.That(Colors.Green.ToUint32(), Is.EqualTo(0xff008000));
+        Assert.That(Colors.Blue.ToUint32(), Is.EqualTo(0xff0000ff));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/ColorExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ColorExtraTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/ColorMatrixExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ColorMatrixExtraTests.cs
@@ -1,0 +1,167 @@
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class ColorMatrixExtraTests
+{
+    [Test]
+    public void Identity_IsIdentity()
+    {
+        Assert.That(ColorMatrix.Identity.IsIdentity, Is.True);
+    }
+
+    [Test]
+    public void DefaultStruct_IsNotIdentity()
+    {
+        Assert.That(default(ColorMatrix).IsIdentity, Is.False);
+    }
+
+    [Test]
+    public void Equals_AndOperators()
+    {
+        var m1 = ColorMatrix.Identity;
+        var m2 = ColorMatrix.Identity;
+        var m3 = ColorMatrix.CreateBrightness(2f);
+
+        Assert.That(m1, Is.EqualTo(m2));
+        Assert.That(m1 == m2, Is.True);
+        Assert.That(m1 != m3, Is.True);
+        Assert.That(m1.Equals((object)m2), Is.True);
+        Assert.That(m1.Equals((object)"not a matrix"), Is.False);
+        Assert.That(m1.GetHashCode(), Is.EqualTo(m2.GetHashCode()));
+    }
+
+    [Test]
+    public void IdentityTimesColor_ReturnsSameColor()
+    {
+        var color = Color.FromArgb(200, 100, 150, 50);
+        var result = ColorMatrix.Identity * color;
+
+        Assert.That(result, Is.EqualTo(color));
+    }
+
+    [Test]
+    public void IdentityTimesIdentity_IsIdentity()
+    {
+        var result = ColorMatrix.Identity * ColorMatrix.Identity;
+        Assert.That(result.IsIdentity, Is.True);
+    }
+
+    [Test]
+    public void CreateBrightness_AppliedToColor_ScalesRGB()
+    {
+        var brightness = ColorMatrix.CreateBrightness(0.5f);
+        var input = Color.FromArgb(255, 200, 100, 50);
+        var output = brightness * input;
+
+        Assert.That(output.R, Is.EqualTo(100).Within(1));
+        Assert.That(output.G, Is.EqualTo(50).Within(1));
+        Assert.That(output.B, Is.EqualTo(25).Within(1));
+        Assert.That(output.A, Is.EqualTo(255));
+    }
+
+    [Test]
+    public void CreateSaturate_One_IsIdentityOnRgb()
+    {
+        var sat = ColorMatrix.CreateSaturate(1f);
+        var input = Color.FromArgb(255, 100, 150, 200);
+        var output = sat * input;
+
+        Assert.That(output.R, Is.EqualTo(input.R).Within(1));
+        Assert.That(output.G, Is.EqualTo(input.G).Within(1));
+        Assert.That(output.B, Is.EqualTo(input.B).Within(1));
+    }
+
+    [Test]
+    public void CreateSaturate_Zero_ProducesGreyscale()
+    {
+        var sat = ColorMatrix.CreateSaturate(0f);
+        var input = Color.FromArgb(255, 200, 200, 200);
+        var output = sat * input;
+
+        Assert.That(output.R, Is.EqualTo(output.G));
+        Assert.That(output.G, Is.EqualTo(output.B));
+    }
+
+    [Test]
+    public void CreateHueRotate_ZeroIsApproxIdentity()
+    {
+        var rot = ColorMatrix.CreateHueRotate(0f);
+        var input = Color.FromArgb(255, 100, 150, 200);
+        var output = rot * input;
+
+        Assert.That(output.R, Is.EqualTo(input.R).Within(2));
+        Assert.That(output.G, Is.EqualTo(input.G).Within(2));
+        Assert.That(output.B, Is.EqualTo(input.B).Within(2));
+    }
+
+    [Test]
+    public void CreateLuminanceToAlpha_PreservesRgb()
+    {
+        var matrix = ColorMatrix.CreateLuminanceToAlpha();
+        var input = Color.FromArgb(0, 100, 150, 200);
+        var output = matrix * input;
+
+        Assert.That(output.R, Is.EqualTo(input.R));
+        Assert.That(output.G, Is.EqualTo(input.G));
+        Assert.That(output.B, Is.EqualTo(input.B));
+    }
+
+    [Test]
+    public void CreateContrast_Zero_IsIdentityScale()
+    {
+        var matrix = ColorMatrix.CreateContrast(0f);
+        var input = Color.FromArgb(255, 128, 128, 128);
+        var output = matrix * input;
+
+        Assert.That(output.R, Is.EqualTo(input.R).Within(1));
+    }
+
+    [Test]
+    public void CreateFromSpan_TooShort_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            Span<float> span = stackalloc float[10];
+            ColorMatrix.CreateFromSpan(span);
+        });
+    }
+
+    [Test]
+    public void ToArray_ReturnsAllTwentyValues()
+    {
+        var array = ColorMatrix.Identity.ToArray();
+
+        Assert.That(array.Length, Is.EqualTo(20));
+        Assert.That(array[0], Is.EqualTo(1));
+        Assert.That(array[6], Is.EqualTo(1));
+        Assert.That(array[12], Is.EqualTo(1));
+        Assert.That(array[18], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ToString_ContainsBrace()
+    {
+        var s = ColorMatrix.Identity.ToString();
+        Assert.That(s, Does.Contain("{"));
+        Assert.That(s, Does.Contain("M00"));
+    }
+
+    [Test]
+    public void Constructor_StoresAllValues()
+    {
+        var m = new ColorMatrix(
+            1, 2, 3, 4, 5,
+            6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20);
+
+        Assert.That(m.M11, Is.EqualTo(1));
+        Assert.That(m.M15, Is.EqualTo(5));
+        Assert.That(m.M21, Is.EqualTo(6));
+        Assert.That(m.M33, Is.EqualTo(13));
+        Assert.That(m.M45, Is.EqualTo(20));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/ColorMatrixExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ColorMatrixExtraTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/CornerRadiusConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CornerRadiusConverterTests.cs
@@ -1,0 +1,85 @@
+using Beutl.Converters;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class CornerRadiusConverterTests
+{
+    private readonly CornerRadiusConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float>)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertTo_OtherTypes_FallsBackToBase()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(int)), Is.False);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsFourComponents()
+    {
+        var radius = new CornerRadius(1, 2, 3, 4);
+        float[] result = (float[])_converter.ConvertTo(null, null, radius, typeof(float[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 1f, 2f, 3f, 4f }));
+    }
+
+    [Test]
+    public void ConvertTo_FourTuple_ReturnsFourComponents()
+    {
+        var radius = new CornerRadius(1, 2, 3, 4);
+        Tuple<float, float, float, float> result =
+            (Tuple<float, float, float, float>)_converter.ConvertTo(null, null, radius, typeof(Tuple<float, float, float, float>))!;
+        Assert.That(result, Is.EqualTo(new Tuple<float, float, float, float>(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_TwoTuple_ReturnsTopLeftAndBottomLeft()
+    {
+        var radius = new CornerRadius(10, 20, 30, 40);
+        Tuple<float, float> result =
+            (Tuple<float, float>)_converter.ConvertTo(null, null, radius, typeof(Tuple<float, float>))!;
+        Assert.That(result.Item1, Is.EqualTo(10f));
+        Assert.That(result.Item2, Is.EqualTo(40f));
+    }
+
+    [Test]
+    public void ConvertFrom_OneElementArray_UsesUniform()
+    {
+        CornerRadius result = (CornerRadius)_converter.ConvertFrom(null, null, new[] { 5f })!;
+        Assert.That(result, Is.EqualTo(new CornerRadius(5)));
+    }
+
+    [Test]
+    public void ConvertFrom_TwoElementArray_UsesPair()
+    {
+        CornerRadius result = (CornerRadius)_converter.ConvertFrom(null, null, new[] { 1f, 3f })!;
+        Assert.That(result, Is.EqualTo(new CornerRadius(1, 3)));
+    }
+
+    [Test]
+    public void ConvertFrom_FourElementArray_UsesAll()
+    {
+        CornerRadius result = (CornerRadius)_converter.ConvertFrom(null, null, new[] { 1f, 2f, 3f, 4f })!;
+        Assert.That(result, Is.EqualTo(new CornerRadius(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Float_UsesUniform()
+    {
+        CornerRadius result = (CornerRadius)_converter.ConvertFrom(null, null, 7f)!;
+        Assert.That(result, Is.EqualTo(new CornerRadius(7)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        CornerRadius result = (CornerRadius)_converter.ConvertFrom(null, null, "1,2,3,4")!;
+        Assert.That(result, Is.EqualTo(new CornerRadius(1, 2, 3, 4)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/CornerRadiusConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CornerRadiusConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/CornerRadiusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CornerRadiusTests.cs
@@ -1,0 +1,173 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class CornerRadiusTests
+{
+    [Test]
+    public void Constructor_Uniform_AppliesToAllCorners()
+    {
+        var r = new CornerRadius(5);
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.TopLeft, Is.EqualTo(5));
+            Assert.That(r.TopRight, Is.EqualTo(5));
+            Assert.That(r.BottomLeft, Is.EqualTo(5));
+            Assert.That(r.BottomRight, Is.EqualTo(5));
+            Assert.That(r.IsUniform, Is.True);
+            Assert.That(r.IsEmpty, Is.False);
+        });
+    }
+
+    [Test]
+    public void Constructor_TopBottom_AppliesToTopAndBottomPairs()
+    {
+        var r = new CornerRadius(top: 1, bottom: 2);
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.TopLeft, Is.EqualTo(1));
+            Assert.That(r.TopRight, Is.EqualTo(1));
+            Assert.That(r.BottomLeft, Is.EqualTo(2));
+            Assert.That(r.BottomRight, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Constructor_Full_StoresAllComponents()
+    {
+        var r = new CornerRadius(1, 2, 3, 4);
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.TopLeft, Is.EqualTo(1));
+            Assert.That(r.TopRight, Is.EqualTo(2));
+            Assert.That(r.BottomRight, Is.EqualTo(3));
+            Assert.That(r.BottomLeft, Is.EqualTo(4));
+            Assert.That(r.IsUniform, Is.False);
+        });
+    }
+
+    [Test]
+    public void Default_IsEmptyAndUniform()
+    {
+        var r = default(CornerRadius);
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.IsEmpty, Is.True);
+            Assert.That(r.IsUniform, Is.True);
+        });
+    }
+
+    [Test]
+    public void Equality_Operators_AndHashCode()
+    {
+        var a = new CornerRadius(1, 2, 3, 4);
+        var b = new CornerRadius(1, 2, 3, 4);
+        var c = new CornerRadius(0, 2, 3, 4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != c, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)"foo"), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            Assert.That(a.GetHashCode(), Is.Not.EqualTo(c.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void ToString_FormatsAllCornersInOrder()
+    {
+        var r = new CornerRadius(1, 2, 3, 4);
+        Assert.That(r.ToString(), Is.EqualTo("1,2,3,4"));
+    }
+
+    [Test]
+    public void Parse_SingleValue_ProducesUniformRadius()
+    {
+        var r = CornerRadius.Parse("5");
+        Assert.That(r, Is.EqualTo(new CornerRadius(5)));
+    }
+
+    [Test]
+    public void Parse_TwoValues_ProducesTopBottomRadius()
+    {
+        var r = CornerRadius.Parse("1,2");
+        Assert.That(r, Is.EqualTo(new CornerRadius(1, 2)));
+    }
+
+    [Test]
+    public void Parse_FourValues_ProducesFullRadius()
+    {
+        var r = CornerRadius.Parse("1,2,3,4");
+        Assert.That(r, Is.EqualTo(new CornerRadius(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void Parse_Empty_Throws()
+    {
+        Assert.Throws<FormatException>(() => CornerRadius.Parse(""));
+    }
+
+    [Test]
+    public void TryParse_ValidAndInvalid()
+    {
+        Assert.That(CornerRadius.TryParse("1,2,3,4", out CornerRadius ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new CornerRadius(1, 2, 3, 4)));
+
+        Assert.That(CornerRadius.TryParse("garbage", out CornerRadius bad), Is.False);
+        Assert.That(bad, Is.EqualTo(default(CornerRadius)));
+
+        Assert.That(CornerRadius.TryParse("5".AsSpan(), out CornerRadius span), Is.True);
+        Assert.That(span, Is.EqualTo(new CornerRadius(5)));
+    }
+
+    [Test]
+    public void With_ReplaceIndividualCorners()
+    {
+        var r = new CornerRadius(1, 2, 3, 4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.WithTopLeft(9), Is.EqualTo(new CornerRadius(9, 2, 3, 4)));
+            Assert.That(r.WithTopRight(9), Is.EqualTo(new CornerRadius(1, 9, 3, 4)));
+            Assert.That(r.WithBottomRight(9), Is.EqualTo(new CornerRadius(1, 2, 9, 4)));
+            Assert.That(r.WithBottomLeft(9), Is.EqualTo(new CornerRadius(1, 2, 3, 9)));
+            Assert.That(r.WithTop(9), Is.EqualTo(new CornerRadius(9, 9, 3, 4)));
+            Assert.That(r.WithBottom(9), Is.EqualTo(new CornerRadius(1, 2, 9, 9)));
+        });
+    }
+
+    [Test]
+    public void TupleConvertible_RoundTripPreservesOrder()
+    {
+        Assert.That(GetTupleLength<CornerRadius>(), Is.EqualTo(4));
+
+        var original = new CornerRadius(1, 2, 3, 4);
+        var tuple = new float[4];
+        ConvertTo<CornerRadius>(original, tuple);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tuple[0], Is.EqualTo(1));
+            Assert.That(tuple[1], Is.EqualTo(2));
+            Assert.That(tuple[2], Is.EqualTo(3));
+            Assert.That(tuple[3], Is.EqualTo(4));
+        });
+
+        var restored = ConvertFrom<CornerRadius>(tuple);
+        Assert.That(restored, Is.EqualTo(original));
+    }
+
+    private static int GetTupleLength<T>() where T : struct, ITupleConvertible<T, float>
+        => T.TupleLength;
+
+    private static void ConvertTo<T>(T value, Span<float> tuple) where T : struct, ITupleConvertible<T, float>
+        => T.ConvertTo(value, tuple);
+
+    private static T ConvertFrom<T>(Span<float> tuple) where T : struct, ITupleConvertible<T, float>
+    {
+        T.ConvertFrom(tuple, out T value);
+        return value;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/CornerRadiusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CornerRadiusTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/CurveMapTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CurveMapTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/CurveMapTests.cs
+++ b/tests/Beutl.UnitTests/Engine/CurveMapTests.cs
@@ -1,0 +1,225 @@
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class CurveMapTests
+{
+    [Test]
+    public void Default_IsIdentityCurve()
+    {
+        var curve = CurveMap.Default;
+        Assert.That(curve.Evaluate(0f), Is.EqualTo(0f).Within(1e-6));
+        Assert.That(curve.Evaluate(0.5f), Is.EqualTo(0.5f).Within(1e-6));
+        Assert.That(curve.Evaluate(1f), Is.EqualTo(1f).Within(1e-6));
+    }
+
+    [Test]
+    public void Evaluate_ClampsBelowZero()
+    {
+        var curve = new CurveMap([new(0.2f, 0.3f), new(1f, 1f)]);
+        Assert.That(curve.Evaluate(-0.5f), Is.EqualTo(0.3f).Within(1e-6));
+    }
+
+    [Test]
+    public void Evaluate_ClampsAboveOne()
+    {
+        var curve = new CurveMap([new(0f, 0f), new(0.8f, 0.6f)]);
+        Assert.That(curve.Evaluate(2f), Is.EqualTo(0.6f).Within(1e-6));
+    }
+
+    [Test]
+    public void Evaluate_LinearInterpolation()
+    {
+        var curve = new CurveMap([new(0f, 0f), new(1f, 1f)]);
+        Assert.That(curve.Evaluate(0.25f), Is.EqualTo(0.25f).Within(1e-6));
+    }
+
+    [Test]
+    public void Evaluate_StepBetweenPoints()
+    {
+        var curve = new CurveMap([new(0f, 0f), new(0.5f, 1f), new(1f, 0f)]);
+        Assert.That(curve.Evaluate(0.25f), Is.EqualTo(0.5f).Within(1e-6));
+        Assert.That(curve.Evaluate(0.75f), Is.EqualTo(0.5f).Within(1e-6));
+    }
+
+    [Test]
+    public void Constructor_NormalizesByX()
+    {
+        var curve = new CurveMap([new(1f, 1f), new(0f, 0f), new(0.5f, 0.5f)]);
+
+        Assert.That(curve.Points[0].Point.X, Is.EqualTo(0f));
+        Assert.That(curve.Points[1].Point.X, Is.EqualTo(0.5f));
+        Assert.That(curve.Points[2].Point.X, Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void WithPoints_ReturnsNewInstance()
+    {
+        var curve = CurveMap.Default;
+        var updated = curve.WithPoints([new(0f, 0.5f), new(1f, 0.5f)]);
+
+        Assert.That(updated, Is.Not.SameAs(curve));
+        Assert.That(updated.Evaluate(0.5f), Is.EqualTo(0.5f).Within(1e-6));
+    }
+
+    [Test]
+    public void EvaluateBezier_PassesThroughEndpoints()
+    {
+        var p0 = new CurveControlPoint(new Point(0f, 0f), default, new Point(0.3f, 0f));
+        var p1 = new CurveControlPoint(new Point(1f, 1f), new Point(-0.3f, 0f), default);
+        var curve = new CurveMap([p0, p1]);
+
+        Assert.That(curve.Evaluate(0f), Is.EqualTo(0f).Within(1e-3));
+        Assert.That(curve.Evaluate(1f), Is.EqualTo(1f).Within(1e-3));
+    }
+
+    [Test]
+    public void Equals_PointsMatch()
+    {
+        var a = new CurveMap([new(0f, 0f), new(1f, 1f)]);
+        var b = new CurveMap([new(0f, 0f), new(1f, 1f)]);
+        var c = new CurveMap([new(0f, 0f), new(0.5f, 0.5f), new(1f, 1f)]);
+
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"not a curve"), Is.False);
+        Assert.That(a.Equals(c), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Equals_NullReturnsFalse()
+    {
+        var curve = CurveMap.Default;
+        Assert.That(curve.Equals((CurveMap?)null), Is.False);
+    }
+
+    [Test]
+    public void Equals_SameInstance()
+    {
+        var curve = CurveMap.Default;
+        Assert.That(curve.Equals(curve), Is.True);
+    }
+
+    [Test]
+    public void EmptyPoints_EvaluateReturnsT()
+    {
+        var curve = new CurveMap([]);
+        Assert.That(curve.Evaluate(0.7f), Is.EqualTo(0.7f).Within(1e-6));
+    }
+}
+
+[TestFixture]
+public class CurveControlPointTests
+{
+    [Test]
+    public void DefaultConstructor_NoHandles()
+    {
+        var p = new CurveControlPoint(0.5f, 0.5f);
+        Assert.That(p.Point.X, Is.EqualTo(0.5f));
+        Assert.That(p.Point.Y, Is.EqualTo(0.5f));
+        Assert.That(p.HasHandles, Is.False);
+        Assert.That(p.LeftHandle, Is.EqualTo(default(Point)));
+        Assert.That(p.RightHandle, Is.EqualTo(default(Point)));
+    }
+
+    [Test]
+    public void Constructor_FromPoint()
+    {
+        var p = new CurveControlPoint(new Point(0.3f, 0.7f));
+        Assert.That(p.Point.X, Is.EqualTo(0.3f));
+        Assert.That(p.HasHandles, Is.False);
+    }
+
+    [Test]
+    public void Constructor_WithHandles()
+    {
+        var p = new CurveControlPoint(new Point(0.5f, 0.5f), new Point(-0.1f, 0f), new Point(0.1f, 0f));
+        Assert.That(p.HasHandles, Is.True);
+        Assert.That(p.LeftHandle.X, Is.EqualTo(-0.1f));
+        Assert.That(p.RightHandle.X, Is.EqualTo(0.1f));
+    }
+
+    [Test]
+    public void AbsoluteHandles_AreOffsetFromPoint()
+    {
+        var p = new CurveControlPoint(new Point(0.5f, 0.5f), new Point(-0.1f, 0.05f), new Point(0.1f, -0.05f));
+
+        Assert.That(p.AbsoluteLeftHandle.X, Is.EqualTo(0.4f).Within(1e-6));
+        Assert.That(p.AbsoluteLeftHandle.Y, Is.EqualTo(0.55f).Within(1e-6));
+        Assert.That(p.AbsoluteRightHandle.X, Is.EqualTo(0.6f).Within(1e-6));
+        Assert.That(p.AbsoluteRightHandle.Y, Is.EqualTo(0.45f).Within(1e-6));
+    }
+
+    [Test]
+    public void WithPoint_ReplacesPoint()
+    {
+        var original = new CurveControlPoint(new Point(0.5f, 0.5f), new Point(-0.1f, 0f), new Point(0.1f, 0f));
+        var updated = original.WithPoint(new Point(0.7f, 0.7f));
+
+        Assert.That(updated.Point.X, Is.EqualTo(0.7f));
+        Assert.That(updated.LeftHandle, Is.EqualTo(original.LeftHandle));
+        Assert.That(updated.RightHandle, Is.EqualTo(original.RightHandle));
+    }
+
+    [Test]
+    public void WithLeftHandle_ReplacesLeftHandle()
+    {
+        var original = new CurveControlPoint(0.5f, 0.5f);
+        var updated = original.WithLeftHandle(new Point(-0.2f, 0f));
+
+        Assert.That(updated.LeftHandle.X, Is.EqualTo(-0.2f));
+        Assert.That(updated.Point, Is.EqualTo(original.Point));
+    }
+
+    [Test]
+    public void WithRightHandle_ReplacesRightHandle()
+    {
+        var original = new CurveControlPoint(0.5f, 0.5f);
+        var updated = original.WithRightHandle(new Point(0.2f, 0f));
+
+        Assert.That(updated.RightHandle.X, Is.EqualTo(0.2f));
+    }
+
+    [Test]
+    public void WithSymmetricHandles_LeftIsNegated()
+    {
+        var p = new CurveControlPoint(0.5f, 0.5f).WithSymmetricHandles(new Point(0.1f, 0.05f));
+
+        Assert.That(p.RightHandle.X, Is.EqualTo(0.1f));
+        Assert.That(p.RightHandle.Y, Is.EqualTo(0.05f));
+        Assert.That(p.LeftHandle.X, Is.EqualTo(-0.1f));
+        Assert.That(p.LeftHandle.Y, Is.EqualTo(-0.05f));
+    }
+
+    [Test]
+    public void Equality_AndHashCode()
+    {
+        var a = new CurveControlPoint(0.5f, 0.5f);
+        var b = new CurveControlPoint(0.5f, 0.5f);
+        var c = new CurveControlPoint(0.6f, 0.6f);
+
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"not a point"), Is.False);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void ToString_NoHandles()
+    {
+        var p = new CurveControlPoint(0.5f, 0.6f);
+        Assert.That(p.ToString(), Is.EqualTo("(0.5,0.6)"));
+    }
+
+    [Test]
+    public void ToString_WithHandles()
+    {
+        var p = new CurveControlPoint(new Point(0.5f, 0.6f), new Point(-0.1f, 0f), new Point(0.1f, 0f));
+        Assert.That(p.ToString(), Does.Contain("L"));
+        Assert.That(p.ToString(), Does.Contain("R"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/FontFamilyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FontFamilyTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/FontFamilyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FontFamilyTests.cs
@@ -1,0 +1,129 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class FontFamilyTests
+{
+    [Test]
+    public void Default_HasNonEmptyName()
+    {
+        Assert.That(FontFamily.Default.Name, Is.Not.Empty);
+    }
+
+    [Test]
+    public void Constructor_StoresName()
+    {
+        var family = new FontFamily("Arial");
+        Assert.That(family.Name, Is.EqualTo("Arial"));
+    }
+
+    [Test]
+    public void Equals_SameName()
+    {
+        var a = new FontFamily("Arial");
+        var b = new FontFamily("Arial");
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a == b, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Equals_DifferentName()
+    {
+        var a = new FontFamily("Arial");
+        var b = new FontFamily("Times");
+        Assert.That(a.Equals(b), Is.False);
+        Assert.That(a != b, Is.True);
+    }
+
+    [Test]
+    public void Equals_Null()
+    {
+        var a = new FontFamily("Arial");
+        Assert.That(a.Equals((FontFamily?)null), Is.False);
+    }
+
+    [Test]
+    public void Operator_NullHandling()
+    {
+        FontFamily? a = null;
+        FontFamily? b = null;
+#pragma warning disable CS8602
+        Assert.That(a == b, Is.True);
+        Assert.That(a != new FontFamily("Arial"), Is.True);
+#pragma warning restore CS8602
+        Assert.That(new FontFamily("Arial") != null, Is.True);
+    }
+
+    [Test]
+    public void Equals_OtherTypeReturnsFalse()
+    {
+        var a = new FontFamily("Arial");
+        Assert.That(a.Equals((object)"Arial"), Is.False);
+    }
+}
+
+[TestFixture]
+public class TypefaceTests
+{
+    [Test]
+    public void Constructor_DefaultStyleAndWeight()
+    {
+        var family = new FontFamily("Arial");
+        var typeface = new Typeface(family);
+
+        Assert.That(typeface.FontFamily, Is.EqualTo(family));
+        Assert.That(typeface.Style, Is.EqualTo(FontStyle.Normal));
+        Assert.That(typeface.Weight, Is.EqualTo(FontWeight.Regular));
+    }
+
+    [Test]
+    public void Constructor_StoresAllFields()
+    {
+        var family = new FontFamily("Arial");
+        var typeface = new Typeface(family, FontStyle.Italic, FontWeight.Bold);
+
+        Assert.That(typeface.Style, Is.EqualTo(FontStyle.Italic));
+        Assert.That(typeface.Weight, Is.EqualTo(FontWeight.Bold));
+    }
+
+    [Test]
+    public void Equality_AllFieldsMatch()
+    {
+        var a = new Typeface(new FontFamily("Arial"), FontStyle.Italic, FontWeight.Bold);
+        var b = new Typeface(new FontFamily("Arial"), FontStyle.Italic, FontWeight.Bold);
+
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a == b, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Equality_DifferentStyle()
+    {
+        var a = new Typeface(new FontFamily("Arial"));
+        var b = new Typeface(new FontFamily("Arial"), FontStyle.Italic);
+
+        Assert.That(a.Equals(b), Is.False);
+        Assert.That(a != b, Is.True);
+    }
+
+    [Test]
+    public void Equality_DifferentWeight()
+    {
+        var a = new Typeface(new FontFamily("Arial"));
+        var b = new Typeface(new FontFamily("Arial"), FontStyle.Normal, FontWeight.Bold);
+
+        Assert.That(a.Equals(b), Is.False);
+    }
+
+    [Test]
+    public void Equality_OtherType()
+    {
+        var a = new Typeface(new FontFamily("Arial"));
+        Assert.That(a.Equals((object)"not a typeface"), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/GradingColorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/GradingColorTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/GradingColorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/GradingColorTests.cs
@@ -1,0 +1,151 @@
+using System.Numerics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class GradingColorTests
+{
+    [Test]
+    public void StaticMembers_AreExpected()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(GradingColor.Zero, Is.EqualTo(new GradingColor(0, 0, 0)));
+            Assert.That(GradingColor.One, Is.EqualTo(new GradingColor(1, 1, 1)));
+        });
+    }
+
+    [Test]
+    public void FromRgb_AndFromVector3_AreEquivalent()
+    {
+        Assert.That(GradingColor.FromRgb(0.1f, 0.2f, 0.3f),
+            Is.EqualTo(GradingColor.FromVector3(new Vector3(0.1f, 0.2f, 0.3f))));
+    }
+
+    [Test]
+    public void FromColor_DivBy255_ProducesNormalizedComponents()
+    {
+        var color = Color.FromArgb(255, 51, 102, 204);
+        var grading = GradingColor.FromColor(color);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(grading.R, Is.EqualTo(51f / 255f).Within(1e-6));
+            Assert.That(grading.G, Is.EqualTo(102f / 255f).Within(1e-6));
+            Assert.That(grading.B, Is.EqualTo(204f / 255f).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void ToVector3_AndToColor_ConvertCorrectly()
+    {
+        var grading = new GradingColor(0.2f, 0.4f, 1f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(grading.ToVector3(), Is.EqualTo(new Vector3(0.2f, 0.4f, 1f)));
+            var converted = grading.ToColor();
+            Assert.That(converted.A, Is.EqualTo(255));
+            Assert.That(converted.R, Is.EqualTo((byte)Math.Clamp(0.2f * 255f, 0f, 255f)));
+            Assert.That(converted.G, Is.EqualTo((byte)Math.Clamp(0.4f * 255f, 0f, 255f)));
+            Assert.That(converted.B, Is.EqualTo((byte)Math.Clamp(1f * 255f, 0f, 255f)));
+        });
+    }
+
+    [Test]
+    public void ToColor_ClampsOutOfRangeComponents()
+    {
+        var negative = new GradingColor(-0.5f, 0.5f, 1.5f).ToColor();
+        Assert.Multiple(() =>
+        {
+            Assert.That(negative.R, Is.EqualTo(0));
+            Assert.That(negative.B, Is.EqualTo(255));
+        });
+    }
+
+    [Test]
+    public void Parse_ValidString_ReturnsExpected()
+    {
+        var color = GradingColor.Parse("0.25, 0.5, 0.75");
+        Assert.That(color, Is.EqualTo(new GradingColor(0.25f, 0.5f, 0.75f)));
+    }
+
+    [Test]
+    public void Parse_NullString_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => GradingColor.Parse((string)null!));
+    }
+
+    [Test]
+    public void Parse_InvalidString_Throws()
+    {
+        Assert.Throws<FormatException>(() => GradingColor.Parse("not-a-color"));
+        Assert.Throws<FormatException>(() => GradingColor.Parse("1,2"));
+    }
+
+    [Test]
+    public void TryParse_HandlesEmptyAndWhitespace()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(GradingColor.TryParse((string?)null, out _), Is.False);
+            Assert.That(GradingColor.TryParse("", out _), Is.False);
+            Assert.That(GradingColor.TryParse("   ", out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void TryParse_ValidString_Succeeds()
+    {
+        Assert.That(GradingColor.TryParse(" 1, 2, 3 ", out GradingColor color), Is.True);
+        Assert.That(color, Is.EqualTo(new GradingColor(1, 2, 3)));
+    }
+
+    [Test]
+    public void Equality_AndOperators()
+    {
+        var a = new GradingColor(1, 2, 3);
+        var b = new GradingColor(1, 2, 3);
+        var c = new GradingColor(4, 5, 6);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != c, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)"foo"), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void Operators_AddSubtractScale()
+    {
+        var a = new GradingColor(0.5f, 1.5f, 2.5f);
+        var b = new GradingColor(1f, 2f, 3f);
+
+        GradingColor sum = a + b;
+        GradingColor diff = b - a;
+        GradingColor scaledA = a * 2f;
+        GradingColor scaledB = 2f * a;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sum.R, Is.EqualTo(1.5f).Within(1e-6));
+            Assert.That(sum.G, Is.EqualTo(3.5f).Within(1e-6));
+            Assert.That(sum.B, Is.EqualTo(5.5f).Within(1e-6));
+            Assert.That(diff.R, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(diff.G, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(diff.B, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(scaledA.R, Is.EqualTo(1f).Within(1e-6));
+            Assert.That(scaledA.B, Is.EqualTo(5f).Within(1e-6));
+            Assert.That(scaledB, Is.EqualTo(scaledA));
+        });
+    }
+
+    [Test]
+    public void ToString_UsesInvariantCulture()
+    {
+        Assert.That(new GradingColor(1.5f, 2.5f, 3.5f).ToString(), Is.EqualTo("1.5, 2.5, 3.5"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GLSLShaderTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GLSLShaderTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Rendering;

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GLSLShaderTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GLSLShaderTests.cs
@@ -1,0 +1,165 @@
+using System.Runtime.InteropServices;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+/// <summary>
+/// <see cref="GLSLShader"/> は <c>GraphicsContextFactory.SharedContext</c> がないと一切動作しない。
+/// Vulkan 経由で実コンパイル/実行できるかをテストする。
+/// </summary>
+[NonParallelizable]
+public class GLSLShaderTests
+{
+    private const string ConstantBlueFragment = """
+        #version 450
+        layout(location = 0) in vec2 fragCoord;
+        layout(location = 0) out vec4 outColor;
+        layout(set = 0, binding = 0) uniform sampler2D srcTexture;
+        layout(push_constant) uniform PC { float dummy; } pc;
+        void main() {
+            outColor = vec4(0.0, 0.0, 1.0, 1.0);
+        }
+        """;
+
+    private const string MalformedFragment = """
+        #version 450
+        layout(location = 0) out vec4 outColor;
+        void main() {
+            outColor = NOT_A_VALID_GLSL_TOKEN;
+        }
+        """;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DummyPush { public float Dummy; }
+
+    [Test]
+    public void TryCreate_ValidShader_Succeeds()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            bool ok = GLSLShader.TryCreate(ConstantBlueFragment, out var shader, out var error);
+
+            try
+            {
+                Assert.That(ok, Is.True, $"Compile failed: {error}");
+                Assert.That(shader, Is.Not.Null);
+                Assert.That(error, Is.Null);
+            }
+            finally
+            {
+                shader?.Dispose();
+            }
+        });
+    }
+
+    [Test]
+    public void TryCreate_EmptySource_ReturnsFailureSynchronously()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        bool ok = GLSLShader.TryCreate("   ", out var shader, out var error);
+
+        Assert.That(ok, Is.False);
+        Assert.That(shader, Is.Null);
+        Assert.That(error, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void TryCreate_InvalidSource_ReturnsFailureWithErrorText()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            bool ok = GLSLShader.TryCreate(MalformedFragment, out var shader, out var error);
+
+            Assert.That(ok, Is.False);
+            Assert.That(shader, Is.Null);
+            Assert.That(error, Is.Not.Null.And.Not.Empty);
+        });
+    }
+
+    [Test]
+    public void Create_InvalidSource_Throws()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => GLSLShader.Create(MalformedFragment));
+        });
+    }
+
+    [Test]
+    public void Apply_AfterDispose_Throws()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var shader = GLSLShader.Create(ConstantBlueFragment);
+            shader.Dispose();
+
+            using var targets = new EffectTargets();
+            var ctx = CreateCustomContext(targets);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                shader.Apply<DummyPush>(ctx, new DummyPush()));
+        });
+    }
+
+    [Test]
+    public void Apply_OverwritesTargetWithShaderOutput()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var targets = new EffectTargets();
+
+            // Set up a 4x4 red EffectTarget so we can detect the shader's blue overwrite.
+            using var sourceRenderTarget = RenderTarget.Create(4, 4);
+            Assume.That(sourceRenderTarget, Is.Not.Null);
+            using (var canvas = new ImmediateCanvas(sourceRenderTarget!))
+            {
+                canvas.Clear(Colors.Red);
+            }
+
+            targets.Add(new EffectTarget(sourceRenderTarget!, new Rect(0, 0, 4, 4)));
+
+            var customCtx = CreateCustomContext(targets);
+
+            using var shader = GLSLShader.Create(ConstantBlueFragment);
+            shader.Apply<DummyPush>(customCtx, new DummyPush());
+
+            // After Apply, the EffectTarget at index 0 should be replaced with the shader output.
+            var resultTarget = targets[0];
+            Assert.That(resultTarget.RenderTarget, Is.Not.Null);
+            Assert.That(resultTarget.RenderTarget!.Texture, Is.Not.Null);
+            Assert.That(resultTarget.RenderTarget.Width, Is.EqualTo(4));
+
+            ctx.WaitIdle();
+
+            // Sample the resulting texture pixels.
+            byte[] pixels = resultTarget.RenderTarget.Texture!.DownloadPixels();
+            // RGBA16Float: 8 bytes per pixel
+            Assert.That(pixels.Length, Is.EqualTo(4 * 4 * 8));
+
+            // First pixel should be (0, 0, 1, 1).
+            float r = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(pixels, 0));
+            float g = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(pixels, 2));
+            float b = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(pixels, 4));
+            Assert.That(r, Is.EqualTo(0f).Within(0.01f));
+            Assert.That(g, Is.EqualTo(0f).Within(0.01f));
+            Assert.That(b, Is.EqualTo(1f).Within(0.01f));
+        });
+    }
+
+    private static CustomFilterEffectContext CreateCustomContext(EffectTargets targets)
+        => new CustomFilterEffectContext(targets);
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextFactoryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextFactoryTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics.Backend;
+﻿using Beutl.Graphics.Backend;
 
 namespace Beutl.UnitTests.Engine.Graphics.Backend;
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextFactoryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextFactoryTests.cs
@@ -1,0 +1,86 @@
+using Beutl.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+[NonParallelizable]
+public class GraphicsContextFactoryTests
+{
+    [Test]
+    public void GetAvailableDevices_ReturnsAtLeastOne()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        var devices = GraphicsContextFactory.GetAvailableDevices();
+
+        Assert.That(devices, Is.Not.Null);
+        Assert.That(devices.Length, Is.GreaterThan(0),
+            "Vulkanインスタンスは作成できているのにデバイスが0件なのは想定外です。");
+
+        foreach (var device in devices)
+        {
+            Assert.That(device.Name, Is.Not.Null.And.Not.Empty);
+            Assert.That(device.ApiVersion, Is.Not.Null.And.Not.Empty);
+        }
+    }
+
+    [Test]
+    public void GetSelectedDevice_ReflectsSelection()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        var selected = GraphicsContextFactory.GetSelectedDevice();
+        Assert.That(selected, Is.Not.Null);
+
+        var devices = GraphicsContextFactory.GetAvailableDevices();
+        Assert.That(devices.Any(d => d.Name == selected!.Name), Is.True,
+            "GetSelectedDevice の返すデバイス名が GetAvailableDevices に含まれていません。");
+    }
+
+    [Test]
+    public void GetOrCreateShared_ReturnsSameInstance()
+    {
+        var first = VulkanTestEnvironment.EnsureAvailable();
+
+        var second = VulkanTestEnvironment.InvokeOnRenderThread(GraphicsContextFactory.GetOrCreateShared);
+
+        Assert.That(second, Is.SameAs(first), "共有 GraphicsContext は使い回されるべきです。");
+        Assert.That(GraphicsContextFactory.SharedContext, Is.SameAs(first));
+    }
+
+    [Test]
+    public void SharedContext_HasExpectedBackend()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        var expected = OperatingSystem.IsMacOS() ? GraphicsBackend.Metal : GraphicsBackend.Vulkan;
+        Assert.That(ctx.Backend, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetEnabledExtensions_IsNotEmpty()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        var extensions = GraphicsContextFactory.GetEnabledExtensions().ToArray();
+
+        Assert.That(extensions, Is.Not.Null);
+        Assert.That(extensions.Length, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void SelectGpuByName_RejectsNullOrEmpty()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        Assert.That(GraphicsContextFactory.SelectGpuByName(null), Is.False);
+        Assert.That(GraphicsContextFactory.SelectGpuByName(string.Empty), Is.False);
+    }
+
+    [Test]
+    public void SelectGpuByName_ReturnsFalseForUnknownName()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        Assert.That(GraphicsContextFactory.SelectGpuByName("__non_existent_gpu__"), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextResourceTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics.Backend;
+﻿using Beutl.Graphics.Backend;
 
 namespace Beutl.UnitTests.Engine.Graphics.Backend;
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextResourceTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/GraphicsContextResourceTests.cs
@@ -1,0 +1,183 @@
+using Beutl.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+[NonParallelizable]
+public class GraphicsContextResourceTests
+{
+    [Test]
+    public void CreateTexture2D_RGBA8_HasMatchingDimensions()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var texture = ctx.CreateTexture2D(64, 32, TextureFormat.RGBA8Unorm);
+
+            Assert.That(texture, Is.Not.Null);
+            Assert.That(texture.Width, Is.EqualTo(64));
+            Assert.That(texture.Height, Is.EqualTo(32));
+            Assert.That(texture.Format, Is.EqualTo(TextureFormat.RGBA8Unorm));
+            Assert.That(texture.NativeHandle, Is.Not.EqualTo(IntPtr.Zero));
+        });
+    }
+
+    [Test]
+    public void CreateTexture2D_DepthFormat_Succeeds()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var depth = ctx.CreateTexture2D(8, 8, TextureFormat.Depth32Float);
+            Assert.That(depth.Format, Is.EqualTo(TextureFormat.Depth32Float));
+        });
+    }
+
+    [Test]
+    public void CreateTexture2D_UploadAndDownload_RoundTrips()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            const int width = 4;
+            const int height = 4;
+            using var texture = ctx.CreateTexture2D(width, height, TextureFormat.RGBA8Unorm);
+            var pixels = new byte[width * height * 4];
+            for (int i = 0; i < pixels.Length; i++)
+                pixels[i] = (byte)(i & 0xFF);
+
+            texture.Upload(pixels);
+            var downloaded = texture.DownloadPixels();
+
+            Assert.That(downloaded.Length, Is.EqualTo(pixels.Length));
+            Assert.That(downloaded, Is.EqualTo(pixels));
+        });
+    }
+
+    [Test]
+    public void CreateBuffer_HostVisible_AllocatesRequestedSize()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var buffer = ctx.CreateBuffer(
+                256,
+                BufferUsage.UniformBuffer | BufferUsage.TransferDestination,
+                MemoryProperty.HostVisible | MemoryProperty.HostCoherent);
+
+            Assert.That(buffer.Size, Is.EqualTo(256));
+        });
+    }
+
+    [Test]
+    public void CreateBuffer_HostVisible_UploadAndMap_RoundTrips()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            int[] payload = [1, 2, 3, 4, 5, 6, 7, 8];
+            ulong size = (ulong)(sizeof(int) * payload.Length);
+            using var buffer = ctx.CreateBuffer(
+                size,
+                BufferUsage.UniformBuffer | BufferUsage.TransferDestination,
+                MemoryProperty.HostVisible | MemoryProperty.HostCoherent);
+
+            buffer.Upload<int>(payload);
+
+            IntPtr ptr = buffer.Map();
+            try
+            {
+                Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+                int[] roundTrip = new int[payload.Length];
+                System.Runtime.InteropServices.Marshal.Copy(ptr, roundTrip, 0, payload.Length);
+                Assert.That(roundTrip, Is.EqualTo(payload));
+            }
+            finally
+            {
+                buffer.Unmap();
+            }
+        });
+    }
+
+    [Test]
+    public void CreateShaderCompiler_ReturnsCompilerInstance()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var compiler = ctx.CreateShaderCompiler();
+            Assert.That(compiler, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void CompileShader_TrivialFragment_ProducesSpirv()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var compiler = ctx.CreateShaderCompiler();
+            const string source = """
+                #version 450
+                layout(location = 0) out vec4 outColor;
+                void main() { outColor = vec4(1.0); }
+                """;
+
+            var spirv = compiler.CompileToSpirv(source, ShaderStage.Fragment);
+
+            Assert.That(spirv, Is.Not.Null);
+            Assert.That(spirv.Length, Is.GreaterThan(0));
+            Assert.That(spirv.Length % 4, Is.EqualTo(0), "SPIR-V は 4 バイト単位の語の列であるべきです。");
+        });
+    }
+
+    [Test]
+    public void CreateSampler_ReturnsSamplerInstance()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var sampler = ctx.CreateSampler();
+            Assert.That(sampler, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void CopyTexture_PreservesContents()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            const int width = 4;
+            const int height = 4;
+            var pixels = new byte[width * height * 4];
+            for (int i = 0; i < pixels.Length; i++)
+                pixels[i] = (byte)((i * 7) & 0xFF);
+
+            using var src = ctx.CreateTexture2D(width, height, TextureFormat.RGBA8Unorm);
+            using var dst = ctx.CreateTexture2D(width, height, TextureFormat.RGBA8Unorm);
+            src.Upload(pixels);
+
+            ctx.CopyTexture(src, dst);
+            ctx.WaitIdle();
+
+            var copied = dst.DownloadPixels();
+            Assert.That(copied, Is.EqualTo(pixels));
+        });
+    }
+
+    [Test]
+    public void WaitIdle_DoesNotThrow()
+    {
+        var ctx = VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() => ctx.WaitIdle());
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/ImmediateCanvasVulkanTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/ImmediateCanvasVulkanTests.cs
@@ -1,0 +1,115 @@
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+/// <summary>
+/// 実 Vulkan テクスチャを介した <see cref="ImmediateCanvas"/> の描画テスト。
+/// <see cref="RenderTarget.CreateNull"/> ではなく <see cref="RenderTarget.Create"/> を使うため、
+/// Vulkan が利用できない環境ではスキップする。
+/// </summary>
+[NonParallelizable]
+public class ImmediateCanvasVulkanTests
+{
+    [Test]
+    public void Clear_FillsSurfaceWithSolidColor()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(8, 8);
+            Assert.That(target, Is.Not.Null);
+
+            using (var canvas = new ImmediateCanvas(target!))
+            {
+                canvas.Clear(Colors.Red);
+            }
+
+            using var snapshot = target!.Snapshot();
+            AssertEveryPixelMatches(snapshot, expectedRed: 1f, expectedGreen: 0f, expectedBlue: 0f);
+        });
+    }
+
+    [Test]
+    public void DrawRectangle_FillsRegionWithBrushColor()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(16, 16);
+            Assert.That(target, Is.Not.Null);
+
+            using (var canvas = new ImmediateCanvas(target!))
+            {
+                canvas.Clear(Colors.Black);
+                canvas.DrawRectangle(new Rect(0, 0, 16, 16), Brushes.Resource.Lime, pen: null);
+            }
+
+            using var snapshot = target!.Snapshot();
+            AssertEveryPixelMatches(snapshot, expectedRed: 0f, expectedGreen: 1f, expectedBlue: 0f);
+        });
+    }
+
+    [Test]
+    public void Clear_OnSubregion_DoesNotAffectClippedAway()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(16, 16);
+            Assert.That(target, Is.Not.Null);
+
+            using (var canvas = new ImmediateCanvas(target!))
+            {
+                canvas.Clear(Colors.Black);
+                using (canvas.PushClip(new Rect(0, 0, 8, 16)))
+                {
+                    canvas.Clear(Colors.White);
+                }
+            }
+
+            using var snapshot = target!.Snapshot();
+            // Linear sRGB: white -> 1, black -> 0
+            AssertHalfPixelMatches(snapshot, x: 2, y: 8, expectedRed: 1f, expectedGreen: 1f, expectedBlue: 1f);
+            AssertHalfPixelMatches(snapshot, x: 12, y: 8, expectedRed: 0f, expectedGreen: 0f, expectedBlue: 0f);
+        });
+    }
+
+    private static void AssertEveryPixelMatches(Bitmap snapshot, float expectedRed, float expectedGreen, float expectedBlue)
+    {
+        // RgbaF16 は 4ch×2byte のハーフフロート。SnapshotはLinearSrgb。
+        Assert.That(snapshot.ColorType, Is.EqualTo(BitmapColorType.RgbaF16));
+        Assert.That(snapshot.ColorSpace, Is.EqualTo(BitmapColorSpace.LinearSrgb));
+
+        var span = snapshot.GetPixelSpan();
+        for (int i = 0; i < span.Length; i += 8)
+        {
+            float r = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(span.Slice(i, 2)));
+            float g = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(span.Slice(i + 2, 2)));
+            float b = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(span.Slice(i + 4, 2)));
+
+            Assert.That(r, Is.EqualTo(expectedRed).Within(0.01f), $"R mismatch at byte offset {i}");
+            Assert.That(g, Is.EqualTo(expectedGreen).Within(0.01f), $"G mismatch at byte offset {i}");
+            Assert.That(b, Is.EqualTo(expectedBlue).Within(0.01f), $"B mismatch at byte offset {i}");
+        }
+    }
+
+    private static void AssertHalfPixelMatches(Bitmap snapshot, int x, int y, float expectedRed, float expectedGreen, float expectedBlue)
+    {
+        int rowBytes = snapshot.RowBytes;
+        var row = snapshot.GetRow(y);
+        int offset = x * 8;
+        float r = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(row.Slice(offset, 2)));
+        float g = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(row.Slice(offset + 2, 2)));
+        float b = (float)BitConverter.UInt16BitsToHalf(BitConverter.ToUInt16(row.Slice(offset + 4, 2)));
+
+        Assert.That(r, Is.EqualTo(expectedRed).Within(0.01f), $"R mismatch at ({x},{y})");
+        Assert.That(g, Is.EqualTo(expectedGreen).Within(0.01f), $"G mismatch at ({x},{y})");
+        Assert.That(b, Is.EqualTo(expectedBlue).Within(0.01f), $"B mismatch at ({x},{y})");
+        _ = rowBytes;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/ImmediateCanvasVulkanTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/ImmediateCanvasVulkanTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/PixelSortEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/PixelSortEffectTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Rendering;

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/PixelSortEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/PixelSortEffectTests.cs
@@ -1,0 +1,108 @@
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+/// <summary>
+/// <see cref="PixelSortEffect"/> は内部的に GLSL シェーダー 3 パスを使う Vulkan 専用パス。
+/// FilterEffectActivator 経由で実行できることを確認する。
+/// </summary>
+[NonParallelizable]
+public class PixelSortEffectTests
+{
+    [Test]
+    public void ApplyTo_HorizontalLuminance_ReplacesTargetWithSortedOutput()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var sourceRenderTarget = CreateGradientTarget(16, 16);
+            Assume.That(sourceRenderTarget, Is.Not.Null);
+
+            var bounds = new Rect(0, 0, 16, 16);
+            using var targets = new EffectTargets
+            {
+                new EffectTarget(sourceRenderTarget!, bounds),
+            };
+
+            using var feCtx = new FilterEffectContext(bounds);
+            var effect = new PixelSortEffect();
+            effect.Direction.CurrentValue = PixelSortDirection.Horizontal;
+            effect.SortKey.CurrentValue = PixelSortKey.Luminance;
+            effect.ThresholdMin.CurrentValue = 0f;
+            effect.ThresholdMax.CurrentValue = 100f;
+            effect.Ascending.CurrentValue = true;
+
+            var resource = (FilterEffect.Resource)(object)effect.ToResource(new CompositionContext(TimeSpan.Zero));
+            effect.ApplyTo(feCtx, resource);
+
+            using var builder = new SKImageFilterBuilder();
+            using var activator = new FilterEffectActivator(targets, builder);
+            activator.Apply(feCtx);
+            activator.Flush(false);
+
+            // Apply 後はソート結果のターゲットに置換されている
+            Assert.That(targets.Count, Is.EqualTo(1));
+            Assert.That(targets[0].RenderTarget, Is.Not.Null);
+            Assert.That(targets[0].RenderTarget!.Width, Is.EqualTo(16));
+            Assert.That(targets[0].RenderTarget!.Height, Is.EqualTo(16));
+        });
+    }
+
+    [Test]
+    public void ApplyTo_VerticalSaturation_DoesNotThrow()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var sourceRenderTarget = CreateGradientTarget(8, 8);
+            Assume.That(sourceRenderTarget, Is.Not.Null);
+
+            var bounds = new Rect(0, 0, 8, 8);
+            using var targets = new EffectTargets
+            {
+                new EffectTarget(sourceRenderTarget!, bounds),
+            };
+
+            using var feCtx = new FilterEffectContext(bounds);
+            var effect = new PixelSortEffect();
+            effect.Direction.CurrentValue = PixelSortDirection.Vertical;
+            effect.SortKey.CurrentValue = PixelSortKey.Saturation;
+            effect.Ascending.CurrentValue = false;
+
+            var resource = (FilterEffect.Resource)(object)effect.ToResource(new CompositionContext(TimeSpan.Zero));
+            effect.ApplyTo(feCtx, resource);
+
+            using var builder = new SKImageFilterBuilder();
+            using var activator = new FilterEffectActivator(targets, builder);
+            Assert.DoesNotThrow(() => activator.Apply(feCtx));
+            Assert.DoesNotThrow(() => activator.Flush(false));
+        });
+    }
+
+    private static RenderTarget? CreateGradientTarget(int width, int height)
+    {
+        var target = RenderTarget.Create(width, height);
+        if (target == null) return null;
+
+        using (var canvas = new ImmediateCanvas(target))
+        {
+            canvas.Clear(Colors.Black);
+            // 水平方向に明度勾配
+            for (int x = 0; x < width; x++)
+            {
+                byte v = (byte)(255 * x / Math.Max(1, width - 1));
+                var brush = new SolidColorBrush(new Color(255, v, v, v));
+                var brushResource = (SolidColorBrush.Resource)(object)brush.ToResource(new CompositionContext(TimeSpan.Zero));
+                canvas.DrawRectangle(new Rect(x, 0, 1, height), brushResource, pen: null);
+            }
+        }
+
+        return target;
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/RenderTargetVulkanTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/RenderTargetVulkanTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics.Rendering;
+﻿using Beutl.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Graphics.Backend;
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/RenderTargetVulkanTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/RenderTargetVulkanTests.cs
@@ -1,0 +1,59 @@
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+[NonParallelizable]
+public class RenderTargetVulkanTests
+{
+    [Test]
+    public void Create_OnRenderThread_UsesGraphicsContext()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(64, 64);
+
+            Assert.That(target, Is.Not.Null);
+            Assert.That(target!.Width, Is.EqualTo(64));
+            Assert.That(target.Height, Is.EqualTo(64));
+            Assert.That(target.IsDisposed, Is.False);
+        });
+    }
+
+    [Test]
+    public void Create_Snapshot_ProducesSizedBitmap()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(16, 8);
+            Assume.That(target, Is.Not.Null);
+
+            using var bitmap = target!.Snapshot();
+
+            Assert.That(bitmap.Width, Is.EqualTo(16));
+            Assert.That(bitmap.Height, Is.EqualTo(8));
+        });
+    }
+
+    [Test]
+    public void ShallowCopy_SharesUnderlyingResource()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var target = RenderTarget.Create(32, 32);
+            Assume.That(target, Is.Not.Null);
+
+            using var copy = target!.ShallowCopy();
+
+            Assert.That(copy, Is.Not.SameAs(target));
+            Assert.That(copy.Width, Is.EqualTo(target.Width));
+            Assert.That(copy.Height, Is.EqualTo(target.Height));
+            Assert.That(copy.IsDisposed, Is.False);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/VulkanTestEnvironment.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/VulkanTestEnvironment.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics.Backend;
+﻿using Beutl.Graphics.Backend;
 using Beutl.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Graphics.Backend;

--- a/tests/Beutl.UnitTests/Engine/Graphics/Backend/VulkanTestEnvironment.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Backend/VulkanTestEnvironment.cs
@@ -1,0 +1,76 @@
+using Beutl.Graphics.Backend;
+using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Backend;
+
+/// <summary>
+/// Vulkan を必要とする単体テスト用の共有初期化ヘルパー。
+/// SwiftShader/MoltenVK が利用可能ならテストを通し、利用不可なら <see cref="Assert.Ignore"/> を呼んでスキップする。
+/// </summary>
+internal static class VulkanTestEnvironment
+{
+    private static readonly object s_lock = new();
+    private static bool s_initialized;
+    private static bool s_isAvailable;
+    private static string? s_unavailableReason;
+
+    public static IGraphicsContext SharedContext { get; private set; } = null!;
+
+    /// <summary>
+    /// Vulkan を必要とするテストの先頭で呼び出す。利用できなければ <see cref="Assert.Ignore"/> を投げてスキップする。
+    /// </summary>
+    public static IGraphicsContext EnsureAvailable()
+    {
+        EnsureInitialized();
+
+        if (!s_isAvailable)
+        {
+            Assert.Ignore(s_unavailableReason ?? "Vulkan is unavailable on this environment.");
+        }
+
+        return SharedContext;
+    }
+
+    /// <summary>
+    /// 共有 Vulkan コンテキストを初期化済みにする。スレッド競合を避けるため最初の呼び出しのみが実初期化を行う。
+    /// </summary>
+    public static void EnsureInitialized()
+    {
+        if (s_initialized) return;
+
+        lock (s_lock)
+        {
+            if (s_initialized) return;
+
+            try
+            {
+                SharedContext = RenderThread.Dispatcher.Invoke(GraphicsContextFactory.GetOrCreateShared)!;
+                if (SharedContext == null)
+                {
+                    s_isAvailable = false;
+                    s_unavailableReason = "GraphicsContextFactory.GetOrCreateShared returned null. "
+                        + "Vulkan/MoltenVK が初期化できない環境です。";
+                }
+                else
+                {
+                    s_isAvailable = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                s_isAvailable = false;
+                s_unavailableReason = $"Vulkan initialization threw: {ex.GetType().Name}: {ex.Message}";
+            }
+            finally
+            {
+                s_initialized = true;
+            }
+        }
+    }
+
+    public static T InvokeOnRenderThread<T>(Func<T> func)
+        => RenderThread.Dispatcher.Invoke(func);
+
+    public static void InvokeOnRenderThread(Action action)
+        => RenderThread.Dispatcher.Invoke(action);
+}

--- a/tests/Beutl.UnitTests/Engine/JsonConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/JsonConvertersTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class TypeJsonConvertersTests
+{
+    private static T RoundTrip<T>(T value)
+    {
+        string json = JsonSerializer.Serialize(value);
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+
+    [Test]
+    public void PointJsonConverter_RoundTrips()
+    {
+        var p = new Point(1.5f, -2.25f);
+        Assert.That(RoundTrip(p), Is.EqualTo(p));
+    }
+
+    [Test]
+    public void PointJsonConverter_WritesString()
+    {
+        string json = JsonSerializer.Serialize(new Point(1.5f, 2f));
+        Assert.That(json, Does.StartWith("\""));
+        Assert.That(json, Does.EndWith("\""));
+    }
+
+    [Test]
+    public void RectJsonConverter_RoundTrips()
+    {
+        var r = new Rect(1, 2, 3, 4);
+        Assert.That(RoundTrip(r), Is.EqualTo(r));
+    }
+
+    [Test]
+    public void SizeJsonConverter_RoundTrips()
+    {
+        var s = new Size(3, 4);
+        Assert.That(RoundTrip(s), Is.EqualTo(s));
+    }
+
+    [Test]
+    public void VectorJsonConverter_RoundTrips()
+    {
+        var v = new Vector(2.5f, 3.5f);
+        var result = RoundTrip(v);
+        Assert.That(result.X, Is.EqualTo(v.X));
+        Assert.That(result.Y, Is.EqualTo(v.Y));
+    }
+
+    [Test]
+    public void ThicknessJsonConverter_RoundTrips()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        Assert.That(RoundTrip(t), Is.EqualTo(t));
+    }
+
+    [Test]
+    public void RelativePointJsonConverter_RoundTrips()
+    {
+        var p = RelativePoint.Parse("0.5,0.5");
+        Assert.That(RoundTrip(p), Is.EqualTo(p));
+    }
+
+    [Test]
+    public void RelativeRectJsonConverter_RoundTrips()
+    {
+        var r = RelativeRect.Parse("0%,0%,100%,100%");
+        Assert.That(RoundTrip(r), Is.EqualTo(r));
+    }
+
+    [Test]
+    public void PixelPointJsonConverter_RoundTrips()
+    {
+        var p = new PixelPoint(3, 4);
+        Assert.That(RoundTrip(p), Is.EqualTo(p));
+    }
+
+    [Test]
+    public void PixelRectJsonConverter_RoundTrips()
+    {
+        var r = new PixelRect(1, 2, 3, 4);
+        Assert.That(RoundTrip(r), Is.EqualTo(r));
+    }
+
+    [Test]
+    public void PixelSizeJsonConverter_RoundTrips()
+    {
+        var s = new PixelSize(3, 4);
+        Assert.That(RoundTrip(s), Is.EqualTo(s));
+    }
+
+    [Test]
+    public void ColorJsonConverter_RoundTrips()
+    {
+        var c = Color.FromArgb(255, 100, 50, 25);
+        Assert.That(RoundTrip(c), Is.EqualTo(c));
+    }
+
+    [Test]
+    public void GradingColorJsonConverter_RoundTrips()
+    {
+        var c = new GradingColor(0.1f, 0.5f, 0.9f);
+        Assert.That(RoundTrip(c), Is.EqualTo(c));
+    }
+
+    [Test]
+    public void CornerRadiusJsonConverter_RoundTrips()
+    {
+        var cr = new CornerRadius(1, 2, 3, 4);
+        Assert.That(RoundTrip(cr), Is.EqualTo(cr));
+    }
+
+    [Test]
+    public void MatrixJsonConverter_RoundTrips_Identity()
+    {
+        var m = Matrix.Identity;
+        Assert.That(RoundTrip(m), Is.EqualTo(m));
+    }
+
+    [Test]
+    public void MatrixJsonConverter_RoundTrips_Scale()
+    {
+        var m = Matrix.CreateScale(2, 3);
+        Assert.That(RoundTrip(m), Is.EqualTo(m));
+    }
+
+    [Test]
+    public void CurveControlPointJsonConverter_RoundTrips()
+    {
+        var p = new CurveControlPoint(0.5f, 0.5f);
+        var result = RoundTrip(p);
+        Assert.That(result.Point, Is.EqualTo(p.Point));
+        Assert.That(result.LeftHandle, Is.EqualTo(p.LeftHandle));
+        Assert.That(result.RightHandle, Is.EqualTo(p.RightHandle));
+    }
+
+    [Test]
+    public void CurveMapJsonConverter_RoundTripsDefaultMap()
+    {
+        var map = CurveMap.Default;
+        var result = RoundTrip(map);
+        Assert.That(result, Is.EqualTo(map));
+    }
+
+    [Test]
+    public void FontFamilyJsonConverter_RoundTrips()
+    {
+        var family = new FontFamily("Arial");
+        var result = RoundTrip(family);
+        Assert.That(result.Name, Is.EqualTo(family.Name));
+    }
+
+    [Test]
+    public void FontFamilyJsonConverter_WritesAsString()
+    {
+        var family = new FontFamily("Arial");
+        string json = JsonSerializer.Serialize(family);
+        Assert.That(json, Is.EqualTo("\"Arial\""));
+    }
+
+    [Test]
+    public void TypefaceJsonConverter_RoundTrips()
+    {
+        var typeface = new Typeface(new FontFamily("Arial"), FontStyle.Italic, FontWeight.Bold);
+        var result = RoundTrip(typeface);
+        Assert.That(result, Is.EqualTo(typeface));
+    }
+
+    [Test]
+    public void TypefaceJsonConverter_WriteStructure()
+    {
+        var typeface = new Typeface(new FontFamily("Arial"), FontStyle.Italic, FontWeight.Bold);
+        string json = JsonSerializer.Serialize(typeface);
+        Assert.That(json, Does.Contain("fontfamily"));
+        Assert.That(json, Does.Contain("Arial"));
+        Assert.That(json, Does.Contain("weight"));
+        Assert.That(json, Does.Contain("style"));
+    }
+
+    [Test]
+    public void TypefaceJsonConverter_DeserializesWithDefaults_WhenWeightAndStyleOmitted()
+    {
+        const string json = "{\"fontfamily\":\"Arial\"}";
+        var result = JsonSerializer.Deserialize<Typeface>(json);
+        Assert.That(result.FontFamily.Name, Is.EqualTo("Arial"));
+        Assert.That(result.Weight, Is.EqualTo(FontWeight.Regular));
+        Assert.That(result.Style, Is.EqualTo(FontStyle.Normal));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/JsonConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/JsonConvertersTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/ListPropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ListPropertyTests.cs
@@ -1,0 +1,176 @@
+using Beutl.Composition;
+using Beutl.Engine;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class ListPropertyTests
+{
+    private static ListProperty<T> Make<T>(string name = "Items")
+    {
+        var property = new ListProperty<T>();
+        property.SetAttributes(name, []);
+        return property;
+    }
+
+    [Test]
+    public void Defaults_AreReportedCorrectly()
+    {
+        var property = Make<int>();
+
+        Assert.That(property.IsAnimatable, Is.False);
+        Assert.That(property.SupportsExpression, Is.False);
+        Assert.That(property.HasLocalValue, Is.True);
+        Assert.That(property.HasExpression, Is.False);
+        Assert.That(property.HasValidator, Is.False);
+        Assert.That(property.ElementType, Is.EqualTo(typeof(int)));
+        Assert.That(property.ValueType.GetGenericTypeDefinition(), Is.EqualTo(typeof(Beutl.Collections.ICoreList<>)));
+        Assert.That(property.DefaultValue, Is.Null);
+    }
+
+    [Test]
+    public void Add_RaisesEdited()
+    {
+        var property = Make<int>();
+        int edited = 0;
+        property.Edited += (_, _) => edited++;
+
+        property.Add(1);
+        property.Add(2);
+
+        Assert.That(property.Count, Is.EqualTo(2));
+        Assert.That(edited, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Remove_AffectsCount()
+    {
+        var property = Make<int>();
+        property.AddRange([1, 2, 3]);
+
+        bool removed = property.Remove(2);
+
+        Assert.That(removed, Is.True);
+        Assert.That(property, Is.EqualTo(new[] { 1, 3 }));
+    }
+
+    [Test]
+    public void Replace_KeepsSameInstance()
+    {
+        var property = Make<int>();
+        var originalRef = property.CurrentValue;
+        property.AddRange([1, 2, 3]);
+
+        property.Replace([10, 20]);
+
+        Assert.That(property.CurrentValue, Is.SameAs(originalRef));
+        Assert.That(property, Is.EqualTo(new[] { 10, 20 }));
+    }
+
+    [Test]
+    public void Indexer_AssignmentReplacesValue()
+    {
+        var property = Make<int>();
+        property.AddRange([1, 2, 3]);
+
+        property[1] = 99;
+
+        Assert.That(property[1], Is.EqualTo(99));
+    }
+
+    [Test]
+    public void Insert_PlacesValueAtIndex()
+    {
+        var property = Make<int>();
+        property.AddRange([1, 3]);
+
+        property.Insert(1, 2);
+
+        Assert.That(property, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void Animation_AlwaysNullAndAcceptsAnyAssignment()
+    {
+        var property = Make<int>();
+
+        Assert.That(property.Animation, Is.Null);
+        Assert.DoesNotThrow(() => property.Animation = null);
+    }
+
+    [Test]
+    public void Expression_AlwaysNullAndSilentSet()
+    {
+        var property = Make<int>();
+
+        Assert.That(property.Expression, Is.Null);
+        Assert.DoesNotThrow(() => property.Expression = null);
+    }
+
+    [Test]
+    public void GetValue_ReturnsCurrentValueInstance()
+    {
+        var property = Make<int>();
+        property.Add(7);
+
+        var value = property.GetValue(CompositionContext.Default);
+
+        Assert.That(value, Is.SameAs(property.CurrentValue));
+    }
+
+    [Test]
+    public void Name_BeforeInitialization_Throws()
+    {
+        var property = new ListProperty<int>();
+
+        Assert.Throws<InvalidOperationException>(() => _ = property.Name);
+    }
+
+    [Test]
+    public void GetEnumerator_AndContains_WorkOnUnderlyingList()
+    {
+        var property = Make<string>();
+        property.AddRange(["a", "b"]);
+
+        Assert.That(property.Contains("a"), Is.True);
+        Assert.That(property.IndexOf("b"), Is.EqualTo(1));
+
+        var seen = new List<string>();
+        foreach (var item in property)
+        {
+            seen.Add(item);
+        }
+
+        Assert.That(seen, Is.EqualTo(new[] { "a", "b" }));
+    }
+
+    [Test]
+    public void CompoundAssign_ReplacesContents()
+    {
+        var property = Make<int>();
+        property.AddRange([1, 2]);
+
+        property <<= new Beutl.Collections.CoreList<int>([9, 8, 7]);
+
+        Assert.That(property, Is.EqualTo(new[] { 9, 8, 7 }));
+    }
+
+    [Test]
+    public void Clear_RemovesAll()
+    {
+        var property = Make<int>();
+        property.AddRange([1, 2, 3]);
+
+        ((Beutl.Collections.ICoreList<int>)property).Clear();
+
+        Assert.That(property.Count, Is.Zero);
+    }
+
+    [Test]
+    public void SerializeExpression_IsNull()
+    {
+        var property = Make<int>();
+
+        Assert.That(property.SerializeExpression(), Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/ListPropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ListPropertyTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Engine;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/LookupTableTests.cs
+++ b/tests/Beutl.UnitTests/Engine/LookupTableTests.cs
@@ -1,0 +1,220 @@
+#pragma warning disable CS0618 // Type or member is obsolete
+
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class LookupTableTests
+{
+    [Test]
+    public void Linear_FillsIdentityRamp()
+    {
+        var data = new byte[256];
+        LookupTable.Linear(data);
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(data[i], Is.EqualTo((byte)i));
+        }
+    }
+
+    [Test]
+    public void Linear_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Linear(new byte[10]));
+    }
+
+    [Test]
+    public void Invert_ReversesRamp()
+    {
+        var data = new byte[256];
+        LookupTable.Invert(data);
+
+        Assert.That(data[0], Is.EqualTo((byte)255));
+        Assert.That(data[255], Is.EqualTo((byte)0));
+        Assert.That(data[128], Is.EqualTo((byte)127));
+    }
+
+    [Test]
+    public void Invert_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Invert(new byte[10]));
+    }
+
+    [Test]
+    public void SetStrength_OneIsNoOp()
+    {
+        var data = new byte[256];
+        LookupTable.Invert(data);
+        var copy = (byte[])data.Clone();
+
+        LookupTable.SetStrength(1f, data);
+
+        Assert.That(data, Is.EqualTo(copy));
+    }
+
+    [Test]
+    public void SetStrength_ZeroBlendsToIdentity()
+    {
+        var data = new byte[256];
+        LookupTable.Invert(data);
+
+        LookupTable.SetStrength(0f, data);
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(data[i], Is.EqualTo((byte)i));
+        }
+    }
+
+    [Test]
+    public void SetStrength_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.SetStrength(0.5f, new byte[10]));
+    }
+
+    [Test]
+    public void SetStrengthArgb_ZeroBlendsAllToIdentity()
+    {
+        var a = new byte[256];
+        var r = new byte[256];
+        var g = new byte[256];
+        var b = new byte[256];
+        LookupTable.Invert(a);
+        LookupTable.Invert(r);
+        LookupTable.Invert(g);
+        LookupTable.Invert(b);
+
+        LookupTable.SetStrength(0f, (a, r, g, b));
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(a[i], Is.EqualTo((byte)i));
+            Assert.That(b[i], Is.EqualTo((byte)i));
+        }
+    }
+
+    [Test]
+    public void Solarisation_ProducesValidByteRange()
+    {
+        var data = new byte[256];
+        LookupTable.Solarisation(data);
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(data[i], Is.InRange((byte)0, (byte)255));
+        }
+    }
+
+    [Test]
+    public void Negaposi_DefaultIs255MinusIndex()
+    {
+        var data = new byte[256];
+        LookupTable.Negaposi(data);
+
+        Assert.That(data[0], Is.EqualTo((byte)255));
+        Assert.That(data[255], Is.EqualTo((byte)0));
+    }
+
+    [Test]
+    public void Negaposi_WithCustomValue()
+    {
+        var data = new byte[256];
+        LookupTable.Negaposi(data, 200);
+
+        Assert.That(data[0], Is.EqualTo((byte)200));
+    }
+
+    [Test]
+    public void Negaposi_RGB_AppliesPerChannel()
+    {
+        var r = new byte[256];
+        var g = new byte[256];
+        var b = new byte[256];
+
+        LookupTable.Negaposi((r, g, b), 200, 150, 100);
+
+        Assert.That(r[0], Is.EqualTo((byte)200));
+        Assert.That(g[0], Is.EqualTo((byte)150));
+        Assert.That(b[0], Is.EqualTo((byte)100));
+    }
+
+    [Test]
+    public void Negaposi_RGB_SameValueOptimizationProducesIdenticalChannels()
+    {
+        var r = new byte[256];
+        var g = new byte[256];
+        var b = new byte[256];
+
+        LookupTable.Negaposi((r, g, b), 255, 255, 255);
+
+        Assert.That(g, Is.EqualTo(r));
+        Assert.That(b, Is.EqualTo(r));
+    }
+
+    [Test]
+    public void Contrast_ZeroProducesIdentity()
+    {
+        var data = new byte[256];
+        LookupTable.Contrast(data, 0);
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(data[i], Is.EqualTo((byte)i));
+        }
+    }
+
+    [Test]
+    public void Contrast_ClampsRange()
+    {
+        var data = new byte[256];
+        LookupTable.Contrast(data, 1000);
+
+        Assert.That(data[0], Is.EqualTo((byte)0));
+        Assert.That(data[255], Is.EqualTo((byte)255));
+    }
+
+    [Test]
+    public void Gamma_OneIsIdentity()
+    {
+        var data = new byte[256];
+        LookupTable.Gamma(data, 1f);
+
+        for (int i = 0; i < 256; i++)
+        {
+            Assert.That(data[i], Is.EqualTo((byte)i).Within((byte)1));
+        }
+    }
+
+    [Test]
+    public void Gamma_ClampsBelowMin()
+    {
+        var data = new byte[256];
+        Assert.DoesNotThrow(() => LookupTable.Gamma(data, 0f));
+    }
+
+    [Test]
+    public void Solarisation_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Solarisation(new byte[10]));
+    }
+
+    [Test]
+    public void Negaposi_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Negaposi(new byte[10]));
+    }
+
+    [Test]
+    public void Contrast_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Contrast(new byte[10], 0));
+    }
+
+    [Test]
+    public void Gamma_ThrowsOnWrongSize()
+    {
+        Assert.Throws<ArgumentException>(() => LookupTable.Gamma(new byte[10], 1f));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/LookupTableTests.cs
+++ b/tests/Beutl.UnitTests/Engine/LookupTableTests.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // Type or member is obsolete
+﻿#pragma warning disable CS0618 // Type or member is obsolete
 
 using Beutl.Graphics;
 

--- a/tests/Beutl.UnitTests/Engine/MatrixTests.cs
+++ b/tests/Beutl.UnitTests/Engine/MatrixTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/MatrixTests.cs
+++ b/tests/Beutl.UnitTests/Engine/MatrixTests.cs
@@ -1,0 +1,189 @@
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class MatrixTests
+{
+    [Test]
+    public void Identity_IsIdentityMatrix()
+    {
+        Matrix id = Matrix.Identity;
+        Assert.That(id.IsIdentity, Is.True);
+        Assert.That(id.M11, Is.EqualTo(1));
+        Assert.That(id.M22, Is.EqualTo(1));
+        Assert.That(id.M33, Is.EqualTo(1));
+        Assert.That(id.M12, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void CreateTranslation_AppliesOffset()
+    {
+        Matrix t = Matrix.CreateTranslation(5, 10);
+        Point p = t.Transform(new Point(1, 2));
+        Assert.That(p, Is.EqualTo(new Point(6, 12)));
+    }
+
+    [Test]
+    public void CreateTranslation_FromVector_Equivalent()
+    {
+        Matrix vec = Matrix.CreateTranslation(new Vector(3, 4));
+        Matrix scalar = Matrix.CreateTranslation(3, 4);
+        Assert.That(vec, Is.EqualTo(scalar));
+    }
+
+    [Test]
+    public void CreateScale_DoublesPointDistance()
+    {
+        Matrix s = Matrix.CreateScale(2, 3);
+        Assert.That(s.Transform(new Point(1, 1)), Is.EqualTo(new Point(2, 3)));
+
+        Matrix sv = Matrix.CreateScale(new Vector(2, 3));
+        Assert.That(sv, Is.EqualTo(s));
+    }
+
+    [Test]
+    public void CreateRotation_RotatesUnitVectors()
+    {
+        Matrix r = Matrix.CreateRotation(MathF.PI / 2f);
+        Point rotated = r.Transform(new Point(1, 0));
+        Assert.That(rotated.X, Is.EqualTo(0).Within(1e-5f));
+        Assert.That(rotated.Y, Is.EqualTo(1).Within(1e-5f));
+    }
+
+    [Test]
+    public void CreateSkew_PerformsShear()
+    {
+        Matrix sk = Matrix.CreateSkew(MathF.PI / 4f, 0);
+        Point p = sk.Transform(new Point(0, 1));
+        Assert.That(p.X, Is.EqualTo(1).Within(1e-5f));
+        Assert.That(p.Y, Is.EqualTo(1).Within(1e-5f));
+    }
+
+    [Test]
+    public void Multiplication_Composes_AppendAndPrepend()
+    {
+        Matrix a = Matrix.CreateTranslation(1, 0);
+        Matrix b = Matrix.CreateTranslation(0, 1);
+
+        Matrix appended = a.Append(b);
+        Matrix prepended = a.Prepend(b);
+
+        Assert.That(appended, Is.EqualTo(a * b));
+        Assert.That(prepended, Is.EqualTo(b * a));
+    }
+
+    [Test]
+    public void GetDeterminant_Identity_IsOne()
+    {
+        Assert.That(Matrix.Identity.GetDeterminant(), Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void HasInverse_True_ForIdentity_AndScale()
+    {
+        Assert.That(Matrix.Identity.HasInverse, Is.True);
+        Assert.That(Matrix.CreateScale(2, 2).HasInverse, Is.True);
+    }
+
+    [Test]
+    public void HasInverse_False_ForZeroDeterminant()
+    {
+        var degenerate = new Matrix(0, 0, 0, 0, 0, 0);
+        Assert.That(degenerate.HasInverse, Is.False);
+        Assert.That(degenerate.TryInvert(out _), Is.False);
+        Assert.That(() => degenerate.Invert(), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void Invert_RoundTripsThroughIdentity()
+    {
+        Matrix t = Matrix.CreateTranslation(5, 10) * Matrix.CreateScale(2, 4);
+        Matrix inv = t.Invert();
+        Matrix product = t * inv;
+
+        Assert.That(product.M11, Is.EqualTo(1).Within(1e-4f));
+        Assert.That(product.M22, Is.EqualTo(1).Within(1e-4f));
+        Assert.That(product.M31, Is.EqualTo(0).Within(1e-4f));
+        Assert.That(product.M32, Is.EqualTo(0).Within(1e-4f));
+    }
+
+    [Test]
+    public void NegationOperator_ReturnsInverse()
+    {
+        Matrix t = Matrix.CreateTranslation(2, 3);
+        Matrix inv = -t;
+        Assert.That((t * inv).M31, Is.EqualTo(0).Within(1e-5f));
+        Assert.That((t * inv).M32, Is.EqualTo(0).Within(1e-5f));
+    }
+
+    [Test]
+    public void Equality_ComparesAllNine()
+    {
+        Matrix a = Matrix.CreateScale(2, 3);
+        Matrix b = Matrix.CreateScale(2, 3);
+        Matrix c = Matrix.CreateScale(2, 4);
+
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void TryDecompose_AffineMatrix_ReturnsTrue()
+    {
+        Matrix m = Matrix.CreateScale(2, 3) * Matrix.CreateTranslation(5, 6);
+
+        Assert.That(m.TryDecomposeTransform(out Vector translate, out Vector scale, out _, out _), Is.True);
+        Assert.That(translate.X, Is.EqualTo(5).Within(1e-4f));
+        Assert.That(translate.Y, Is.EqualTo(6).Within(1e-4f));
+        Assert.That(scale.X, Is.EqualTo(2).Within(1e-4f));
+        Assert.That(scale.Y, Is.EqualTo(3).Within(1e-4f));
+    }
+
+    [Test]
+    public void TryDecompose_PerspectiveMatrix_ReturnsFalse()
+    {
+        var perspective = new Matrix(1, 0, 0.01f, 0, 1, 0, 0, 0, 1);
+        Assert.That(perspective.TryDecomposeTransform(out _, out _, out _, out _), Is.False);
+    }
+
+    [Test]
+    public void ComposeTransform_RoundTripsTranslation()
+    {
+        Matrix m = Matrix.ComposeTransform(new Vector(5, 6), Vector.One, Vector.Zero, 0);
+        Assert.That(m.M31, Is.EqualTo(5).Within(1e-5f));
+        Assert.That(m.M32, Is.EqualTo(6).Within(1e-5f));
+    }
+
+    [Test]
+    public void ToString_NonPerspective_UsesShortForm()
+    {
+        Matrix m = Matrix.CreateTranslation(2, 3);
+        string s = m.ToString();
+        Assert.That(s, Does.StartWith("matrix("));
+        Assert.That(s.Split(',').Length, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void ToString_Perspective_UsesNineValueForm()
+    {
+        var m = new Matrix(1, 0, 0.5f, 0, 1, 0, 0, 0, 1);
+        string s = m.ToString();
+        Assert.That(s.Split(',').Length, Is.EqualTo(9));
+    }
+
+    [Test]
+    public void Parse_NonPerspective_FromString()
+    {
+        Matrix m = Matrix.Parse("matrix(1, 0, 0, 1, 5, 6)");
+        Assert.That(m, Is.EqualTo(Matrix.CreateTranslation(5, 6)));
+    }
+
+    [Test]
+    public void TryParse_InvalidString_ReturnsFalse()
+    {
+        Assert.That(Matrix.TryParse("not a matrix", out _), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/MediaExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/MediaExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/MediaExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/Engine/MediaExtensionsTests.cs
@@ -1,0 +1,88 @@
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class MediaExtensionsTests
+{
+    [Test]
+    public void CalculateScaling_None_IsIdentity()
+    {
+        var scale = Stretch.None.CalculateScaling(new Size(100, 100), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(1f));
+        Assert.That(scale.Y, Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void CalculateScaling_Fill_DistinctScales()
+    {
+        var scale = Stretch.Fill.CalculateScaling(new Size(200, 100), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(4f));
+        Assert.That(scale.Y, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void CalculateScaling_Uniform_PicksMin()
+    {
+        var scale = Stretch.Uniform.CalculateScaling(new Size(200, 100), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(2f));
+        Assert.That(scale.Y, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void CalculateScaling_UniformToFill_PicksMax()
+    {
+        var scale = Stretch.UniformToFill.CalculateScaling(new Size(200, 100), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(4f));
+        Assert.That(scale.Y, Is.EqualTo(4f));
+    }
+
+    [Test]
+    public void CalculateScaling_UpOnly_PreventsShrink()
+    {
+        var scale = Stretch.Fill.CalculateScaling(new Size(50, 25), new Size(100, 100), StretchDirection.UpOnly);
+        Assert.That(scale.X, Is.EqualTo(1f));
+        Assert.That(scale.Y, Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void CalculateScaling_DownOnly_PreventsGrow()
+    {
+        var scale = Stretch.Fill.CalculateScaling(new Size(200, 200), new Size(100, 100), StretchDirection.DownOnly);
+        Assert.That(scale.X, Is.EqualTo(1f));
+        Assert.That(scale.Y, Is.EqualTo(1f));
+    }
+
+    [Test]
+    public void CalculateScaling_ZeroSourceSize_ProducesZeroScale()
+    {
+        var scale = Stretch.Fill.CalculateScaling(new Size(100, 100), new Size(0, 0));
+        Assert.That(scale.X, Is.EqualTo(0f));
+        Assert.That(scale.Y, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void CalculateScaling_UnconstrainedWidth_PropagatesY()
+    {
+        var scale = Stretch.Uniform.CalculateScaling(new Size(float.PositiveInfinity, 100), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(scale.Y));
+        Assert.That(scale.Y, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void CalculateScaling_UnconstrainedHeight_PropagatesX()
+    {
+        var scale = Stretch.Uniform.CalculateScaling(new Size(200, float.PositiveInfinity), new Size(50, 50));
+        Assert.That(scale.X, Is.EqualTo(scale.Y));
+        Assert.That(scale.X, Is.EqualTo(4f));
+    }
+
+    [Test]
+    public void CalculateSize_StretchedSourceMatchesScaling()
+    {
+        var size = Stretch.Uniform.CalculateSize(new Size(200, 100), new Size(50, 50));
+        Assert.That(size.Width, Is.EqualTo(100f));
+        Assert.That(size.Height, Is.EqualTo(100f));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelPointConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelPointConverterTests.cs
@@ -1,0 +1,162 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PixelPointConverterTests
+{
+    private readonly PixelPointConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(int[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<int, int>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertTo_UnknownTarget_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(DateTime)), Is.False);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(int[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<int, int>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_UnknownSource_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(DateTime)), Is.False);
+    }
+
+    [Test]
+    public void ConvertTo_IntArray_ReturnsXY()
+    {
+        var p = new PixelPoint(3, 4);
+        int[] result = (int[])_converter.ConvertTo(null, null, p, typeof(int[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 3, 4 }));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple_ReturnsXY()
+    {
+        var p = new PixelPoint(7, 8);
+        var result = (Tuple<int, int>)_converter.ConvertTo(null, null, p, typeof(Tuple<int, int>))!;
+        Assert.That(result, Is.EqualTo(new Tuple<int, int>(7, 8)));
+    }
+
+    [Test]
+    public void ConvertTo_Point_PreservesXY()
+    {
+        var p = new PixelPoint(2, 5);
+        Point pt = (Point)_converter.ConvertTo(null, null, p, typeof(Point))!;
+        Assert.That(pt, Is.EqualTo(new Point(2, 5)));
+    }
+
+    [Test]
+    public void ConvertTo_Rect_PutsAtOrigin()
+    {
+        var p = new PixelPoint(11, 22);
+        Rect r = (Rect)_converter.ConvertTo(null, null, p, typeof(Rect))!;
+        Assert.That(r.X, Is.EqualTo(11));
+        Assert.That(r.Y, Is.EqualTo(22));
+        Assert.That(r.Width, Is.EqualTo(0));
+        Assert.That(r.Height, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ConvertTo_Size_PreservesXY()
+    {
+        var p = new PixelPoint(3, 4);
+        Size s = (Size)_converter.ConvertTo(null, null, p, typeof(Size))!;
+        Assert.That(s, Is.EqualTo(new Size(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelRect_StartsWithZeroSize()
+    {
+        var p = new PixelPoint(5, 6);
+        PixelRect r = (PixelRect)_converter.ConvertTo(null, null, p, typeof(PixelRect))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(5, 6, 0, 0)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelSize_PreservesXY()
+    {
+        var p = new PixelPoint(3, 4);
+        PixelSize s = (PixelSize)_converter.ConvertTo(null, null, p, typeof(PixelSize))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_IntArray_ReturnsPixelPoint()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new[] { 1, 2 })!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsPixelPoint()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new Tuple<int, int>(8, 9))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(8, 9)));
+    }
+
+    [Test]
+    public void ConvertFrom_Point_TruncatesCoordinates()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new Point(1.9f, 2.7f))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_Rect_UsesXY()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new Rect(3.2f, 4.8f, 10, 20))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Size_UsesWidthHeight()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new Size(5, 6))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(5, 6)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelRect_UsesXY()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new PixelRect(7, 8, 10, 11))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(7, 8)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelSize_UsesWidthHeight()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, new PixelSize(3, 4))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        PixelPoint p = (PixelPoint)_converter.ConvertFrom(null, null, "12,34")!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(12, 34)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelPointConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelPointConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/PixelRectConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelRectConverterTests.cs
@@ -1,0 +1,131 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PixelRectConverterTests
+{
+    private readonly PixelRectConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(int[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<int, int, int, int>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<int, int, int, int>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_IntArray_ReturnsXYWidthHeight()
+    {
+        var r = new PixelRect(1, 2, 3, 4);
+        int[] result = (int[])_converter.ConvertTo(null, null, r, typeof(int[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public void ConvertTo_Point_UsesXY()
+    {
+        var r = new PixelRect(1, 2, 30, 40);
+        Point p = (Point)_converter.ConvertTo(null, null, r, typeof(Point))!;
+        Assert.That(p, Is.EqualTo(new Point(1, 2)));
+    }
+
+    [Test]
+    public void ConvertTo_Rect_PreservesValues()
+    {
+        var r = new PixelRect(1, 2, 3, 4);
+        Rect rect = (Rect)_converter.ConvertTo(null, null, r, typeof(Rect))!;
+        Assert.That(rect, Is.EqualTo(new Rect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Size_UsesWidthHeight()
+    {
+        var r = new PixelRect(1, 2, 30, 40);
+        Size s = (Size)_converter.ConvertTo(null, null, r, typeof(Size))!;
+        Assert.That(s, Is.EqualTo(new Size(30, 40)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelPoint_UsesXY()
+    {
+        var r = new PixelRect(5, 6, 7, 8);
+        PixelPoint p = (PixelPoint)_converter.ConvertTo(null, null, r, typeof(PixelPoint))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(5, 6)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelSize_UsesWidthHeight()
+    {
+        var r = new PixelRect(5, 6, 7, 8);
+        PixelSize s = (PixelSize)_converter.ConvertTo(null, null, r, typeof(PixelSize))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(7, 8)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsRect()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new Tuple<int, int, int, int>(1, 2, 3, 4))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Point_StartsWithZeroSize()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new Point(2.5f, 3.5f))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(2, 3, 0, 0)));
+    }
+
+    [Test]
+    public void ConvertFrom_Rect_TruncatesCoordinates()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new Rect(1.5f, 2.5f, 3.5f, 4.5f))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Size_StartsAtOrigin()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new Size(10, 20))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(0, 0, 10, 20)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelPoint_StartsWithZeroSize()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new PixelPoint(2, 3))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(2, 3, 0, 0)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelSize_StartsAtOrigin()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, new PixelSize(10, 20))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(0, 0, 10, 20)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        PixelRect r = (PixelRect)_converter.ConvertFrom(null, null, "1,2,3,4")!;
+        Assert.That(r, Is.EqualTo(new PixelRect(1, 2, 3, 4)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelRectConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelRectConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/PixelRectExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelRectExtraTests.cs
@@ -1,0 +1,128 @@
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PixelRectExtraTests
+{
+    [Test]
+    public void Empty_IsAllZero()
+    {
+        Assert.That(PixelRect.Empty, Is.EqualTo(new PixelRect(0, 0, 0, 0)));
+        Assert.That(PixelRect.Empty.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Constructor_FromSize_PositionAtOrigin()
+    {
+        var r = new PixelRect(new PixelSize(100, 200));
+        Assert.That(r.Position, Is.EqualTo(PixelPoint.Origin));
+        Assert.That(r.Size, Is.EqualTo(new PixelSize(100, 200)));
+    }
+
+    [Test]
+    public void Constructor_FromPositionAndSize_AssignsAll()
+    {
+        var r = new PixelRect(new PixelPoint(5, 6), new PixelSize(10, 20));
+        Assert.That(r.Right, Is.EqualTo(15));
+        Assert.That(r.Bottom, Is.EqualTo(26));
+    }
+
+    [Test]
+    public void Constructor_FromTwoCorners_CalculatesSize()
+    {
+        var r = new PixelRect(new PixelPoint(1, 2), new PixelPoint(11, 22));
+        Assert.That(r.Width, Is.EqualTo(10));
+        Assert.That(r.Height, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Corners_ExposeExpectedPoints()
+    {
+        var r = new PixelRect(0, 0, 10, 20);
+        Assert.That(r.TopLeft, Is.EqualTo(new PixelPoint(0, 0)));
+        Assert.That(r.TopRight, Is.EqualTo(new PixelPoint(10, 0)));
+        Assert.That(r.BottomLeft, Is.EqualTo(new PixelPoint(0, 20)));
+        Assert.That(r.BottomRight, Is.EqualTo(new PixelPoint(10, 20)));
+        Assert.That(r.Center, Is.EqualTo(new PixelPoint(5, 10)));
+    }
+
+    [Test]
+    public void Equality_AndHashCode()
+    {
+        var a = new PixelRect(0, 0, 10, 20);
+        var b = new PixelRect(0, 0, 10, 20);
+        var c = new PixelRect(5, 0, 10, 20);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Intersect_Disjoint_ReturnsEmpty()
+    {
+        var a = new PixelRect(0, 0, 10, 10);
+        var b = new PixelRect(100, 100, 10, 10);
+        Assert.That(a.Intersect(b), Is.EqualTo(PixelRect.Empty));
+    }
+
+    [Test]
+    public void Union_HandlesEmptyOperands()
+    {
+        var a = new PixelRect(0, 0, 10, 10);
+        Assert.That(PixelRect.Empty.Union(a), Is.EqualTo(a));
+        Assert.That(a.Union(PixelRect.Empty), Is.EqualTo(a));
+    }
+
+    [Test]
+    public void With_Methods_ReplaceFields()
+    {
+        var r = new PixelRect(1, 2, 3, 4);
+        Assert.That(r.WithX(9), Is.EqualTo(new PixelRect(9, 2, 3, 4)));
+        Assert.That(r.WithY(9), Is.EqualTo(new PixelRect(1, 9, 3, 4)));
+        Assert.That(r.WithWidth(9), Is.EqualTo(new PixelRect(1, 2, 9, 4)));
+        Assert.That(r.WithHeight(9), Is.EqualTo(new PixelRect(1, 2, 3, 9)));
+    }
+
+    [Test]
+    public void ToRect_AndFromRect_RoundTripScale1()
+    {
+        var pr = new PixelRect(0, 0, 100, 50);
+        Rect r = pr.ToRect(1f);
+        Assert.That(r, Is.EqualTo(new Rect(0, 0, 100, 50)));
+        Assert.That(PixelRect.FromRect(r), Is.EqualTo(pr));
+    }
+
+    [Test]
+    public void ToRect_VectorScale_DividesEachAxis()
+    {
+        var pr = new PixelRect(0, 0, 100, 50);
+        Rect r = pr.ToRect(new Vector(2f, 5f));
+        Assert.That(r, Is.EqualTo(new Rect(0, 0, 50, 10)));
+    }
+
+    [Test]
+    public void FromRect_WithScale_CeilsBottomRight()
+    {
+        var r = new Rect(0, 0, 1.5f, 2.5f);
+        Assert.That(PixelRect.FromRect(r, 1f),
+            Is.EqualTo(new PixelRect(0, 0, 2, 3)));
+        Assert.That(PixelRect.FromRect(r, new Vector(2, 4)),
+            Is.EqualTo(new PixelRect(0, 0, 3, 10)));
+    }
+
+    [Test]
+    public void TryParse_InvalidString_ReturnsFalse()
+    {
+        Assert.That(PixelRect.TryParse("garbage", out PixelRect r), Is.False);
+        Assert.That(r, Is.EqualTo(default(PixelRect)));
+    }
+
+    [Test]
+    public void ToString_UsesInvariantCulture()
+    {
+        Assert.That(new PixelRect(1, 2, 3, 4).ToString(), Is.EqualTo("1, 2, 3, 4"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelRectExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelRectExtraTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/PixelSizeConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelSizeConverterTests.cs
@@ -1,0 +1,150 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PixelSizeConverterTests
+{
+    private readonly PixelSizeConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(int[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<int, int>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Vector)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(int[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<int, int>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Vector)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_IntArray_ReturnsWidthHeight()
+    {
+        var s = new PixelSize(7, 9);
+        int[] result = (int[])_converter.ConvertTo(null, null, s, typeof(int[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 7, 9 }));
+    }
+
+    [Test]
+    public void ConvertTo_Point_PreservesWidthHeight()
+    {
+        var s = new PixelSize(3, 4);
+        Point p = (Point)_converter.ConvertTo(null, null, s, typeof(Point))!;
+        Assert.That(p, Is.EqualTo(new Point(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Rect_StartsAtOrigin()
+    {
+        var s = new PixelSize(2, 5);
+        Rect r = (Rect)_converter.ConvertTo(null, null, s, typeof(Rect))!;
+        Assert.That(r, Is.EqualTo(new Rect(0, 0, 2, 5)));
+    }
+
+    [Test]
+    public void ConvertTo_Size_PreservesWidthHeight()
+    {
+        var s = new PixelSize(3, 4);
+        Size sz = (Size)_converter.ConvertTo(null, null, s, typeof(Size))!;
+        Assert.That(sz, Is.EqualTo(new Size(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Vector_PreservesXY()
+    {
+        var s = new PixelSize(11, 12);
+        Vector v = (Vector)_converter.ConvertTo(null, null, s, typeof(Vector))!;
+        Assert.That(v.X, Is.EqualTo(11));
+        Assert.That(v.Y, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void ConvertTo_PixelPoint_PreservesXY()
+    {
+        var s = new PixelSize(2, 5);
+        PixelPoint p = (PixelPoint)_converter.ConvertTo(null, null, s, typeof(PixelPoint))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(2, 5)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelRect_StartsAtOrigin()
+    {
+        var s = new PixelSize(2, 5);
+        PixelRect r = (PixelRect)_converter.ConvertTo(null, null, s, typeof(PixelRect))!;
+        Assert.That(r, Is.EqualTo(new PixelRect(0, 0, 2, 5)));
+    }
+
+    [Test]
+    public void ConvertFrom_IntArray_ReturnsSize()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new[] { 1, 2 })!;
+        Assert.That(s, Is.EqualTo(new PixelSize(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsSize()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new Tuple<int, int>(8, 9))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(8, 9)));
+    }
+
+    [Test]
+    public void ConvertFrom_Point_TruncatesCoordinates()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new Point(1.9f, 2.7f))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_Rect_UsesWidthHeight()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new Rect(1, 2, 30.7f, 40.9f))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(30, 40)));
+    }
+
+    [Test]
+    public void ConvertFrom_Size_TruncatesCoordinates()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new Size(2.5f, 3.5f))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(2, 3)));
+    }
+
+    [Test]
+    public void ConvertFrom_Vector_TruncatesCoordinates()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new Vector(2.9f, 3.5f))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(2, 3)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelPoint_PreservesXY()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, new PixelPoint(11, 12))!;
+        Assert.That(s, Is.EqualTo(new PixelSize(11, 12)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        PixelSize s = (PixelSize)_converter.ConvertFrom(null, null, "10,20")!;
+        Assert.That(s, Is.EqualTo(new PixelSize(10, 20)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelSizeConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelSizeConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/PixelTypesTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelTypesTests.cs
@@ -1,0 +1,155 @@
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PixelPointTests
+{
+    [Test]
+    public void Origin_IsZeroZero()
+    {
+        Assert.That(PixelPoint.Origin, Is.EqualTo(new PixelPoint(0, 0)));
+    }
+
+    [Test]
+    public void Equality_AndOperators()
+    {
+        var a = new PixelPoint(1, 2);
+        var b = new PixelPoint(1, 2);
+        var c = new PixelPoint(2, 1);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void AddSubtract_ProducePerComponent()
+    {
+        var a = new PixelPoint(1, 2);
+        var b = new PixelPoint(3, 4);
+        Assert.That(a + b, Is.EqualTo(new PixelPoint(4, 6)));
+        Assert.That(b - a, Is.EqualTo(new PixelPoint(2, 2)));
+    }
+
+    [Test]
+    public void WithX_WithY_ReplaceComponent()
+    {
+        var p = new PixelPoint(1, 2);
+        Assert.That(p.WithX(7), Is.EqualTo(new PixelPoint(7, 2)));
+        Assert.That(p.WithY(9), Is.EqualTo(new PixelPoint(1, 9)));
+    }
+
+    [Test]
+    public void ToPoint_DividesByScale()
+    {
+        var p = new PixelPoint(10, 20);
+        Assert.That(p.ToPoint(2f), Is.EqualTo(new Point(5, 10)));
+        Assert.That(p.ToPoint(new Vector(2, 4)), Is.EqualTo(new Point(5, 5)));
+    }
+
+    [Test]
+    public void FromPoint_TruncatesToInteger()
+    {
+        Assert.That(PixelPoint.FromPoint(new Point(1.7f, 2.9f)),
+            Is.EqualTo(new PixelPoint(1, 2)));
+        Assert.That(PixelPoint.FromPoint(new Point(1.5f, 2.5f), 2f),
+            Is.EqualTo(new PixelPoint(3, 5)));
+        Assert.That(PixelPoint.FromPoint(new Point(1.5f, 2.5f), new Vector(2, 4)),
+            Is.EqualTo(new PixelPoint(3, 10)));
+    }
+
+    [Test]
+    public void Parse_ReadsTwoInts()
+    {
+        Assert.That(PixelPoint.Parse("3,4"), Is.EqualTo(new PixelPoint(3, 4)));
+        Assert.That(PixelPoint.Parse("3,4".AsSpan()), Is.EqualTo(new PixelPoint(3, 4)));
+    }
+
+    [Test]
+    public void TryParse_InvalidString_ReturnsFalse()
+    {
+        Assert.That(PixelPoint.TryParse("nope", out PixelPoint p), Is.False);
+        Assert.That(p, Is.EqualTo(default(PixelPoint)));
+    }
+
+    [Test]
+    public void ToString_UsesInvariantCulture()
+    {
+        Assert.That(new PixelPoint(3, 4).ToString(), Is.EqualTo("3, 4"));
+    }
+}
+
+public class PixelSizeTests
+{
+    [Test]
+    public void Empty_IsZeroZero()
+    {
+        Assert.That(PixelSize.Empty, Is.EqualTo(new PixelSize(0, 0)));
+    }
+
+    [Test]
+    public void AspectRatio_DividesWidthByHeight()
+    {
+        Assert.That(new PixelSize(1920, 1080).AspectRatio,
+            Is.EqualTo(1920f / 1080f).Within(1e-5f));
+    }
+
+    [Test]
+    public void Equality_AndHashCode()
+    {
+        var a = new PixelSize(100, 50);
+        var b = new PixelSize(100, 50);
+        var c = new PixelSize(50, 100);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void WithWidth_WithHeight_ReplaceDimension()
+    {
+        var s = new PixelSize(100, 50);
+        Assert.That(s.WithWidth(200), Is.EqualTo(new PixelSize(200, 50)));
+        Assert.That(s.WithHeight(75), Is.EqualTo(new PixelSize(100, 75)));
+    }
+
+    [Test]
+    public void ToSize_DividesByScale()
+    {
+        var s = new PixelSize(100, 50);
+        Assert.That(s.ToSize(2f), Is.EqualTo(new Size(50, 25)));
+        Assert.That(s.ToSize(new Vector(2, 5)), Is.EqualTo(new Size(50, 10)));
+    }
+
+    [Test]
+    public void FromSize_CeilsValues()
+    {
+        Assert.That(PixelSize.FromSize(new Size(1.1f, 2.2f), 1f),
+            Is.EqualTo(new PixelSize(2, 3)));
+        Assert.That(PixelSize.FromSize(new Size(1f, 2f), new Vector(2, 3)),
+            Is.EqualTo(new PixelSize(2, 6)));
+    }
+
+    [Test]
+    public void Parse_ReadsTwoInts()
+    {
+        Assert.That(PixelSize.Parse("100,50"), Is.EqualTo(new PixelSize(100, 50)));
+    }
+
+    [Test]
+    public void TryParse_InvalidString_ReturnsFalse()
+    {
+        Assert.That(PixelSize.TryParse("nope", out PixelSize s), Is.False);
+        Assert.That(s, Is.EqualTo(default(PixelSize)));
+    }
+
+    [Test]
+    public void ToString_UsesInvariantCulture()
+    {
+        Assert.That(new PixelSize(100, 50).ToString(), Is.EqualTo("100, 50"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PixelTypesTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PixelTypesTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;

--- a/tests/Beutl.UnitTests/Engine/PointConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PointConverterTests.cs
@@ -1,0 +1,99 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PointConverterTests
+{
+    private readonly PointConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertTo_UnknownTarget_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(DateTime)), Is.False);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<float, float>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsXY()
+    {
+        var p = new Point(2.5f, -1.25f);
+        object? result = _converter.ConvertTo(null, null, p, typeof(float[]));
+        Assert.That(result, Is.EqualTo(new[] { 2.5f, -1.25f }));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple_ReturnsXY()
+    {
+        var p = new Point(3, 4);
+        object? result = _converter.ConvertTo(null, null, p, typeof(Tuple<float, float>));
+        Assert.That(result, Is.EqualTo(new Tuple<float, float>(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Rect_PutsPointAtOrigin()
+    {
+        var p = new Point(5, 6);
+        Rect r = (Rect)_converter.ConvertTo(null, null, p, typeof(Rect))!;
+        Assert.That(r.X, Is.EqualTo(5));
+        Assert.That(r.Y, Is.EqualTo(6));
+        Assert.That(r.Width, Is.EqualTo(0));
+        Assert.That(r.Height, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ConvertTo_PixelPoint_TruncatesCoordinates()
+    {
+        var p = new Point(1.9f, 2.7f);
+        PixelPoint pp = (PixelPoint)_converter.ConvertTo(null, null, p, typeof(PixelPoint))!;
+        Assert.That(pp.X, Is.EqualTo(1));
+        Assert.That(pp.Y, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsPoint()
+    {
+        Point p = (Point)_converter.ConvertFrom(null, null, new float[] { 1.5f, -2.0f })!;
+        Assert.That(p.X, Is.EqualTo(1.5f));
+        Assert.That(p.Y, Is.EqualTo(-2.0f));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelSize_ReturnsPoint()
+    {
+        Point p = (Point)_converter.ConvertFrom(null, null, new PixelSize(10, 20))!;
+        Assert.That(p, Is.EqualTo(new Point(10, 20)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_RoundTripsViaParse()
+    {
+        Point parsed = (Point)_converter.ConvertFrom(null, null, "1.5,2.5")!;
+        Assert.That(parsed, Is.EqualTo(new Point(1.5f, 2.5f)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PointConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PointConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/PointTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PointTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Beutl.Graphics;
 

--- a/tests/Beutl.UnitTests/Engine/PointTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PointTests.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+using System.Text;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PointTests
+{
+    [Test]
+    public void Default_IsZero_AndNotInvalid()
+    {
+        var p = new Point();
+        Assert.That(p.IsDefault, Is.True);
+        Assert.That(p.IsInvalid, Is.False);
+    }
+
+    [Test]
+    public void Invalid_HasNaNComponents()
+    {
+        Assert.That(Point.Invalid.IsInvalid, Is.True);
+    }
+
+    [Test]
+    public void Constructor_StoresComponents()
+    {
+        var p = new Point(3, 4);
+        Assert.That(p.X, Is.EqualTo(3));
+        Assert.That(p.Y, Is.EqualTo(4));
+        Assert.That(p.IsDefault, Is.False);
+    }
+
+    [Test]
+    public void ImplicitToVector_PreservesComponents()
+    {
+        var p = new Point(2, 3);
+        Vector v = p;
+        Assert.That(v.X, Is.EqualTo(2));
+        Assert.That(v.Y, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Negate_FlipsComponents()
+    {
+        Assert.That(-new Point(1, -2), Is.EqualTo(new Point(-1, 2)));
+    }
+
+    [Test]
+    public void Operators_AddSubtractMultiplyDivide()
+    {
+        var a = new Point(1, 2);
+        var b = new Point(3, 4);
+        var v = new Vector(5, 6);
+
+        Assert.That(a + b, Is.EqualTo(new Point(4, 6)));
+        Assert.That(a + v, Is.EqualTo(new Point(6, 8)));
+        Assert.That(b - a, Is.EqualTo(new Point(2, 2)));
+        Assert.That(b - v, Is.EqualTo(new Point(-2, -2)));
+        Assert.That(a * 3f, Is.EqualTo(new Point(3, 6)));
+        Assert.That(3f * a, Is.EqualTo(new Point(3, 6)));
+        Assert.That(b / 2f, Is.EqualTo(new Point(1.5f, 2)));
+    }
+
+    [Test]
+    public void Equality_AndHashCode()
+    {
+        var a = new Point(1, 2);
+        var b = new Point(1, 2);
+        var c = new Point(1, 3);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"foo"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void WithX_WithY_ReplaceComponent()
+    {
+        var p = new Point(1, 2);
+        Assert.That(p.WithX(9), Is.EqualTo(new Point(9, 2)));
+        Assert.That(p.WithY(7), Is.EqualTo(new Point(1, 7)));
+    }
+
+    [Test]
+    public void Deconstruct_ReturnsComponents()
+    {
+        var (x, y) = new Point(10, 20);
+        Assert.That(x, Is.EqualTo(10));
+        Assert.That(y, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Transform_ByTranslation_AppliesOffset()
+    {
+        var p = new Point(1, 2);
+        Matrix m = Matrix.CreateTranslation(10, 20);
+        Assert.That(p.Transform(m), Is.EqualTo(new Point(11, 22)));
+        Assert.That(p * m, Is.EqualTo(new Point(11, 22)));
+    }
+
+    [Test]
+    public void Parse_DefaultCulture()
+    {
+        Assert.That(Point.Parse("1,2"), Is.EqualTo(new Point(1, 2)));
+        Assert.That(Point.Parse("1,2".AsSpan()), Is.EqualTo(new Point(1, 2)));
+    }
+
+    [Test]
+    public void Parse_WithCulture_AcceptsAlternateSeparator()
+    {
+        var fr = CultureInfo.GetCultureInfo("fr");
+        Assert.That(Point.Parse("1;2", fr), Is.EqualTo(new Point(1, 2)));
+    }
+
+    [Test]
+    public void TryParse_ValidAndInvalid()
+    {
+        Assert.That(Point.TryParse("1,2", out Point ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new Point(1, 2)));
+
+        Assert.That(Point.TryParse("garbage", out Point bad), Is.False);
+        Assert.That(bad, Is.EqualTo(default(Point)));
+    }
+
+    [Test]
+    public void Parse_Utf8_RoundTrip()
+    {
+        ReadOnlySpan<byte> source = "1.5,2.5"u8;
+        Assert.That(Point.Parse(source), Is.EqualTo(new Point(1.5f, 2.5f)));
+
+        Assert.That(Point.TryParse(source, out Point ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new Point(1.5f, 2.5f)));
+
+        Assert.That(Point.TryParse("garbage"u8, null, out _), Is.False);
+    }
+
+    [Test]
+    public void ToString_NoCulture_UsesInvariant()
+    {
+        Assert.That(new Point(1.5f, 2.5f).ToString(), Is.EqualTo("1.5, 2.5"));
+    }
+
+    [Test]
+    public void TryFormat_Char_AndUtf8_ReturnSameContent()
+    {
+        var p = new Point(1.5f, 2.5f);
+        Span<char> chars = stackalloc char[32];
+        Span<byte> bytes = stackalloc byte[32];
+
+        Assert.That(p.TryFormat(chars, out int cw), Is.True);
+        Assert.That(p.TryFormat(bytes, out int bw), Is.True);
+
+        Assert.That(chars[..cw].ToString(), Is.EqualTo(Encoding.UTF8.GetString(bytes[..bw])));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PredefinedColorsAndBrushesTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PredefinedColorsAndBrushesTests.cs
@@ -1,0 +1,68 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class PredefinedColorsAndBrushesTests
+{
+    [Test]
+    public void Colors_BasicColors_HaveExpectedArgb()
+    {
+        Assert.That(Colors.Black, Is.EqualTo(Color.FromArgb(0xff, 0x00, 0x00, 0x00)));
+        Assert.That(Colors.White, Is.EqualTo(Color.FromArgb(0xff, 0xff, 0xff, 0xff)));
+        Assert.That(Colors.Red, Is.EqualTo(Color.FromArgb(0xff, 0xff, 0x00, 0x00)));
+        Assert.That(Colors.Lime, Is.EqualTo(Color.FromArgb(0xff, 0x00, 0xff, 0x00)));
+        Assert.That(Colors.Blue, Is.EqualTo(Color.FromArgb(0xff, 0x00, 0x00, 0xff)));
+        Assert.That(Colors.Transparent, Is.EqualTo(Color.FromArgb(0x00, 0xff, 0xff, 0xff)));
+    }
+
+    [Test]
+    public void Colors_AliceBlue_HasExpectedArgb()
+    {
+        Assert.That(Colors.AliceBlue, Is.EqualTo(Color.FromArgb(0xff, 0xf0, 0xf8, 0xff)));
+    }
+
+    [Test]
+    public void Colors_Yellow_HasExpectedArgb()
+    {
+        Assert.That(Colors.Yellow, Is.EqualTo(Color.FromArgb(0xff, 0xff, 0xff, 0x00)));
+    }
+
+    [Test]
+    public void Colors_Aqua_HasExpectedArgb()
+    {
+        Assert.That(Colors.Aqua, Is.EqualTo(Color.FromArgb(0xff, 0x00, 0xff, 0xff)));
+    }
+
+    [Test]
+    public void Brushes_BasicBrushes_HaveMatchingColors()
+    {
+        Assert.That(Brushes.Black.Color.GetValue(Composition.CompositionContext.Default), Is.EqualTo(Colors.Black));
+        Assert.That(Brushes.White.Color.GetValue(Composition.CompositionContext.Default), Is.EqualTo(Colors.White));
+        Assert.That(Brushes.Red.Color.GetValue(Composition.CompositionContext.Default), Is.EqualTo(Colors.Red));
+        Assert.That(Brushes.Transparent.Color.GetValue(Composition.CompositionContext.Default), Is.EqualTo(Colors.Transparent));
+    }
+
+    [Test]
+    public void Brushes_GreatVariety_DoNotThrow()
+    {
+        Assert.That(Brushes.AliceBlue, Is.Not.Null);
+        Assert.That(Brushes.AntiqueWhite, Is.Not.Null);
+        Assert.That(Brushes.Aqua, Is.Not.Null);
+        Assert.That(Brushes.Aquamarine, Is.Not.Null);
+        Assert.That(Brushes.Azure, Is.Not.Null);
+        Assert.That(Brushes.Beige, Is.Not.Null);
+        Assert.That(Brushes.Bisque, Is.Not.Null);
+        Assert.That(Brushes.BlanchedAlmond, Is.Not.Null);
+        Assert.That(Brushes.Yellow, Is.Not.Null);
+        Assert.That(Brushes.YellowGreen, Is.Not.Null);
+    }
+
+    [Test]
+    public void Colors_NewBrushPerInvocation_DistinctButColorEqual()
+    {
+        var b1 = Brushes.Black;
+        var b2 = Brushes.Black;
+        Assert.That(b1.Color.GetValue(Composition.CompositionContext.Default),
+            Is.EqualTo(b2.Color.GetValue(Composition.CompositionContext.Default)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/PredefinedColorsAndBrushesTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PredefinedColorsAndBrushesTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/PropertyFactoryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PropertyFactoryTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Engine;
+﻿using Beutl.Engine;
 using DisplayAttribute = System.ComponentModel.DataAnnotations.DisplayAttribute;
 using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
 using ValidationAttribute = System.ComponentModel.DataAnnotations.ValidationAttribute;

--- a/tests/Beutl.UnitTests/Engine/PropertyFactoryTests.cs
+++ b/tests/Beutl.UnitTests/Engine/PropertyFactoryTests.cs
@@ -1,0 +1,110 @@
+using Beutl.Engine;
+using DisplayAttribute = System.ComponentModel.DataAnnotations.DisplayAttribute;
+using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
+using ValidationAttribute = System.ComponentModel.DataAnnotations.ValidationAttribute;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class PropertyFactoryTests
+{
+    [Test]
+    public void Create_ReturnsSimpleProperty_NotAnimatable()
+    {
+        IProperty<double> property = Property.Create(1.5);
+
+        Assert.That(property, Is.InstanceOf<SimpleProperty<double>>());
+        Assert.That(property.IsAnimatable, Is.False);
+        Assert.That(property.SupportsExpression, Is.True);
+        Assert.That(property.DefaultValue, Is.EqualTo(1.5));
+        Assert.That(property.CurrentValue, Is.EqualTo(1.5));
+        Assert.That(property.HasLocalValue, Is.False);
+    }
+
+    [Test]
+    public void Create_WithDefaultedGeneric_UsesTypeDefault()
+    {
+        IProperty<int> property = Property.Create<int>();
+
+        Assert.That(property.DefaultValue, Is.EqualTo(0));
+        Assert.That(property.CurrentValue, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Create_WithValidationAttributes_AppliesValidatorOnSet()
+    {
+        IProperty<int> property = Property.Create(0, new RangeAttribute(0, 10));
+        property.SetAttributes("Test", []);
+
+        property.CurrentValue = 100;
+
+        Assert.That(property.CurrentValue, Is.EqualTo(10), "Out-of-range value should be coerced to max.");
+    }
+
+    [Test]
+    public void Create_WithoutValidationAttributes_HasNoValidator()
+    {
+        var property = (SimpleProperty<int>)Property.Create(5);
+
+        Assert.That(property.HasValidator, Is.False);
+    }
+
+    [Test]
+    public void Create_WithEmptyValidationAttributesParams_HasNoValidator()
+    {
+        var property = (SimpleProperty<int>)Property.Create(5, new ValidationAttribute[0]);
+
+        Assert.That(property.HasValidator, Is.False);
+    }
+
+    [Test]
+    public void CreateAnimatable_ReturnsAnimatableProperty()
+    {
+        IProperty<float> property = Property.CreateAnimatable(2.0f);
+
+        Assert.That(property, Is.InstanceOf<AnimatableProperty<float>>());
+        Assert.That(property.IsAnimatable, Is.True);
+        Assert.That(property.DefaultValue, Is.EqualTo(2.0f));
+    }
+
+    [Test]
+    public void CreateAnimatable_WithValidationAttributes_AppliesValidator()
+    {
+        IProperty<int> property = Property.CreateAnimatable(0, new RangeAttribute(-5, 5));
+        property.SetAttributes("Test", []);
+
+        property.CurrentValue = -100;
+
+        Assert.That(property.CurrentValue, Is.EqualTo(-5));
+    }
+
+    [Test]
+    public void CreateList_ReturnsListProperty()
+    {
+        IListProperty<string> property = Property.CreateList<string>();
+
+        Assert.That(property, Is.InstanceOf<ListProperty<string>>());
+        Assert.That(property.ElementType, Is.EqualTo(typeof(string)));
+        Assert.That(property.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetLocalizedName_ReturnsDisplayNameWhenAttributeSet()
+    {
+        IProperty<int> property = Property.Create(0);
+        property.SetAttributes(
+            "RawName",
+            new Attribute[] { new DisplayAttribute { Name = "Friendly" } });
+
+        Assert.That(Property.GetLocalizedName(property), Is.EqualTo("Friendly"));
+    }
+
+    [Test]
+    public void GetLocalizedName_FallsBackToPropertyName()
+    {
+        IProperty<int> property = Property.Create(0);
+        property.SetAttributes("RawName", []);
+
+        Assert.That(Property.GetLocalizedName(property), Is.EqualTo("RawName"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/RectConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RectConverterTests.cs
@@ -1,0 +1,139 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class RectConverterTests
+{
+    private readonly RectConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<float, float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelRect)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsXYWidthHeight()
+    {
+        var r = new Rect(1, 2, 3, 4);
+        float[] result = (float[])_converter.ConvertTo(null, null, r, typeof(float[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 1f, 2f, 3f, 4f }));
+    }
+
+    [Test]
+    public void ConvertTo_Point_UsesXY()
+    {
+        var r = new Rect(1.5f, 2.5f, 30, 40);
+        Point p = (Point)_converter.ConvertTo(null, null, r, typeof(Point))!;
+        Assert.That(p, Is.EqualTo(new Point(1.5f, 2.5f)));
+    }
+
+    [Test]
+    public void ConvertTo_Size_UsesWidthHeight()
+    {
+        var r = new Rect(1, 2, 30, 40);
+        Size s = (Size)_converter.ConvertTo(null, null, r, typeof(Size))!;
+        Assert.That(s, Is.EqualTo(new Size(30, 40)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelPoint_TruncatesXY()
+    {
+        var r = new Rect(1.7f, 2.9f, 3, 4);
+        PixelPoint p = (PixelPoint)_converter.ConvertTo(null, null, r, typeof(PixelPoint))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(1, 2)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelRect_TruncatesAllValues()
+    {
+        var r = new Rect(1.5f, 2.5f, 3.5f, 4.5f);
+        PixelRect pr = (PixelRect)_converter.ConvertTo(null, null, r, typeof(PixelRect))!;
+        Assert.That(pr, Is.EqualTo(new PixelRect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelSize_TruncatesWidthHeight()
+    {
+        var r = new Rect(1, 2, 3.7f, 4.9f);
+        PixelSize ps = (PixelSize)_converter.ConvertTo(null, null, r, typeof(PixelSize))!;
+        Assert.That(ps, Is.EqualTo(new PixelSize(3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsRect()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new float[] { 1.5f, 2.5f, 3.5f, 4.5f })!;
+        Assert.That(r, Is.EqualTo(new Rect(1.5f, 2.5f, 3.5f, 4.5f)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsRect()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new Tuple<float, float, float, float>(1, 2, 3, 4))!;
+        Assert.That(r, Is.EqualTo(new Rect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Point_StartsWithZeroSize()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new Point(2, 3))!;
+        Assert.That(r, Is.EqualTo(new Rect(2, 3, 0, 0)));
+    }
+
+    [Test]
+    public void ConvertFrom_Size_StartsAtOrigin()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new Size(10, 20))!;
+        Assert.That(r, Is.EqualTo(new Rect(0, 0, 10, 20)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelPoint_StartsWithZeroSize()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new PixelPoint(5, 6))!;
+        Assert.That(r, Is.EqualTo(new Rect(5, 6, 0, 0)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelRect_PreservesValues()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new PixelRect(1, 2, 3, 4))!;
+        Assert.That(r, Is.EqualTo(new Rect(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelSize_StartsAtOrigin()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, new PixelSize(10, 20))!;
+        Assert.That(r, Is.EqualTo(new Rect(0, 0, 10, 20)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        Rect r = (Rect)_converter.ConvertFrom(null, null, "1,2,3,4")!;
+        Assert.That(r, Is.EqualTo(new Rect(1, 2, 3, 4)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/RectConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RectConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/RelativePointTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RelativePointTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Beutl.Graphics;
 

--- a/tests/Beutl.UnitTests/Engine/RelativePointTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RelativePointTests.cs
@@ -1,0 +1,197 @@
+using System.Globalization;
+using System.Text;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class RelativePointTests
+{
+    [Test]
+    public void StaticMembers_AreExpectedRelativePoints()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RelativePoint.TopLeft.Point, Is.EqualTo(new Point(0, 0)));
+            Assert.That(RelativePoint.TopLeft.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(RelativePoint.Center.Point, Is.EqualTo(new Point(0.5f, 0.5f)));
+            Assert.That(RelativePoint.Center.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(RelativePoint.BottomRight.Point, Is.EqualTo(new Point(1, 1)));
+            Assert.That(RelativePoint.BottomRight.Unit, Is.EqualTo(RelativeUnit.Relative));
+        });
+    }
+
+    [Test]
+    public void Constructor_FromXY_StoresComponents()
+    {
+        var p = new RelativePoint(0.25f, 0.75f, RelativeUnit.Relative);
+        Assert.Multiple(() =>
+        {
+            Assert.That(p.Point, Is.EqualTo(new Point(0.25f, 0.75f)));
+            Assert.That(p.Unit, Is.EqualTo(RelativeUnit.Relative));
+        });
+    }
+
+    [Test]
+    public void Equality_RespectsBothPointAndUnit()
+    {
+        var a = new RelativePoint(1, 2, RelativeUnit.Absolute);
+        var b = new RelativePoint(1, 2, RelativeUnit.Absolute);
+        var differentUnit = new RelativePoint(1, 2, RelativeUnit.Relative);
+        var differentPoint = new RelativePoint(2, 2, RelativeUnit.Absolute);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != differentUnit, Is.True);
+            Assert.That(a != differentPoint, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)"foo"), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            Assert.That(a.GetHashCode(), Is.Not.EqualTo(differentUnit.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void ToPixels_Absolute_ReturnsRawPoint()
+    {
+        var p = new RelativePoint(10, 20, RelativeUnit.Absolute);
+        Assert.That(p.ToPixels(new Size(200, 100)), Is.EqualTo(new Point(10, 20)));
+    }
+
+    [Test]
+    public void ToPixels_Relative_ScalesBySize()
+    {
+        var p = new RelativePoint(0.5f, 0.25f, RelativeUnit.Relative);
+        Assert.That(p.ToPixels(new Size(200, 400)), Is.EqualTo(new Point(100, 100)));
+    }
+
+    [Test]
+    public void Parse_PercentageProducesRelativeUnit()
+    {
+        var rp = RelativePoint.Parse("50%, 25%");
+        Assert.Multiple(() =>
+        {
+            Assert.That(rp.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(rp.Point.X, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(rp.Point.Y, Is.EqualTo(0.25f).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void Parse_WithoutPercentageProducesAbsoluteUnit()
+    {
+        var rp = RelativePoint.Parse("3,4");
+        Assert.Multiple(() =>
+        {
+            Assert.That(rp.Unit, Is.EqualTo(RelativeUnit.Absolute));
+            Assert.That(rp.Point, Is.EqualTo(new Point(3, 4)));
+        });
+    }
+
+    [Test]
+    public void Parse_MixedUnit_Throws()
+    {
+        Assert.Throws<FormatException>(() => RelativePoint.Parse("50%, 25"));
+    }
+
+    [Test]
+    public void TryParse_ReturnsFalseOnGarbage()
+    {
+        Assert.That(RelativePoint.TryParse("nope", out RelativePoint result), Is.False);
+        Assert.That(result, Is.EqualTo(default(RelativePoint)));
+    }
+
+    [Test]
+    public void TryParse_ParsesValidString()
+    {
+        Assert.That(RelativePoint.TryParse("10,20", out RelativePoint result), Is.True);
+        Assert.That(result, Is.EqualTo(new RelativePoint(10, 20, RelativeUnit.Absolute)));
+    }
+
+    [Test]
+    public void Parse_Utf8_PercentAndAbsolute()
+    {
+        var relative = RelativePoint.Parse("50%, 25%"u8);
+        var absolute = RelativePoint.Parse("3,4"u8);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(relative.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(relative.Point.X, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(absolute.Unit, Is.EqualTo(RelativeUnit.Absolute));
+            Assert.That(absolute.Point, Is.EqualTo(new Point(3, 4)));
+        });
+    }
+
+    [Test]
+    public void TryParse_Utf8_HandlesGarbage()
+    {
+        Assert.That(RelativePoint.TryParse("oops"u8, out RelativePoint result), Is.False);
+        Assert.That(result, Is.EqualTo(default(RelativePoint)));
+
+        Assert.That(RelativePoint.TryParse("1,2"u8, out RelativePoint ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new RelativePoint(1, 2, RelativeUnit.Absolute)));
+    }
+
+    [Test]
+    public void ToString_FormatsAbsoluteAndRelative()
+    {
+        var absolute = new RelativePoint(1.5f, 2.5f, RelativeUnit.Absolute);
+        var relative = new RelativePoint(0.25f, 0.5f, RelativeUnit.Relative);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(absolute.ToString(), Is.EqualTo(new Point(1.5f, 2.5f).ToString()));
+            Assert.That(relative.ToString(), Is.EqualTo("25%, 50%"));
+        });
+    }
+
+    [Test]
+    public void ToString_WithProvider_UsesProviderSeparator()
+    {
+        var fr = CultureInfo.GetCultureInfo("fr-FR");
+        var absolute = new RelativePoint(1.5f, 2.5f, RelativeUnit.Absolute);
+        var relative = new RelativePoint(0.25f, 0.5f, RelativeUnit.Relative);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(absolute.ToString(fr), Does.Contain(";"));
+            Assert.That(relative.ToString(fr), Does.Contain(";").And.Contain("%"));
+            Assert.That(relative.ToString("g", fr), Is.EqualTo(relative.ToString(fr)));
+        });
+    }
+
+    [Test]
+    public void TryFormat_Char_FormatsBothUnits()
+    {
+        Span<char> buffer = stackalloc char[32];
+
+        var absolute = new RelativePoint(1.5f, 2.5f, RelativeUnit.Absolute);
+        Assert.That(absolute.TryFormat(buffer, out int absWritten), Is.True);
+        Assert.That(buffer[..absWritten].ToString(), Is.EqualTo(absolute.ToString()));
+
+        var relative = new RelativePoint(0.25f, 0.5f, RelativeUnit.Relative);
+        Assert.That(relative.TryFormat(buffer, out int relWritten, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(buffer[..relWritten].ToString(), Is.EqualTo("25%, 50%"));
+    }
+
+    [Test]
+    public void TryFormat_Utf8_MatchesCharOutput()
+    {
+        var relative = new RelativePoint(0.25f, 0.5f, RelativeUnit.Relative);
+        Span<char> chars = stackalloc char[32];
+        Span<byte> bytes = stackalloc byte[32];
+
+        Assert.That(relative.TryFormat(chars, out int cw, default, CultureInfo.InvariantCulture), Is.True);
+        Assert.That(relative.TryFormat(bytes, out int bw, default, CultureInfo.InvariantCulture), Is.True);
+
+        Assert.That(Encoding.UTF8.GetString(bytes[..bw]), Is.EqualTo(chars[..cw].ToString()));
+    }
+
+    [Test]
+    public void TryParse_StringWithProvider_DelegatesToSpan()
+    {
+        Assert.That(RelativePoint.TryParse("10,20", CultureInfo.InvariantCulture, out RelativePoint result), Is.True);
+        Assert.That(result, Is.EqualTo(new RelativePoint(10, 20, RelativeUnit.Absolute)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/RelativeRectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RelativeRectTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Beutl.Graphics;
 

--- a/tests/Beutl.UnitTests/Engine/RelativeRectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/RelativeRectTests.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+using System.Text;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class RelativeRectTests
+{
+    [Test]
+    public void Fill_IsRelativeFullRectangle()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RelativeRect.Fill.Rect, Is.EqualTo(new Rect(0, 0, 1, 1)));
+            Assert.That(RelativeRect.Fill.Unit, Is.EqualTo(RelativeUnit.Relative));
+        });
+    }
+
+    [Test]
+    public void Constructors_AllProduceSameRect()
+    {
+        var rect = new Rect(1, 2, 3, 4);
+        var fromComponents = new RelativeRect(1, 2, 3, 4, RelativeUnit.Absolute);
+        var fromRect = new RelativeRect(rect, RelativeUnit.Absolute);
+        var fromPositionSize = new RelativeRect(new Point(1, 2), new Size(3, 4), RelativeUnit.Absolute);
+        var fromCorners = new RelativeRect(new Point(1, 2), new Point(4, 6), RelativeUnit.Absolute);
+        var fromSizeOnly = new RelativeRect(new Size(3, 4), RelativeUnit.Absolute);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fromComponents, Is.EqualTo(fromRect));
+            Assert.That(fromComponents, Is.EqualTo(fromPositionSize));
+            Assert.That(fromCorners.Rect, Is.EqualTo(rect));
+            Assert.That(fromSizeOnly.Rect, Is.EqualTo(new Rect(0, 0, 3, 4)));
+        });
+    }
+
+    [Test]
+    public void Equality_RespectsBothRectAndUnit()
+    {
+        var a = new RelativeRect(1, 2, 3, 4, RelativeUnit.Absolute);
+        var b = new RelativeRect(1, 2, 3, 4, RelativeUnit.Absolute);
+        var differentUnit = new RelativeRect(1, 2, 3, 4, RelativeUnit.Relative);
+        var differentRect = new RelativeRect(0, 2, 3, 4, RelativeUnit.Absolute);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a == b, Is.True);
+            Assert.That(a != differentUnit, Is.True);
+            Assert.That(a != differentRect, Is.True);
+            Assert.That(a.Equals((object)b), Is.True);
+            Assert.That(a.Equals((object)"foo"), Is.False);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void ToPixels_Absolute_ReturnsRawRect()
+    {
+        var rr = new RelativeRect(10, 20, 30, 40, RelativeUnit.Absolute);
+        Assert.That(rr.ToPixels(new Size(100, 200)), Is.EqualTo(new Rect(10, 20, 30, 40)));
+    }
+
+    [Test]
+    public void ToPixels_Relative_ScalesAllComponents()
+    {
+        var rr = new RelativeRect(0.1f, 0.2f, 0.5f, 0.25f, RelativeUnit.Relative);
+        Assert.That(rr.ToPixels(new Size(100, 400)), Is.EqualTo(new Rect(10, 80, 50, 100)));
+    }
+
+    [Test]
+    public void Parse_AbsoluteRectangle()
+    {
+        var rr = RelativeRect.Parse("1,2,3,4");
+        Assert.Multiple(() =>
+        {
+            Assert.That(rr.Unit, Is.EqualTo(RelativeUnit.Absolute));
+            Assert.That(rr.Rect, Is.EqualTo(new Rect(1, 2, 3, 4)));
+        });
+    }
+
+    [Test]
+    public void Parse_RelativeRectangleAllPercent()
+    {
+        var rr = RelativeRect.Parse("10%, 20%, 50%, 25%");
+        Assert.Multiple(() =>
+        {
+            Assert.That(rr.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(rr.Rect.X, Is.EqualTo(0.1f).Within(1e-6));
+            Assert.That(rr.Rect.Y, Is.EqualTo(0.2f).Within(1e-6));
+            Assert.That(rr.Rect.Width, Is.EqualTo(0.5f).Within(1e-6));
+            Assert.That(rr.Rect.Height, Is.EqualTo(0.25f).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void Parse_MixedUnit_Throws()
+    {
+        Assert.Throws<FormatException>(() => RelativeRect.Parse("10%, 20, 50%, 25%"));
+    }
+
+    [Test]
+    public void TryParse_ReturnsFalseOnGarbage()
+    {
+        Assert.That(RelativeRect.TryParse("nope", out RelativeRect result), Is.False);
+        Assert.That(result, Is.EqualTo(default(RelativeRect)));
+    }
+
+    [Test]
+    public void TryParse_AbsoluteString()
+    {
+        Assert.That(RelativeRect.TryParse("0,0,10,20", out RelativeRect result), Is.True);
+        Assert.That(result, Is.EqualTo(new RelativeRect(0, 0, 10, 20, RelativeUnit.Absolute)));
+    }
+
+    [Test]
+    public void Parse_StringWithProvider_AcceptsAlternateSeparator()
+    {
+        var fr = CultureInfo.GetCultureInfo("fr-FR");
+        var parsed = RelativeRect.Parse("1;2;3;4", fr);
+        Assert.That(parsed, Is.EqualTo(new RelativeRect(1, 2, 3, 4, RelativeUnit.Absolute)));
+
+        Assert.That(RelativeRect.TryParse("1;2;3;4", fr, out RelativeRect result), Is.True);
+        Assert.That(result, Is.EqualTo(parsed));
+    }
+
+    [Test]
+    public void Parse_Utf8_AbsoluteAndRelative()
+    {
+        var absolute = RelativeRect.Parse("1,2,3,4"u8);
+        var relative = RelativeRect.Parse("10%, 20%, 50%, 25%"u8);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(absolute.Unit, Is.EqualTo(RelativeUnit.Absolute));
+            Assert.That(absolute.Rect, Is.EqualTo(new Rect(1, 2, 3, 4)));
+            Assert.That(relative.Unit, Is.EqualTo(RelativeUnit.Relative));
+            Assert.That(relative.Rect.Width, Is.EqualTo(0.5f).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void Parse_Utf8_MixedUnitThrows()
+    {
+        Assert.Throws<FormatException>(() => RelativeRect.Parse("10%, 20, 50%, 25%"u8));
+    }
+
+    [Test]
+    public void TryParse_Utf8_HandlesGarbage()
+    {
+        Assert.That(RelativeRect.TryParse("oops"u8, out RelativeRect _), Is.False);
+        Assert.That(RelativeRect.TryParse("1,2,3,4"u8, out RelativeRect ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new RelativeRect(1, 2, 3, 4, RelativeUnit.Absolute)));
+    }
+
+    [Test]
+    public void ToString_AbsoluteAndRelative()
+    {
+        var absolute = new RelativeRect(1.5f, 2.5f, 3.5f, 4.5f, RelativeUnit.Absolute);
+        var relative = new RelativeRect(0.25f, 0.5f, 0.5f, 0.5f, RelativeUnit.Relative);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(absolute.ToString(), Is.EqualTo(absolute.Rect.ToString()));
+            Assert.That(relative.ToString(), Is.EqualTo("25%, 50%, 50%, 50%"));
+        });
+    }
+
+    [Test]
+    public void ToString_WithProvider_UsesProviderSeparator()
+    {
+        var fr = CultureInfo.GetCultureInfo("fr-FR");
+        var relative = new RelativeRect(0.25f, 0.5f, 0.5f, 0.5f, RelativeUnit.Relative);
+        var absolute = new RelativeRect(1.5f, 2.5f, 3.5f, 4.5f, RelativeUnit.Absolute);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(relative.ToString(fr), Does.Contain(";").And.Contain("%"));
+            Assert.That(absolute.ToString(fr), Does.Contain(";"));
+            Assert.That(relative.ToString("g", fr), Is.EqualTo(relative.ToString(fr)));
+        });
+    }
+
+    [Test]
+    public void TryFormat_Char_AndUtf8_ReturnSameContent()
+    {
+        var rects = new[]
+        {
+            new RelativeRect(1.5f, 2.5f, 3.5f, 4.5f, RelativeUnit.Absolute),
+            new RelativeRect(0.25f, 0.5f, 0.5f, 0.5f, RelativeUnit.Relative),
+        };
+
+        Span<char> chars = stackalloc char[64];
+        Span<byte> bytes = stackalloc byte[64];
+
+        foreach (RelativeRect rr in rects)
+        {
+            Assert.That(rr.TryFormat(chars, out int cw, default, CultureInfo.InvariantCulture), Is.True);
+            Assert.That(rr.TryFormat(bytes, out int bw, default, CultureInfo.InvariantCulture), Is.True);
+
+            Assert.That(chars[..cw].ToString(), Is.EqualTo(Encoding.UTF8.GetString(bytes[..bw])));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SimpleConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SimpleConvertersTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;

--- a/tests/Beutl.UnitTests/Engine/SimpleConvertersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SimpleConvertersTests.cs
@@ -1,0 +1,437 @@
+using System.Numerics;
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class RelativePointConverterTests
+{
+    private readonly RelativePointConverter _converter = new();
+
+    [Test]
+    public void CanConvertFrom_String_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_Other_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(int)), Is.False);
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var result = (RelativePoint)_converter.ConvertFrom(null, null, "0.5,0.5")!;
+        Assert.That(result, Is.EqualTo(RelativePoint.Parse("0.5,0.5")));
+    }
+}
+
+public class RelativeRectConverterTests
+{
+    private readonly RelativeRectConverter _converter = new();
+
+    [Test]
+    public void CanConvertFrom_String_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_Other_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(double)), Is.False);
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var result = (RelativeRect)_converter.ConvertFrom(null, null, "0%,0%,100%,100%")!;
+        Assert.That(result, Is.EqualTo(RelativeRect.Parse("0%,0%,100%,100%")));
+    }
+}
+
+public class FontFamilyConverterTests
+{
+    private readonly FontFamilyConverter _converter = new();
+
+    [Test]
+    public void CanConvertFrom_String_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_Other_ReturnsFalse()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(int)), Is.False);
+    }
+
+    [Test]
+    public void ConvertFrom_String_ReturnsFontFamily()
+    {
+        var family = (FontFamily)_converter.ConvertFrom(null, null, "Arial")!;
+        Assert.That(family.Name, Is.EqualTo("Arial"));
+    }
+}
+
+public class MatrixConverterTests
+{
+    private readonly MatrixConverter _converter = new();
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_Length6_ReturnsAffineMatrix()
+    {
+        var array = new float[] { 1, 2, 3, 4, 5, 6 };
+        var matrix = (Matrix)_converter.ConvertFrom(null, null, array)!;
+        Assert.That(matrix.M11, Is.EqualTo(1));
+        Assert.That(matrix.M12, Is.EqualTo(2));
+        Assert.That(matrix.M21, Is.EqualTo(3));
+        Assert.That(matrix.M22, Is.EqualTo(4));
+        Assert.That(matrix.M31, Is.EqualTo(5));
+        Assert.That(matrix.M32, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_Length9_ReturnsFullMatrix()
+    {
+        var array = new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        var matrix = (Matrix)_converter.ConvertFrom(null, null, array)!;
+        Assert.That(matrix.M11, Is.EqualTo(1));
+        Assert.That(matrix.M22, Is.EqualTo(5));
+        Assert.That(matrix.M33, Is.EqualTo(9));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var matrix = (Matrix)_converter.ConvertFrom(null, null, "none")!;
+        Assert.That(matrix, Is.EqualTo(Matrix.Identity));
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_Returns9Components()
+    {
+        var matrix = Matrix.Identity;
+        var array = (float[])_converter.ConvertTo(null, null, matrix, typeof(float[]))!;
+        Assert.That(array.Length, Is.EqualTo(9));
+        Assert.That(array[0], Is.EqualTo(1));
+        Assert.That(array[4], Is.EqualTo(1));
+        Assert.That(array[8], Is.EqualTo(1));
+    }
+}
+
+public class ThicknessConverterTests
+{
+    private readonly ThicknessConverter _converter = new();
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsLeftTopRightBottom()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        var array = (float[])_converter.ConvertTo(null, null, t, typeof(float[]))!;
+        Assert.That(array, Is.EqualTo(new[] { 1f, 2f, 3f, 4f }));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple4_ReturnsLeftTopRightBottom()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        var tup = (Tuple<float, float, float, float>)_converter.ConvertTo(null, null, t, typeof(Tuple<float, float, float, float>))!;
+        Assert.That(tup, Is.EqualTo(new Tuple<float, float, float, float>(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple2_ReturnsLeftTop()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        var tup = (Tuple<float, float>)_converter.ConvertTo(null, null, t, typeof(Tuple<float, float>))!;
+        Assert.That(tup, Is.EqualTo(new Tuple<float, float>(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_SingleFloat_ReturnsUniformThickness()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, 5f)!;
+        Assert.That(t, Is.EqualTo(new Thickness(5)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArrayLength1_ReturnsUniform()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, new[] { 7f })!;
+        Assert.That(t, Is.EqualTo(new Thickness(7)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArrayLength2_ReturnsTwoComponent()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, new[] { 1f, 2f })!;
+        Assert.That(t, Is.EqualTo(new Thickness(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArrayLength4_ReturnsFourComponent()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, new[] { 1f, 2f, 3f, 4f })!;
+        Assert.That(t, Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple2_ReturnsTwoComponent()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, new Tuple<float, float>(1, 2))!;
+        Assert.That(t, Is.EqualTo(new Thickness(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple4_ReturnsFourComponent()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, new Tuple<float, float, float, float>(1, 2, 3, 4))!;
+        Assert.That(t, Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var t = (Thickness)_converter.ConvertFrom(null, null, "1,2,3,4")!;
+        Assert.That(t, Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+}
+
+public class GradingColorConverterTests
+{
+    private readonly GradingColorConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Vector3)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Color)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Vector3)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Color)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsRGB()
+    {
+        var c = new GradingColor(0.1f, 0.2f, 0.3f);
+        var array = (float[])_converter.ConvertTo(null, null, c, typeof(float[]))!;
+        Assert.That(array, Is.EqualTo(new[] { 0.1f, 0.2f, 0.3f }));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple_ReturnsRGB()
+    {
+        var c = new GradingColor(0.1f, 0.2f, 0.3f);
+        var tup = (Tuple<float, float, float>)_converter.ConvertTo(null, null, c, typeof(Tuple<float, float, float>))!;
+        Assert.That(tup.Item1, Is.EqualTo(0.1f));
+        Assert.That(tup.Item2, Is.EqualTo(0.2f));
+        Assert.That(tup.Item3, Is.EqualTo(0.3f));
+    }
+
+    [Test]
+    public void ConvertTo_Vector3_ReturnsXYZ()
+    {
+        var c = new GradingColor(0.1f, 0.2f, 0.3f);
+        var v = (Vector3)_converter.ConvertTo(null, null, c, typeof(Vector3))!;
+        Assert.That(v, Is.EqualTo(c.ToVector3()));
+    }
+
+    [Test]
+    public void ConvertTo_Color_ReturnsColor()
+    {
+        var c = new GradingColor(0.1f, 0.2f, 0.3f);
+        var color = (Color)_converter.ConvertTo(null, null, c, typeof(Color))!;
+        Assert.That(color, Is.EqualTo(c.ToColor()));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsGradingColor()
+    {
+        var c = (GradingColor)_converter.ConvertFrom(null, null, new[] { 0.1f, 0.2f, 0.3f })!;
+        Assert.That(c.R, Is.EqualTo(0.1f));
+        Assert.That(c.G, Is.EqualTo(0.2f));
+        Assert.That(c.B, Is.EqualTo(0.3f));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsGradingColor()
+    {
+        var c = (GradingColor)_converter.ConvertFrom(null, null, new Tuple<float, float, float>(0.4f, 0.5f, 0.6f))!;
+        Assert.That(c.R, Is.EqualTo(0.4f));
+        Assert.That(c.G, Is.EqualTo(0.5f));
+        Assert.That(c.B, Is.EqualTo(0.6f));
+    }
+
+    [Test]
+    public void ConvertFrom_Vector3_ReturnsGradingColor()
+    {
+        var c = (GradingColor)_converter.ConvertFrom(null, null, new Vector3(0.4f, 0.5f, 0.6f))!;
+        Assert.That(c, Is.EqualTo(GradingColor.FromVector3(new Vector3(0.4f, 0.5f, 0.6f))));
+    }
+
+    [Test]
+    public void ConvertFrom_Color_ReturnsGradingColor()
+    {
+        var color = Color.FromArgb(255, 128, 64, 32);
+        var c = (GradingColor)_converter.ConvertFrom(null, null, color)!;
+        Assert.That(c, Is.EqualTo(GradingColor.FromColor(color)));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var c = (GradingColor)_converter.ConvertFrom(null, null, "0.1, 0.2, 0.3")!;
+        Assert.That(c, Is.EqualTo(GradingColor.Parse("0.1, 0.2, 0.3")));
+    }
+}
+
+public class ColorConverterTests
+{
+    private readonly ColorConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(byte[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float, float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<byte, byte, byte, byte>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(int)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(uint)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(byte[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(int)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(uint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_ByteArray_ReturnsARGB()
+    {
+        var color = Color.FromArgb(255, 100, 50, 25);
+        var array = (byte[])_converter.ConvertTo(null, null, color, typeof(byte[]))!;
+        Assert.That(array, Is.EqualTo(new byte[] { 255, 100, 50, 25 }));
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsNormalizedARGB()
+    {
+        var color = Color.FromArgb(255, 255, 0, 0);
+        var array = (float[])_converter.ConvertTo(null, null, color, typeof(float[]))!;
+        Assert.That(array.Length, Is.EqualTo(4));
+        Assert.That(array[0], Is.EqualTo(1f));
+        Assert.That(array[1], Is.EqualTo(1f));
+        Assert.That(array[2], Is.EqualTo(0f));
+        Assert.That(array[3], Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ConvertTo_TupleByte_ReturnsARGB()
+    {
+        var color = Color.FromArgb(255, 100, 50, 25);
+        var tup = (Tuple<byte, byte, byte, byte>)_converter.ConvertTo(null, null, color, typeof(Tuple<byte, byte, byte, byte>))!;
+        Assert.That(tup, Is.EqualTo(new Tuple<byte, byte, byte, byte>(255, 100, 50, 25)));
+    }
+
+    [Test]
+    public void ConvertTo_Int_ReturnsInt32()
+    {
+        var color = Color.FromArgb(255, 0, 0, 0);
+        var i = (int)_converter.ConvertTo(null, null, color, typeof(int))!;
+        Assert.That(i, Is.EqualTo(color.ToInt32()));
+    }
+
+    [Test]
+    public void ConvertTo_Uint_ReturnsUInt32()
+    {
+        var color = Color.FromArgb(255, 100, 50, 25);
+        var u = (uint)_converter.ConvertTo(null, null, color, typeof(uint))!;
+        Assert.That(u, Is.EqualTo(color.ToUint32()));
+    }
+
+    [Test]
+    public void ConvertFrom_ByteArray_ReturnsColor()
+    {
+        var color = (Color)_converter.ConvertFrom(null, null, new byte[] { 255, 100, 50, 25 })!;
+        Assert.That(color, Is.EqualTo(Color.FromArgb(255, 100, 50, 25)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsColor()
+    {
+        var color = (Color)_converter.ConvertFrom(null, null, new[] { 1f, 1f, 0f, 0f })!;
+        Assert.That(color.A, Is.EqualTo(255));
+        Assert.That(color.R, Is.EqualTo(255));
+        Assert.That(color.G, Is.EqualTo(0));
+        Assert.That(color.B, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ConvertFrom_Int_ReturnsColor()
+    {
+        var orig = Color.FromArgb(255, 100, 50, 25);
+        var color = (Color)_converter.ConvertFrom(null, null, orig.ToInt32())!;
+        Assert.That(color, Is.EqualTo(orig));
+    }
+
+    [Test]
+    public void ConvertFrom_Uint_ReturnsColor()
+    {
+        var orig = Color.FromArgb(255, 100, 50, 25);
+        var color = (Color)_converter.ConvertFrom(null, null, orig.ToUint32())!;
+        Assert.That(color, Is.EqualTo(orig));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        var color = (Color)_converter.ConvertFrom(null, null, "#FF0000")!;
+        Assert.That(color, Is.EqualTo(Color.Parse("#FF0000")));
+    }
+
+    [Test]
+    public void ConvertFrom_TupleByte_ReturnsColor()
+    {
+        var color = (Color)_converter.ConvertFrom(null, null, new Tuple<byte, byte, byte, byte>(255, 100, 50, 25))!;
+        Assert.That(color, Is.EqualTo(Color.FromArgb(255, 100, 50, 25)));
+    }
+
+    [Test]
+    public void ConvertFrom_TupleFloat_ReturnsColor()
+    {
+        var color = (Color)_converter.ConvertFrom(null, null, new Tuple<float, float, float, float>(1, 1, 0, 0))!;
+        Assert.That(color, Is.EqualTo(Color.FromArgb(255, 255, 0, 0)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SimplePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SimplePropertyTests.cs
@@ -1,0 +1,238 @@
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Engine.Expressions;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class SimplePropertyTests
+{
+    private static SimpleProperty<T> Make<T>(T defaultValue, string name = "Value")
+    {
+        var property = new SimpleProperty<T>(defaultValue);
+        property.SetAttributes(name, []);
+        return property;
+    }
+
+    [Test]
+    public void Name_BeforeInitialization_Throws()
+    {
+        var property = new SimpleProperty<int>(0);
+
+        Assert.Throws<InvalidOperationException>(() => _ = property.Name);
+    }
+
+    [Test]
+    public void ValueType_ReportsGenericArgument()
+    {
+        var property = Make(0);
+
+        Assert.That(property.ValueType, Is.EqualTo(typeof(int)));
+    }
+
+    [Test]
+    public void CurrentValue_SetSameValue_DoesNotRaiseEvents()
+    {
+        var property = Make(10);
+        int valueChanged = 0;
+        int edited = 0;
+
+        property.ValueChanged += (_, _) => valueChanged++;
+        property.Edited += (_, _) => edited++;
+
+        property.CurrentValue = 10;
+
+        Assert.That(valueChanged, Is.Zero);
+        Assert.That(edited, Is.Zero);
+        Assert.That(property.HasLocalValue, Is.False);
+    }
+
+    [Test]
+    public void CurrentValue_NewValue_RaisesValueChangedAndEdited()
+    {
+        var property = Make(0);
+        PropertyValueChangedEventArgs<int>? args = null;
+        int edited = 0;
+        property.ValueChanged += (_, e) => args = e;
+        property.Edited += (_, _) => edited++;
+
+        property.CurrentValue = 42;
+
+        Assert.That(args, Is.Not.Null);
+        Assert.That(args!.Property, Is.SameAs(property));
+        Assert.That(args.OldValue, Is.EqualTo(0));
+        Assert.That(args.NewValue, Is.EqualTo(42));
+        Assert.That(edited, Is.EqualTo(1));
+        Assert.That(property.HasLocalValue, Is.True);
+    }
+
+    [Test]
+    public void CompoundAssign_SetsCurrentValue()
+    {
+        var property = Make(0);
+
+        property <<= 7;
+
+        Assert.That(property.CurrentValue, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Animation_SetNonNull_Throws()
+    {
+        var property = Make(0);
+
+        Assert.Throws<InvalidOperationException>(() => property.Animation = new Beutl.Animation.KeyFrameAnimation<int>());
+    }
+
+    [Test]
+    public void Animation_SetNull_DoesNotThrow()
+    {
+        var property = Make(0);
+
+        Assert.DoesNotThrow(() => property.Animation = null);
+        Assert.That(property.Animation, Is.Null);
+    }
+
+    [Test]
+    public void Expression_AssigningRaisesExpressionChangedAndEdited()
+    {
+        var property = Make(0.0);
+        IExpression<double>? captured = null;
+        int edited = 0;
+        property.ExpressionChanged += e => captured = e;
+        property.Edited += (_, _) => edited++;
+
+        var expression = Expression.Create<double>("1+2");
+        property.Expression = expression;
+
+        Assert.That(captured, Is.SameAs(expression));
+        Assert.That(edited, Is.EqualTo(1));
+        Assert.That(property.HasExpression, Is.True);
+    }
+
+    [Test]
+    public void Expression_AssigningSameValue_DoesNotRaise()
+    {
+        var property = Make(0.0);
+        var expression = Expression.Create<double>("1+2");
+        property.Expression = expression;
+        int edited = 0;
+        property.Edited += (_, _) => edited++;
+
+        property.Expression = expression;
+
+        Assert.That(edited, Is.Zero);
+    }
+
+    [Test]
+    public void GetValue_WithoutExpression_ReturnsCurrentValue()
+    {
+        var property = Make(0);
+        property.CurrentValue = 99;
+
+        int value = property.GetValue(CompositionContext.Default);
+
+        Assert.That(value, Is.EqualTo(99));
+    }
+
+    [Test]
+    public void ResetToDefault_RestoresDefaultsAndClearsState()
+    {
+        var property = Make(7);
+        property.CurrentValue = 100;
+        property.Expression = Expression.Create<int>("1+2");
+
+        property.ResetToDefault();
+
+        Assert.That(property.CurrentValue, Is.EqualTo(7));
+        Assert.That(property.HasLocalValue, Is.False);
+        Assert.That(property.HasExpression, Is.False);
+    }
+
+    [Test]
+    public void GetAttributes_ReturnsAttributesPassedToSetAttributes()
+    {
+        var attrs = new Attribute[] { new ObsoleteAttribute("test") };
+        var property = new SimpleProperty<int>(0);
+        property.SetAttributes("Foo", attrs);
+
+        Assert.That(property.GetAttributes(), Is.SameAs(attrs));
+        Assert.That(property.Name, Is.EqualTo("Foo"));
+    }
+
+    [Test]
+    public void GetOwnerObject_AfterSet_ReturnsAssignedOwner()
+    {
+        var property = Make(0);
+        var owner = new TestEngineObjectForProperty();
+
+        property.SetOwnerObject(owner);
+
+        Assert.That(property.GetOwnerObject(), Is.SameAs(owner));
+    }
+
+    [Test]
+    public void SetOwnerObject_SameValue_NoEffect()
+    {
+        var property = Make(0);
+        var owner = new TestEngineObjectForProperty();
+        property.SetOwnerObject(owner);
+
+        // Should not throw or alter behavior.
+        property.SetOwnerObject(owner);
+
+        Assert.That(property.GetOwnerObject(), Is.SameAs(owner));
+    }
+
+    [Test]
+    public void ToString_WithoutExpression_FormatsSimpleSummary()
+    {
+        var property = Make(5);
+
+        Assert.That(property.ToString(), Does.Contain("Simple"));
+        Assert.That(property.ToString(), Does.Contain("Default: 5"));
+    }
+
+    [Test]
+    public void ToString_WithExpression_IncludesExpressionString()
+    {
+        var property = Make(0.0);
+        property.Expression = Expression.Create<double>("1+2");
+
+        Assert.That(property.ToString(), Does.Contain("Expression"));
+        Assert.That(property.ToString(), Does.Contain("1+2"));
+    }
+
+    [Test]
+    public void ToAnimatable_PreservesLocalValue()
+    {
+        var property = Make(1);
+        property.CurrentValue = 42;
+
+        IProperty<int> animatable = property.ToAnimatable();
+
+        Assert.That(animatable, Is.InstanceOf<AnimatableProperty<int>>());
+        Assert.That(animatable.DefaultValue, Is.EqualTo(1));
+        Assert.That(animatable.CurrentValue, Is.EqualTo(42));
+        Assert.That(animatable.IsAnimatable, Is.True);
+    }
+
+    [Test]
+    public void ToAnimatable_WithoutLocalValue_KeepsDefault()
+    {
+        var property = Make(7);
+
+        IProperty<int> animatable = property.ToAnimatable();
+
+        Assert.That(animatable.CurrentValue, Is.EqualTo(7));
+        Assert.That(animatable.HasLocalValue, Is.False);
+    }
+}
+
+public partial class TestEngineObjectForProperty : EngineObject
+{
+    public TestEngineObjectForProperty()
+    {
+        ScanProperties<TestEngineObjectForProperty>();
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SimplePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SimplePropertyTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Engine.Expressions;
 

--- a/tests/Beutl.UnitTests/Engine/SizeConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SizeConverterTests.cs
@@ -1,0 +1,86 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class SizeConverterTests
+{
+    private readonly SizeConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Rect)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Vector)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsWidthHeight()
+    {
+        var size = new Size(7, 9);
+        float[] result = (float[])_converter.ConvertTo(null, null, size, typeof(float[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 7f, 9f }));
+    }
+
+    [Test]
+    public void ConvertTo_Point_PreservesCoords()
+    {
+        var size = new Size(3, 4);
+        Point p = (Point)_converter.ConvertTo(null, null, size, typeof(Point))!;
+        Assert.That(p, Is.EqualTo(new Point(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Rect_StartsAtOrigin()
+    {
+        var size = new Size(2, 5);
+        Rect r = (Rect)_converter.ConvertTo(null, null, size, typeof(Rect))!;
+        Assert.That(r.X, Is.EqualTo(0));
+        Assert.That(r.Y, Is.EqualTo(0));
+        Assert.That(r.Width, Is.EqualTo(2));
+        Assert.That(r.Height, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void ConvertTo_PixelSize_TruncatesToInt()
+    {
+        var size = new Size(1.7f, 2.4f);
+        PixelSize pixel = (PixelSize)_converter.ConvertTo(null, null, size, typeof(PixelSize))!;
+        Assert.That(pixel.Width, Is.EqualTo(1));
+        Assert.That(pixel.Height, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ConvertFrom_Vector_PreservesXY()
+    {
+        Size s = (Size)_converter.ConvertFrom(null, null, new Vector(3, 4))!;
+        Assert.That(s, Is.EqualTo(new Size(3, 4)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsSize()
+    {
+        Size s = (Size)_converter.ConvertFrom(null, null, new float[] { 5.5f, 6.6f })!;
+        Assert.That(s.Width, Is.EqualTo(5.5f));
+        Assert.That(s.Height, Is.EqualTo(6.6f));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        Size s = (Size)_converter.ConvertFrom(null, null, "10,20")!;
+        Assert.That(s, Is.EqualTo(new Size(10, 20)));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SizeConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SizeConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/SoundSamplingHelperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SoundSamplingHelperTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Audio;
+﻿using Beutl.Audio;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/SoundSamplingHelperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SoundSamplingHelperTests.cs
@@ -1,0 +1,119 @@
+using Beutl.Audio;
+
+namespace Beutl.UnitTests.Engine;
+
+public class SoundSamplingHelperTests
+{
+    [Test]
+    public void DownsampleMinMax_EmptySamples_ClearsBuffers()
+    {
+        Span<float> mins = stackalloc float[3];
+        Span<float> maxs = stackalloc float[3];
+        mins.Fill(0.5f);
+        maxs.Fill(0.5f);
+
+        SoundSamplingHelper.DownsampleMinMax(ReadOnlySpan<float>.Empty, mins, maxs);
+
+        for (int i = 0; i < mins.Length; i++)
+        {
+            Assert.That(mins[i], Is.EqualTo(0f));
+            Assert.That(maxs[i], Is.EqualTo(0f));
+        }
+    }
+
+    [Test]
+    public void DownsampleMinMax_ZeroBars_DoesNothing()
+    {
+        SoundSamplingHelper.DownsampleMinMax(
+            new float[] { 1f, 2f, 3f }, Span<float>.Empty, Span<float>.Empty);
+    }
+
+    [Test]
+    public void DownsampleMinMax_LengthMismatch_Throws()
+    {
+        ReadOnlySpan<float> samples = [1f, 2f, 3f];
+        var mins = new float[2];
+        var maxs = new float[3];
+
+        try
+        {
+            SoundSamplingHelper.DownsampleMinMax(samples, mins, maxs);
+            Assert.Fail("expected ArgumentException");
+        }
+        catch (ArgumentException)
+        {
+            Assert.Pass();
+        }
+    }
+
+    [Test]
+    public void DownsampleMinMax_DistributesSamplesIntoBins()
+    {
+        float[] samples = [-2f, -1f, 0f, 1f, 2f, 3f];
+        var mins = new float[3];
+        var maxs = new float[3];
+
+        SoundSamplingHelper.DownsampleMinMax(samples, mins, maxs);
+
+        Assert.That(mins[0], Is.EqualTo(-2f));
+        Assert.That(maxs[0], Is.EqualTo(-1f));
+        Assert.That(mins[1], Is.EqualTo(0f));
+        Assert.That(maxs[1], Is.EqualTo(1f));
+        Assert.That(mins[2], Is.EqualTo(2f));
+        Assert.That(maxs[2], Is.EqualTo(3f));
+    }
+
+    [Test]
+    public void DownsampleMinMax_MoreBinsThanSamples_NoInfinitiesLeak()
+    {
+        float[] samples = [4f, -4f];
+        var mins = new float[5];
+        var maxs = new float[5];
+
+        SoundSamplingHelper.DownsampleMinMax(samples, mins, maxs);
+
+        // The function ensures sentinels are replaced — no infinities should leak.
+        for (int i = 0; i < mins.Length; i++)
+        {
+            Assert.That(float.IsInfinity(mins[i]), Is.False);
+            Assert.That(float.IsInfinity(maxs[i]), Is.False);
+            Assert.That(mins[i], Is.LessThanOrEqualTo(maxs[i]));
+        }
+    }
+
+    [Test]
+    public void ExtractWindow_CenteredOnIndex_CopiesNeighborhood()
+    {
+        float[] samples = [1, 2, 3, 4, 5, 6, 7];
+        Span<float> dest = stackalloc float[3];
+
+        SoundSamplingHelper.ExtractWindow(samples, centerIndex: 3, dest);
+
+        // window n=3, start = 3 - 3/2 = 2 -> samples[2..4]
+        Assert.That(dest[0], Is.EqualTo(3f));
+        Assert.That(dest[1], Is.EqualTo(4f));
+        Assert.That(dest[2], Is.EqualTo(5f));
+    }
+
+    [Test]
+    public void ExtractWindow_OutsideRange_FillsZeros()
+    {
+        float[] samples = [10, 20];
+        Span<float> dest = stackalloc float[5];
+
+        SoundSamplingHelper.ExtractWindow(samples, centerIndex: 0, dest);
+
+        // window n=5, start = 0 - 2 = -2. Indices -2,-1,0,1,2 -> map to 0,0,10,20,0
+        Assert.That(dest[0], Is.EqualTo(0f));
+        Assert.That(dest[1], Is.EqualTo(0f));
+        Assert.That(dest[2], Is.EqualTo(10f));
+        Assert.That(dest[3], Is.EqualTo(20f));
+        Assert.That(dest[4], Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ExtractWindow_EmptyDestination_DoesNothing()
+    {
+        SoundSamplingHelper.ExtractWindow(new float[] { 1, 2, 3 }, 1, Span<float>.Empty);
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
@@ -1,0 +1,117 @@
+using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class SpeedIntegratorTests
+{
+    private static KeyFrameAnimation<float> ConstantSpeed(float value)
+    {
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = value,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromSeconds(10),
+            Value = value,
+            Easing = new LinearEasing()
+        });
+        return animation;
+    }
+
+    [Test]
+    public void SampleRate_Setter_InvalidatesCache()
+    {
+        bool invalidated = false;
+        using var integrator = new SpeedIntegrator(60, () => invalidated = true);
+        integrator.SampleRate = 44100;
+        Assert.That(invalidated, Is.True);
+    }
+
+    [Test]
+    public void SampleRate_SetSameValue_DoesNotInvalidate()
+    {
+        bool invalidated = false;
+        using var integrator = new SpeedIntegrator(60, () => invalidated = true);
+        integrator.SampleRate = 60;
+        Assert.That(invalidated, Is.False);
+    }
+
+    [Test]
+    public void TryGetCache_BeforeInit_ReturnsMinusOne()
+    {
+        using var integrator = new SpeedIntegrator(60);
+        var (key, value) = integrator.TryGetCache(0);
+        Assert.That(key, Is.EqualTo(-1));
+        Assert.That(value, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Integrate_Speed100_ReturnsSameTime()
+    {
+        using var integrator = new SpeedIntegrator(60);
+        var animation = ConstantSpeed(100f);
+        integrator.EnsureCache(animation);
+
+        var result = integrator.Integrate(TimeSpan.FromSeconds(2), animation);
+
+        Assert.That(result.TotalSeconds, Is.EqualTo(2.0).Within(0.05));
+    }
+
+    [Test]
+    public void Integrate_Speed200_DoublesTime()
+    {
+        using var integrator = new SpeedIntegrator(60);
+        var animation = ConstantSpeed(200f);
+        integrator.EnsureCache(animation);
+
+        var result = integrator.Integrate(TimeSpan.FromSeconds(1), animation);
+
+        Assert.That(result.TotalSeconds, Is.EqualTo(2.0).Within(0.05));
+    }
+
+    [Test]
+    public void Integrate_Speed0_ReturnsZero()
+    {
+        using var integrator = new SpeedIntegrator(60);
+        var animation = ConstantSpeed(0f);
+        integrator.EnsureCache(animation);
+
+        var result = integrator.Integrate(TimeSpan.FromSeconds(2), animation);
+
+        Assert.That(result.TotalSeconds, Is.EqualTo(0).Within(0.05));
+    }
+
+    [Test]
+    public void EnsureCache_NullAnimation_NoThrow()
+    {
+        using var integrator = new SpeedIntegrator(60);
+        Assert.DoesNotThrow(() => integrator.EnsureCache(null));
+    }
+
+    [Test]
+    public void Dispose_ClearsState()
+    {
+        var integrator = new SpeedIntegrator(60);
+        integrator.EnsureCache(ConstantSpeed(100f));
+        integrator.Dispose();
+
+        var (key, _) = integrator.TryGetCache(0);
+        Assert.That(key, Is.EqualTo(-1));
+    }
+
+    [Test]
+    public void Invalidate_FiresCallback()
+    {
+        int callbackCount = 0;
+        using var integrator = new SpeedIntegrator(60, () => callbackCount++);
+        integrator.Invalidate();
+        Assert.That(callbackCount, Is.EqualTo(1));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Beutl.Graphics;
 

--- a/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
@@ -1,0 +1,154 @@
+using System.Globalization;
+using System.Text;
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class ThicknessTests
+{
+    [Test]
+    public void Constructor_Uniform_AllSidesEqual()
+    {
+        var t = new Thickness(5);
+        Assert.That(t.Left, Is.EqualTo(5));
+        Assert.That(t.Top, Is.EqualTo(5));
+        Assert.That(t.Right, Is.EqualTo(5));
+        Assert.That(t.Bottom, Is.EqualTo(5));
+        Assert.That(t.IsUniform, Is.True);
+    }
+
+    [Test]
+    public void Constructor_HorizontalVertical_PairsSides()
+    {
+        var t = new Thickness(2, 3);
+        Assert.That(t.Left, Is.EqualTo(2));
+        Assert.That(t.Right, Is.EqualTo(2));
+        Assert.That(t.Top, Is.EqualTo(3));
+        Assert.That(t.Bottom, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Constructor_FourValues_AssignsEachSide()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        Assert.That(t.Left, Is.EqualTo(1));
+        Assert.That(t.Top, Is.EqualTo(2));
+        Assert.That(t.Right, Is.EqualTo(3));
+        Assert.That(t.Bottom, Is.EqualTo(4));
+        Assert.That(t.IsUniform, Is.False);
+        Assert.That(t.IsDefault, Is.False);
+    }
+
+    [Test]
+    public void IsEmpty_AndIsDefault_TrueOnlyForZero()
+    {
+        Assert.That(new Thickness(0).IsEmpty, Is.True);
+        Assert.That(new Thickness(0).IsDefault, Is.True);
+        Assert.That(new Thickness(1).IsEmpty, Is.False);
+        Assert.That(new Thickness(1, 2, 3, 4).IsDefault, Is.False);
+    }
+
+    [Test]
+    public void Equality_ChecksAllSides()
+    {
+        var a = new Thickness(1, 2, 3, 4);
+        var b = new Thickness(1, 2, 3, 4);
+        var c = new Thickness(0, 2, 3, 4);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void AddSubtractMultiply_ProducePerSideResults()
+    {
+        var a = new Thickness(1, 2, 3, 4);
+        var b = new Thickness(10, 20, 30, 40);
+
+        Assert.That(a + b, Is.EqualTo(new Thickness(11, 22, 33, 44)));
+        Assert.That(b - a, Is.EqualTo(new Thickness(9, 18, 27, 36)));
+        Assert.That(a * 2f, Is.EqualTo(new Thickness(2, 4, 6, 8)));
+    }
+
+    [Test]
+    public void Deconstruct_ExposesEachSide()
+    {
+        var (l, t, r, b) = new Thickness(1, 2, 3, 4);
+        Assert.That(l, Is.EqualTo(1));
+        Assert.That(t, Is.EqualTo(2));
+        Assert.That(r, Is.EqualTo(3));
+        Assert.That(b, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void WithMethods_OnlyChangeOneSide()
+    {
+        var t = new Thickness(1, 2, 3, 4);
+        Assert.That(t.WithLeft(9), Is.EqualTo(new Thickness(9, 2, 3, 4)));
+        Assert.That(t.WithTop(9), Is.EqualTo(new Thickness(1, 9, 3, 4)));
+        Assert.That(t.WithRight(9), Is.EqualTo(new Thickness(1, 2, 9, 4)));
+        Assert.That(t.WithBottom(9), Is.EqualTo(new Thickness(1, 2, 3, 9)));
+    }
+
+    [Test]
+    public void ToString_AdaptsToUniformity()
+    {
+        Assert.That(new Thickness(5).ToString(), Is.EqualTo("5"));
+        Assert.That(new Thickness(2, 3).ToString(), Is.EqualTo("2, 3"));
+        Assert.That(new Thickness(1, 2, 3, 4).ToString(), Is.EqualTo("1, 2, 3, 4"));
+    }
+
+    [Test]
+    public void Parse_ConvertsOneTwoOrFourValues()
+    {
+        Assert.That(Thickness.Parse("5"), Is.EqualTo(new Thickness(5)));
+        Assert.That(Thickness.Parse("2, 3"), Is.EqualTo(new Thickness(2, 3)));
+        Assert.That(Thickness.Parse("1, 2, 3, 4"), Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void Parse_WithProvider_AcceptsAlternateSeparator()
+    {
+        var fr = CultureInfo.GetCultureInfo("fr");
+        Assert.That(Thickness.Parse("1; 2; 3; 4", fr), Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void TryParse_InvalidString_ReturnsFalse()
+    {
+        Assert.That(Thickness.TryParse("garbage", out Thickness t), Is.False);
+        Assert.That(t, Is.EqualTo(default(Thickness)));
+        Assert.That(Thickness.TryParse(""u8, out _), Is.False);
+    }
+
+    [Test]
+    public void Parse_Utf8_RoundTrip()
+    {
+        Assert.That(Thickness.Parse("1, 2, 3, 4"u8), Is.EqualTo(new Thickness(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void TryFormat_Char_AndUtf8_ReturnSameContent()
+    {
+        var values = new[]
+        {
+            new Thickness(5),
+            new Thickness(2, 3),
+            new Thickness(1, 2, 3, 4),
+        };
+
+        foreach (Thickness t in values)
+        {
+            Span<char> chars = stackalloc char[64];
+            Span<byte> bytes = stackalloc byte[64];
+
+            Assert.That(t.TryFormat(chars, out int cw), Is.True);
+            Assert.That(t.TryFormat(bytes, out int bw), Is.True);
+
+            Assert.That(chars[..cw].ToString(),
+                Is.EqualTo(Encoding.UTF8.GetString(bytes[..bw])));
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
+++ b/tests/Beutl.UnitTests/Engine/ThicknessTests.cs
@@ -139,11 +139,11 @@ public class ThicknessTests
             new Thickness(1, 2, 3, 4),
         };
 
+        Span<char> chars = stackalloc char[64];
+        Span<byte> bytes = stackalloc byte[64];
+
         foreach (Thickness t in values)
         {
-            Span<char> chars = stackalloc char[64];
-            Span<byte> bytes = stackalloc byte[64];
-
             Assert.That(t.TryFormat(chars, out int cw), Is.True);
             Assert.That(t.TryFormat(bytes, out int bw), Is.True);
 

--- a/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
@@ -1,0 +1,154 @@
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class TimeRangeExtraTests
+{
+    [Test]
+    public void Empty_HasZeroStartAndDuration()
+    {
+        Assert.That(TimeRange.Empty.Start, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(TimeRange.Empty.Duration, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(TimeRange.Empty.End, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void DefaultConstructor_EqualsEmpty()
+    {
+        var range = new TimeRange();
+
+        Assert.That(range, Is.EqualTo(TimeRange.Empty));
+    }
+
+    [Test]
+    public void DurationOnlyConstructor_StartsAtZero()
+    {
+        var range = new TimeRange(TimeSpan.FromSeconds(3));
+
+        Assert.That(range.Start, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(range.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void FromRange_DerivesDurationFromEndMinusStart()
+    {
+        var range = TimeRange.FromRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(7));
+
+        Assert.That(range.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(range.Duration, Is.EqualTo(TimeSpan.FromSeconds(5)));
+        Assert.That(range.End, Is.EqualTo(TimeSpan.FromSeconds(7)));
+    }
+
+    [Test]
+    public void IsEmpty_TrueOnlyWhenStartGreaterThanEnd()
+    {
+        // duration > 0 means End > Start, so IsEmpty stays false even at zero duration.
+        var zero = new TimeRange();
+        var positive = TimeRange.FromSeconds(1, 2);
+        var negative = new TimeRange(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-1));
+
+        Assert.That(zero.IsEmpty, Is.False);
+        Assert.That(positive.IsEmpty, Is.False);
+        Assert.That(negative.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Contains_TimeSpan_ExcludesEnd()
+    {
+        var range = TimeRange.FromSeconds(2, 3);
+
+        Assert.That(range.Contains(TimeSpan.FromSeconds(2)), Is.True);
+        Assert.That(range.Contains(TimeSpan.FromSeconds(4)), Is.True);
+        Assert.That(range.Contains(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That(range.Contains(TimeSpan.FromSeconds(1.99)), Is.False);
+    }
+
+    [Test]
+    public void WithStart_PreservesDuration()
+    {
+        var range = TimeRange.FromSeconds(2, 3);
+
+        var modified = range.WithStart(TimeSpan.FromSeconds(10));
+
+        Assert.That(modified.Start, Is.EqualTo(TimeSpan.FromSeconds(10)));
+        Assert.That(modified.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void WithDuration_PreservesStart()
+    {
+        var range = TimeRange.FromSeconds(2, 3);
+
+        var modified = range.WithDuration(TimeSpan.FromSeconds(10));
+
+        Assert.That(modified.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(modified.Duration, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+
+    [Test]
+    public void AddStart_OffsetsStart()
+    {
+        var range = TimeRange.FromSeconds(2, 3);
+
+        var shifted = range.AddStart(TimeSpan.FromSeconds(5));
+
+        Assert.That(shifted.Start, Is.EqualTo(TimeSpan.FromSeconds(7)));
+        Assert.That(shifted.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void SubtractStart_RewindsStart()
+    {
+        var range = TimeRange.FromSeconds(5, 3);
+
+        var shifted = range.SubtractStart(TimeSpan.FromSeconds(2));
+
+        Assert.That(shifted.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+        Assert.That(shifted.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void Union_WithIsEmptyOperand_ReturnsOther()
+    {
+        // IsEmpty is defined as Start > End, so a negative-duration range is treated as empty.
+        var range = TimeRange.FromSeconds(1, 2);
+        var emptyByDef = new TimeRange(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(-1));
+
+        Assert.That(emptyByDef.IsEmpty, Is.True);
+        Assert.That(emptyByDef.Union(range), Is.EqualTo(range));
+        Assert.That(range.Union(emptyByDef), Is.EqualTo(range));
+    }
+
+    [Test]
+    public void Intersect_NoOverlap_ReturnsEmpty()
+    {
+        var a = TimeRange.FromSeconds(0, 1);
+        var b = TimeRange.FromSeconds(5, 1);
+
+        Assert.That(a.Intersect(b), Is.EqualTo(TimeRange.Empty));
+    }
+
+    [Test]
+    public void Equality_OnEqualRanges_IsTrueAndHashesMatch()
+    {
+        var a = TimeRange.FromSeconds(2, 3);
+        var b = TimeRange.FromSeconds(2, 3);
+        var c = TimeRange.FromSeconds(2, 4);
+
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"foo"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void ToString_FormatsHoursMinutesSecondsAndHundredths()
+    {
+        var range = TimeRange.FromSeconds(3, 5);
+
+        Assert.That(range.ToString(), Does.Match(@"\d{2}:\d{2}:\d{2}\.\d{2}"));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/VectorConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/VectorConverterTests.cs
@@ -1,0 +1,137 @@
+using Beutl.Converters;
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine;
+
+public class VectorConverterTests
+{
+    private readonly VectorConverter _converter = new();
+
+    [Test]
+    public void CanConvertTo_KnownTargets_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertTo(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Tuple<float, float>)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertTo(null, typeof(PixelSize)), Is.True);
+    }
+
+    [Test]
+    public void CanConvertFrom_KnownSources_ReturnsTrue()
+    {
+        Assert.That(_converter.CanConvertFrom(null, typeof(float[])), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Tuple<float, float>)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Point)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(Size)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelPoint)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(PixelSize)), Is.True);
+        Assert.That(_converter.CanConvertFrom(null, typeof(string)), Is.True);
+    }
+
+    [Test]
+    public void ConvertTo_FloatArray_ReturnsXY()
+    {
+        var v = new Vector(2.5f, -1.25f);
+        float[] result = (float[])_converter.ConvertTo(null, null, v, typeof(float[]))!;
+        Assert.That(result, Is.EqualTo(new[] { 2.5f, -1.25f }));
+    }
+
+    [Test]
+    public void ConvertTo_Tuple_ReturnsXY()
+    {
+        var v = new Vector(3, 4);
+        var result = (Tuple<float, float>)_converter.ConvertTo(null, null, v, typeof(Tuple<float, float>))!;
+        Assert.That(result, Is.EqualTo(new Tuple<float, float>(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Point_ReturnsXY()
+    {
+        var v = new Vector(3, 4);
+        Point p = (Point)_converter.ConvertTo(null, null, v, typeof(Point))!;
+        Assert.That(p, Is.EqualTo(new Point(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_Size_ReturnsXY()
+    {
+        var v = new Vector(3, 4);
+        Size s = (Size)_converter.ConvertTo(null, null, v, typeof(Size))!;
+        Assert.That(s, Is.EqualTo(new Size(3, 4)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelPoint_TruncatesXY()
+    {
+        var v = new Vector(1.9f, 2.7f);
+        PixelPoint p = (PixelPoint)_converter.ConvertTo(null, null, v, typeof(PixelPoint))!;
+        Assert.That(p, Is.EqualTo(new PixelPoint(1, 2)));
+    }
+
+    [Test]
+    public void ConvertTo_PixelSize_TruncatesXY()
+    {
+        var v = new Vector(1.9f, 2.7f);
+        PixelSize p = (PixelSize)_converter.ConvertTo(null, null, v, typeof(PixelSize))!;
+        Assert.That(p, Is.EqualTo(new PixelSize(1, 2)));
+    }
+
+    [Test]
+    public void ConvertFrom_FloatArray_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new float[] { 1.5f, 2.5f })!;
+        Assert.That(v.X, Is.EqualTo(1.5f));
+        Assert.That(v.Y, Is.EqualTo(2.5f));
+    }
+
+    [Test]
+    public void ConvertFrom_Tuple_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new Tuple<float, float>(7, 8))!;
+        Assert.That(v.X, Is.EqualTo(7));
+        Assert.That(v.Y, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void ConvertFrom_Point_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new Point(2.5f, 3.5f))!;
+        Assert.That(v.X, Is.EqualTo(2.5f));
+        Assert.That(v.Y, Is.EqualTo(3.5f));
+    }
+
+    [Test]
+    public void ConvertFrom_Size_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new Size(4, 5))!;
+        Assert.That(v.X, Is.EqualTo(4));
+        Assert.That(v.Y, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelPoint_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new PixelPoint(11, 12))!;
+        Assert.That(v.X, Is.EqualTo(11));
+        Assert.That(v.Y, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void ConvertFrom_PixelSize_ReturnsVector()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, new PixelSize(11, 12))!;
+        Assert.That(v.X, Is.EqualTo(11));
+        Assert.That(v.Y, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void ConvertFrom_String_UsesParse()
+    {
+        Vector v = (Vector)_converter.ConvertFrom(null, null, "1.5,2.5")!;
+        Assert.That(v.X, Is.EqualTo(1.5f));
+        Assert.That(v.Y, Is.EqualTo(2.5f));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/VectorConverterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/VectorConverterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Converters;
+﻿using Beutl.Converters;
 using Beutl.Graphics;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/VectorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/VectorTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 
 namespace Beutl.UnitTests.Engine;
 

--- a/tests/Beutl.UnitTests/Engine/VectorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/VectorTests.cs
@@ -1,0 +1,176 @@
+using Beutl.Graphics;
+
+namespace Beutl.UnitTests.Engine;
+
+public class VectorTests
+{
+    [Test]
+    public void Constants_HaveExpectedValues()
+    {
+        Assert.That(Vector.Zero, Is.EqualTo(new Vector(0, 0)));
+        Assert.That(Vector.One, Is.EqualTo(new Vector(1, 1)));
+        Assert.That(Vector.UnitX, Is.EqualTo(new Vector(1, 0)));
+        Assert.That(Vector.UnitY, Is.EqualTo(new Vector(0, 1)));
+        Assert.That(Vector.Zero.IsDefault, Is.True);
+        Assert.That(Vector.One.IsDefault, Is.False);
+    }
+
+    [Test]
+    public void Length_ReturnsEuclideanDistance()
+    {
+        var v = new Vector(3, 4);
+        Assert.That(v.Length, Is.EqualTo(5f).Within(1e-5f));
+        Assert.That(v.SquaredLength, Is.EqualTo(25f).Within(1e-5f));
+    }
+
+    [Test]
+    public void Add_Sum_OfComponents()
+    {
+        var a = new Vector(1, 2);
+        var b = new Vector(3, 4);
+        Assert.That(a + b, Is.EqualTo(new Vector(4, 6)));
+        Assert.That(Vector.Add(a, b), Is.EqualTo(new Vector(4, 6)));
+    }
+
+    [Test]
+    public void Subtract_Difference_OfComponents()
+    {
+        var a = new Vector(5, 6);
+        var b = new Vector(1, 2);
+        Assert.That(a - b, Is.EqualTo(new Vector(4, 4)));
+        Assert.That(Vector.Subtract(a, b), Is.EqualTo(new Vector(4, 4)));
+    }
+
+    [Test]
+    public void Multiply_ScalarFromBothSides_AndDot()
+    {
+        var v = new Vector(2, 3);
+        Assert.That(v * 2f, Is.EqualTo(new Vector(4, 6)));
+        Assert.That(2f * v, Is.EqualTo(new Vector(4, 6)));
+        Assert.That(Vector.Multiply(v, 2f), Is.EqualTo(new Vector(4, 6)));
+        Assert.That(Vector.Multiply(v, new Vector(2, 3)), Is.EqualTo(new Vector(4, 9)));
+        Assert.That(v * new Vector(2, 3), Is.EqualTo(2f * 2f + 3f * 3f));
+    }
+
+    [Test]
+    public void Divide_ByScalarAndVector()
+    {
+        var v = new Vector(4, 9);
+        Assert.That(v / 2f, Is.EqualTo(new Vector(2, 4.5f)));
+        Assert.That(Vector.Divide(v, 2f), Is.EqualTo(new Vector(2, 4.5f)));
+        Assert.That(Vector.Divide(v, new Vector(2, 3)), Is.EqualTo(new Vector(2, 3)));
+    }
+
+    [Test]
+    public void Negate_FlipsBothComponents()
+    {
+        var v = new Vector(1, -2);
+        Assert.That(-v, Is.EqualTo(new Vector(-1, 2)));
+        Assert.That(Vector.Negate(v), Is.EqualTo(new Vector(-1, 2)));
+        Assert.That(v.Negate(), Is.EqualTo(new Vector(-1, 2)));
+    }
+
+    [Test]
+    public void Dot_AndCross_ProduceExpectedScalars()
+    {
+        var a = new Vector(1, 2);
+        var b = new Vector(3, 4);
+        Assert.That(Vector.Dot(a, b), Is.EqualTo(11f));
+        Assert.That(Vector.Cross(a, b), Is.EqualTo(-2f));
+    }
+
+    [Test]
+    public void Normalize_ProducesUnitVector()
+    {
+        var v = new Vector(3, 4);
+        Vector n = v.Normalize();
+        Assert.That(n.Length, Is.EqualTo(1f).Within(1e-5f));
+        Assert.That(Vector.Normalize(v), Is.EqualTo(n));
+    }
+
+    [Test]
+    public void WithX_WithY_ReplaceComponentImmutably()
+    {
+        var v = new Vector(1, 2);
+        Assert.That(v.WithX(7), Is.EqualTo(new Vector(7, 2)));
+        Assert.That(v.WithY(9), Is.EqualTo(new Vector(1, 9)));
+    }
+
+    [Test]
+    public void Equality_ComparesByComponents()
+    {
+        var a = new Vector(1, 2);
+        var b = new Vector(1, 2);
+        var c = new Vector(1, 3);
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+        Assert.That(a.Equals((object)b), Is.True);
+        Assert.That(a.Equals((object)"x"), Is.False);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void NearlyEquals_TolerantWithinFloatEpsilon()
+    {
+        var a = new Vector(1f, 2f);
+        var b = new Vector(1f + float.Epsilon, 2f - float.Epsilon);
+        Assert.That(a.NearlyEquals(b), Is.True);
+    }
+
+    [Test]
+    public void Deconstruct_ReturnsComponents()
+    {
+        var v = new Vector(7, 8);
+        var (x, y) = v;
+        Assert.That(x, Is.EqualTo(7));
+        Assert.That(y, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void ImplicitToPoint_PreservesComponents()
+    {
+        var v = new Vector(2, 3);
+        Point p = (Point)v;
+        Assert.That(p.X, Is.EqualTo(2));
+        Assert.That(p.Y, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ToString_RoundTripsThroughParse()
+    {
+        var v = new Vector(1.5f, -2.5f);
+        string s = v.ToString();
+        Vector parsed = Vector.Parse(s);
+        Assert.That(parsed, Is.EqualTo(v));
+    }
+
+    [Test]
+    public void TryParse_ValidAndInvalid()
+    {
+        Assert.That(Vector.TryParse("3,4", out Vector ok), Is.True);
+        Assert.That(ok, Is.EqualTo(new Vector(3, 4)));
+
+        Assert.That(Vector.TryParse("garbage", out Vector bad), Is.False);
+        Assert.That(bad, Is.EqualTo(default(Vector)));
+
+        Assert.That(Vector.TryParse("3,4"u8, null, out Vector utf8Ok), Is.True);
+        Assert.That(utf8Ok, Is.EqualTo(new Vector(3, 4)));
+
+        Assert.That(Vector.TryParse("garbage"u8, null, out _), Is.False);
+    }
+
+    [Test]
+    public void TryFormat_Char_AndUtf8_WriteSameContent()
+    {
+        var v = new Vector(1.5f, 2.5f);
+        Span<char> chars = stackalloc char[32];
+        Span<byte> bytes = stackalloc byte[32];
+
+        Assert.That(v.TryFormat(chars, out int charsWritten), Is.True);
+        Assert.That(v.TryFormat(bytes, out int bytesWritten), Is.True);
+
+        string charText = chars[..charsWritten].ToString();
+        string utf8Text = System.Text.Encoding.UTF8.GetString(bytes[..bytesWritten]);
+        Assert.That(charText, Is.EqualTo(utf8Text));
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/ElementBehaviorTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ElementBehaviorTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Engine;
+﻿using Beutl.Engine;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/ElementBehaviorTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ElementBehaviorTests.cs
@@ -1,0 +1,216 @@
+using Beutl.Engine;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class ElementBehaviorTests
+{
+    [Test]
+    public void Range_FollowsStartAndLength()
+    {
+        var element = new Element
+        {
+            Start = TimeSpan.FromSeconds(1),
+            Length = TimeSpan.FromSeconds(2)
+        };
+
+        Assert.That(element.Range.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(element.Range.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void Start_ChangePropagatesToObjectsAndRaisesEditedWithRanges()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(2) };
+        var obj = new TestObject();
+        element.AddObject(obj);
+        ElementEditedEventArgs? args = null;
+        element.Edited += (_, e) => args = e as ElementEditedEventArgs;
+
+        element.Start = TimeSpan.FromSeconds(5);
+
+        Assert.That(args, Is.Not.Null);
+        Assert.That(args!.AffectedRange, Is.Not.Empty);
+        Assert.That(obj.TimeRange.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+        Assert.That(obj.TimeRange.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void Length_ChangePropagatesToObjects()
+    {
+        var element = new Element { Start = TimeSpan.FromSeconds(1) };
+        var obj = new TestObject();
+        element.AddObject(obj);
+
+        element.Length = TimeSpan.FromSeconds(7);
+
+        Assert.That(obj.TimeRange.Duration, Is.EqualTo(TimeSpan.FromSeconds(7)));
+    }
+
+    [Test]
+    public void ZIndex_ChangePropagatesToObjects()
+    {
+        var element = new Element();
+        var obj = new TestObject();
+        element.AddObject(obj);
+
+        element.ZIndex = 4;
+
+        Assert.That(obj.ZIndex, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void IsEnabled_ChangeRaisesEdited()
+    {
+        var element = new Element();
+        int count = 0;
+        element.Edited += (_, _) => count++;
+
+        element.IsEnabled = false;
+
+        Assert.That(count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AddObject_FlowOperator_AlsoAddsPortalBeforeIt()
+    {
+        var element = new Element();
+
+        element.AddObject(new TestFlowOperator());
+
+        Assert.That(element.Objects.Count, Is.EqualTo(2));
+        Assert.That(element.Objects[0], Is.InstanceOf<PortalObject>());
+        Assert.That(element.Objects[1], Is.InstanceOf<TestFlowOperator>());
+    }
+
+    [Test]
+    public void AddObject_NormalObject_NoPortalAdded()
+    {
+        var element = new Element();
+
+        element.AddObject(new TestObject());
+
+        Assert.That(element.Objects.Count, Is.EqualTo(1));
+        Assert.That(element.Objects[0], Is.InstanceOf<TestObject>());
+    }
+
+    [Test]
+    public void InsertObject_FlowOperator_InsertsPortalBeforeIt()
+    {
+        var element = new Element();
+        element.AddObject(new TestObject());
+
+        element.InsertObject(0, new TestFlowOperator());
+
+        Assert.That(element.Objects.Count, Is.EqualTo(3));
+        Assert.That(element.Objects[0], Is.InstanceOf<PortalObject>());
+        Assert.That(element.Objects[1], Is.InstanceOf<TestFlowOperator>());
+        Assert.That(element.Objects[2], Is.InstanceOf<TestObject>());
+    }
+
+    [Test]
+    public void InsertObject_NormalObject_InsertsAtIndex()
+    {
+        var element = new Element();
+        element.AddObject(new TestObject());
+
+        element.InsertObject(0, new TestObject { Tag = "First" });
+
+        Assert.That(element.Objects.Count, Is.EqualTo(2));
+        Assert.That(((TestObject)element.Objects[0]).Tag, Is.EqualTo("First"));
+    }
+
+    [Test]
+    public void RemoveObject_RemovesFromCollection()
+    {
+        var element = new Element();
+        var obj = new TestObject();
+        element.AddObject(obj);
+
+        element.RemoveObject(obj);
+
+        Assert.That(element.Objects, Does.Not.Contain(obj));
+    }
+
+    [Test]
+    public void HasOriginalDuration_NoProvider_ReturnsFalse()
+    {
+        var element = new Element();
+        element.AddObject(new TestObject());
+
+        Assert.That(element.HasOriginalDuration(), Is.False);
+        Assert.That(element.TryGetOriginalDuration(out var ts), Is.False);
+        Assert.That(ts, Is.EqualTo(default(TimeSpan)));
+    }
+
+    [Test]
+    public void HasOriginalDuration_WithProvider_ReturnsTrueAndDuration()
+    {
+        var element = new Element();
+        element.AddObject(new TestDurationObject(TimeSpan.FromSeconds(8)));
+
+        Assert.That(element.HasOriginalDuration(), Is.True);
+        Assert.That(element.TryGetOriginalDuration(out var ts), Is.True);
+        Assert.That(ts, Is.EqualTo(TimeSpan.FromSeconds(8)));
+    }
+
+    [Test]
+    public void NotifySplitted_DispatchesToSplittables()
+    {
+        var element = new Element();
+        var splittable = new TestSplittable();
+        element.AddObject(splittable);
+
+        element.NotifySplitted(backward: true, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        Assert.That(splittable.LastBackward, Is.True);
+        Assert.That(splittable.LastStartDelta, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(splittable.LastDurationDelta, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestObject : EngineObject
+    {
+        public string Tag { get; init; } = string.Empty;
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestFlowOperator : EngineObject, IFlowOperator
+    {
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestDurationObject : EngineObject, IOriginalDurationProvider
+    {
+        private readonly TimeSpan _duration;
+
+        public TestDurationObject(TimeSpan duration)
+        {
+            _duration = duration;
+        }
+
+        public bool HasOriginalDuration() => true;
+
+        public bool TryGetOriginalDuration(out TimeSpan timeSpan)
+        {
+            timeSpan = _duration;
+            return true;
+        }
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestSplittable : EngineObject, ISplittable
+    {
+        public bool LastBackward { get; private set; }
+        public TimeSpan LastStartDelta { get; private set; }
+        public TimeSpan LastDurationDelta { get; private set; }
+
+        public void NotifySplitted(bool backward, TimeSpan startDelta, TimeSpan durationDelta)
+        {
+            LastBackward = backward;
+            LastStartDelta = startDelta;
+            LastDurationDelta = durationDelta;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/ListExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ListExtensionsTests.cs
@@ -1,0 +1,145 @@
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class ListExtensionsTests
+{
+    [Test]
+    public void OrderedAdd_InsertsBeforeFirstLargerOrEqualKey()
+    {
+        var list = new List<int> { 1, 3, 5 };
+
+        list.OrderedAdd(2, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 1, 2, 3, 5 }));
+    }
+
+    [Test]
+    public void OrderedAdd_AppendsWhenLargestKey()
+    {
+        var list = new List<int> { 1, 2, 3 };
+
+        list.OrderedAdd(99, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 1, 2, 3, 99 }));
+    }
+
+    [Test]
+    public void OrderedAdd_PrependsWhenSmallestKey()
+    {
+        var list = new List<int> { 5, 6, 7 };
+
+        list.OrderedAdd(1, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 1, 5, 6, 7 }));
+    }
+
+    [Test]
+    public void OrderedAdd_EqualKeyInsertedBeforeExisting()
+    {
+        var list = new List<(int Key, string Tag)>
+        {
+            (1, "a"),
+            (3, "b"),
+        };
+
+        list.OrderedAdd<(int Key, string Tag), int>((3, "c"), x => x.Key);
+
+        Assert.That(list[0], Is.EqualTo((1, "a")));
+        Assert.That(list[1], Is.EqualTo((3, "c")));
+        Assert.That(list[2], Is.EqualTo((3, "b")));
+    }
+
+    [Test]
+    public void OrderedAdd_EmptyListAppends()
+    {
+        var list = new List<int>();
+
+        list.OrderedAdd(42, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 42 }));
+    }
+
+    [Test]
+    public void OrderedAdd_UsesProvidedComparer()
+    {
+        // Reverse comparer keeps list in descending order, so smaller key gets appended.
+        var list = new List<int> { 5, 3, 1 };
+        IComparer<int> reverse = Comparer<int>.Create((a, b) => b.CompareTo(a));
+
+        list.OrderedAdd(2, x => x, reverse);
+
+        Assert.That(list, Is.EqualTo(new[] { 5, 3, 2, 1 }));
+    }
+
+    [Test]
+    public void OrderedAdd_NullList_Throws()
+    {
+        List<int>? list = null;
+
+        Assert.Throws<ArgumentNullException>(() => list!.OrderedAdd(1, x => x));
+    }
+
+    [Test]
+    public void OrderedAdd_NullKeySelector_Throws()
+    {
+        var list = new List<int>();
+
+        Assert.Throws<ArgumentNullException>(() => list.OrderedAdd(1, (Func<int, int>)null!));
+    }
+
+    [Test]
+    public void OrderedAddDescending_InsertsBeforeFirstSmallerOrEqualKey()
+    {
+        var list = new List<int> { 9, 5, 3, 1 };
+
+        list.OrderedAddDescending(4, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 9, 5, 4, 3, 1 }));
+    }
+
+    [Test]
+    public void OrderedAddDescending_AppendsWhenSmallest()
+    {
+        var list = new List<int> { 9, 5, 3 };
+
+        list.OrderedAddDescending(1, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 9, 5, 3, 1 }));
+    }
+
+    [Test]
+    public void OrderedAddDescending_PrependsWhenLargestOrEqual()
+    {
+        var list = new List<int> { 9, 5, 3 };
+
+        list.OrderedAddDescending(9, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 9, 9, 5, 3 }));
+    }
+
+    [Test]
+    public void OrderedAddDescending_EmptyListAppends()
+    {
+        var list = new List<int>();
+
+        list.OrderedAddDescending(7, x => x);
+
+        Assert.That(list, Is.EqualTo(new[] { 7 }));
+    }
+
+    [Test]
+    public void OrderedAddDescending_NullList_Throws()
+    {
+        List<int>? list = null;
+
+        Assert.Throws<ArgumentNullException>(() => list!.OrderedAddDescending(1, x => x));
+    }
+
+    [Test]
+    public void OrderedAddDescending_NullKeySelector_Throws()
+    {
+        var list = new List<int>();
+
+        Assert.Throws<ArgumentNullException>(() => list.OrderedAddDescending(1, (Func<int, int>)null!));
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/ListExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/ListExtensionsTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.ProjectSystem;
+﻿namespace Beutl.UnitTests.ProjectSystem;
 
 [TestFixture]
 public class ListExtensionsTests

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMarkerTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMarkerTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMarkerTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMarkerTests.cs
@@ -1,0 +1,95 @@
+using Beutl.Media;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class SceneMarkerTests
+{
+    [Test]
+    public void DefaultConstructor_HasYellowColorAndEmptyStrings()
+    {
+        var marker = new SceneMarker();
+
+        Assert.That(marker.Time, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(marker.Color, Is.EqualTo(Colors.Yellow));
+        Assert.That(marker.Note, Is.EqualTo(string.Empty));
+        Assert.That(marker.Name, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void ParameterizedConstructor_AssignsValues()
+    {
+        var marker = new SceneMarker(
+            TimeSpan.FromSeconds(2),
+            name: "intro",
+            color: Colors.Red,
+            note: "first marker");
+
+        Assert.That(marker.Time, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(marker.Name, Is.EqualTo("intro"));
+        Assert.That(marker.Color, Is.EqualTo(Colors.Red));
+        Assert.That(marker.Note, Is.EqualTo("first marker"));
+    }
+
+    [Test]
+    public void ParameterizedConstructor_NullsBecomeDefaults()
+    {
+        var marker = new SceneMarker(TimeSpan.FromSeconds(1));
+
+        Assert.That(marker.Name, Is.EqualTo(string.Empty));
+        Assert.That(marker.Color, Is.EqualTo(Colors.Yellow));
+        Assert.That(marker.Note, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Time_NegativeValueIsClampedToZero()
+    {
+        var marker = new SceneMarker { Time = TimeSpan.FromSeconds(-1) };
+
+        Assert.That(marker.Time, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void Time_PositiveValueIsAssigned()
+    {
+        var marker = new SceneMarker { Time = TimeSpan.FromSeconds(3.5) };
+
+        Assert.That(marker.Time, Is.EqualTo(TimeSpan.FromSeconds(3.5)));
+    }
+
+    [Test]
+    public void Note_AssigningNullKeepsEmptyString()
+    {
+        var marker = new SceneMarker { Note = "hello" };
+
+        marker.Note = null!;
+
+        Assert.That(marker.Note, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Color_RaisesPropertyChanged()
+    {
+        var marker = new SceneMarker();
+        var captured = new List<string?>();
+        marker.PropertyChanged += (_, e) => captured.Add(e.PropertyName);
+
+        marker.Color = Colors.Blue;
+
+        Assert.That(captured, Does.Contain(nameof(SceneMarker.Color)));
+        Assert.That(marker.Color, Is.EqualTo(Colors.Blue));
+    }
+
+    [Test]
+    public void Time_RaisesPropertyChanged()
+    {
+        var marker = new SceneMarker();
+        var captured = new List<string?>();
+        marker.PropertyChanged += (_, e) => captured.Add(e.PropertyName);
+
+        marker.Time = TimeSpan.FromSeconds(1);
+
+        Assert.That(captured, Does.Contain(nameof(SceneMarker.Time)));
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/TimeSpanExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/TimeSpanExtensionsTests.cs
@@ -1,0 +1,99 @@
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class TimeSpanExtensionsTests
+{
+    [TestCase(0.0, 30, 0.0)]
+    [TestCase(1.0, 30, 30.0)]
+    [TestCase(0.5, 60, 30.0)]
+    [TestCase(0.04166, 24, 0.99984)]
+    public void ToFrameNumber_Double_ReturnsSecondsTimesRate(double seconds, double rate, double expected)
+    {
+        TimeSpan ts = TimeSpan.FromSeconds(seconds);
+
+        double frame = ts.ToFrameNumber(rate);
+
+        Assert.That(frame, Is.EqualTo(expected).Within(1e-9));
+    }
+
+    [TestCase(0.0, 30, 0.0)]
+    [TestCase(1.0, 30, 30.0)]
+    [TestCase(2.0, 60, 120.0)]
+    public void ToFrameNumber_Int_ReturnsSecondsTimesRate(double seconds, int rate, double expected)
+    {
+        TimeSpan ts = TimeSpan.FromSeconds(seconds);
+
+        double frame = ts.ToFrameNumber(rate);
+
+        Assert.That(frame, Is.EqualTo(expected).Within(1e-9));
+    }
+
+    [Test]
+    public void ToTimeSpan_Double_ReturnsFractionalSeconds()
+    {
+        TimeSpan ts = 30.0.ToTimeSpan(60.0);
+
+        Assert.That(ts, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+    }
+
+    [Test]
+    public void ToTimeSpan_Int_ReturnsExactTickQuotient()
+    {
+        TimeSpan ts = 30.ToTimeSpan(60);
+
+        Assert.That(ts.Ticks, Is.EqualTo(TimeSpan.TicksPerSecond * 30 / 60));
+    }
+
+    [Test]
+    public void ToTimeSpan_Int_AvoidsFloatingPointError()
+    {
+        TimeSpan ts = 1.ToTimeSpan(3);
+
+        Assert.That(ts.Ticks, Is.EqualTo(TimeSpan.TicksPerSecond / 3));
+    }
+
+    [Test]
+    public void RoundToRate_RoundsUpAtSeventyPercentOfFrame()
+    {
+        // 0.7 frames at 10 fps -> rounds to 1 frame (AwayFromZero)
+        TimeSpan ts = TimeSpan.FromSeconds(0.07);
+
+        TimeSpan rounded = ts.RoundToRate(10.0);
+
+        Assert.That(rounded.TotalSeconds, Is.EqualTo(0.1).Within(1e-9));
+    }
+
+    [Test]
+    public void RoundToRate_RoundsDownBelowHalfFrame()
+    {
+        // 0.2 frames at 10 fps -> rounds to 0 frames
+        TimeSpan ts = TimeSpan.FromSeconds(0.02);
+
+        TimeSpan rounded = ts.RoundToRate(10.0);
+
+        Assert.That(rounded, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void FloorToRate_DropsFractionalFrame()
+    {
+        // 1.4 frames at 10 fps -> 1 frame
+        TimeSpan ts = TimeSpan.FromSeconds(0.14);
+
+        TimeSpan floored = ts.FloorToRate(10.0);
+
+        Assert.That(floored.TotalSeconds, Is.EqualTo(0.1).Within(1e-9));
+    }
+
+    [Test]
+    public void FloorToRate_ZeroReturnsZero()
+    {
+        Assert.That(TimeSpan.Zero.FloorToRate(30.0), Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void RoundToRate_ZeroReturnsZero()
+    {
+        Assert.That(TimeSpan.Zero.RoundToRate(30.0), Is.EqualTo(TimeSpan.Zero));
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/TimeSpanExtensionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/TimeSpanExtensionsTests.cs
@@ -1,4 +1,4 @@
-namespace Beutl.UnitTests.ProjectSystem;
+﻿namespace Beutl.UnitTests.ProjectSystem;
 
 [TestFixture]
 public class TimeSpanExtensionsTests

--- a/tests/Beutl.UnitTests/ProjectSystem/TimelineOptionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/TimelineOptionsTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/TimelineOptionsTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/TimelineOptionsTests.cs
@@ -1,0 +1,147 @@
+using System.Numerics;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class TimelineOptionsTests
+{
+    [Test]
+    public void DefaultConstructor_AssignsBaseDefaults()
+    {
+        var options = new TimelineOptions();
+
+        Assert.That(options.Scale, Is.EqualTo(1f));
+        Assert.That(options.Offset, Is.EqualTo(Vector2.Zero));
+        Assert.That(options.MaxLayerCount, Is.EqualTo(50));
+        Assert.That(options.BpmGrid, Is.EqualTo(new BpmGridOptions()));
+    }
+
+    [Test]
+    public void Constructor_WithScaleAndOffset_DefaultsLayerCountToFifty()
+    {
+        var options = new TimelineOptions(0.5f, new Vector2(10, 20));
+
+        Assert.That(options.Scale, Is.EqualTo(0.5f));
+        Assert.That(options.Offset, Is.EqualTo(new Vector2(10, 20)));
+        Assert.That(options.MaxLayerCount, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void Constructor_AcceptsCustomMaxLayerCount()
+    {
+        var options = new TimelineOptions(1f, Vector2.Zero, 200);
+
+        Assert.That(options.MaxLayerCount, Is.EqualTo(200));
+    }
+
+    [Test]
+    public void ScaleInit_ClampsValuesAboveTwo()
+    {
+        var options = new TimelineOptions { Scale = 5f };
+
+        Assert.That(options.Scale, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void ScaleInit_KeepsValuesAtOrBelowTwo()
+    {
+        var below = new TimelineOptions { Scale = 1.5f };
+        var equal = new TimelineOptions { Scale = 2f };
+
+        Assert.That(below.Scale, Is.EqualTo(1.5f));
+        Assert.That(equal.Scale, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void OffsetInit_ClampsNegativeComponentsToZero()
+    {
+        var options = new TimelineOptions { Offset = new Vector2(-5, -10) };
+
+        Assert.That(options.Offset, Is.EqualTo(Vector2.Zero));
+    }
+
+    [Test]
+    public void OffsetInit_KeepsComponentwiseMaxAgainstZero()
+    {
+        var options = new TimelineOptions { Offset = new Vector2(-3, 7) };
+
+        Assert.That(options.Offset, Is.EqualTo(new Vector2(0, 7)));
+    }
+
+    [Test]
+    public void OffsetInit_PositiveValuesPreserved()
+    {
+        var options = new TimelineOptions { Offset = new Vector2(11, 22) };
+
+        Assert.That(options.Offset, Is.EqualTo(new Vector2(11, 22)));
+    }
+
+    [Test]
+    public void RecordEquality_OnEqualValues_ReturnsTrue()
+    {
+        var a = new TimelineOptions(0.5f, new Vector2(10, 20), 75);
+        var b = new TimelineOptions(0.5f, new Vector2(10, 20), 75);
+
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void RecordWith_OverridesScale()
+    {
+        var original = new TimelineOptions(0.5f, new Vector2(10, 20));
+
+        var modified = original with { Scale = 1.5f };
+
+        Assert.That(modified.Scale, Is.EqualTo(1.5f));
+        Assert.That(modified.Offset, Is.EqualTo(original.Offset));
+        Assert.That(modified.MaxLayerCount, Is.EqualTo(original.MaxLayerCount));
+    }
+}
+
+[TestFixture]
+public class BpmGridOptionsTests
+{
+    [Test]
+    public void DefaultConstructor_AssignsBaselineValues()
+    {
+        var options = new BpmGridOptions();
+
+        Assert.That(options.Bpm, Is.EqualTo(120.0));
+        Assert.That(options.Subdivisions, Is.EqualTo(4));
+        Assert.That(options.Offset, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(options.IsEnabled, Is.False);
+    }
+
+    [Test]
+    public void Constructor_AssignsAllValues()
+    {
+        var options = new BpmGridOptions(140.0, 8, TimeSpan.FromSeconds(0.5), true);
+
+        Assert.That(options.Bpm, Is.EqualTo(140.0));
+        Assert.That(options.Subdivisions, Is.EqualTo(8));
+        Assert.That(options.Offset, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+        Assert.That(options.IsEnabled, Is.True);
+    }
+
+    [Test]
+    public void RecordEquality_OnEqualValues_ReturnsTrue()
+    {
+        var a = new BpmGridOptions(140.0, 8, TimeSpan.FromSeconds(1), true);
+        var b = new BpmGridOptions(140.0, 8, TimeSpan.FromSeconds(1), true);
+
+        Assert.That(a, Is.EqualTo(b));
+    }
+
+    [Test]
+    public void RecordWith_OverridesIsEnabled()
+    {
+        var original = new BpmGridOptions();
+
+        var modified = original with { IsEnabled = true };
+
+        Assert.That(modified.IsEnabled, Is.True);
+        Assert.That(modified.Bpm, Is.EqualTo(original.Bpm));
+    }
+}

--- a/tests/Beutl.UnitTests/Threading/DispatcherOperationTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherOperationTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Threading;
+﻿using Beutl.Threading;
 
 namespace Beutl.UnitTests.Threading;
 

--- a/tests/Beutl.UnitTests/Threading/DispatcherOperationTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherOperationTests.cs
@@ -1,0 +1,60 @@
+using Beutl.Threading;
+
+namespace Beutl.UnitTests.Threading;
+
+public class DispatcherOperationTests
+{
+    [Test]
+    public void Run_InvokesAction()
+    {
+        bool invoked = false;
+        var op = new DispatcherOperation(() => invoked = true, DispatchPriority.Medium, CancellationToken.None);
+
+        op.Run();
+
+        Assert.That(invoked, Is.True);
+    }
+
+    [Test]
+    public void Run_WithCancelledToken_DoesNotInvokeAction()
+    {
+        bool invoked = false;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var op = new DispatcherOperation(() => invoked = true, DispatchPriority.Medium, cts.Token);
+
+        op.Run();
+
+        Assert.That(invoked, Is.False);
+    }
+
+    [Test]
+    public void Properties_PreserveConstructorArguments()
+    {
+        Action action = () => { };
+        var op = new DispatcherOperation(action, DispatchPriority.High, CancellationToken.None);
+
+        Assert.That(op.Action, Is.SameAs(action));
+        Assert.That(op.Priority, Is.EqualTo(DispatchPriority.High));
+        Assert.That(op.Token, Is.EqualTo(CancellationToken.None));
+    }
+
+    [Test]
+    public void Run_WhenFlowSuppressed_StillInvokes()
+    {
+        ExecutionContext.SuppressFlow();
+        try
+        {
+            bool invoked = false;
+            var op = new DispatcherOperation(() => invoked = true, DispatchPriority.Low, CancellationToken.None);
+
+            op.Run();
+
+            Assert.That(invoked, Is.True);
+        }
+        finally
+        {
+            ExecutionContext.RestoreFlow();
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
+++ b/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Threading;
+﻿using Beutl.Threading;
 
 namespace Beutl.UnitTests.Threading;
 

--- a/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
+++ b/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
@@ -1,0 +1,87 @@
+using Beutl.Threading;
+
+namespace Beutl.UnitTests.Threading;
+
+public class OperationQueueTests
+{
+    [Test]
+    public void Enqueue_TryDequeue_ReturnsItemsByPriority()
+    {
+        var queue = new OperationQueue();
+
+        var low = NewOperation("low", DispatchPriority.Low);
+        var medium = NewOperation("medium", DispatchPriority.Medium);
+        var high = NewOperation("high", DispatchPriority.High);
+
+        queue.Enqueue(low);
+        queue.Enqueue(medium);
+        queue.Enqueue(high);
+
+        Assert.That(queue.TryDequeue(out var first), Is.True);
+        Assert.That(first, Is.SameAs(high));
+
+        Assert.That(queue.TryDequeue(out var second), Is.True);
+        Assert.That(second, Is.SameAs(medium));
+
+        Assert.That(queue.TryDequeue(out var third), Is.True);
+        Assert.That(third, Is.SameAs(low));
+    }
+
+    [Test]
+    public void TryDequeue_OnEmpty_ReturnsFalse()
+    {
+        var queue = new OperationQueue();
+
+        Assert.That(queue.TryDequeue(out var op), Is.False);
+        Assert.That(op, Is.Null);
+    }
+
+    [Test]
+    public void Count_OnlyCountsPriorityAtOrAboveMinimum()
+    {
+        var queue = new OperationQueue();
+
+        queue.Enqueue(NewOperation("a", DispatchPriority.Low));
+        queue.Enqueue(NewOperation("b", DispatchPriority.Medium));
+        queue.Enqueue(NewOperation("c", DispatchPriority.Medium));
+        queue.Enqueue(NewOperation("d", DispatchPriority.High));
+
+        Assert.That(queue.Count(DispatchPriority.Low), Is.EqualTo(4));
+        Assert.That(queue.Count(DispatchPriority.Medium), Is.EqualTo(3));
+        Assert.That(queue.Count(DispatchPriority.High), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Any_ReflectsPresenceAtOrAboveMinimum()
+    {
+        var queue = new OperationQueue();
+
+        Assert.That(queue.Any(DispatchPriority.Low), Is.False);
+
+        queue.Enqueue(NewOperation("a", DispatchPriority.Low));
+
+        Assert.That(queue.Any(DispatchPriority.Low), Is.True);
+        Assert.That(queue.Any(DispatchPriority.Medium), Is.False);
+    }
+
+    [Test]
+    public void Enqueue_PreservesFifoWithinSamePriority()
+    {
+        var queue = new OperationQueue();
+        var first = NewOperation("first", DispatchPriority.Medium);
+        var second = NewOperation("second", DispatchPriority.Medium);
+
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+
+        Assert.That(queue.TryDequeue(out var dequeued1), Is.True);
+        Assert.That(dequeued1, Is.SameAs(first));
+        Assert.That(queue.TryDequeue(out var dequeued2), Is.True);
+        Assert.That(dequeued2, Is.SameAs(second));
+    }
+
+    private static DispatcherOperation NewOperation(string label, DispatchPriority priority)
+    {
+        return new DispatcherOperation(() => { _ = label; }, priority, CancellationToken.None);
+    }
+}

--- a/tests/Beutl.UnitTests/Threading/TimerQueueTests.cs
+++ b/tests/Beutl.UnitTests/Threading/TimerQueueTests.cs
@@ -1,0 +1,81 @@
+using Beutl.Threading;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Beutl.UnitTests.Threading;
+
+public class TimerQueueTests
+{
+    [Test]
+    public void Next_OnEmpty_ReturnsNull()
+    {
+        var time = new FakeTimeProvider();
+        var queue = new TimerQueue(time);
+
+        Assert.That(queue.Next, Is.Null);
+    }
+
+    [Test]
+    public void Next_ReturnsSmallestTimestamp()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        var queue = new TimerQueue(time);
+
+        DateTimeOffset later = time.GetUtcNow().AddSeconds(60);
+        DateTimeOffset earlier = time.GetUtcNow().AddSeconds(10);
+
+        queue.Enqueue(later, DispatchPriority.Medium, () => { }, CancellationToken.None);
+        queue.Enqueue(earlier, DispatchPriority.Medium, () => { }, CancellationToken.None);
+
+        Assert.That(queue.Next, Is.EqualTo(earlier));
+    }
+
+    [Test]
+    public void TryDequeue_DoesNothingWhenTimestampInFuture()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        var queue = new TimerQueue(time);
+        DateTimeOffset future = time.GetUtcNow().AddMinutes(5);
+
+        queue.Enqueue(future, DispatchPriority.Medium, () => { }, CancellationToken.None);
+
+        Assert.That(queue.TryDequeue(out var ops), Is.False);
+        Assert.That(ops, Is.Null);
+    }
+
+    [Test]
+    public void TryDequeue_ReturnsOperationsForReachedTimestamp()
+    {
+        var start = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+        var time = new FakeTimeProvider(start);
+        var queue = new TimerQueue(time);
+        DateTimeOffset stamp = start.AddSeconds(1);
+
+        queue.Enqueue(stamp, DispatchPriority.Low, () => { }, CancellationToken.None);
+        queue.Enqueue(stamp, DispatchPriority.High, () => { }, CancellationToken.None);
+
+        // Not yet reached.
+        Assert.That(queue.TryDequeue(out _), Is.False);
+
+        time.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.That(queue.TryDequeue(out var ops), Is.True);
+        Assert.That(ops, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Enqueue_SameTimestampAccumulates()
+    {
+        var time = new FakeTimeProvider();
+        var queue = new TimerQueue(time);
+        DateTimeOffset stamp = time.GetUtcNow().AddSeconds(1);
+
+        queue.Enqueue(stamp, DispatchPriority.Medium, () => { }, CancellationToken.None);
+        queue.Enqueue(stamp, DispatchPriority.Medium, () => { }, CancellationToken.None);
+        queue.Enqueue(stamp, DispatchPriority.Medium, () => { }, CancellationToken.None);
+
+        time.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.That(queue.TryDequeue(out var ops), Is.True);
+        Assert.That(ops, Has.Count.EqualTo(3));
+    }
+}

--- a/tests/Beutl.UnitTests/Threading/TimerQueueTests.cs
+++ b/tests/Beutl.UnitTests/Threading/TimerQueueTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Threading;
+﻿using Beutl.Threading;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Beutl.UnitTests.Threading;

--- a/tests/Beutl.UnitTests/Utilities/MathUtilitiesEdgeTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/MathUtilitiesEdgeTests.cs
@@ -1,0 +1,28 @@
+using Beutl.Utilities;
+
+namespace Beutl.UnitTests.Utilities;
+
+public class MathUtilitiesEdgeTests
+{
+    [Test]
+    public void AreClose_DoubleWithCustomEps_TrueWhenInsideEpsilon()
+    {
+        Assert.That(MathUtilities.AreClose(1.0, 1.001, 0.01), Is.True);
+        Assert.That(MathUtilities.AreClose(1.0, 1.05, 0.01), Is.False);
+        Assert.That(MathUtilities.AreClose(double.PositiveInfinity, double.PositiveInfinity, 1e-9), Is.True);
+    }
+
+    [Test]
+    public void AreClose_DoubleNoEps_HandlesInfinity()
+    {
+        Assert.That(MathUtilities.AreClose(double.PositiveInfinity, double.PositiveInfinity), Is.True);
+        Assert.That(MathUtilities.AreClose(double.NegativeInfinity, double.NegativeInfinity), Is.True);
+    }
+
+    [Test]
+    public void AreClose_FloatNoEps_HandlesInfinity()
+    {
+        Assert.That(MathUtilities.AreClose(float.PositiveInfinity, float.PositiveInfinity), Is.True);
+        Assert.That(MathUtilities.AreClose(float.NegativeInfinity, float.NegativeInfinity), Is.True);
+    }
+}

--- a/tests/Beutl.UnitTests/Utilities/MathUtilitiesEdgeTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/MathUtilitiesEdgeTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Utilities;
+﻿using Beutl.Utilities;
 
 namespace Beutl.UnitTests.Utilities;
 

--- a/tests/Beutl.UnitTests/Utilities/RefStringTokenizerExtraTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/RefStringTokenizerExtraTests.cs
@@ -1,0 +1,104 @@
+using System.Globalization;
+using Beutl.Utilities;
+
+namespace Beutl.UnitTests.Utilities;
+
+public class RefStringTokenizerExtraTests
+{
+    [Test]
+    public void ReadInt32_MaxKeyword_ReturnsIntMax()
+    {
+        var t = new RefStringTokenizer("Max".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(int.MaxValue));
+    }
+
+    [Test]
+    public void ReadInt32_MinKeyword_ReturnsIntMin()
+    {
+        var t = new RefStringTokenizer("min".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(int.MinValue));
+    }
+
+    [Test]
+    public void ReadDouble_MaxAndMin_ReturnsExtremes()
+    {
+        var max = new RefStringTokenizer("MAX".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(max.ReadDouble(), Is.EqualTo(double.MaxValue));
+
+        var min = new RefStringTokenizer("min".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(min.ReadDouble(), Is.EqualTo(double.MinValue));
+    }
+
+    [Test]
+    public void ReadSingle_MaxAndMin_ReturnsExtremes()
+    {
+        var max = new RefStringTokenizer("Max".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(max.ReadSingle(), Is.EqualTo(float.MaxValue));
+
+        var min = new RefStringTokenizer("MIN".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(min.ReadSingle(), Is.EqualTo(float.MinValue));
+    }
+
+    [Test]
+    public void TryReadInt32_InvalidKeyword_ReturnsFalse()
+    {
+        var t = new RefStringTokenizer("notanint".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.TryReadInt32(out int value), Is.False);
+        Assert.That(value, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Multiple_Tokens_AreSeparatedByCommaWithSpaces()
+    {
+        var t = new RefStringTokenizer("1, 2 ,3".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(1));
+        Assert.That(t.ReadInt32(), Is.EqualTo(2));
+        Assert.That(t.ReadInt32(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void DoubleSeparator_ThrowsFormatException()
+    {
+        Assert.That(() =>
+        {
+            var t = new RefStringTokenizer("1,,2".AsSpan(), CultureInfo.InvariantCulture);
+            t.ReadInt32();
+            t.ReadInt32();
+        }, Throws.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void TrailingSeparator_ThrowsFormatException()
+    {
+        Assert.That(() =>
+        {
+            var t = new RefStringTokenizer("1,".AsSpan(), CultureInfo.InvariantCulture);
+            t.ReadInt32();
+        }, Throws.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void CurrentToken_ReturnsLastReadSpan()
+    {
+        var t = new RefStringTokenizer("hello,world".AsSpan(), CultureInfo.InvariantCulture);
+        ReadOnlySpan<char> first = t.ReadString();
+        Assert.That(first.ToString(), Is.EqualTo("hello"));
+        Assert.That(t.CurrentToken.ToString(), Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void TryReadDouble_OnEmpty_ReturnsFalse()
+    {
+        var t = new RefStringTokenizer("".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.TryReadDouble(out double value), Is.False);
+        Assert.That(value, Is.EqualTo(0d));
+    }
+
+    [Test]
+    public void TryReadSingle_OnEmpty_ReturnsFalse()
+    {
+        var t = new RefStringTokenizer("".AsSpan(), CultureInfo.InvariantCulture);
+        Assert.That(t.TryReadSingle(out float value), Is.False);
+        Assert.That(value, Is.EqualTo(0f));
+    }
+}

--- a/tests/Beutl.UnitTests/Utilities/RefStringTokenizerExtraTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/RefStringTokenizerExtraTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Beutl.Utilities;
 
 namespace Beutl.UnitTests.Utilities;

--- a/tests/Beutl.UnitTests/Utilities/RefUtf8StringTokenizerExtraTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/RefUtf8StringTokenizerExtraTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using Beutl.Utilities;
 

--- a/tests/Beutl.UnitTests/Utilities/RefUtf8StringTokenizerExtraTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/RefUtf8StringTokenizerExtraTests.cs
@@ -1,0 +1,91 @@
+using System.Globalization;
+using System.Text;
+using Beutl.Utilities;
+
+namespace Beutl.UnitTests.Utilities;
+
+public class RefUtf8StringTokenizerExtraTests
+{
+    [Test]
+    public void ReadInt32_MaxKeyword_ReturnsIntMax()
+    {
+        var t = new RefUtf8StringTokenizer("Max"u8, CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(int.MaxValue));
+    }
+
+    [Test]
+    public void ReadInt32_MinKeyword_ReturnsIntMin()
+    {
+        var t = new RefUtf8StringTokenizer("min"u8, CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(int.MinValue));
+    }
+
+    [Test]
+    public void ReadDouble_MaxKeyword_ReturnsDoubleMax()
+    {
+        var t = new RefUtf8StringTokenizer("MAX"u8, CultureInfo.InvariantCulture);
+        Assert.That(t.ReadDouble(), Is.EqualTo(double.MaxValue));
+    }
+
+    [Test]
+    public void ReadSingle_MaxKeyword_ReturnsFloatMax()
+    {
+        var t = new RefUtf8StringTokenizer("Max"u8, CultureInfo.InvariantCulture);
+        Assert.That(t.ReadSingle(), Is.EqualTo(float.MaxValue));
+    }
+
+    [Test]
+    public void Multiple_Tokens_AreSeparatedByCommaWithSpaces()
+    {
+        var t = new RefUtf8StringTokenizer("1, 2 ,3"u8, CultureInfo.InvariantCulture);
+        Assert.That(t.ReadInt32(), Is.EqualTo(1));
+        Assert.That(t.ReadInt32(), Is.EqualTo(2));
+        Assert.That(t.ReadInt32(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void DoubleSeparator_ThrowsFormatException()
+    {
+        Assert.That(() =>
+        {
+            var t = new RefUtf8StringTokenizer("1,,2"u8, CultureInfo.InvariantCulture);
+            t.ReadInt32();
+            t.ReadInt32();
+        }, Throws.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void TrailingSeparator_ThrowsFormatException()
+    {
+        Assert.That(() =>
+        {
+            var t = new RefUtf8StringTokenizer("1,"u8, CultureInfo.InvariantCulture);
+            t.ReadInt32();
+        }, Throws.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void CurrentToken_ReturnsLastReadSpan()
+    {
+        var t = new RefUtf8StringTokenizer("hello,world"u8, CultureInfo.InvariantCulture);
+        ReadOnlySpan<byte> first = t.ReadString();
+        Assert.That(Encoding.UTF8.GetString(first), Is.EqualTo("hello"));
+        Assert.That(Encoding.UTF8.GetString(t.CurrentToken), Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void TryReadDouble_OnEmpty_ReturnsFalse()
+    {
+        var t = new RefUtf8StringTokenizer(""u8, CultureInfo.InvariantCulture);
+        Assert.That(t.TryReadDouble(out double value), Is.False);
+        Assert.That(value, Is.EqualTo(0d));
+    }
+
+    [Test]
+    public void TryReadSingle_OnEmpty_ReturnsFalse()
+    {
+        var t = new RefUtf8StringTokenizer(""u8, CultureInfo.InvariantCulture);
+        Assert.That(t.TryReadSingle(out float value), Is.False);
+        Assert.That(value, Is.EqualTo(0f));
+    }
+}

--- a/tests/Beutl.UnitTests/Utilities/StringFormatsTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/StringFormatsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Beutl.Utilities;
 
 namespace Beutl.UnitTests.Utilities;
@@ -14,5 +14,41 @@ public class StringFormatsTests
     public string ToHumanReadableSize_ShouldReturnCorrectFormat(double size)
     {
         return StringFormats.ToHumanReadableSize(size, formatProvider: CultureInfo.InvariantCulture);
+    }
+
+    [Test]
+    public void ToHumanReadableSize_LargerThanGB_StaysAtGB()
+    {
+        // Once the recursive call reaches the GB scale (last unit), it stops
+        // even if the size is still larger than the standard.
+        double bytes = 5d * 1024 * 1024 * 1024;
+        Assert.That(
+            StringFormats.ToHumanReadableSize(bytes, formatProvider: CultureInfo.InvariantCulture),
+            Is.EqualTo("5.00 GB"));
+    }
+
+    [Test]
+    public void ToHumanReadableSize_CustomStandard_RespectsBase1000()
+    {
+        // With a base-1000 standard, 1500 -> 1.50 KB
+        Assert.That(
+            StringFormats.ToHumanReadableSize(1500, standard: 1000, formatProvider: CultureInfo.InvariantCulture),
+            Is.EqualTo("1.50 KB"));
+    }
+
+    [Test]
+    public void ToHumanReadableSize_StartingScale_ChoosesProvidedUnit()
+    {
+        // Starting at scale=2 (MB), 4 stays at "4.00 MB" since 4 <= 1024.
+        Assert.That(
+            StringFormats.ToHumanReadableSize(4, scale: 2, formatProvider: CultureInfo.InvariantCulture),
+            Is.EqualTo("4.00 MB"));
+    }
+
+    [Test]
+    public void ToHumanReadableSize_NoFormatProvider_UsesCurrent()
+    {
+        // Sanity check: doesn't throw and returns a non-empty string.
+        Assert.That(StringFormats.ToHumanReadableSize(1024), Is.Not.Empty);
     }
 }

--- a/tests/Beutl.UnitTests/Utilities/StringFormatsTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/StringFormatsTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Beutl.Utilities;
 
 namespace Beutl.UnitTests.Utilities;

--- a/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
@@ -66,14 +66,23 @@ public class WeakEventTests
         Assert.That(s2.Received, Is.EqualTo(new[] { "hello" }));
     }
 
+    private sealed class GenericEventSource
+    {
+        public event EventHandler<PropertyChangedEventArgs>? Changed;
+
+        public void Raise(string property)
+            => Changed?.Invoke(this, new PropertyChangedEventArgs(property));
+    }
+
     [Test]
     public void Register_ActionStyle_AlsoWorks()
     {
-        WeakEvent<Source, PropertyChangedEventArgs> ev = WeakEvent.Register<Source, PropertyChangedEventArgs>(
-            (s, h) => s.PropertyChanged += new PropertyChangedEventHandler(h),
-            (s, h) => s.PropertyChanged -= new PropertyChangedEventHandler(h));
+        WeakEvent<GenericEventSource, PropertyChangedEventArgs> ev =
+            WeakEvent.Register<GenericEventSource, PropertyChangedEventArgs>(
+                (s, h) => s.Changed += h,
+                (s, h) => s.Changed -= h);
 
-        var src = new Source();
+        var src = new GenericEventSource();
         var sub = new Subscriber();
         ev.Subscribe(src, sub);
         src.Raise("x");

--- a/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using Beutl.Utilities;
+
+namespace Beutl.UnitTests.Utilities;
+
+public class WeakEventTests
+{
+    private sealed class Source : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Raise(string property)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+    }
+
+    private sealed class Subscriber : IWeakEventSubscriber<PropertyChangedEventArgs>
+    {
+        public List<string?> Received { get; } = [];
+
+        public void OnEvent(object? sender, WeakEvent ev, PropertyChangedEventArgs e)
+        {
+            Received.Add(e.PropertyName);
+        }
+    }
+
+    [Test]
+    public void Subscribe_ReceivesEvent()
+    {
+        var src = new Source();
+        var sub = new Subscriber();
+
+        WeakEvents.PropertyChanged.Subscribe(src, sub);
+        src.Raise("X");
+
+        Assert.That(sub.Received, Is.EqualTo(new[] { "X" }));
+    }
+
+    [Test]
+    public void Unsubscribe_StopsReceivingFurtherEvents()
+    {
+        var src = new Source();
+        var sub = new Subscriber();
+
+        WeakEvents.PropertyChanged.Subscribe(src, sub);
+        src.Raise("A");
+
+        WeakEvents.PropertyChanged.Unsubscribe(src, sub);
+        src.Raise("B");
+
+        Assert.That(sub.Received, Is.EqualTo(new[] { "A" }));
+    }
+
+    [Test]
+    public void MultipleSubscribers_AllReceiveEvent()
+    {
+        var src = new Source();
+        var s1 = new Subscriber();
+        var s2 = new Subscriber();
+
+        WeakEvents.PropertyChanged.Subscribe(src, s1);
+        WeakEvents.PropertyChanged.Subscribe(src, s2);
+
+        src.Raise("hello");
+
+        Assert.That(s1.Received, Is.EqualTo(new[] { "hello" }));
+        Assert.That(s2.Received, Is.EqualTo(new[] { "hello" }));
+    }
+
+    [Test]
+    public void Register_ActionStyle_AlsoWorks()
+    {
+        WeakEvent<Source, PropertyChangedEventArgs> ev = WeakEvent.Register<Source, PropertyChangedEventArgs>(
+            (s, h) => s.PropertyChanged += new PropertyChangedEventHandler(h),
+            (s, h) => s.PropertyChanged -= new PropertyChangedEventHandler(h));
+
+        var src = new Source();
+        var sub = new Subscriber();
+        ev.Subscribe(src, sub);
+        src.Raise("x");
+
+        Assert.That(sub.Received, Is.EqualTo(new[] { "x" }));
+    }
+}

--- a/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
+++ b/tests/Beutl.UnitTests/Utilities/WeakEventTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Beutl.Utilities;
 
 namespace Beutl.UnitTests.Utilities;


### PR DESCRIPTION
## Description

- Add ~13K lines of new unit tests across `Beutl.Core`, `Beutl.Engine`, `Beutl.ProjectSystem`, `Beutl.Threading`, and `Beutl.Utilities` to raise coverage of previously untested converters, collections, animations, math/geometry primitives, and editor services.
- Cover Vulkan-dependent graphics backends (GLSL shaders, pixel sort, immediate canvas, render target) behind a shared `VulkanTestEnvironment` so suites are skipped cleanly when Vulkan is unavailable.
- Exercise serialization paths for JSON converters, `CoreProperty` registration, and hierarchical/observable infrastructure to lock in current behavior ahead of further refactors.

## Breaking changes

None.

## Fixed issues

None.