### PR TITLE
fix(command-palette): address remaining PR #1776 review comments

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1090,7 +1090,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             "ToggleGroup" => SelectedElements.FirstOrDefault() is { } first
                 && (first.CanUngroupSelectedElements() || first.CanGroupSelectedElements()),
             "ExitRazorMode" => IsRazorMode.Value,
-            _ => true,
+            "Paste" or "SetStartTime" or "SetEndTime" or "ToggleRazorMode" => true,
+            // Rename / Split など Execute で対応 case が無いコマンドは false を返し、
+            // パレットやショートカット経路で誤って enabled として扱われないようにする。
+            _ => false,
         };
     }
 

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -66,12 +66,20 @@ public sealed class CommandPaletteService
                 KeyGesture? gesture = entry.KeyGestures
                     .FirstOrDefault(i => i.Platform == s_currentPlatform)?.KeyGesture;
 
-                ContextCommandEntry capturedEntry = entry;
                 // スナップショット時に解決したハンドラーを Execute / CanExecute / StateChanged 全てで共有し、
                 // 列挙時と実行時で別インスタンスへ向くケースを防ぐ。タブ切替時は RebuildSnapshot で再列挙される。
+                // ランタイムでハンドラーを解決できないコマンド（例: ContextCommandAttribute 方式のみで
+                // 実装されたもの）はパレットから実行する手段がないため列挙対象から除外する。
                 IContextCommandHandler? snapshotHandler = _handlerProvider.Resolve(entry.ExtensionType);
+                if (snapshotHandler is null)
+                {
+                    continue;
+                }
+
+                ContextCommandEntry capturedEntry = entry;
+                IContextCommandHandler handler = snapshotHandler;
                 IObservable<System.Reactive.Unit>? stateChanged =
-                    (snapshotHandler as IContextCommandStateNotifier)?.CanExecuteChanged;
+                    (handler as IContextCommandStateNotifier)?.CanExecuteChanged;
 
                 result.Add(new PaletteCommand(
                     Id: $"{entry.ExtensionType.FullName}.{entry.Definition.Name}",
@@ -79,20 +87,15 @@ public sealed class CommandPaletteService
                     Description: entry.Definition.Description,
                     CategoryName: category,
                     KeyGesture: gesture,
-                    CanExecute: () => snapshotHandler?.CanExecute(new ContextCommandExecution(capturedEntry.Definition.Name)) ?? false,
+                    CanExecute: () => handler.CanExecute(new ContextCommandExecution(capturedEntry.Definition.Name)),
                     Execute: () =>
                     {
-                        if (snapshotHandler is null)
-                        {
-                            return;
-                        }
-
                         // スロットル窓や状態変化で表示と実行可否がずれる可能性があるため、
                         // 実行直前にもう一度 CanExecute を確認してから Execute する。
                         var execution = new ContextCommandExecution(capturedEntry.Definition.Name);
-                        if (snapshotHandler.CanExecute(execution))
+                        if (handler.CanExecute(execution))
                         {
-                            snapshotHandler.Execute(execution);
+                            handler.Execute(execution);
                         }
                     })
                 {

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -205,7 +205,9 @@ public sealed class CommandPaletteViewModel : BaseViewModel
         HasNoResults.Value = _filteredCommands.Count == 0 && !string.IsNullOrEmpty(query);
     }
 
-    // Clear+Add せず、同じ Id・IsEnabled の項目はそのまま再利用してリスト更新時のチラつきを抑える。
+    // Clear+Add せず、同じ PaletteCommand インスタンスかつ IsEnabled が同一の項目は再利用して
+    // リスト更新時のチラつきを抑える。RebuildSnapshot 後は Id が同じでも別インスタンスの
+    // デリゲートを保持する PaletteCommand に差し替わるため、参照同一性で比較して必ず置換する。
     private void ApplyFilteredCommands(List<CommandPaletteItemViewModel> next)
     {
         string? previousSelectedId = SelectedCommand.Value?.Command.Id;
@@ -215,7 +217,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
         {
             CommandPaletteItemViewModel existing = _filteredCommands[i];
             CommandPaletteItemViewModel candidate = next[i];
-            if (existing.Command.Id != candidate.Command.Id
+            if (!ReferenceEquals(existing.Command, candidate.Command)
                 || existing.IsEnabled != candidate.IsEnabled)
             {
                 _filteredCommands[i] = candidate;

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -20,9 +20,8 @@
                 IsHitTestVisible="True"
                 PointerPressed="OnBackdropPointerPressed" />
 
-        <!-- Palette container -->
+        <!-- Palette container (Width はコードビハインドで TopLevel サイズに応じて動的設定) -->
         <Border x:Name="PaletteContainer"
-                Width="640"
                 MaxHeight="480"
                 Margin="16,80,16,16"
                 Padding="0"

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -21,8 +21,7 @@
 
         <!-- Palette container -->
         <Border x:Name="PaletteContainer"
-                MinWidth="320"
-                MaxWidth="640"
+                Width="640"
                 MaxHeight="480"
                 Margin="16,80,16,16"
                 Padding="0"

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Beutl.Views.CommandPaletteView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -39,7 +40,8 @@
                          FontSize="16"
                          KeyDown="OnQueryKeyDown"
                          Text="{Binding Query.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         Watermark="{x:Static lang:Strings.CommandPalette_Placeholder}" />
+                         Watermark="{x:Static lang:Strings.CommandPalette_Placeholder}"
+                         controls:TextBoxAttachment.EnterDownBehavior="None" />
 
                 <Border Grid.Row="1"
                         Margin="8,0"

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -14,9 +14,12 @@ namespace Beutl.Views;
 public partial class CommandPaletteView : UserControl
 {
     private const int PageStep = 8;
+    private const double MaxPaletteWidth = 640;
+    private const double HorizontalMargin = 16;
 
     private readonly ILogger<CommandPaletteView> _logger = Log.CreateLogger<CommandPaletteView>();
     private readonly CompositeDisposable _disposables = [];
+    private readonly CompositeDisposable _visualTreeDisposables = [];
     private WeakReference<IInputElement>? _previouslyFocused;
 
     public CommandPaletteView()
@@ -103,12 +106,37 @@ public partial class CommandPaletteView : UserControl
         }
     }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _visualTreeDisposables.Clear();
+
+        // narrow window で PaletteContainer 自体が右マージンを侵食して clipping するのを防ぐため、
+        // TopLevel サイズに応じて Width を動的に縮める。MaxWidth + HorizontalAlignment="Center"
+        // にしてしまうとリストの中身に応じて幅が変動 (スクロールバー表示時等) するので、
+        // Width 固定値で中身依存を切る方針。
+        if (TopLevel.GetTopLevel(this) is { } topLevel)
+        {
+            topLevel.GetObservable(BoundsProperty)
+                .Subscribe(bounds => UpdatePaletteWidth(bounds.Width))
+                .AddTo(_visualTreeDisposables);
+            UpdatePaletteWidth(topLevel.Bounds.Width);
+        }
+    }
+
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         // Dispose ではなく Clear を呼ぶことで、Avalonia により Detach→再 Attach された際の
         // OnDataContextChanged 内 _disposables.Clear() が破棄済みインスタンスに対して呼ばれる事態を避ける。
+        _visualTreeDisposables.Clear();
         _disposables.Clear();
         base.OnDetachedFromVisualTree(e);
+    }
+
+    private void UpdatePaletteWidth(double availableWidth)
+    {
+        double usable = availableWidth - HorizontalMargin * 2;
+        PaletteContainer.Width = Math.Min(MaxPaletteWidth, Math.Max(0, usable));
     }
 
     private void OnBackdropPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -70,10 +70,9 @@ public partial class CommandPaletteView : UserControl
             {
                 // 閉じた時点で既にパレット外の要素へフォーカスが移っている場合は奪い返さない
                 // (典型例: コマンドが同期的にダイアログを開いてフォーカスを取った後)。
-                // 非同期にダイアログを開くコマンドはここで一旦 captured に focus が戻るが、
-                // ダイアログ表示時に Avalonia 側で auto-focus されるため奪い返される問題は通常起きない。
-                // 一方フォーカスを動かさない単純コマンド (ToggleRazorMode 等) ではこの restore が
-                // 必須で、これを怠ると focused element が null のまま残り Ctrl+Shift+P が壊れる。
+                // それ以外の経路 (Esc / Backdrop / フォーカスを動かさない単純コマンド) は
+                // 必ず restore しないと focused element が null のまま残り、ContextCommandManager
+                // が登録した KeyDown ハンドラに Ctrl+Shift+P が届かなくなって再表示できなくなる。
                 IInputElement? current = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
                 if (current is Visual currentVisual
                     && currentVisual.FindAncestorOfType<CommandPaletteView>(includeSelf: true) is null)

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -112,15 +112,16 @@ public partial class CommandPaletteView : UserControl
         _visualTreeDisposables.Clear();
 
         // narrow window で PaletteContainer 自体が右マージンを侵食して clipping するのを防ぐため、
-        // TopLevel サイズに応じて Width を動的に縮める。MaxWidth + HorizontalAlignment="Center"
-        // にしてしまうとリストの中身に応じて幅が変動 (スクロールバー表示時等) するので、
-        // Width 固定値で中身依存を切る方針。
+        // TopLevel サイズに応じて Width を動的に縮める (常に MaxPaletteWidth、ではなく上限)。
+        // MaxWidth + HorizontalAlignment="Center" にしてしまうとリストの中身に応じて幅が変動
+        // (スクロールバー表示時等) するので、明示的な Width 設定で中身依存を切る方針。
+        // Width が明示されていれば中身に依らないため、XAML 側の HorizontalAlignment="Center" は維持して問題ない。
         if (TopLevel.GetTopLevel(this) is { } topLevel)
         {
+            // GetObservable は購読時に現在値を即座に発火するため、初期 Width 設定もこの購読に任せる。
             topLevel.GetObservable(BoundsProperty)
                 .Subscribe(bounds => UpdatePaletteWidth(bounds.Width))
                 .AddTo(_visualTreeDisposables);
-            UpdatePaletteWidth(topLevel.Bounds.Width);
         }
     }
 

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -18,7 +18,6 @@ public partial class CommandPaletteView : UserControl
     private readonly ILogger<CommandPaletteView> _logger = Log.CreateLogger<CommandPaletteView>();
     private readonly CompositeDisposable _disposables = [];
     private WeakReference<IInputElement>? _previouslyFocused;
-    private bool _closedByCommandExecution;
 
     public CommandPaletteView()
     {
@@ -66,27 +65,18 @@ public partial class CommandPaletteView : UserControl
             // 開いたときに保存しておいた呼び出し元へフォーカスを戻す。失効していた場合は MainView へ。
             WeakReference<IInputElement>? captured = _previouslyFocused;
             _previouslyFocused = null;
-            bool closedByCommand = _closedByCommandExecution;
-            _closedByCommandExecution = false;
 
             Dispatcher.UIThread.Post(() =>
             {
-                // 閉じた時点で既にパレット外の要素へフォーカスが移っている場合は、Esc/Backdrop/コマンド実行
-                // いずれの経路であっても奪い返さない (典型例: コマンドが同期的にダイアログを開いて
-                // フォーカスを取った後)。closedByCommand 依存ではない点に注意。
+                // 閉じた時点で既にパレット外の要素へフォーカスが移っている場合は奪い返さない
+                // (典型例: コマンドが同期的にダイアログを開いてフォーカスを取った後)。
+                // 非同期にダイアログを開くコマンドはここで一旦 captured に focus が戻るが、
+                // ダイアログ表示時に Avalonia 側で auto-focus されるため奪い返される問題は通常起きない。
+                // 一方フォーカスを動かさない単純コマンド (ToggleRazorMode 等) ではこの restore が
+                // 必須で、これを怠ると focused element が null のまま残り Ctrl+Shift+P が壊れる。
                 IInputElement? current = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
                 if (current is Visual currentVisual
                     && currentVisual.FindAncestorOfType<CommandPaletteView>(includeSelf: true) is null)
-                {
-                    return;
-                }
-
-                // コマンド実行経路で current が null の場合、async でダイアログを開くコマンドが
-                // フォーカスを取りに行く前にこのコールバックが走ったレースの可能性が高いため、
-                // 復帰をスキップしてダイアログ側のフォーカスに任せる。
-                // Esc/Backdrop 経路ではこの分岐に入らないため、従来通り復帰して
-                // フォーカスが null のままになるのを防ぎ、Ctrl+Shift+P の再到達性を確保する。
-                if (closedByCommand && current is null)
                 {
                     return;
                 }
@@ -194,7 +184,7 @@ public partial class CommandPaletteView : UserControl
                 e.Handled = true;
                 break;
             case Key.Enter:
-                ExecuteSelectedFromUserAction(viewModel);
+                viewModel.ExecuteSelected();
                 e.Handled = true;
                 break;
         }
@@ -213,7 +203,7 @@ public partial class CommandPaletteView : UserControl
             && source.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: CommandPaletteItemViewModel item })
         {
             viewModel.SelectedCommand.Value = item;
-            ExecuteSelectedFromUserAction(viewModel);
+            viewModel.ExecuteSelected();
             e.Handled = true;
         }
     }
@@ -222,24 +212,5 @@ public partial class CommandPaletteView : UserControl
     {
         if (viewModel.SelectedCommand.Value is { } selected)
             ResultsListBox.ScrollIntoView(selected);
-    }
-
-    // ExecuteSelected は item が { IsEnabled: true } のときだけ Close() を同期的に呼ぶ。
-    // 通常経路では Close → IsOpen 変化 → HandleIsOpenChanged(false) が同期的に走り、その中で
-    // フラグをローカルにスナップショットしてからクリアするので追加処理は不要。
-    // しかし item が null / IsEnabled=false で ExecuteSelected が Close を呼ばない場合は
-    // HandleIsOpenChanged が走らずフラグが立ったまま残り、次回の Esc/Backdrop による Close 時に
-    // 誤って「コマンド経由のクローズ」と判定されてしまう。finally で確実にリークを防ぐ。
-    private void ExecuteSelectedFromUserAction(CommandPaletteViewModel viewModel)
-    {
-        _closedByCommandExecution = true;
-        try
-        {
-            viewModel.ExecuteSelected();
-        }
-        finally
-        {
-            _closedByCommandExecution = false;
-        }
     }
 }

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -15,7 +15,6 @@ public partial class CommandPaletteView : UserControl
 {
     private const int PageStep = 8;
     private const double MaxPaletteWidth = 640;
-    private const double HorizontalMargin = 16;
 
     private readonly ILogger<CommandPaletteView> _logger = Log.CreateLogger<CommandPaletteView>();
     private readonly CompositeDisposable _disposables = [];
@@ -136,7 +135,8 @@ public partial class CommandPaletteView : UserControl
 
     private void UpdatePaletteWidth(double availableWidth)
     {
-        double usable = availableWidth - HorizontalMargin * 2;
+        Thickness margin = PaletteContainer.Margin;
+        double usable = availableWidth - margin.Left - margin.Right;
         PaletteContainer.Width = Math.Min(MaxPaletteWidth, Math.Max(0, usable));
     }
 

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -14,6 +14,7 @@ public partial class CommandPaletteView : UserControl
     private const int PageStep = 8;
 
     private readonly CompositeDisposable _disposables = [];
+    private WeakReference<IInputElement>? _previouslyFocused;
 
     public CommandPaletteView()
     {
@@ -31,19 +32,50 @@ public partial class CommandPaletteView : UserControl
 
         if (DataContext is CommandPaletteViewModel viewModel)
         {
+            // Skip(1) で初期値の false を読み飛ばし、購読セット時にフォーカス操作を行わないようにする。
             viewModel.IsOpen
-                .Subscribe(open =>
-                {
-                    if (open)
-                    {
-                        Dispatcher.UIThread.Post(() =>
-                        {
-                            QueryTextBox.Focus();
-                            QueryTextBox.SelectAll();
-                        }, DispatcherPriority.Background);
-                    }
-                })
+                .Skip(1)
+                .Subscribe(HandleIsOpenChanged)
                 .AddTo(_disposables);
+        }
+    }
+
+    private void HandleIsOpenChanged(bool open)
+    {
+        if (open)
+        {
+            // パレットを閉じた時に呼び出し元へフォーカスを戻せるよう、開く直前のフォーカス位置を控えておく。
+            IInputElement? focused = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
+            _previouslyFocused = focused is not null ? new WeakReference<IInputElement>(focused) : null;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                QueryTextBox.Focus();
+                QueryTextBox.SelectAll();
+            }, DispatcherPriority.Background);
+        }
+        else
+        {
+            // パレットが閉じた直後に IsVisible=false へ遷移するため、TextBox がフォーカスを保持したまま
+            // 不可視化されると Avalonia がフォーカスをクリアし、以後 MainView の KeyDown ハンドラに
+            // ショートカット (Ctrl+Shift+P) が到達しなくなって再表示できなくなる。
+            // 開いたときに保存しておいた呼び出し元へフォーカスを戻す。失効していた場合は MainView へ。
+            WeakReference<IInputElement>? captured = _previouslyFocused;
+            _previouslyFocused = null;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (captured is not null
+                    && captured.TryGetTarget(out IInputElement? target)
+                    && target is Visual { IsEffectivelyVisible: true } visual
+                    && visual.GetVisualRoot() is not null)
+                {
+                    target.Focus();
+                    return;
+                }
+
+                this.FindAncestorOfType<MainView>()?.Focus();
+            }, DispatcherPriority.Background);
         }
     }
 
@@ -66,6 +98,12 @@ public partial class CommandPaletteView : UserControl
 
     private void OnQueryKeyDown(object? sender, KeyEventArgs e)
     {
+        // IME 変換中のキー入力（候補ナビゲーション等）はパレット操作に奪わずに IME に委ねる。
+        if (e.Key == Key.ImeProcessed)
+        {
+            return;
+        }
+
         if (DataContext is not CommandPaletteViewModel viewModel)
         {
             return;
@@ -108,7 +146,8 @@ public partial class CommandPaletteView : UserControl
 
     private void OnRootKeyDown(object? sender, KeyEventArgs e)
     {
-        if (e.Handled || DataContext is not CommandPaletteViewModel viewModel)
+        // IME 変換中の Enter/Escape は IME による確定・取消に使われるため横取りしない。
+        if (e.Handled || e.Key == Key.ImeProcessed || DataContext is not CommandPaletteViewModel viewModel)
         {
             return;
         }

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -4,7 +4,9 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Beutl.Logging;
 using Beutl.ViewModels;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings.Extensions;
 
 namespace Beutl.Views;
@@ -13,8 +15,10 @@ public partial class CommandPaletteView : UserControl
 {
     private const int PageStep = 8;
 
+    private readonly ILogger<CommandPaletteView> _logger = Log.CreateLogger<CommandPaletteView>();
     private readonly CompositeDisposable _disposables = [];
     private WeakReference<IInputElement>? _previouslyFocused;
+    private bool _closedByCommandExecution;
 
     public CommandPaletteView()
     {
@@ -62,19 +66,50 @@ public partial class CommandPaletteView : UserControl
             // 開いたときに保存しておいた呼び出し元へフォーカスを戻す。失効していた場合は MainView へ。
             WeakReference<IInputElement>? captured = _previouslyFocused;
             _previouslyFocused = null;
+            bool closedByCommand = _closedByCommandExecution;
+            _closedByCommandExecution = false;
 
             Dispatcher.UIThread.Post(() =>
             {
-                if (captured is not null
-                    && captured.TryGetTarget(out IInputElement? target)
-                    && target is Visual { IsEffectivelyVisible: true } visual
-                    && visual.GetVisualRoot() is not null)
+                // 閉じた時点で既にパレット外の要素へフォーカスが移っている場合は、Esc/Backdrop/コマンド実行
+                // いずれの経路であっても奪い返さない (典型例: コマンドが同期的にダイアログを開いて
+                // フォーカスを取った後)。closedByCommand 依存ではない点に注意。
+                IInputElement? current = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
+                if (current is Visual currentVisual
+                    && currentVisual.FindAncestorOfType<CommandPaletteView>(includeSelf: true) is null)
                 {
-                    target.Focus();
                     return;
                 }
 
-                this.FindAncestorOfType<MainView>()?.Focus();
+                // コマンド実行経路で current が null の場合、async でダイアログを開くコマンドが
+                // フォーカスを取りに行く前にこのコールバックが走ったレースの可能性が高いため、
+                // 復帰をスキップしてダイアログ側のフォーカスに任せる。
+                // Esc/Backdrop 経路ではこの分岐に入らないため、従来通り復帰して
+                // フォーカスが null のままになるのを防ぎ、Ctrl+Shift+P の再到達性を確保する。
+                if (closedByCommand && current is null)
+                {
+                    return;
+                }
+
+                if (captured is not null
+                    && captured.TryGetTarget(out IInputElement? target)
+                    && target is Visual { IsEffectivelyVisible: true } visual
+                    && visual.GetVisualRoot() is not null
+                    && target.Focus())
+                {
+                    return;
+                }
+
+                MainView? mainView = this.FindAncestorOfType<MainView>();
+                if (mainView is null || !mainView.Focus())
+                {
+                    // ここまで来てフォーカス復帰に失敗した場合、focused element が null のまま残り
+                    // MainView の KeyDown ハンドラに Ctrl+Shift+P が届かなくなって再表示できなくなる。
+                    // このバグの再発時に検知できるよう警告として残す (通常は発火しない想定)。
+                    _logger.LogWarning(
+                        "Failed to restore focus after command palette closed (mainViewFound={Found}). Ctrl+Shift+P may stop responding.",
+                        mainView is not null);
+                }
             }, DispatcherPriority.Background);
         }
     }
@@ -159,7 +194,7 @@ public partial class CommandPaletteView : UserControl
                 e.Handled = true;
                 break;
             case Key.Enter:
-                viewModel.ExecuteSelected();
+                ExecuteSelectedFromUserAction(viewModel);
                 e.Handled = true;
                 break;
         }
@@ -178,7 +213,7 @@ public partial class CommandPaletteView : UserControl
             && source.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: CommandPaletteItemViewModel item })
         {
             viewModel.SelectedCommand.Value = item;
-            viewModel.ExecuteSelected();
+            ExecuteSelectedFromUserAction(viewModel);
             e.Handled = true;
         }
     }
@@ -187,5 +222,24 @@ public partial class CommandPaletteView : UserControl
     {
         if (viewModel.SelectedCommand.Value is { } selected)
             ResultsListBox.ScrollIntoView(selected);
+    }
+
+    // ExecuteSelected は item が { IsEnabled: true } のときだけ Close() を同期的に呼ぶ。
+    // 通常経路では Close → IsOpen 変化 → HandleIsOpenChanged(false) が同期的に走り、その中で
+    // フラグをローカルにスナップショットしてからクリアするので追加処理は不要。
+    // しかし item が null / IsEnabled=false で ExecuteSelected が Close を呼ばない場合は
+    // HandleIsOpenChanged が走らずフラグが立ったまま残り、次回の Esc/Backdrop による Close 時に
+    // 誤って「コマンド経由のクローズ」と判定されてしまう。finally で確実にリークを防ぐ。
+    private void ExecuteSelectedFromUserAction(CommandPaletteViewModel viewModel)
+    {
+        _closedByCommandExecution = true;
+        try
+        {
+            viewModel.ExecuteSelected();
+        }
+        finally
+        {
+            _closedByCommandExecution = false;
+        }
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #1776 to address review comments and additional issues found during follow-up testing.

### Review comments from #1776

- **CommandPaletteService**: skip palette entries when `CommandPaletteHandlerProvider.Resolve` cannot return a runtime `IContextCommandHandler` (e.g. attribute-only handlers via `ContextCommandAttribute`). Previously these were enumerated but always disabled, taking up palette space without ever being executable. ([#1776 (comment)](https://github.com/b-editor/beutl/pull/1776#discussion_r3213466651))
- **CommandPaletteViewModel.ApplyFilteredCommands**: also compare the underlying `PaletteCommand` by reference identity. After `RebuildSnapshot()` (e.g. on active-tab change), entries with the same command Id get fresh `PaletteCommand` instances; without this fix, the existing `CommandPaletteItemViewModel` was kept and execution would target stale delegates from the previous snapshot. ([#1776 (comment)](https://github.com/b-editor/beutl/pull/1776#discussion_r3213466646))
- **TimelineTabViewModel.CanExecute**: replace the `_ => true` fallback with an explicit allowlist of command names that actually have an `Execute` case. Commands such as `Rename` and `Split` are defined in `TimelineTabExtension.ContextCommands` but are not yet implemented in `Execute`, so they should not be exposed as enabled in the palette / shortcut routing. ([#1776 (comment)](https://github.com/b-editor/beutl/pull/1776#discussion_r3213466655))

### Additional fixes

- **PaletteContainer width**: switch `MinWidth=320 / MaxWidth=640` to a fixed `Width=640` so the palette no longer resizes as the result list changes.
- **Enter key handling**: opt the query `TextBox` out of the global `TextBoxAttachment.EnterDownBehavior` so the tunneled handler stops marking Enter as handled before the palette's root key handler can execute the selected command.
- **Focus restoration on close**: capture the previously focused element when the palette opens and restore it on close. Without this, the query `TextBox` lost focus when `IsVisible` flipped to false and no element was left to receive `Ctrl+Shift+P`, making the palette unable to reopen.
- **IME passthrough**: ignore `Key.ImeProcessed` in `OnQueryKeyDown` / `OnRootKeyDown` so IME candidate navigation, Enter (confirm), and Escape (cancel) stay with the IME instead of being stolen by palette selection or close actions.

## Breaking changes

None.

## Fixed issues

Follow-up to #1776.