### PR TITLE
feat: add history view with jump-to-step

### DIFF
--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -1,3 +1,5 @@
+using Beutl.Language;
+
 namespace Beutl.Editor;
 
 public sealed class HistoryEntry
@@ -23,6 +25,12 @@ public sealed class HistoryEntry
     public DateTime Timestamp { get; }
 
     public bool IsInitial { get; }
+
+    public string DisplayLabel => IsInitial
+        ? Strings.History_Initial
+        : DisplayName ?? Name ?? Strings.History_Unnamed;
+
+    public string TransactionLabel => TransactionId?.ToString() ?? "•";
 
     internal static HistoryEntry CreateInitial()
     {

--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -1,0 +1,42 @@
+namespace Beutl.Editor;
+
+public sealed class HistoryEntry
+{
+    private HistoryEntry(long? transactionId, string? name, string? displayName, int operationCount, DateTime timestamp, bool isInitial)
+    {
+        TransactionId = transactionId;
+        Name = name;
+        DisplayName = displayName;
+        OperationCount = operationCount;
+        Timestamp = timestamp;
+        IsInitial = isInitial;
+    }
+
+    public long? TransactionId { get; }
+
+    public string? Name { get; }
+
+    public string? DisplayName { get; }
+
+    public int OperationCount { get; }
+
+    public DateTime Timestamp { get; }
+
+    public bool IsInitial { get; }
+
+    internal static HistoryEntry CreateInitial()
+    {
+        return new HistoryEntry(null, null, null, 0, DateTime.Now, true);
+    }
+
+    internal static HistoryEntry FromTransaction(HistoryTransaction transaction)
+    {
+        return new HistoryEntry(
+            transaction.Id,
+            transaction.Name,
+            transaction.DisplayName,
+            transaction.OperationCount,
+            DateTime.Now,
+            false);
+    }
+}

--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -1,4 +1,4 @@
-using Beutl.Language;
+﻿using Beutl.Language;
 
 namespace Beutl.Editor;
 

--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -2,49 +2,94 @@ using Beutl.Language;
 
 namespace Beutl.Editor;
 
-public sealed class HistoryEntry
+public abstract class HistoryEntry
 {
-    private HistoryEntry(long? transactionId, string? name, string? displayName, int operationCount, DateTime timestamp, bool isInitial)
+    private protected HistoryEntry(DateTime timestamp)
     {
-        TransactionId = transactionId;
-        Name = name;
-        DisplayName = displayName;
-        OperationCount = operationCount;
         Timestamp = timestamp;
-        IsInitial = isInitial;
     }
-
-    public long? TransactionId { get; }
-
-    public string? Name { get; }
-
-    public string? DisplayName { get; }
-
-    public int OperationCount { get; }
 
     public DateTime Timestamp { get; }
 
-    public bool IsInitial { get; }
+    public abstract bool IsInitial { get; }
 
-    public string DisplayLabel => IsInitial
-        ? Strings.History_Initial
-        : DisplayName ?? Name ?? Strings.History_Unnamed;
+    public abstract long? TransactionId { get; }
 
-    public string TransactionLabel => TransactionId?.ToString() ?? "•";
+    public abstract string? Name { get; }
+
+    public abstract string? DisplayName { get; }
+
+    public abstract int OperationCount { get; }
+
+    public abstract string DisplayLabel { get; }
+
+    public abstract string TransactionLabel { get; }
 
     internal static HistoryEntry CreateInitial()
     {
-        return new HistoryEntry(null, null, null, 0, DateTime.Now, true);
+        return new InitialHistoryEntry(DateTime.UtcNow);
     }
 
     internal static HistoryEntry FromTransaction(HistoryTransaction transaction)
     {
-        return new HistoryEntry(
+        return new TransactionHistoryEntry(
             transaction.Id,
             transaction.Name,
             transaction.DisplayName,
             transaction.OperationCount,
-            DateTime.Now,
-            false);
+            DateTime.UtcNow);
     }
+}
+
+public sealed class InitialHistoryEntry : HistoryEntry
+{
+    internal InitialHistoryEntry(DateTime timestamp) : base(timestamp)
+    {
+    }
+
+    public override bool IsInitial => true;
+
+    public override long? TransactionId => null;
+
+    public override string? Name => null;
+
+    public override string? DisplayName => null;
+
+    public override int OperationCount => 0;
+
+    public override string DisplayLabel => Strings.History_Initial;
+
+    public override string TransactionLabel => "•";
+}
+
+public sealed class TransactionHistoryEntry : HistoryEntry
+{
+    internal TransactionHistoryEntry(
+        long transactionId,
+        string? name,
+        string? displayName,
+        int operationCount,
+        DateTime timestamp) : base(timestamp)
+    {
+        TransactionIdValue = transactionId;
+        Name = name;
+        DisplayName = displayName;
+        OperationCount = operationCount;
+    }
+
+    public override bool IsInitial => false;
+
+    public override long? TransactionId => TransactionIdValue;
+
+    public long TransactionIdValue { get; }
+
+    public override string? Name { get; }
+
+    public override string? DisplayName { get; }
+
+    public override int OperationCount { get; }
+
+    public override string DisplayLabel => DisplayName ?? Name ?? Strings.History_Unnamed;
+
+    public override string TransactionLabel => TransactionIdValue.ToString();
 }

--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -23,7 +23,7 @@ public abstract class HistoryEntry
 
     public abstract string DisplayLabel { get; }
 
-    public abstract string TransactionLabel { get; }
+    public string TransactionLabel => TransactionId?.ToString() ?? "•";
 
     internal static HistoryEntry CreateInitial()
     {
@@ -58,8 +58,6 @@ public sealed class InitialHistoryEntry : HistoryEntry
     public override int OperationCount => 0;
 
     public override string DisplayLabel => Strings.History_Initial;
-
-    public override string TransactionLabel => "•";
 }
 
 public sealed class TransactionHistoryEntry : HistoryEntry
@@ -71,7 +69,7 @@ public sealed class TransactionHistoryEntry : HistoryEntry
         int operationCount,
         DateTime timestamp) : base(timestamp)
     {
-        TransactionIdValue = transactionId;
+        TransactionId = transactionId;
         Name = name;
         DisplayName = displayName;
         OperationCount = operationCount;
@@ -79,9 +77,7 @@ public sealed class TransactionHistoryEntry : HistoryEntry
 
     public override bool IsInitial => false;
 
-    public override long? TransactionId => TransactionIdValue;
-
-    public long TransactionIdValue { get; }
+    public override long? TransactionId { get; }
 
     public override string? Name { get; }
 
@@ -90,6 +86,4 @@ public sealed class TransactionHistoryEntry : HistoryEntry
     public override int OperationCount { get; }
 
     public override string DisplayLabel => DisplayName ?? Name ?? Strings.History_Unnamed;
-
-    public override string TransactionLabel => TransactionIdValue.ToString();
 }

--- a/src/Beutl.Editor/HistoryEntry.cs
+++ b/src/Beutl.Editor/HistoryEntry.cs
@@ -27,7 +27,7 @@ public abstract class HistoryEntry
 
     internal static HistoryEntry CreateInitial()
     {
-        return new InitialHistoryEntry(DateTime.UtcNow);
+        return new InitialHistoryEntry(DateTime.Now);
     }
 
     internal static HistoryEntry FromTransaction(HistoryTransaction transaction)
@@ -37,7 +37,7 @@ public abstract class HistoryEntry
             transaction.Name,
             transaction.DisplayName,
             transaction.OperationCount,
-            DateTime.UtcNow);
+            DateTime.Now);
     }
 }
 

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
@@ -63,6 +65,31 @@ public sealed class HistoryManager : IDisposable
         {
             return [.. _entries];
         }
+    }
+
+    /// <summary>
+    /// Atomically takes an initial snapshot and subscribes to subsequent
+    /// <see cref="INotifyCollectionChanged.CollectionChanged"/> events on
+    /// <see cref="Entries"/>. Use this when the consumer needs to mirror the
+    /// collection without dropping events that fire between the snapshot and
+    /// the subscription on a separate thread.
+    /// </summary>
+    /// <returns>An <see cref="IDisposable"/> that unsubscribes the handler.</returns>
+    public IDisposable SubscribeEntries(
+        NotifyCollectionChangedEventHandler handler,
+        out HistoryEntry[] initialSnapshot)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(handler);
+
+        INotifyCollectionChanged source = _entries;
+        lock (_lock)
+        {
+            initialSnapshot = [.. _entries];
+            source.CollectionChanged += handler;
+        }
+
+        return Disposable.Create(() => source.CollectionChanged -= handler);
     }
 
     public void Commit(string? name = null, [CallerArgumentExpression(nameof(name))] string? expression = null)

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -197,53 +197,86 @@ public sealed class HistoryManager : IDisposable
         ThrowIfDisposed();
 
         bool moved = false;
-        lock (_lock)
+        bool stateMutated = false;
+        Exception? failure = null;
+
+        try
         {
-            if (index < 0 || index >= _entries.Count)
+            lock (_lock)
             {
-                _logger.LogDebug("JumpTo requested with out-of-range index: {Index} (Entries: {EntryCount})",
-                    index, _entries.Count);
-                return false;
-            }
-
-            if (_currentTransaction.HasOperations)
-            {
-                _logger.LogDebug("Rolling back current transaction before JumpTo");
-                using (SuppressRecording())
+                if (index < 0 || index >= _entries.Count)
                 {
-                    _currentTransaction.Revert(_context);
+                    _logger.LogDebug("JumpTo requested with out-of-range index: {Index} (Entries: {EntryCount})",
+                        index, _entries.Count);
+                    return false;
                 }
-                _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
-            }
 
-            while (_undoStack.Count > index)
-            {
-                HistoryTransaction transaction = _undoStack.Pop();
-                _logger.LogDebug("JumpTo undoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
-                using (SuppressRecording())
+                if (_currentTransaction.HasOperations)
                 {
-                    transaction.Revert(_context);
+                    _logger.LogDebug("Rolling back current transaction before JumpTo");
+                    // Always replace the current transaction even if Revert throws,
+                    // otherwise the same operations would re-apply on the next commit.
+                    try
+                    {
+                        using (SuppressRecording())
+                        {
+                            _currentTransaction.Revert(_context);
+                        }
+                    }
+                    finally
+                    {
+                        _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
+                        stateMutated = true;
+                    }
                 }
-                _redoStack.Push(transaction);
-                moved = true;
-            }
 
-            while (_undoStack.Count < index && _redoStack.Count > 0)
-            {
-                HistoryTransaction transaction = _redoStack.Pop();
-                _logger.LogDebug("JumpTo redoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
-                using (SuppressRecording())
+                try
                 {
-                    transaction.Apply(_context);
+                    while (_undoStack.Count > index)
+                    {
+                        HistoryTransaction transaction = _undoStack.Pop();
+                        _logger.LogDebug("JumpTo undoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
+                        using (SuppressRecording())
+                        {
+                            transaction.Revert(_context);
+                        }
+                        _redoStack.Push(transaction);
+                        moved = true;
+                        stateMutated = true;
+                    }
+
+                    while (_undoStack.Count < index && _redoStack.Count > 0)
+                    {
+                        HistoryTransaction transaction = _redoStack.Pop();
+                        _logger.LogDebug("JumpTo redoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
+                        using (SuppressRecording())
+                        {
+                            transaction.Apply(_context);
+                        }
+                        _undoStack.Push(transaction);
+                        moved = true;
+                        stateMutated = true;
+                    }
                 }
-                _undoStack.Push(transaction);
-                moved = true;
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "JumpTo failed at undo={UndoCount}, redo={RedoCount}, target={Target}; history is in a partial state",
+                        _undoStack.Count, _redoStack.Count, index);
+                    failure = ex;
+                }
+            }
+        }
+        finally
+        {
+            if (stateMutated)
+            {
+                NotifyStateChanged();
             }
         }
 
-        if (moved)
+        if (failure is not null)
         {
-            NotifyStateChanged();
+            throw failure;
         }
         return moved;
     }

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Collections.ObjectModel;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using Beutl.Editor.Observers;
@@ -18,6 +19,7 @@ public sealed class HistoryManager : IDisposable
     private readonly Subject<HistoryState> _stateChanged = new();
     private readonly List<IDisposable> _subscriptions = new();
     private readonly object _lock = new();
+    private readonly ObservableCollection<HistoryEntry> _entries = new();
     private long _transactionIdCounter;
     private HistoryTransaction _currentTransaction;
     private bool _isDisposed;
@@ -28,6 +30,7 @@ public sealed class HistoryManager : IDisposable
         _sequenceGenerator = sequenceGenerator ?? throw new ArgumentNullException(nameof(sequenceGenerator));
         _context = new OperationExecutionContext(root);
         _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
+        _entries.Add(HistoryEntry.CreateInitial());
     }
 
     public CoreObject Root { get; }
@@ -41,6 +44,13 @@ public sealed class HistoryManager : IDisposable
 
     public IObservable<HistoryState> StateChanged => _stateChanged.AsObservable();
 
+    public ReadOnlyObservableCollection<HistoryEntry> Entries =>
+        _readOnlyEntries ??= new ReadOnlyObservableCollection<HistoryEntry>(_entries);
+
+    private ReadOnlyObservableCollection<HistoryEntry>? _readOnlyEntries;
+
+    public int CurrentIndex => _undoStack.Count;
+
     public void Commit(string? name = null, [CallerArgumentExpression(nameof(name))] string? expression = null)
     {
         ThrowIfDisposed();
@@ -53,8 +63,11 @@ public sealed class HistoryManager : IDisposable
                 _currentTransaction.DisplayName = name;
                 _logger.LogDebug("Committing transaction: {TransactionName} (ID: {TransactionId}, Operations: {OperationCount})",
                     expression, _currentTransaction.Id, _currentTransaction.OperationCount);
+                int currentEntryIndex = _undoStack.Count;
                 _undoStack.Push(_currentTransaction);
                 _redoStack.Clear();
+                TruncateEntriesAfter(currentEntryIndex);
+                _entries.Add(HistoryEntry.FromTransaction(_currentTransaction));
                 _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
             }
             else
@@ -171,10 +184,76 @@ public sealed class HistoryManager : IDisposable
             int redoCount = _redoStack.Count;
             _undoStack.Clear();
             _redoStack.Clear();
+            _entries.Clear();
+            _entries.Add(HistoryEntry.CreateInitial());
             _logger.LogDebug("Cleared history stacks (Undo: {UndoCount}, Redo: {RedoCount})", undoCount, redoCount);
         }
 
         NotifyStateChanged();
+    }
+
+    public bool JumpTo(int index)
+    {
+        ThrowIfDisposed();
+
+        bool moved = false;
+        lock (_lock)
+        {
+            if (index < 0 || index >= _entries.Count)
+            {
+                _logger.LogDebug("JumpTo requested with out-of-range index: {Index} (Entries: {EntryCount})",
+                    index, _entries.Count);
+                return false;
+            }
+
+            if (_currentTransaction.HasOperations)
+            {
+                _logger.LogDebug("Rolling back current transaction before JumpTo");
+                using (SuppressRecording())
+                {
+                    _currentTransaction.Revert(_context);
+                }
+                _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
+            }
+
+            while (_undoStack.Count > index)
+            {
+                HistoryTransaction transaction = _undoStack.Pop();
+                _logger.LogDebug("JumpTo undoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
+                using (SuppressRecording())
+                {
+                    transaction.Revert(_context);
+                }
+                _redoStack.Push(transaction);
+                moved = true;
+            }
+
+            while (_undoStack.Count < index && _redoStack.Count > 0)
+            {
+                HistoryTransaction transaction = _redoStack.Pop();
+                _logger.LogDebug("JumpTo redoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
+                using (SuppressRecording())
+                {
+                    transaction.Apply(_context);
+                }
+                _undoStack.Push(transaction);
+                moved = true;
+            }
+        }
+
+        if (moved)
+        {
+            NotifyStateChanged();
+        }
+        return moved;
+    }
+
+    private void TruncateEntriesAfter(int lastKeptIndex)
+    {
+        for (int i = _entries.Count - 1; i > lastKeptIndex; i--)
+        {
+            _entries.RemoveAt(i);
+        }
     }
 
     public IDisposable Subscribe(IOperationObserver observer)

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -74,22 +74,34 @@ public sealed class HistoryManager : IDisposable
     /// collection without dropping events that fire between the snapshot and
     /// the subscription on a separate thread.
     /// </summary>
-    /// <returns>An <see cref="IDisposable"/> that unsubscribes the handler.</returns>
-    public IDisposable SubscribeEntries(
-        NotifyCollectionChangedEventHandler handler,
-        out HistoryEntry[] initialSnapshot)
+    /// <returns>
+    /// A tuple containing the unsubscribe disposable and the initial snapshot.
+    /// </returns>
+    public (IDisposable Subscription, HistoryEntry[] InitialSnapshot) SubscribeEntries(
+        NotifyCollectionChangedEventHandler handler)
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(handler);
 
         INotifyCollectionChanged source = _entries;
+        HistoryEntry[] snapshot;
         lock (_lock)
         {
-            initialSnapshot = [.. _entries];
+            snapshot = [.. _entries];
             source.CollectionChanged += handler;
         }
 
-        return Disposable.Create(() => source.CollectionChanged -= handler);
+        // Unsubscribe under the same lock that mutators hold so a concurrent
+        // Commit/Clear/JumpTo cannot fire one last event after Dispose returns.
+        var subscription = Disposable.Create(() =>
+        {
+            lock (_lock)
+            {
+                source.CollectionChanged -= handler;
+            }
+        });
+
+        return (subscription, snapshot);
     }
 
     public void Commit(string? name = null, [CallerArgumentExpression(nameof(name))] string? expression = null)

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -20,6 +20,7 @@ public sealed class HistoryManager : IDisposable
     private readonly List<IDisposable> _subscriptions = new();
     private readonly object _lock = new();
     private readonly ObservableCollection<HistoryEntry> _entries = new();
+    private readonly ReadOnlyObservableCollection<HistoryEntry> _readOnlyEntries;
     private long _transactionIdCounter;
     private HistoryTransaction _currentTransaction;
     private bool _isDisposed;
@@ -31,6 +32,7 @@ public sealed class HistoryManager : IDisposable
         _context = new OperationExecutionContext(root);
         _currentTransaction = new HistoryTransaction(Interlocked.Increment(ref _transactionIdCounter));
         _entries.Add(HistoryEntry.CreateInitial());
+        _readOnlyEntries = new ReadOnlyObservableCollection<HistoryEntry>(_entries);
     }
 
     public CoreObject Root { get; }
@@ -44,12 +46,24 @@ public sealed class HistoryManager : IDisposable
 
     public IObservable<HistoryState> StateChanged => _stateChanged.AsObservable();
 
-    public ReadOnlyObservableCollection<HistoryEntry> Entries =>
-        _readOnlyEntries ??= new ReadOnlyObservableCollection<HistoryEntry>(_entries);
-
-    private ReadOnlyObservableCollection<HistoryEntry>? _readOnlyEntries;
+    public ReadOnlyObservableCollection<HistoryEntry> Entries => _readOnlyEntries;
 
     public int CurrentIndex => _undoStack.Count;
+
+    /// <summary>
+    /// Returns a thread-safe snapshot of the current entries taken under the
+    /// internal lock. Use this from threads other than the writer to avoid
+    /// racing with concurrent <see cref="Commit"/>, <see cref="Clear"/>, or
+    /// <see cref="JumpTo"/> mutations.
+    /// </summary>
+    public HistoryEntry[] GetEntriesSnapshot()
+    {
+        ThrowIfDisposed();
+        lock (_lock)
+        {
+            return [.. _entries];
+        }
+    }
 
     public void Commit(string? name = null, [CallerArgumentExpression(nameof(name))] string? expression = null)
     {
@@ -232,14 +246,18 @@ public sealed class HistoryManager : IDisposable
 
                 try
                 {
+                    // Peek-then-pop preserves stack integrity if Revert/Apply throws:
+                    // the failing transaction stays on the originating stack so it
+                    // is not lost from history altogether.
                     while (_undoStack.Count > index)
                     {
-                        HistoryTransaction transaction = _undoStack.Pop();
+                        HistoryTransaction transaction = _undoStack.Peek();
                         _logger.LogDebug("JumpTo undoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
                         using (SuppressRecording())
                         {
                             transaction.Revert(_context);
                         }
+                        _undoStack.Pop();
                         _redoStack.Push(transaction);
                         moved = true;
                         stateMutated = true;
@@ -247,12 +265,13 @@ public sealed class HistoryManager : IDisposable
 
                     while (_undoStack.Count < index && _redoStack.Count > 0)
                     {
-                        HistoryTransaction transaction = _redoStack.Pop();
+                        HistoryTransaction transaction = _redoStack.Peek();
                         _logger.LogDebug("JumpTo redoing transaction: {TransactionName} (ID: {TransactionId})", transaction.Name, transaction.Id);
                         using (SuppressRecording())
                         {
                             transaction.Apply(_context);
                         }
+                        _redoStack.Pop();
                         _undoStack.Push(transaction);
                         moved = true;
                         stateMutated = true;

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -237,8 +237,26 @@ public sealed class HistoryManager : IDisposable
             int redoCount = _redoStack.Count;
             _undoStack.Clear();
             _redoStack.Clear();
-            _entries.Clear();
-            _entries.Add(HistoryEntry.CreateInitial());
+
+            // Avoid Clear() + Add(): a VM mirror on a different thread would
+            // queue both events; the Reset path would resync to the already
+            // re-added initial entry, and the queued Add would then duplicate
+            // it. Emitting Replace + RemoveAt lets each event apply
+            // independently without a Reset.
+            HistoryEntry newInitial = HistoryEntry.CreateInitial();
+            if (_entries.Count == 0)
+            {
+                _entries.Add(newInitial);
+            }
+            else
+            {
+                _entries[0] = newInitial;
+                for (int i = _entries.Count - 1; i > 0; i--)
+                {
+                    _entries.RemoveAt(i);
+                }
+            }
+
             _logger.LogDebug("Cleared history stacks (Undo: {UndoCount}, Redo: {RedoCount})", undoCount, redoCount);
         }
 

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -75,9 +75,10 @@ public sealed class HistoryManager : IDisposable
     /// the subscription on a separate thread.
     /// </summary>
     /// <returns>
-    /// A tuple containing the unsubscribe disposable and the initial snapshot.
+    /// A tuple containing the unsubscribe disposable, the initial snapshot,
+    /// and the current index captured atomically with the snapshot.
     /// </returns>
-    public (IDisposable Subscription, HistoryEntry[] InitialSnapshot) SubscribeEntries(
+    public (IDisposable Subscription, HistoryEntry[] InitialSnapshot, int InitialCurrentIndex) SubscribeEntries(
         NotifyCollectionChangedEventHandler handler)
     {
         ThrowIfDisposed();
@@ -85,9 +86,11 @@ public sealed class HistoryManager : IDisposable
 
         INotifyCollectionChanged source = _entries;
         HistoryEntry[] snapshot;
+        int currentIndex;
         lock (_lock)
         {
             snapshot = [.. _entries];
+            currentIndex = _undoStack.Count;
             source.CollectionChanged += handler;
         }
 
@@ -101,7 +104,7 @@ public sealed class HistoryManager : IDisposable
             }
         });
 
-        return (subscription, snapshot);
+        return (subscription, snapshot, currentIndex);
     }
 
     public void Commit(string? name = null, [CallerArgumentExpression(nameof(name))] string? expression = null)
@@ -339,6 +342,18 @@ public sealed class HistoryManager : IDisposable
                     _logger.LogError(ex, "JumpTo failed at undo={UndoCount}, redo={RedoCount}, target={Target}; history is in a partial state",
                         _undoStack.Count, _redoStack.Count, index);
                     failure = ex;
+                }
+
+                // Forward loop exits when _redoStack is empty; if that happened
+                // before reaching the requested index (e.g. residual stack drift
+                // from a previously-failed step), do not silently report success.
+                if (failure is null && _undoStack.Count != index)
+                {
+                    _logger.LogError(
+                        "JumpTo could not reach target index {Target} (undo={UndoCount}, redo={RedoCount}); stacks are out of sync with entries",
+                        index, _undoStack.Count, _redoStack.Count);
+                    failure = new InvalidOperationException(
+                        $"JumpTo could not reach target index {index} (undo={_undoStack.Count}, redo={_redoStack.Count}).");
                 }
             }
         }

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -228,6 +228,9 @@
   <data name="History_Unnamed" xml:space="preserve">
     <value>(無題)</value>
   </data>
+  <data name="History_OperationFailed" xml:space="preserve">
+    <value>履歴操作に失敗しました。</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -219,6 +219,12 @@
   <data name="Output" xml:space="preserve">
     <value>出力</value>
   </data>
+  <data name="History" xml:space="preserve">
+    <value>履歴</value>
+  </data>
+  <data name="History_Initial" xml:space="preserve">
+    <value>初期状態</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -225,6 +225,9 @@
   <data name="History_Initial" xml:space="preserve">
     <value>初期状態</value>
   </data>
+  <data name="History_Unnamed" xml:space="preserve">
+    <value>(無題)</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -107,6 +107,9 @@
   <data name="History_Initial" xml:space="preserve">
     <value>Initial state</value>
   </data>
+  <data name="History_Unnamed" xml:space="preserve">
+    <value>(Unnamed)</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -110,6 +110,9 @@
   <data name="History_Unnamed" xml:space="preserve">
     <value>(Unnamed)</value>
   </data>
+  <data name="History_OperationFailed" xml:space="preserve">
+    <value>History operation failed.</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -101,6 +101,12 @@
   <data name="Output" xml:space="preserve">
     <value>Output</value>
   </data>
+  <data name="History" xml:space="preserve">
+    <value>History</value>
+  </data>
+  <data name="History_Initial" xml:space="preserve">
+    <value>Initial state</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/src/Beutl/Services/PrimitiveImpls/HistoryTabExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/HistoryTabExtension.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Tools;

--- a/src/Beutl/Services/PrimitiveImpls/HistoryTabExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/HistoryTabExtension.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Tools;
+using Beutl.Views.Tools;
+
+namespace Beutl.Services.PrimitiveImpls;
+
+[PrimitiveImpl]
+public sealed class HistoryTabExtension : ToolTabExtension
+{
+    public static readonly HistoryTabExtension Instance = new();
+
+    public override string Name => "History";
+
+    public override string DisplayName => Strings.History;
+
+    public override string? Header => Strings.History;
+
+    public override bool CanMultiple => false;
+
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
+
+    public override bool OpenByDefault => false;
+
+    public override int DefaultOrder => 100;
+
+    public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
+    {
+        if (editorContext is EditViewModel)
+        {
+            control = new HistoryView();
+            return true;
+        }
+
+        control = null;
+        return false;
+    }
+
+    public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
+    {
+        if (editorContext is EditViewModel editViewModel)
+        {
+            context = new HistoryViewModel(editViewModel);
+            return true;
+        }
+
+        context = null;
+        return false;
+    }
+}

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -49,6 +49,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         EqualizerPropertiesExtension.Instance,
         ScriptEditorExtension.Instance,
         FileBrowserTabExtension.Instance,
+        HistoryTabExtension.Instance,
         DefaultTutorialExtension.Instance
     ];
 

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -30,12 +30,17 @@ public sealed class HistoryViewModel : IToolContext
         _currentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
         CurrentIndex = _currentIndex;
 
-        ResyncEntries();
+        // Atomically capture the initial snapshot and subscribe under the
+        // manager's lock so commits/clears that happen during construction
+        // are not lost between the snapshot and the subscription.
+        IDisposable subscription = _historyManager.SubscribeEntries(
+            OnManagerEntriesChanged,
+            out HistoryEntry[] initialSnapshot);
+        _disposables.Add(subscription);
 
-        if (_historyManager.Entries is INotifyCollectionChanged notifying)
+        foreach (HistoryEntry entry in initialSnapshot)
         {
-            notifying.CollectionChanged += OnManagerEntriesChanged;
-            _disposables.Add(Disposable.Create(() => notifying.CollectionChanged -= OnManagerEntriesChanged));
+            _entries.Add(entry);
         }
 
         _historyManager.StateChanged

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -30,7 +30,7 @@ public sealed class HistoryViewModel : IToolContext
         _currentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
         CurrentIndex = _currentIndex;
 
-        SyncEntriesAndIndex();
+        ResyncEntries();
 
         if (_historyManager.Entries is INotifyCollectionChanged notifying)
         {
@@ -41,7 +41,11 @@ public sealed class HistoryViewModel : IToolContext
         _historyManager.StateChanged
             .Subscribe(
                 _ => DispatchToUI(SyncCurrentIndex),
-                ex => _logger.LogError(ex, "HistoryManager.StateChanged stream errored"))
+                ex =>
+                {
+                    _logger.LogError(ex, "HistoryManager.StateChanged stream errored; UI sync stopped");
+                    NotificationService.ShowError(Strings.History, Strings.History_OperationFailed);
+                })
             .DisposeWith(_disposables);
     }
 
@@ -61,10 +65,11 @@ public sealed class HistoryViewModel : IToolContext
         {
             _historyManager.JumpTo(index);
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            _logger.LogDebug(ex, "JumpTo({Index}) skipped — manager is disposed", index);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             ReportFailure(ex, $"Failed to jump to history index {index}");
         }
@@ -76,10 +81,11 @@ public sealed class HistoryViewModel : IToolContext
         {
             _historyManager.Undo();
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            _logger.LogDebug(ex, "Undo skipped — manager is disposed");
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             ReportFailure(ex, "Failed to undo");
         }
@@ -91,10 +97,11 @@ public sealed class HistoryViewModel : IToolContext
         {
             _historyManager.Redo();
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            _logger.LogDebug(ex, "Redo skipped — manager is disposed");
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             ReportFailure(ex, "Failed to redo");
         }
@@ -122,18 +129,97 @@ public sealed class HistoryViewModel : IToolContext
 
     private void OnManagerEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        DispatchToUI(SyncEntriesAndIndex);
+        DispatchToUI(() => ApplyManagerChange(e));
     }
 
-    private void SyncEntriesAndIndex()
+    // Mirrors a single CollectionChanged event from HistoryManager onto the
+    // UI-thread-bound _entries. Granular Add/Remove/Replace events let the
+    // ListBox preserve selection, scroll position, and virtualization caches
+    // instead of being torn down by a Reset on every commit.
+    private void ApplyManagerChange(NotifyCollectionChangedEventArgs e)
     {
-        SyncEntries();
+        try
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add when e.NewItems is not null:
+                {
+                    int insertIndex = e.NewStartingIndex >= 0 ? e.NewStartingIndex : _entries.Count;
+                    foreach (object? item in e.NewItems)
+                    {
+                        if (item is HistoryEntry entry)
+                        {
+                            _entries.Insert(insertIndex++, entry);
+                        }
+                    }
+                    break;
+                }
+                case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
+                {
+                    int removeAt = e.OldStartingIndex;
+                    if (removeAt < 0)
+                    {
+                        ResyncEntries();
+                    }
+                    else
+                    {
+                        for (int i = 0; i < e.OldItems.Count; i++)
+                        {
+                            if (removeAt < _entries.Count)
+                            {
+                                _entries.RemoveAt(removeAt);
+                            }
+                        }
+                    }
+                    break;
+                }
+                case NotifyCollectionChangedAction.Replace when e.NewItems is not null:
+                {
+                    int start = e.NewStartingIndex;
+                    for (int i = 0; i < e.NewItems.Count; i++)
+                    {
+                        if (e.NewItems[i] is HistoryEntry entry && start + i < _entries.Count)
+                        {
+                            _entries[start + i] = entry;
+                        }
+                    }
+                    break;
+                }
+                case NotifyCollectionChangedAction.Reset:
+                default:
+                    ResyncEntries();
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to apply HistoryManager.Entries change ({Action}); falling back to full resync", e.Action);
+            try
+            {
+                ResyncEntries();
+            }
+            catch (Exception resyncEx)
+            {
+                _logger.LogError(resyncEx, "Full resync of history entries also failed");
+            }
+        }
+
         SyncCurrentIndex();
     }
 
-    private void SyncEntries()
+    private void ResyncEntries()
     {
-        var snapshot = _historyManager.Entries.ToList();
+        HistoryEntry[] snapshot;
+        try
+        {
+            snapshot = _historyManager.GetEntriesSnapshot();
+        }
+        catch (ObjectDisposedException)
+        {
+            _entries.Clear();
+            return;
+        }
+
         _entries.Clear();
         foreach (HistoryEntry entry in snapshot)
         {
@@ -143,18 +229,41 @@ public sealed class HistoryViewModel : IToolContext
 
     private void SyncCurrentIndex()
     {
-        _currentIndex.Value = _historyManager.CurrentIndex;
+        try
+        {
+            _currentIndex.Value = _historyManager.CurrentIndex;
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    private static void DispatchToUI(Action action)
+    private void DispatchToUI(Action action)
     {
         if (Dispatcher.UIThread.CheckAccess())
         {
-            action();
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception in UI-thread history sync");
+            }
         }
         else
         {
-            Dispatcher.UIThread.Post(action);
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unhandled exception in UI-thread history sync");
+                }
+            });
         }
     }
 

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -133,9 +133,9 @@ public sealed class HistoryViewModel : IToolContext
     }
 
     // Mirrors a single CollectionChanged event from HistoryManager onto the
-    // UI-thread-bound _entries. Granular Add/Remove/Replace events let the
-    // ListBox preserve selection, scroll position, and virtualization caches
-    // instead of being torn down by a Reset on every commit.
+    // UI-thread-bound _entries. Granular Add/Remove/Replace/Move events let
+    // the ListBox preserve selection, scroll position, and virtualization
+    // caches instead of being torn down by a Reset on every commit.
     private void ApplyManagerChange(NotifyCollectionChangedEventArgs e)
     {
         try
@@ -176,12 +176,31 @@ public sealed class HistoryViewModel : IToolContext
                 case NotifyCollectionChangedAction.Replace when e.NewItems is not null:
                 {
                     int start = e.NewStartingIndex;
+                    if (start < 0)
+                    {
+                        ResyncEntries();
+                        break;
+                    }
                     for (int i = 0; i < e.NewItems.Count; i++)
                     {
                         if (e.NewItems[i] is HistoryEntry entry && start + i < _entries.Count)
                         {
                             _entries[start + i] = entry;
                         }
+                    }
+                    break;
+                }
+                case NotifyCollectionChangedAction.Move:
+                {
+                    if (e.OldStartingIndex < 0 || e.NewStartingIndex < 0
+                        || e.OldStartingIndex >= _entries.Count
+                        || e.NewStartingIndex >= _entries.Count)
+                    {
+                        ResyncEntries();
+                    }
+                    else
+                    {
+                        _entries.Move(e.OldStartingIndex, e.NewStartingIndex);
                     }
                     break;
                 }
@@ -194,14 +213,7 @@ public sealed class HistoryViewModel : IToolContext
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to apply HistoryManager.Entries change ({Action}); falling back to full resync", e.Action);
-            try
-            {
-                ResyncEntries();
-            }
-            catch (Exception resyncEx)
-            {
-                _logger.LogError(resyncEx, "Full resync of history entries also failed");
-            }
+            ResyncEntries();
         }
 
         SyncCurrentIndex();
@@ -214,8 +226,9 @@ public sealed class HistoryViewModel : IToolContext
         {
             snapshot = _historyManager.GetEntriesSnapshot();
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            _logger.LogDebug(ex, "ResyncEntries skipped — manager is disposed; clearing UI-side mirror");
             _entries.Clear();
             return;
         }
@@ -233,14 +246,15 @@ public sealed class HistoryViewModel : IToolContext
         {
             _currentIndex.Value = _historyManager.CurrentIndex;
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            _logger.LogDebug(ex, "SyncCurrentIndex skipped — manager is disposed");
         }
     }
 
     private void DispatchToUI(Action action)
     {
-        if (Dispatcher.UIThread.CheckAccess())
+        void RunGuarded()
         {
             try
             {
@@ -251,19 +265,14 @@ public sealed class HistoryViewModel : IToolContext
                 _logger.LogError(ex, "Unhandled exception in UI-thread history sync");
             }
         }
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            RunGuarded();
+        }
         else
         {
-            Dispatcher.UIThread.Post(() =>
-            {
-                try
-                {
-                    action();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Unhandled exception in UI-thread history sync");
-                }
-            });
+            Dispatcher.UIThread.Post(RunGuarded);
         }
     }
 

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -33,9 +33,8 @@ public sealed class HistoryViewModel : IToolContext
         // Atomically capture the initial snapshot and subscribe under the
         // manager's lock so commits/clears that happen during construction
         // are not lost between the snapshot and the subscription.
-        IDisposable subscription = _historyManager.SubscribeEntries(
-            OnManagerEntriesChanged,
-            out HistoryEntry[] initialSnapshot);
+        (IDisposable subscription, HistoryEntry[] initialSnapshot) =
+            _historyManager.SubscribeEntries(OnManagerEntriesChanged);
         _disposables.Add(subscription);
 
         foreach (HistoryEntry entry in initialSnapshot)

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -27,13 +27,12 @@ public sealed class HistoryViewModel : IToolContext
         _historyManager = editViewModel.HistoryManager;
 
         Entries = new ReadOnlyObservableCollection<HistoryEntry>(_entries);
-        _currentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
-        CurrentIndex = _currentIndex;
 
-        // Atomically capture the initial snapshot and subscribe under the
-        // manager's lock so commits/clears that happen during construction
-        // are not lost between the snapshot and the subscription.
-        (IDisposable subscription, HistoryEntry[] initialSnapshot) =
+        // Atomically capture entries snapshot, current index, and subscribe in
+        // one lock acquisition. Reading CurrentIndex separately would let a
+        // commit slip in between the index read and the subscription, leaving
+        // _currentIndex stale until the next history mutation.
+        (IDisposable subscription, HistoryEntry[] initialSnapshot, int initialCurrentIndex) =
             _historyManager.SubscribeEntries(OnManagerEntriesChanged);
         _disposables.Add(subscription);
 
@@ -41,6 +40,9 @@ public sealed class HistoryViewModel : IToolContext
         {
             _entries.Add(entry);
         }
+
+        _currentIndex = new ReactivePropertySlim<int>(initialCurrentIndex);
+        CurrentIndex = _currentIndex;
 
         _historyManager.StateChanged
             .Subscribe(
@@ -51,6 +53,12 @@ public sealed class HistoryViewModel : IToolContext
                     NotificationService.ShowError(Strings.History, Strings.History_OperationFailed);
                 })
             .DisposeWith(_disposables);
+
+        // A commit/clear/jump that fired between SubscribeEntries returning
+        // and the StateChanged subscription above would have updated entries
+        // (delivered to OnManagerEntriesChanged) but bypassed CurrentIndex.
+        // Re-sync once now to close that window.
+        DispatchToUI(SyncCurrentIndex);
     }
 
     public ToolTabExtension Extension => HistoryTabExtension.Instance;
@@ -73,7 +81,7 @@ public sealed class HistoryViewModel : IToolContext
         {
             _logger.LogDebug(ex, "JumpTo({Index}) skipped — manager is disposed", index);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
             ReportFailure(ex, $"Failed to jump to history index {index}");
         }
@@ -89,7 +97,7 @@ public sealed class HistoryViewModel : IToolContext
         {
             _logger.LogDebug(ex, "Undo skipped — manager is disposed");
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
             ReportFailure(ex, "Failed to undo");
         }
@@ -105,7 +113,7 @@ public sealed class HistoryViewModel : IToolContext
         {
             _logger.LogDebug(ex, "Redo skipped — manager is disposed");
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
             ReportFailure(ex, "Failed to redo");
         }

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Reactive.Disposables;
 using System.Text.Json.Nodes;
@@ -147,67 +147,67 @@ public sealed class HistoryViewModel : IToolContext
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add when e.NewItems is not null:
-                {
-                    int insertIndex = e.NewStartingIndex >= 0 ? e.NewStartingIndex : _entries.Count;
-                    foreach (object? item in e.NewItems)
                     {
-                        if (item is HistoryEntry entry)
+                        int insertIndex = e.NewStartingIndex >= 0 ? e.NewStartingIndex : _entries.Count;
+                        foreach (object? item in e.NewItems)
                         {
-                            _entries.Insert(insertIndex++, entry);
-                        }
-                    }
-                    break;
-                }
-                case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
-                {
-                    int removeAt = e.OldStartingIndex;
-                    if (removeAt < 0)
-                    {
-                        ResyncEntries();
-                    }
-                    else
-                    {
-                        for (int i = 0; i < e.OldItems.Count; i++)
-                        {
-                            if (removeAt < _entries.Count)
+                            if (item is HistoryEntry entry)
                             {
-                                _entries.RemoveAt(removeAt);
+                                _entries.Insert(insertIndex++, entry);
                             }
                         }
-                    }
-                    break;
-                }
-                case NotifyCollectionChangedAction.Replace when e.NewItems is not null:
-                {
-                    int start = e.NewStartingIndex;
-                    if (start < 0)
-                    {
-                        ResyncEntries();
                         break;
                     }
-                    for (int i = 0; i < e.NewItems.Count; i++)
+                case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
                     {
-                        if (e.NewItems[i] is HistoryEntry entry && start + i < _entries.Count)
+                        int removeAt = e.OldStartingIndex;
+                        if (removeAt < 0)
                         {
-                            _entries[start + i] = entry;
+                            ResyncEntries();
                         }
+                        else
+                        {
+                            for (int i = 0; i < e.OldItems.Count; i++)
+                            {
+                                if (removeAt < _entries.Count)
+                                {
+                                    _entries.RemoveAt(removeAt);
+                                }
+                            }
+                        }
+                        break;
                     }
-                    break;
-                }
+                case NotifyCollectionChangedAction.Replace when e.NewItems is not null:
+                    {
+                        int start = e.NewStartingIndex;
+                        if (start < 0)
+                        {
+                            ResyncEntries();
+                            break;
+                        }
+                        for (int i = 0; i < e.NewItems.Count; i++)
+                        {
+                            if (e.NewItems[i] is HistoryEntry entry && start + i < _entries.Count)
+                            {
+                                _entries[start + i] = entry;
+                            }
+                        }
+                        break;
+                    }
                 case NotifyCollectionChangedAction.Move:
-                {
-                    if (e.OldStartingIndex < 0 || e.NewStartingIndex < 0
-                        || e.OldStartingIndex >= _entries.Count
-                        || e.NewStartingIndex >= _entries.Count)
                     {
-                        ResyncEntries();
+                        if (e.OldStartingIndex < 0 || e.NewStartingIndex < 0
+                            || e.OldStartingIndex >= _entries.Count
+                            || e.NewStartingIndex >= _entries.Count)
+                        {
+                            ResyncEntries();
+                        }
+                        else
+                        {
+                            _entries.Move(e.OldStartingIndex, e.NewStartingIndex);
+                        }
+                        break;
                     }
-                    else
-                    {
-                        _entries.Move(e.OldStartingIndex, e.NewStartingIndex);
-                    }
-                    break;
-                }
                 case NotifyCollectionChangedAction.Reset:
                 default:
                     ResyncEntries();

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -1,0 +1,109 @@
+using System.Reactive.Linq;
+using System.Text.Json.Nodes;
+using Avalonia.Threading;
+using Beutl.Editor;
+using Beutl.Logging;
+using Beutl.Services.PrimitiveImpls;
+using Microsoft.Extensions.Logging;
+using Reactive.Bindings;
+
+namespace Beutl.ViewModels.Tools;
+
+public sealed class HistoryViewModel : IToolContext
+{
+    private readonly ILogger _logger = Log.CreateLogger<HistoryViewModel>();
+    private readonly CompositeDisposable _disposables = [];
+    private readonly EditViewModel _editViewModel;
+    private readonly HistoryManager _historyManager;
+
+    public HistoryViewModel(EditViewModel editViewModel)
+    {
+        _editViewModel = editViewModel;
+        _historyManager = editViewModel.HistoryManager;
+
+        Entries = _historyManager.Entries;
+        CurrentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
+
+        _historyManager.StateChanged
+            .Subscribe(_ =>
+            {
+                if (Dispatcher.UIThread.CheckAccess())
+                {
+                    CurrentIndex.Value = _historyManager.CurrentIndex;
+                }
+                else
+                {
+                    Dispatcher.UIThread.Post(() => CurrentIndex.Value = _historyManager.CurrentIndex);
+                }
+            })
+            .DisposeWith(_disposables);
+    }
+
+    public ToolTabExtension Extension => HistoryTabExtension.Instance;
+
+    public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
+
+    public string Header => Strings.History;
+
+    public IReadOnlyList<HistoryEntry> Entries { get; }
+
+    public ReactivePropertySlim<int> CurrentIndex { get; }
+
+    public void JumpTo(HistoryEntry entry)
+    {
+        if (entry is null) return;
+        var index = ((System.Collections.Generic.IList<HistoryEntry>)Entries).IndexOf(entry);
+        if (index < 0) return;
+
+        try
+        {
+            _historyManager.JumpTo(index);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to jump to history index {Index}", index);
+        }
+    }
+
+    public void Undo()
+    {
+        try
+        {
+            _historyManager.Undo();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to undo");
+        }
+    }
+
+    public void Redo()
+    {
+        try
+        {
+            _historyManager.Redo();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to redo");
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        return _editViewModel.GetService(serviceType);
+    }
+
+    public void ReadFromJson(JsonObject json)
+    {
+    }
+
+    public void WriteToJson(JsonObject json)
+    {
+    }
+}

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -1,8 +1,11 @@
-using System.Reactive.Linq;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Reactive.Disposables;
 using System.Text.Json.Nodes;
 using Avalonia.Threading;
 using Beutl.Editor;
 using Beutl.Logging;
+using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
@@ -15,27 +18,30 @@ public sealed class HistoryViewModel : IToolContext
     private readonly CompositeDisposable _disposables = [];
     private readonly EditViewModel _editViewModel;
     private readonly HistoryManager _historyManager;
+    private readonly ObservableCollection<HistoryEntry> _entries = [];
+    private readonly ReactivePropertySlim<int> _currentIndex;
 
     public HistoryViewModel(EditViewModel editViewModel)
     {
         _editViewModel = editViewModel;
         _historyManager = editViewModel.HistoryManager;
 
-        Entries = _historyManager.Entries;
-        CurrentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
+        Entries = new ReadOnlyObservableCollection<HistoryEntry>(_entries);
+        _currentIndex = new ReactivePropertySlim<int>(_historyManager.CurrentIndex);
+        CurrentIndex = _currentIndex;
+
+        SyncEntriesAndIndex();
+
+        if (_historyManager.Entries is INotifyCollectionChanged notifying)
+        {
+            notifying.CollectionChanged += OnManagerEntriesChanged;
+            _disposables.Add(Disposable.Create(() => notifying.CollectionChanged -= OnManagerEntriesChanged));
+        }
 
         _historyManager.StateChanged
-            .Subscribe(_ =>
-            {
-                if (Dispatcher.UIThread.CheckAccess())
-                {
-                    CurrentIndex.Value = _historyManager.CurrentIndex;
-                }
-                else
-                {
-                    Dispatcher.UIThread.Post(() => CurrentIndex.Value = _historyManager.CurrentIndex);
-                }
-            })
+            .Subscribe(
+                _ => DispatchToUI(SyncCurrentIndex),
+                ex => _logger.LogError(ex, "HistoryManager.StateChanged stream errored"))
             .DisposeWith(_disposables);
     }
 
@@ -45,23 +51,22 @@ public sealed class HistoryViewModel : IToolContext
 
     public string Header => Strings.History;
 
-    public IReadOnlyList<HistoryEntry> Entries { get; }
+    public ReadOnlyObservableCollection<HistoryEntry> Entries { get; }
 
-    public ReactivePropertySlim<int> CurrentIndex { get; }
+    public IReadOnlyReactiveProperty<int> CurrentIndex { get; }
 
-    public void JumpTo(HistoryEntry entry)
+    public void JumpTo(int index)
     {
-        if (entry is null) return;
-        var index = ((System.Collections.Generic.IList<HistoryEntry>)Entries).IndexOf(entry);
-        if (index < 0) return;
-
         try
         {
             _historyManager.JumpTo(index);
         }
-        catch (Exception ex)
+        catch (ObjectDisposedException)
         {
-            _logger.LogError(ex, "Failed to jump to history index {Index}", index);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ReportFailure(ex, $"Failed to jump to history index {index}");
         }
     }
 
@@ -71,9 +76,12 @@ public sealed class HistoryViewModel : IToolContext
         {
             _historyManager.Undo();
         }
-        catch (Exception ex)
+        catch (ObjectDisposedException)
         {
-            _logger.LogError(ex, "Failed to undo");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ReportFailure(ex, "Failed to undo");
         }
     }
 
@@ -83,9 +91,12 @@ public sealed class HistoryViewModel : IToolContext
         {
             _historyManager.Redo();
         }
-        catch (Exception ex)
+        catch (ObjectDisposedException)
         {
-            _logger.LogError(ex, "Failed to redo");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ReportFailure(ex, "Failed to redo");
         }
     }
 
@@ -101,9 +112,55 @@ public sealed class HistoryViewModel : IToolContext
 
     public void ReadFromJson(JsonObject json)
     {
+        // History is editor-session state and is not persisted across loads.
     }
 
     public void WriteToJson(JsonObject json)
     {
+        // History is editor-session state and is not persisted across loads.
+    }
+
+    private void OnManagerEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        DispatchToUI(SyncEntriesAndIndex);
+    }
+
+    private void SyncEntriesAndIndex()
+    {
+        SyncEntries();
+        SyncCurrentIndex();
+    }
+
+    private void SyncEntries()
+    {
+        var snapshot = _historyManager.Entries.ToList();
+        _entries.Clear();
+        foreach (HistoryEntry entry in snapshot)
+        {
+            _entries.Add(entry);
+        }
+    }
+
+    private void SyncCurrentIndex()
+    {
+        _currentIndex.Value = _historyManager.CurrentIndex;
+    }
+
+    private static void DispatchToUI(Action action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(action);
+        }
+    }
+
+    private void ReportFailure(Exception ex, string context)
+    {
+        _logger.LogError(ex, "{Context}", context);
+        NotificationService.ShowError(Strings.History, Strings.History_OperationFailed);
     }
 }

--- a/src/Beutl/Views/Tools/HistoryView.axaml
+++ b/src/Beutl/Views/Tools/HistoryView.axaml
@@ -20,10 +20,10 @@
                            VerticalAlignment="Center"
                            FontFamily="Consolas, monospace"
                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                           Text="{Binding TransactionId, FallbackValue=&#x2022;}" />
+                           Text="{Binding TransactionLabel}" />
                 <TextBlock Grid.Column="2"
                            VerticalAlignment="Center"
-                           Text="{Binding DisplayName, FallbackValue={x:Static lang:Strings.History_Initial}}"
+                           Text="{Binding DisplayLabel}"
                            TextTrimming="CharacterEllipsis" />
                 <TextBlock Grid.Column="4"
                            VerticalAlignment="Center"

--- a/src/Beutl/Views/Tools/HistoryView.axaml
+++ b/src/Beutl/Views/Tools/HistoryView.axaml
@@ -1,0 +1,82 @@
+<UserControl x:Class="Beutl.Views.Tools.HistoryView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:editor="using:Beutl.Editor"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:viewModels="using:Beutl.ViewModels.Tools"
+             d:DesignHeight="450"
+             d:DesignWidth="280"
+             x:CompileBindings="True"
+             x:DataType="viewModels:HistoryViewModel"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <DataTemplate x:Key="HistoryEntryTemplate" x:DataType="editor:HistoryEntry">
+            <Grid Margin="0" ColumnDefinitions="Auto,8,*,8,Auto">
+                <TextBlock Grid.Column="0"
+                           MinWidth="32"
+                           VerticalAlignment="Center"
+                           FontFamily="Consolas, monospace"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           Text="{Binding TransactionId, FallbackValue=&#x2022;}" />
+                <TextBlock Grid.Column="2"
+                           VerticalAlignment="Center"
+                           Text="{Binding DisplayName, FallbackValue={x:Static lang:Strings.History_Initial}}"
+                           TextTrimming="CharacterEllipsis" />
+                <TextBlock Grid.Column="4"
+                           VerticalAlignment="Center"
+                           FontSize="11"
+                           Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                           Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss}'}" />
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+    <UserControl.Styles>
+        <Style Selector="ListBox#HistoryList ListBoxItem.future">
+            <Setter Property="Opacity" Value="0.5" />
+        </Style>
+        <Style Selector="ListBox#HistoryList ListBoxItem.current">
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,*">
+        <Grid Grid.Row="0"
+              Height="36"
+              Margin="4,4,4,0"
+              ColumnDefinitions="Auto,Auto,*">
+            <Button Grid.Column="0"
+                    Padding="6"
+                    Click="OnUndoClick"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="{x:Static lang:Strings.Undo}">
+                <ui:SymbolIcon Symbol="Undo" />
+            </Button>
+            <Button Grid.Column="1"
+                    Margin="4,0,0,0"
+                    Padding="6"
+                    Click="OnRedoClick"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="{x:Static lang:Strings.Redo}">
+                <ui:SymbolIcon Symbol="Redo" />
+            </Button>
+            <TextBlock Grid.Column="2"
+                       Margin="8,0,0,0"
+                       VerticalAlignment="Center"
+                       FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       Text="{Binding CurrentIndex.Value, StringFormat='#{0}'}" />
+        </Grid>
+
+        <ListBox x:Name="HistoryList"
+                 Grid.Row="1"
+                 Margin="4"
+                 Background="Transparent"
+                 ItemTemplate="{StaticResource HistoryEntryTemplate}"
+                 ItemsSource="{Binding Entries}"
+                 SelectionMode="Single"
+                 SelectionChanged="OnSelectionChanged" />
+    </Grid>
+</UserControl>

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Interactivity;

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -36,7 +36,7 @@ public partial class HistoryView : UserControl
             {
                 viewModel.CurrentIndex.Subscribe(
                     _ => SyncSelection(),
-                    ex => _logger.LogError(ex, "CurrentIndex stream errored")),
+                    ex => _logger.LogError(ex, "CurrentIndex stream errored; selection will stop syncing")),
             };
 
             ((INotifyCollectionChanged)viewModel.Entries).CollectionChanged += OnEntriesChanged;

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -1,22 +1,28 @@
 using System.Collections.Specialized;
+using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Beutl.Editor;
+using Beutl.Logging;
 using Beutl.ViewModels.Tools;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Views.Tools;
 
 public partial class HistoryView : UserControl
 {
-    private IDisposable? _currentIndexSubscription;
+    private readonly ILogger _logger = Log.CreateLogger<HistoryView>();
+    private CompositeDisposable? _viewModelSubscriptions;
     private HistoryViewModel? _currentViewModel;
+    // Guards re-entrant JumpTo calls when SelectedIndex is updated programmatically
+    // in response to ViewModel-driven state changes.
     private bool _suppressSelectionChanged;
 
     public HistoryView()
     {
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
-        DetachedFromVisualTree += (_, _) => Detach();
+        DetachedFromVisualTree += OnDetachedFromVisualTree;
     }
 
     private void OnDataContextChanged(object? sender, EventArgs e)
@@ -26,26 +32,30 @@ public partial class HistoryView : UserControl
         if (DataContext is HistoryViewModel viewModel)
         {
             _currentViewModel = viewModel;
-            _currentIndexSubscription = viewModel.CurrentIndex
-                .Subscribe(_ => SyncSelection());
-
-            if (viewModel.Entries is INotifyCollectionChanged ncc)
+            _viewModelSubscriptions = new CompositeDisposable
             {
-                ncc.CollectionChanged += OnEntriesChanged;
-            }
+                viewModel.CurrentIndex.Subscribe(
+                    _ => SyncSelection(),
+                    ex => _logger.LogError(ex, "CurrentIndex stream errored")),
+            };
+
+            ((INotifyCollectionChanged)viewModel.Entries).CollectionChanged += OnEntriesChanged;
+            _viewModelSubscriptions.Add(Disposable.Create(viewModel,
+                vm => ((INotifyCollectionChanged)vm.Entries).CollectionChanged -= OnEntriesChanged));
 
             SyncSelection();
         }
     }
 
+    private void OnDetachedFromVisualTree(object? sender, EventArgs e)
+    {
+        Detach();
+    }
+
     private void Detach()
     {
-        _currentIndexSubscription?.Dispose();
-        _currentIndexSubscription = null;
-        if (_currentViewModel is { Entries: INotifyCollectionChanged ncc })
-        {
-            ncc.CollectionChanged -= OnEntriesChanged;
-        }
+        _viewModelSubscriptions?.Dispose();
+        _viewModelSubscriptions = null;
         _currentViewModel = null;
     }
 
@@ -94,11 +104,12 @@ public partial class HistoryView : UserControl
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (_suppressSelectionChanged) return;
-        if (_currentViewModel is null) return;
-        if (e.AddedItems is null || e.AddedItems.Count == 0) return;
-        if (e.AddedItems[0] is not HistoryEntry entry) return;
+        if (_currentViewModel is null || HistoryList is null) return;
 
-        _currentViewModel.JumpTo(entry);
+        int index = HistoryList.SelectedIndex;
+        if (index < 0) return;
+
+        _currentViewModel.JumpTo(index);
         UpdateItemAppearance();
     }
 

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using System.Reactive.Disposables;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Beutl.Editor;
@@ -22,7 +23,6 @@ public partial class HistoryView : UserControl
     {
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
-        DetachedFromVisualTree += OnDetachedFromVisualTree;
         HistoryList.ContainerPrepared += OnContainerPrepared;
         HistoryList.ContainerClearing += OnContainerClearing;
     }
@@ -30,28 +30,42 @@ public partial class HistoryView : UserControl
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         Detach();
-
-        if (DataContext is HistoryViewModel viewModel)
-        {
-            _currentViewModel = viewModel;
-            _viewModelSubscriptions = new CompositeDisposable
-            {
-                viewModel.CurrentIndex.Subscribe(
-                    _ => SyncSelection(),
-                    ex => _logger.LogError(ex, "CurrentIndex stream errored; selection will stop syncing")),
-            };
-
-            ((INotifyCollectionChanged)viewModel.Entries).CollectionChanged += OnEntriesChanged;
-            _viewModelSubscriptions.Add(Disposable.Create(viewModel,
-                vm => ((INotifyCollectionChanged)vm.Entries).CollectionChanged -= OnEntriesChanged));
-
-            SyncSelection();
-        }
+        TryAttach();
     }
 
-    private void OnDetachedFromVisualTree(object? sender, EventArgs e)
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        // Re-attach when the same control is reinserted into the visual tree
+        // (e.g. switching dock tabs) where DataContextChanged would not fire
+        // again because the DataContext reference did not change.
+        TryAttach();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         Detach();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void TryAttach()
+    {
+        if (_currentViewModel is not null) return;
+        if (DataContext is not HistoryViewModel viewModel) return;
+
+        _currentViewModel = viewModel;
+        _viewModelSubscriptions = new CompositeDisposable
+        {
+            viewModel.CurrentIndex.Subscribe(
+                _ => SyncSelection(),
+                ex => _logger.LogError(ex, "CurrentIndex stream errored; selection will stop syncing")),
+        };
+
+        ((INotifyCollectionChanged)viewModel.Entries).CollectionChanged += OnEntriesChanged;
+        _viewModelSubscriptions.Add(Disposable.Create(viewModel,
+            vm => ((INotifyCollectionChanged)vm.Entries).CollectionChanged -= OnEntriesChanged));
+
+        SyncSelection();
     }
 
     private void Detach()
@@ -137,7 +151,19 @@ public partial class HistoryView : UserControl
         if (index < 0) return;
 
         _currentViewModel.JumpTo(index);
-        UpdateItemAppearance();
+
+        // If JumpTo did not actually move (failure, no-op, or same index),
+        // StateChanged may not have fired and the selected row would otherwise
+        // remain on the clicked index, drifting from the real CurrentIndex.
+        // Re-sync so a subsequent click on the same row re-issues JumpTo.
+        if (_currentViewModel.CurrentIndex.Value != index)
+        {
+            SyncSelection();
+        }
+        else
+        {
+            UpdateItemAppearance();
+        }
     }
 
     private void OnUndoClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -1,0 +1,114 @@
+using System.Collections.Specialized;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Beutl.Editor;
+using Beutl.ViewModels.Tools;
+
+namespace Beutl.Views.Tools;
+
+public partial class HistoryView : UserControl
+{
+    private IDisposable? _currentIndexSubscription;
+    private HistoryViewModel? _currentViewModel;
+    private bool _suppressSelectionChanged;
+
+    public HistoryView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        DetachedFromVisualTree += (_, _) => Detach();
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        Detach();
+
+        if (DataContext is HistoryViewModel viewModel)
+        {
+            _currentViewModel = viewModel;
+            _currentIndexSubscription = viewModel.CurrentIndex
+                .Subscribe(_ => SyncSelection());
+
+            if (viewModel.Entries is INotifyCollectionChanged ncc)
+            {
+                ncc.CollectionChanged += OnEntriesChanged;
+            }
+
+            SyncSelection();
+        }
+    }
+
+    private void Detach()
+    {
+        _currentIndexSubscription?.Dispose();
+        _currentIndexSubscription = null;
+        if (_currentViewModel is { Entries: INotifyCollectionChanged ncc })
+        {
+            ncc.CollectionChanged -= OnEntriesChanged;
+        }
+        _currentViewModel = null;
+    }
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        SyncSelection();
+    }
+
+    private void SyncSelection()
+    {
+        if (_currentViewModel is null || HistoryList is null) return;
+
+        int target = _currentViewModel.CurrentIndex.Value;
+        if (target < 0 || target >= _currentViewModel.Entries.Count)
+        {
+            return;
+        }
+
+        try
+        {
+            _suppressSelectionChanged = true;
+            HistoryList.SelectedIndex = target;
+        }
+        finally
+        {
+            _suppressSelectionChanged = false;
+        }
+
+        UpdateItemAppearance();
+    }
+
+    private void UpdateItemAppearance()
+    {
+        if (_currentViewModel is null || HistoryList is null) return;
+
+        int current = _currentViewModel.CurrentIndex.Value;
+        for (int i = 0; i < _currentViewModel.Entries.Count; i++)
+        {
+            if (HistoryList.ContainerFromIndex(i) is not ListBoxItem item) continue;
+
+            item.Classes.Set("current", i == current);
+            item.Classes.Set("future", i > current);
+        }
+    }
+
+    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressSelectionChanged) return;
+        if (_currentViewModel is null) return;
+        if (e.AddedItems is null || e.AddedItems.Count == 0) return;
+        if (e.AddedItems[0] is not HistoryEntry entry) return;
+
+        _currentViewModel.JumpTo(entry);
+        UpdateItemAppearance();
+    }
+
+    private void OnUndoClick(object? sender, RoutedEventArgs e)
+    {
+        _currentViewModel?.Undo();
+    }
+
+    private void OnRedoClick(object? sender, RoutedEventArgs e)
+    {
+        _currentViewModel?.Redo();
+    }
+}

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -23,6 +23,8 @@ public partial class HistoryView : UserControl
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
         DetachedFromVisualTree += OnDetachedFromVisualTree;
+        HistoryList.ContainerPrepared += OnContainerPrepared;
+        HistoryList.ContainerClearing += OnContainerClearing;
     }
 
     private void OnDataContextChanged(object? sender, EventArgs e)
@@ -96,9 +98,34 @@ public partial class HistoryView : UserControl
         {
             if (HistoryList.ContainerFromIndex(i) is not ListBoxItem item) continue;
 
-            item.Classes.Set("current", i == current);
-            item.Classes.Set("future", i > current);
+            ApplyItemClasses(item, i, current);
         }
+    }
+
+    // ContainerPrepared fires whenever a ListBoxItem becomes realized
+    // (including after recycling), so this is where freshly attached
+    // containers get their current/future classes set.
+    private void OnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
+    {
+        if (_currentViewModel is null || e.Container is not ListBoxItem item) return;
+
+        ApplyItemClasses(item, e.Index, _currentViewModel.CurrentIndex.Value);
+    }
+
+    // Strip our state classes when a container is recycled so it does not
+    // re-appear at a new index carrying stale styling.
+    private void OnContainerClearing(object? sender, ContainerClearingEventArgs e)
+    {
+        if (e.Container is not ListBoxItem item) return;
+
+        item.Classes.Set("current", false);
+        item.Classes.Set("future", false);
+    }
+
+    private static void ApplyItemClasses(ListBoxItem item, int index, int currentIndex)
+    {
+        item.Classes.Set("current", index == currentIndex);
+        item.Classes.Set("future", index > currentIndex);
     }
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -855,6 +855,163 @@ public class HistoryManagerTests
         });
     }
 
+    [Test]
+    public void HistoryEntry_Subtypes_AreSealedDiscriminatedUnion()
+    {
+        var initial = HistoryEntry.CreateInitial();
+        var transactional = HistoryEntry.FromTransaction(new HistoryTransaction(7));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(initial, Is.InstanceOf<InitialHistoryEntry>());
+            Assert.That(transactional, Is.InstanceOf<TransactionHistoryEntry>());
+            Assert.That(initial.TransactionId, Is.Null);
+            Assert.That(transactional.TransactionId, Is.EqualTo(7L));
+        });
+    }
+
+    #endregion
+
+    #region JumpTo Failure / Disposal Tests
+
+    [Test]
+    public void JumpTo_AfterDispose_ShouldThrowObjectDisposedException()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.JumpTo(0));
+    }
+
+    [Test]
+    public void JumpTo_WhenRevertThrowsMidLoop_ShouldNotifyForCompletedStepsAndRethrow()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+
+        // _undoStack (bottom -> top): Faulty, Step2, Step3
+        // JumpTo(0) reverts Step3 (ok) -> Step2 (ok) -> Faulty (throws).
+        var faulty = CustomOperation.Create(
+            () => _root.Value = 100,
+            () => throw new InvalidOperationException("Boom"),
+            _sequenceGenerator,
+            "Faulty");
+        faulty.Apply(new OperationExecutionContext(_root));
+        manager.Record(faulty);
+        manager.Commit("Faulty");
+
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+        CreateValueOperation(manager, 300, 200, "Step3");
+        manager.Commit("Step3");
+
+        HistoryState? observed = null;
+        using var sub = manager.StateChanged.Subscribe(s => observed = s);
+
+        Assert.Throws<InvalidOperationException>(() => manager.JumpTo(0));
+
+        Assert.Multiple(() =>
+        {
+            // Successful steps must still notify.
+            Assert.That(observed, Is.Not.Null);
+            // Stack integrity preserved by peek-then-pop: Step2/Step3 moved to redo,
+            // Faulty stays on undo.
+            Assert.That(manager.UndoCount, Is.EqualTo(1));
+            Assert.That(manager.RedoCount, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void JumpTo_WhenPendingRevertThrows_ShouldStillReplaceCurrentTransaction()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Committed");
+        manager.Commit("Committed");
+
+        // Pending op whose revert throws — but its operation should NOT survive
+        // into the next commit because JumpTo's finally swaps _currentTransaction.
+        var pending = CustomOperation.Create(
+            () => _root.Value = 999,
+            () => throw new InvalidOperationException("PendingRevertFailed"),
+            _sequenceGenerator,
+            "Pending");
+        pending.Apply(new OperationExecutionContext(_root));
+        manager.Record(pending);
+
+        Assert.Throws<InvalidOperationException>(() => manager.JumpTo(0));
+
+        // A subsequent commit must not include the pending operation.
+        CreateValueOperation(manager, 50, 999, "After");
+        manager.Commit("After");
+
+        Assert.That(manager.PeekUndo()?.OperationCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void JumpTo_RejumpForwardAfterCommitCollapse_ShouldFail()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+        CreateValueOperation(manager, 300, 200, "Step3");
+        manager.Commit("Step3");
+
+        // Jump back, then commit -> redo stack collapses, entries truncate.
+        manager.JumpTo(1);
+        CreateValueOperation(manager, 50, 100, "Replacement");
+        manager.Commit("Replacement");
+
+        int previousValue = _root.Value;
+        bool moved = manager.JumpTo(3); // No longer reachable.
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.False);
+            Assert.That(_root.Value, Is.EqualTo(previousValue));
+            Assert.That(manager.Entries.Count, Is.EqualTo(3));
+        });
+    }
+
+    #endregion
+
+    #region Snapshot Tests
+
+    [Test]
+    public void GetEntriesSnapshot_ReturnsLockSafeCopy()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+
+        HistoryEntry[] snapshot = manager.GetEntriesSnapshot();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Length, Is.EqualTo(2));
+            Assert.That(snapshot[0].IsInitial, Is.True);
+            Assert.That(snapshot[1].DisplayName, Is.EqualTo("Step1"));
+        });
+
+        // Mutating the manager must not affect the snapshot reference.
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+        Assert.That(snapshot.Length, Is.EqualTo(2));
+        Assert.That(manager.Entries.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void GetEntriesSnapshot_AfterDispose_ShouldThrow()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.GetEntriesSnapshot());
+    }
+
     #endregion
 
     #region BeginRecordingScope Tests

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1072,6 +1072,30 @@ public class HistoryManagerTests
             manager.SubscribeEntries(null!));
     }
 
+    [Test]
+    public void Clear_DoesNotEmitResetEvent()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+
+        var actions = new List<NotifyCollectionChangedAction>();
+        var (sub, _) = manager.SubscribeEntries((_, e) => actions.Add(e.Action));
+        using (sub)
+        {
+            manager.Clear();
+        }
+
+        // Reset would force a full resync that races with the follow-up Add of
+        // the new initial entry on a UI-thread mirror; the Clear implementation
+        // must use granular events instead.
+        Assert.That(actions, Does.Not.Contain(NotifyCollectionChangedAction.Reset));
+        Assert.That(manager.Entries.Count, Is.EqualTo(1));
+        Assert.That(manager.Entries[0].IsInitial, Is.True);
+    }
+
     #endregion
 
     #region BeginRecordingScope Tests

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1021,21 +1021,21 @@ public class HistoryManagerTests
         manager.Commit("Step1");
 
         var received = new List<NotifyCollectionChangedAction>();
-        using IDisposable sub = manager.SubscribeEntries(
-            (_, e) => received.Add(e.Action),
-            out HistoryEntry[] snapshot);
-
-        Assert.Multiple(() =>
+        var (sub, snapshot) = manager.SubscribeEntries((_, e) => received.Add(e.Action));
+        using (sub)
         {
-            Assert.That(snapshot.Length, Is.EqualTo(2));
-            Assert.That(snapshot[0].IsInitial, Is.True);
-            Assert.That(snapshot[1].DisplayName, Is.EqualTo("Step1"));
-        });
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot.Length, Is.EqualTo(2));
+                Assert.That(snapshot[0].IsInitial, Is.True);
+                Assert.That(snapshot[1].DisplayName, Is.EqualTo("Step1"));
+            });
 
-        CreateValueOperation(manager, 200, 100, "Step2");
-        manager.Commit("Step2");
+            CreateValueOperation(manager, 200, 100, "Step2");
+            manager.Commit("Step2");
 
-        Assert.That(received, Does.Contain(NotifyCollectionChangedAction.Add));
+            Assert.That(received, Does.Contain(NotifyCollectionChangedAction.Add));
+        }
     }
 
     [Test]
@@ -1043,9 +1043,7 @@ public class HistoryManagerTests
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         int callCount = 0;
-        IDisposable sub = manager.SubscribeEntries(
-            (_, _) => callCount++,
-            out _);
+        var (sub, _) = manager.SubscribeEntries((_, _) => callCount++);
 
         sub.Dispose();
 
@@ -1062,7 +1060,7 @@ public class HistoryManagerTests
         manager.Dispose();
 
         Assert.Throws<ObjectDisposedException>(() =>
-            manager.SubscribeEntries((_, _) => { }, out _));
+            manager.SubscribeEntries((_, _) => { }));
     }
 
     [Test]
@@ -1071,7 +1069,7 @@ public class HistoryManagerTests
         using var manager = new HistoryManager(_root, _sequenceGenerator);
 
         Assert.Throws<ArgumentNullException>(() =>
-            manager.SubscribeEntries(null!, out _));
+            manager.SubscribeEntries(null!));
     }
 
     #endregion

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1074,7 +1074,7 @@ public class HistoryManagerTests
         manager.Commit("Step1");
 
         var received = new List<NotifyCollectionChangedAction>();
-        var (sub, snapshot) = manager.SubscribeEntries((_, e) => received.Add(e.Action));
+        var (sub, snapshot, currentIndex) = manager.SubscribeEntries((_, e) => received.Add(e.Action));
         using (sub)
         {
             Assert.Multiple(() =>
@@ -1082,6 +1082,7 @@ public class HistoryManagerTests
                 Assert.That(snapshot.Length, Is.EqualTo(2));
                 Assert.That(snapshot[0].IsInitial, Is.True);
                 Assert.That(snapshot[1].DisplayName, Is.EqualTo("Step1"));
+                Assert.That(currentIndex, Is.EqualTo(1));
             });
 
             CreateValueOperation(manager, 200, 100, "Step2");
@@ -1096,7 +1097,7 @@ public class HistoryManagerTests
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         int callCount = 0;
-        var (sub, _) = manager.SubscribeEntries((_, _) => callCount++);
+        var (sub, _, _) = manager.SubscribeEntries((_, _) => callCount++);
 
         sub.Dispose();
 
@@ -1135,7 +1136,7 @@ public class HistoryManagerTests
         manager.Commit("Step2");
 
         var actions = new List<NotifyCollectionChangedAction>();
-        var (sub, _) = manager.SubscribeEntries((_, e) => actions.Add(e.Action));
+        var (sub, _, _) = manager.SubscribeEntries((_, e) => actions.Add(e.Action));
         using (sub)
         {
             manager.Clear();

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -885,6 +885,59 @@ public class HistoryManagerTests
     }
 
     [Test]
+    public void JumpTo_WhenApplyThrowsMidForwardLoop_ShouldKeepFailingTransactionOnRedoStack()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+
+        // Faulty's first Apply (the explicit pre-record call) succeeds; any
+        // subsequent Apply (e.g. via Redo / JumpTo forward) throws.
+        bool firstApply = true;
+        var faulty = CustomOperation.Create(
+            () =>
+            {
+                if (firstApply)
+                {
+                    firstApply = false;
+                    _root.Value = 300;
+                    return;
+                }
+                throw new InvalidOperationException("Boom");
+            },
+            () => _root.Value = 200,
+            _sequenceGenerator,
+            "Faulty");
+        faulty.Apply(new OperationExecutionContext(_root));
+        manager.Record(faulty);
+        manager.Commit("Faulty");
+
+        manager.JumpTo(0);
+        // After jumping back: undo=[], redo=[Step1, Step2, Faulty(top)]
+        Assert.That(manager.RedoCount, Is.EqualTo(3));
+
+        HistoryState? observed = null;
+        using var sub = manager.StateChanged.Subscribe(s => observed = s);
+
+        Assert.Throws<InvalidOperationException>(() => manager.JumpTo(3));
+
+        Assert.Multiple(() =>
+        {
+            // peek-then-pop keeps the throwing transaction on redo while the
+            // ones that already applied move to undo.
+            Assert.That(manager.UndoCount, Is.EqualTo(2));
+            Assert.That(manager.RedoCount, Is.EqualTo(1));
+            Assert.That(manager.PeekRedo()?.DisplayName, Is.EqualTo("Faulty"));
+            // Successful steps must still emit a state-change notification.
+            Assert.That(observed, Is.Not.Null);
+        });
+    }
+
+    [Test]
     public void JumpTo_WhenRevertThrowsMidLoop_ShouldNotifyForCompletedStepsAndRethrow()
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Editor;
+﻿using System.Collections.Specialized;
+using Beutl.Editor;
 using Beutl.Editor.Operations;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
@@ -1010,6 +1011,67 @@ public class HistoryManagerTests
         manager.Dispose();
 
         Assert.Throws<ObjectDisposedException>(() => manager.GetEntriesSnapshot());
+    }
+
+    [Test]
+    public void SubscribeEntries_ReturnsCurrentSnapshotAndForwardsLaterChanges()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+
+        var received = new List<NotifyCollectionChangedAction>();
+        using IDisposable sub = manager.SubscribeEntries(
+            (_, e) => received.Add(e.Action),
+            out HistoryEntry[] snapshot);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Length, Is.EqualTo(2));
+            Assert.That(snapshot[0].IsInitial, Is.True);
+            Assert.That(snapshot[1].DisplayName, Is.EqualTo("Step1"));
+        });
+
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+
+        Assert.That(received, Does.Contain(NotifyCollectionChangedAction.Add));
+    }
+
+    [Test]
+    public void SubscribeEntries_DisposalUnsubscribesHandler()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        int callCount = 0;
+        IDisposable sub = manager.SubscribeEntries(
+            (_, _) => callCount++,
+            out _);
+
+        sub.Dispose();
+
+        CreateValueOperation(manager, 1, 0, "AfterUnsubscribe");
+        manager.Commit("AfterUnsubscribe");
+
+        Assert.That(callCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SubscribeEntries_AfterDispose_ShouldThrow()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+            manager.SubscribeEntries((_, _) => { }, out _));
+    }
+
+    [Test]
+    public void SubscribeEntries_NullHandler_ShouldThrow()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+
+        Assert.Throws<ArgumentNullException>(() =>
+            manager.SubscribeEntries(null!, out _));
     }
 
     #endregion

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -575,10 +575,287 @@ public class HistoryManagerTests
             "Test Operation");
     }
 
+    private CustomOperation CreateValueOperation(HistoryManager manager, int targetValue, int previousValue, string description)
+    {
+        var op = CustomOperation.Create(
+            () => _root.Value = targetValue,
+            () => _root.Value = previousValue,
+            _sequenceGenerator,
+            description);
+        op.Apply(new OperationExecutionContext(_root));
+        manager.Record(op);
+        return op;
+    }
+
     private class TestCoreObject : CoreObject
     {
         public int Value { get; set; }
     }
+
+    #region JumpTo / Entries Tests
+
+    [Test]
+    public void Entries_AfterConstruction_ShouldContainSingleInitialEntry()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(manager.Entries.Count, Is.EqualTo(1));
+            Assert.That(manager.Entries[0].IsInitial, Is.True);
+            Assert.That(manager.CurrentIndex, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Entries_AfterCommit_ShouldAppendTransactionEntry()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Set");
+        manager.Commit("First");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(manager.Entries.Count, Is.EqualTo(2));
+            Assert.That(manager.Entries[0].IsInitial, Is.True);
+            Assert.That(manager.Entries[1].IsInitial, Is.False);
+            Assert.That(manager.Entries[1].DisplayName, Is.EqualTo("First"));
+            Assert.That(manager.CurrentIndex, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Commit_AfterUndo_ShouldTruncateEntriesAndKeepInitial()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+
+        manager.Undo();
+        Assert.That(manager.Entries.Count, Is.EqualTo(3));
+
+        CreateValueOperation(manager, 50, 100, "Replacement");
+        manager.Commit("Replacement");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(manager.Entries.Count, Is.EqualTo(3));
+            Assert.That(manager.Entries[0].IsInitial, Is.True);
+            Assert.That(manager.Entries[1].DisplayName, Is.EqualTo("Step1"));
+            Assert.That(manager.Entries[2].DisplayName, Is.EqualTo("Replacement"));
+        });
+    }
+
+    [Test]
+    public void Clear_ShouldLeaveSingleInitialEntry()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+
+        manager.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(manager.Entries.Count, Is.EqualTo(1));
+            Assert.That(manager.Entries[0].IsInitial, Is.True);
+            Assert.That(manager.CurrentIndex, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void JumpTo_OutOfRangeIndex_ShouldReturnFalseWithoutMutation()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+
+        int countBefore = manager.UndoCount;
+        bool moved1 = manager.JumpTo(-1);
+        bool moved2 = manager.JumpTo(manager.Entries.Count);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved1, Is.False);
+            Assert.That(moved2, Is.False);
+            Assert.That(manager.UndoCount, Is.EqualTo(countBefore));
+            Assert.That(_root.Value, Is.EqualTo(100));
+        });
+    }
+
+    [Test]
+    public void JumpTo_ToCurrentIndex_ShouldReturnFalseAndNotNotify()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+
+        HistoryState? receivedState = null;
+        using var sub = manager.StateChanged.Subscribe(s => receivedState = s);
+
+        bool moved = manager.JumpTo(manager.CurrentIndex);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.False);
+            Assert.That(receivedState, Is.Null);
+        });
+    }
+
+    [Test]
+    public void JumpTo_ToPastIndex_ShouldRevertInLifoOrder()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+        CreateValueOperation(manager, 300, 200, "Step3");
+        manager.Commit("Step3");
+
+        bool moved = manager.JumpTo(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.True);
+            Assert.That(_root.Value, Is.EqualTo(0));
+            Assert.That(manager.UndoCount, Is.EqualTo(0));
+            Assert.That(manager.RedoCount, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void JumpTo_ToFutureIndex_ShouldReapplyInOrder()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+        CreateValueOperation(manager, 200, 100, "Step2");
+        manager.Commit("Step2");
+        CreateValueOperation(manager, 300, 200, "Step3");
+        manager.Commit("Step3");
+
+        manager.JumpTo(0);
+        Assert.That(_root.Value, Is.EqualTo(0));
+
+        bool moved = manager.JumpTo(2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.True);
+            Assert.That(_root.Value, Is.EqualTo(200));
+            Assert.That(manager.UndoCount, Is.EqualTo(2));
+            Assert.That(manager.RedoCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void JumpTo_WithUncommittedOperations_ShouldRollbackBeforeJumping()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Committed");
+        manager.Commit("Committed");
+
+        // Uncommitted operation that mutates state.
+        var pending = CustomOperation.Create(
+            () => _root.Value = 999,
+            () => _root.Value = 100,
+            _sequenceGenerator,
+            "Pending");
+        pending.Apply(new OperationExecutionContext(_root));
+        manager.Record(pending);
+
+        bool moved = manager.JumpTo(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.True);
+            Assert.That(_root.Value, Is.EqualTo(0));
+            // The uncommitted operation must not survive into a future commit.
+            CreateValueOperation(manager, 50, 0, "AfterJump");
+            manager.Commit("AfterJump");
+            Assert.That(manager.PeekUndo()?.OperationCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void JumpTo_ToInitialIndex_ShouldRestoreInitialState()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "Step1");
+        manager.Commit("Step1");
+
+        bool moved = manager.JumpTo(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moved, Is.True);
+            Assert.That(manager.CurrentIndex, Is.EqualTo(0));
+            Assert.That(manager.CanUndo, Is.False);
+            Assert.That(manager.CanRedo, Is.True);
+            Assert.That(_root.Value, Is.EqualTo(0));
+        });
+    }
+
+    #endregion
+
+    #region HistoryEntry Tests
+
+    [Test]
+    public void HistoryEntry_Initial_ShouldUseInitialLabel()
+    {
+        var entry = HistoryEntry.CreateInitial();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.IsInitial, Is.True);
+            Assert.That(entry.TransactionId, Is.Null);
+            Assert.That(entry.DisplayLabel, Is.EqualTo(Beutl.Language.Strings.History_Initial));
+            Assert.That(entry.TransactionLabel, Is.EqualTo("•"));
+        });
+    }
+
+    [Test]
+    public void HistoryEntry_FromTransaction_DisplayLabelPrefersDisplayName()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("Friendly");
+
+        HistoryEntry entry = manager.Entries[1];
+        Assert.That(entry.DisplayLabel, Is.EqualTo("Friendly"));
+    }
+
+    [Test]
+    public void HistoryEntry_FromTransaction_FallsBackToUnnamedWhenAllNull()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        // Commit with a literal null name -> CallerArgumentExpression captures "(string?)null"
+        // which is non-null, so we directly construct the entry to test the fallback path.
+        var transaction = new HistoryTransaction(42);
+        var entry = HistoryEntry.FromTransaction(transaction);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.IsInitial, Is.False);
+            Assert.That(entry.DisplayLabel, Is.EqualTo(Beutl.Language.Strings.History_Unnamed));
+            Assert.That(entry.TransactionLabel, Is.EqualTo("42"));
+        });
+    }
+
+    #endregion
 
     #region BeginRecordingScope Tests
 


### PR DESCRIPTION
## Description

Adds a history tool tab that lists every committed transaction and lets the user jump to any entry directly, on top of the existing Undo/Redo flow.

- New `HistoryTabExtension` registered as a primitive tool, hosting a `HistoryViewModel` / `HistoryView` pane with Undo/Redo buttons and a current-position indicator.
- Extends `HistoryManager` with an observable `Entries` collection, a `CurrentIndex`, and a `JumpTo(int)` API that replays undo/redo against `_undoStack`/`_redoStack` to reach any committed state. Initial entry is materialized via `HistoryEntry.CreateInitial()`, and `Clear()` resets the entry list.
- `HistoryEntry` exposes `DisplayLabel` / `TransactionLabel` so list rows always render readable text — initial state, the user-supplied display name, the `CallerArgumentExpression` name, or `(Unnamed)` as a final fallback. This avoids blank rows for `Commit()` call sites that omit a name (e.g. equalizer edits, `EditViewModel.CommandHandler`).
- New localized strings: `Strings.History_Initial` (`Initial state` / `初期状態`) and `Strings.History_Unnamed` (`(Unnamed)` / `(無題)`).

## Breaking changes

None. `HistoryManager`'s public surface is additive (`Entries`, `CurrentIndex`, `JumpTo`); existing `Commit` / `Undo` / `Redo` callers are unaffected.

## Fixed issues

N/A