### PR TITLE
feat: HDR decoding and encoding for Media Foundation extension

### DIFF
--- a/Beutl.slnx
+++ b/Beutl.slnx
@@ -28,6 +28,7 @@
     <Project Path="tests/Beutl.Graphics3DTests/Beutl.Graphics3DTests.csproj" />
     <Project Path="tests\Beutl.Benchmarks\Beutl.Benchmarks.csproj" />
     <Project Path="tests\Beutl.Extensions.AVFoundation.Tests\Beutl.Extensions.AVFoundation.Tests.csproj" />
+    <Project Path="tests\Beutl.Extensions.MediaFoundation.Tests\Beutl.Extensions.MediaFoundation.Tests.csproj" />
     <Project Path="tests\Beutl.FFmpegBenchmarks\Beutl.FFmpegBenchmarks.csproj" />
     <Project Path="tests\Beutl.UnitTests\Beutl.UnitTests.csproj" />
     <Project Path="tests\DirectoryViewTest\DirectoryViewTest.csproj" />

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -31,6 +31,10 @@
     <EmbeddedResource Update="Properties\Strings.resx" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Beutl.Extensions.MediaFoundation.Tests" />
+  </ItemGroup>
+
   <Choose>
     <When Condition="'$(MFBuildIn)'=='True'">
       <PropertyGroup>

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -236,14 +236,32 @@ internal sealed class MFDecoder : IDisposable
             IMFSample yuy2Sample = sample;
             if (_useDXVA2 && _mfOutBufferSample != null)
             {
-                if (!ConvertColor(sample))
+                IMFSample input = sample;
+                // Hardware VideoProcessorMFTs sometimes hold a frame of latency
+                // (the first ProcessInput returns NEED_MORE_INPUT). Feed extra
+                // samples from the same stream until output is produced; bail
+                // out only on a hard error or when the stream is exhausted.
+                const int MaxFeedRetries = 4;
+                int retries = 0;
+                while (true)
                 {
-                    // ProcessOutput failed (or needs more input) — _mfOutBufferSample
-                    // holds stale/incomplete data. Skip this frame instead of copying
-                    // garbage to the caller's buffer.
-                    return 0;
+                    ConvertColorStatus status = ConvertColor(input);
+                    if (status == ConvertColorStatus.Success)
+                    {
+                        yuy2Sample = _mfOutBufferSample;
+                        break;
+                    }
+                    if (status == ConvertColorStatus.HardError || retries++ >= MaxFeedRetries)
+                    {
+                        return 0;
+                    }
+                    IMFSample? next = ReadSample(_mediaInfo.VideoStreamIndex);
+                    if (next is null)
+                    {
+                        return 0;
+                    }
+                    input = next;
                 }
-                yuy2Sample = _mfOutBufferSample;
             }
 
             return SampleUtilities.SampleCopyToBuffer(yuy2Sample, buf, _mediaInfo.OutImageBufferSize);
@@ -466,12 +484,19 @@ internal sealed class MFDecoder : IDisposable
     }
 
     // MF_E_TRANSFORM_NEED_MORE_INPUT — the transform hasn't accumulated enough
-    // input for an output sample yet. Treated as a transient retry signal rather
-    // than a real error; caller skips the frame and tries again on the next read.
+    // input for an output sample yet. Caller should feed another input sample
+    // and retry rather than treating this as a frame-read failure.
     private const uint MF_E_TRANSFORM_NEED_MORE_INPUT = 0xC00D6D72;
 
-    // NV12 -> YUY2. Returns true if _mfOutBufferSample now holds valid output.
-    private bool ConvertColor(IMFSample sample)
+    private enum ConvertColorStatus
+    {
+        Success,
+        NeedMoreInput,
+        HardError,
+    }
+
+    // NV12 -> YUY2. On Success, _mfOutBufferSample holds the converted frame.
+    private ConvertColorStatus ConvertColor(IMFSample sample)
     {
         _transform!.ProcessInput(0, sample, 0);
 
@@ -479,14 +504,16 @@ internal sealed class MFDecoder : IDisposable
         Result result = _transform.ProcessOutput(ProcessOutputFlags.None, 1, ref mftOutputDataBuffer, out _);
         if (result.Success)
         {
-            return true;
+            return ConvertColorStatus.Success;
         }
 
-        if ((uint)result.Code != MF_E_TRANSFORM_NEED_MORE_INPUT)
+        if ((uint)result.Code == MF_E_TRANSFORM_NEED_MORE_INPUT)
         {
-            _logger.LogError("VideoProcessorMFT.ProcessOutput failed: HRESULT 0x{HResult:X8}", (uint)result.Code);
+            return ConvertColorStatus.NeedMoreInput;
         }
-        return false;
+
+        _logger.LogError("VideoProcessorMFT.ProcessOutput failed: HRESULT 0x{HResult:X8}", (uint)result.Code);
+        return ConvertColorStatus.HardError;
     }
 
     private void ChangeColorConvertSettingAndCreateBuffer()

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -251,13 +251,24 @@ internal sealed class MFDecoder : IDisposable
                         yuy2Sample = _mfOutBufferSample;
                         break;
                     }
-                    if (status == ConvertColorStatus.HardError || retries++ >= MaxFeedRetries)
+                    if (status == ConvertColorStatus.HardError)
                     {
+                        // ConvertColor already logged the HRESULT.
+                        return 0;
+                    }
+                    if (retries++ >= MaxFeedRetries)
+                    {
+                        _logger.LogWarning(
+                            "VideoProcessorMFT still returns NEED_MORE_INPUT after {MaxRetries} feeds at frame {Frame}; dropping",
+                            MaxFeedRetries, frame);
                         return 0;
                     }
                     IMFSample? next = ReadSample(_mediaInfo.VideoStreamIndex);
                     if (next is null)
                     {
+                        _logger.LogWarning(
+                            "VideoProcessorMFT needs more input but stream ended at frame {Frame}; dropping",
+                            frame);
                         return 0;
                     }
                     input = next;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -41,11 +41,17 @@ internal sealed class MFDecoder : IDisposable
     private IDirect3DDevice9? _device;
     private IMFTransform? _transform;
     private MFMediaInfo _mediaInfo;
-    private readonly bool _useDXVA2;
+    private bool _useDXVA2;
     private IMFSample? _mfOutBufferSample;
     private long _firstGapTimeStamp = 0;
     private long _currentVideoTimeStamp = 0;
     private long _currentAudioTimeStamp = 0;
+
+    // Threshold of consecutive ConvertColor HardError results before we surface
+    // a single high-visibility log (not LogError per-frame). The decode loop keeps
+    // running, but the user gets a clear signal that something systemic is wrong.
+    private int _consecutiveConvertColorErrors = 0;
+    private const int ConvertColorErrorReportThreshold = 30;
 
     private readonly MFSampleCache _sampleCache;
 
@@ -102,8 +108,18 @@ internal sealed class MFDecoder : IDisposable
                 }
                 catch (Exception ex)
                 {
+                    // Video stream configuration failed but the user asked for video.
+                    // Falling through to an audio-only reader would silently drop the
+                    // visual content the caller expected, so we let the original
+                    // exception bubble up after logging — MFReader catches it.
                     _logger.LogError(ex, "ConfigureDecoder(_videoSourceReader, _mediaInfo.VideoStreamIndex) failed");
                     _mediaInfo.VideoStreamIndex = -1;
+                    if (!options.StreamsToLoad.HasFlag(MediaMode.Audio))
+                    {
+                        throw;
+                    }
+                    _logger.LogWarning(
+                        "Video stream configuration failed; continuing with audio-only because StreamsToLoad includes Audio");
                 }
             }
 
@@ -151,6 +167,9 @@ internal sealed class MFDecoder : IDisposable
                 {
                     _useDXVA2 = false;
                     _logger.LogError(ex, "ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER) failed");
+                    _logger.LogWarning(
+                        "DXVA2 initialization failed mid-setup; falling back to software decoding. " +
+                        "Some D3D attributes remain on the source reader but VideoProcessorMFT is disabled.");
                 }
             }
 
@@ -241,6 +260,7 @@ internal sealed class MFDecoder : IDisposable
                 if (status == ConvertColorStatus.Success)
                 {
                     yuy2Sample = _mfOutBufferSample;
+                    _consecutiveConvertColorErrors = 0;
                 }
                 else
                 {
@@ -257,6 +277,16 @@ internal sealed class MFDecoder : IDisposable
                         _logger.LogWarning(
                             "VideoProcessorMFT returned NEED_MORE_INPUT for a synchronous converter at frame {Frame}; dropping",
                             frame);
+                    }
+                    else if (status == ConvertColorStatus.HardError)
+                    {
+                        _consecutiveConvertColorErrors++;
+                        if (_consecutiveConvertColorErrors == ConvertColorErrorReportThreshold)
+                        {
+                            _logger.LogError(
+                                "VideoProcessorMFT has failed {Count} frames in a row; preview is likely stuck on dropped frames. Toggle UseDXVA2 off in settings to recover.",
+                                _consecutiveConvertColorErrors);
+                        }
                     }
                     return 0;
                 }
@@ -573,28 +603,26 @@ internal sealed class MFDecoder : IDisposable
         destHeight = funcAlign(destHeight, AlignHeightSize);
         destWidth = funcAlign(destWidth, AlignWidth);
 
-        // 色変換 NV12 -> YUY2
-        // 動画の幅は 2の倍数、高さは 16の倍数でないとダメっぽい？
+        // VideoProcessorMFT input/output configuration: NV12 → YUY2. Frame width
+        // must be a multiple of 2 and height a multiple of 16 for the MFT to
+        // accept the type pair.
         using var inputMediaType = MediaFactory.MFCreateMediaType();
         inputMediaType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
         inputMediaType.Set(MediaTypeAttributeKeys.Subtype, VideoFormatGuids.NV12);
-        inputMediaType.Set(MediaTypeAttributeKeys.AllSamplesIndependent, true); // UnCompressed
-        inputMediaType.Set(MediaTypeAttributeKeys.FixedSizeSamples, true); // UnCompressed
+        inputMediaType.Set(MediaTypeAttributeKeys.AllSamplesIndependent, true);
+        inputMediaType.Set(MediaTypeAttributeKeys.FixedSizeSamples, true);
 
-        // Todo: 後で確認
         inputMediaType.Set(MediaTypeAttributeKeys.PixelAspectRatio, ((ulong)pixelNume << 32) | pixelDenom);
         inputMediaType.Set(MediaTypeAttributeKeys.FrameSize, ((ulong)width << 32) | height);
         _transform.SetInputType(0, inputMediaType, 0);
 
         using var outputMediaType = MediaFactory.MFCreateMediaType();
         outputMediaType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
-        // YUY2
         outputMediaType.Set(MediaTypeAttributeKeys.Subtype, VideoFormatGuids.YUY2);
-        outputMediaType.Set(MediaTypeAttributeKeys.AllSamplesIndependent, true); // UnCompressed
-        outputMediaType.Set(MediaTypeAttributeKeys.FixedSizeSamples, true); // UnCompressed
+        outputMediaType.Set(MediaTypeAttributeKeys.AllSamplesIndependent, true);
+        outputMediaType.Set(MediaTypeAttributeKeys.FixedSizeSamples, true);
 
         inputMediaType.Set(MediaTypeAttributeKeys.PixelAspectRatio, ((ulong)1 << 32) | 1);
-        //spOutputMediaType.Set(MediaTypeAttributeKeys.PixelAspectRatio, ((long)1 << 32) | 1);
         outputMediaType.Set(MediaTypeAttributeKeys.FrameSize, ((ulong)destWidth << 32) | destHeight);
         _transform.SetOutputType(0, outputMediaType, 0);
 
@@ -903,8 +931,11 @@ internal sealed class MFDecoder : IDisposable
                 {
                     _transform?.ProcessMessage(TMessageType.MessageNotifyEndOfStream, 0);
                 }
-                catch (Exception ex)
+                catch (SharpGenException ex)
                 {
+                    // Swallow only MF HRESULT failures here — letting OOM /
+                    // ThreadAbort propagate is intentional. ProcessMessage during
+                    // Dispose is best-effort cleanup; if it fails, log and continue.
                     _logger.LogError(ex, "_transform?.ProcessMessage failed");
                 }
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -20,6 +20,7 @@ using WAVEFORMATEX = Windows.Win32.Media.Audio.WAVEFORMATEX;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;
+
 using Beutl.Embedding.MediaFoundation;
 #else
 namespace Beutl.Extensions.MediaFoundation.Decoding;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -781,15 +781,15 @@ internal sealed class MFDecoder : IDisposable
             }
 
             Guid subType = mediaType.GetGUID(MediaTypeAttributeKeys.Subtype);
-            // YUY2 — still the Source Reader output, even for HDR input. We do carry
-            // the original PQ/HLG transfer tag up to MFReader so Skia reinterprets the
-            // 8-bit samples in the right color space. True 10-bit preservation would
-            // need a P010 output path; that's a future extension on this code.
+            // Source Reader is always asked for YUY2 (see ConfigureDecoder), even
+            // for HDR input — the original PQ/HLG transfer tag is carried up to
+            // MFReader so Skia reinterprets the 8-bit samples in the right color
+            // space. True 10-bit preservation would need a P010 output path;
+            // that's a future extension on this code.
             bih.Compression = new FourCC("YUY2");
             bih.BitCount = 16;
 
             _mediaInfo.ImageFormat = bih;
-            _mediaInfo.OutputSubType = subType;
             _mediaInfo.TotalFrameCount =
                 TimestampUtilities.ConvertFrameFromTimeStamp(_mediaInfo.HnsDuration, _mediaInfo.Fps);
             _mediaInfo.OutImageBufferSize = bih.Width * bih.Height * (bih.BitCount / 8);

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -66,8 +66,6 @@ internal sealed class MFDecoder : IDisposable
         _sampleCache =
             new MFSampleCache(new(extension.Settings.MaxVideoBufferSize, extension.Settings.MaxAudioBufferSize));
 
-        // Honor the setting. The old code hard-coded false which silently
-        // defeated the DXVA2 code path even when the user opted in.
         _useDXVA2 = InitializeDXVA2(extension.Settings.UseDXVA2);
 
         try
@@ -161,9 +159,6 @@ internal sealed class MFDecoder : IDisposable
         {
             _logger.LogError(ex, "An exception occurred during initialization of the video stream.");
             throw;
-        }
-        finally
-        {
         }
     }
 
@@ -291,8 +286,10 @@ internal sealed class MFDecoder : IDisposable
 
                 sample = ReadSample(_mediaInfo.VideoStreamIndex);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "ReadFrame: aborting read loop at frame {Frame} (currentFrame={CurrentFrame})",
+                    frame, currentFrame);
                 break;
             }
         }
@@ -345,8 +342,10 @@ internal sealed class MFDecoder : IDisposable
 
                 sample = ReadSample(_mediaInfo.AudioStreamIndex);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "ReadAudio: aborting read loop at sample {Start} (length={Length})",
+                    start, length);
                 break;
             }
         }
@@ -466,7 +465,15 @@ internal sealed class MFDecoder : IDisposable
         _transform!.ProcessInput(0, sample, 0);
 
         OutputDataBuffer mftOutputDataBuffer = new() { Sample = _mfOutBufferSample };
-        _transform.ProcessOutput(ProcessOutputFlags.None, 1, ref mftOutputDataBuffer, out _);//.CheckError();
+        // MF_E_TRANSFORM_NEED_MORE_INPUT (0xC00D6D72) is benign — the transform
+        // hasn't accumulated enough input for an output sample yet. Anything else
+        // is a real failure that would otherwise leave the output buffer with
+        // stale/garbage data and propagate as wrong colors downstream.
+        Result result = _transform.ProcessOutput(ProcessOutputFlags.None, 1, ref mftOutputDataBuffer, out _);
+        if (result.Failure && (uint)result.Code != 0xC00D6D72)
+        {
+            _logger.LogError("VideoProcessorMFT.ProcessOutput failed: HRESULT 0x{HResult:X8}", (uint)result.Code);
+        }
     }
 
     private void ChangeColorConvertSettingAndCreateBuffer()
@@ -566,6 +573,11 @@ internal sealed class MFDecoder : IDisposable
         _mfOutBufferSample.AddBuffer(buffer);
     }
 
+    // MF_E_INVALIDSTREAMNUMBER (0xC00D36B3) is how Source Reader signals "no more
+    // streams" — that's our intended loop terminator. Any other failure should
+    // surface so we don't silently mis-select streams.
+    private const uint MF_E_INVALIDSTREAMNUMBER = 0xC00D36B3;
+
     private static void SelectStream(IMFSourceReader sourceReader, Guid selectMajorType)
     {
         for (int streamIndex = 0; true; streamIndex++)
@@ -590,7 +602,7 @@ internal sealed class MFDecoder : IDisposable
                     sourceReader.SetStreamSelection(streamIndex, false);
                 }
             }
-            catch
+            catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
             {
                 break;
             }
@@ -667,7 +679,7 @@ internal sealed class MFDecoder : IDisposable
                     Debug.Fail("");
                 }
             }
-            catch
+            catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
             {
                 break;
             }
@@ -705,25 +717,30 @@ internal sealed class MFDecoder : IDisposable
                 _mediaInfo.IsHdr = MFColorSpaceHelper.IsHdrTransfer(_mediaInfo.TransferFunction);
             }
 
-            IMFMediaType mediaType = sourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
+            using IMFMediaType mediaType = sourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
 
             MediaFactory.MFCreateMFVideoFormatFromMFMediaType(mediaType, out IntPtr pMFVF, out var pcbSize);
-            var ppMFVF = (MFVIDEOFORMAT*)pMFVF;
+            try
+            {
+                var ppMFVF = (MFVIDEOFORMAT*)pMFVF;
 
-            bih.Width = (int)ppMFVF->videoInfo.dwWidth;
-            bih.Height = (int)ppMFVF->videoInfo.dwHeight;
+                bih.Width = (int)ppMFVF->videoInfo.dwWidth;
+                bih.Height = (int)ppMFVF->videoInfo.dwHeight;
 
-            RECT rcSrc = RECT.FromXYWH(0, 0, bih.Width, bih.Height);
-            RECT destRect = AspectRatioUtilities.CorrectAspectRatio(
-                rcSrc,
-                ppMFVF->videoInfo.PixelAspectRatio,
-                new MFRatio { Denominator = 1, Numerator = 1 });
-            bih.Width = destRect.right;
-            bih.Height = destRect.bottom;
+                RECT rcSrc = RECT.FromXYWH(0, 0, bih.Width, bih.Height);
+                RECT destRect = AspectRatioUtilities.CorrectAspectRatio(
+                    rcSrc,
+                    ppMFVF->videoInfo.PixelAspectRatio,
+                    new MFRatio { Denominator = 1, Numerator = 1 });
+                bih.Width = destRect.right;
+                bih.Height = destRect.bottom;
 
-            _mediaInfo.Fps = ppMFVF->videoInfo.FramesPerSecond;
-
-            Marshal.FreeCoTaskMem((nint)ppMFVF);
+                _mediaInfo.Fps = ppMFVF->videoInfo.FramesPerSecond;
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(pMFVF);
+            }
 
             Guid subType = mediaType.GetGUID(MediaTypeAttributeKeys.Subtype);
             // YUY2 — still the Source Reader output, even for HDR input. We do carry
@@ -751,13 +768,18 @@ internal sealed class MFDecoder : IDisposable
                 out IntPtr pWF,
                 out uint pcbSize,
                 0);
-            var ppWF = (WAVEFORMATEX*)pWF;
+            try
+            {
+                var ppWF = (WAVEFORMATEX*)pWF;
 
-            ppWF->wFormatTag = (ushort)PInvoke.WAVE_FORMAT_PCM;
+                ppWF->wFormatTag = (ushort)PInvoke.WAVE_FORMAT_PCM;
 
-            _mediaInfo.AudioFormat = WaveFormat.MarshalFrom((nint)ppWF);
-
-            Marshal.FreeCoTaskMem((nint)ppWF);
+                _mediaInfo.AudioFormat = WaveFormat.MarshalFrom((nint)ppWF);
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(pWF);
+            }
 
             _mediaInfo.TotalAudioSampleCount =
                 TimestampUtilities.ConvertSampleFromTimeStamp(_mediaInfo.HnsDuration,
@@ -810,9 +832,12 @@ internal sealed class MFDecoder : IDisposable
         _logger.LogInformation("TestFirstReadSample - firstGapTimeStamp: {firstGapTimeStamp}", _firstGapTimeStamp);
     }
 
-    // IMFMediaType.Get* throws when the attribute isn't set. For optional color
-    // metadata (a lot of legacy files lack these tags) we want a soft default
-    // rather than an exception bubbling up through the constructor.
+    // MF_E_ATTRIBUTENOTFOUND (0xC00D36E6) is the only exception we want to
+    // swallow here — IMFMediaType.Get* raises it when the optional color tag
+    // is missing, which is normal for legacy containers. Any other HRESULT
+    // (or non-MF exception) indicates a real failure that must surface.
+    private const uint MF_E_ATTRIBUTENOTFOUND = 0xC00D36E6;
+
     private static TEnum TryGetEnum<TEnum>(IMFMediaType mediaType, Guid key, TEnum fallback)
         where TEnum : struct, Enum
     {
@@ -821,7 +846,7 @@ internal sealed class MFDecoder : IDisposable
             uint value = mediaType.GetUInt32(key);
             return (TEnum)Enum.ToObject(typeof(TEnum), (int)value);
         }
-        catch
+        catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_ATTRIBUTENOTFOUND)
         {
             return fallback;
         }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -150,7 +150,12 @@ internal sealed class MFDecoder : IDisposable
                 throw new Exception(message);
             }
 
-            if (_useDXVA2 && _videoSourceReader != null)
+            // VideoStreamIndex may have been reset to -1 above when video
+            // ConfigureDecoder threw but the caller still wanted audio; in
+            // that case there is no video stream to attach DXVA2 to, and
+            // GetServiceForStream(-1, ...) would immediately throw and turn
+            // the intended audio-only fallback into a second failure.
+            if (_useDXVA2 && _videoSourceReader != null && _mediaInfo.VideoStreamIndex != -1)
             {
                 // Send a message to the decoder to tell it to use DXVA2.
                 nint videoDecoderPtr = _videoSourceReader.GetServiceForStream(

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -261,8 +261,65 @@ internal sealed class MFDecoder : IDisposable
         int funcCopyBuffer(IMFSample sample)
         {
             IMFSample yuy2Sample = sample;
-            if (_useDXVA2 && _mfOutBufferSample != null)
+
+            // Source Reader's GetCurrentMediaType can lag behind the underlying
+            // decoder's actual output. In DXVA2 mode the hardware decoder
+            // switches to NV12 once the D3D Manager is attached, but Source
+            // Reader keeps reporting the YUY2 we set via SetCurrentMediaType
+            // until the first sample is read — and the CurrentMediaTypeChanged
+            // flag does not reliably fire across every Media Foundation build.
+            // If we trusted the reported subtype we would leave
+            // _mfOutBufferSample null and copy the NV12 buffer straight into
+            // a YUY2-shaped destination, which Yuy2ToBgra then renders as a
+            // doubled, magenta+green frame. Disambiguate by buffer length:
+            // NV12 is w*h*1.5 bytes, YUY2 is w*h*2.
+            int actualLen = sample.TotalLength;
+            int yuy2ExpectedLen = _mediaInfo.OutImageBufferSize;
+            int nv12ExpectedLen = (yuy2ExpectedLen / 4) * 3;
+            // 64-byte slack absorbs stride/height alignment padding the codec
+            // may add to NV12 surfaces (e.g. 1088-row tile padding on 1080p).
+            bool sampleLooksLikeNv12 = actualLen < yuy2ExpectedLen
+                                    && actualLen >= nv12ExpectedLen - 64;
+
+            if (sampleLooksLikeNv12)
             {
+                // Lazy NV12→YUY2 transform setup: the constructor-time call to
+                // ChangeColorConvertSettingAndCreateBuffer may have skipped
+                // setup because GetCurrentMediaType reported YUY2. Force it
+                // now that we know the actual sample is NV12.
+                if (_mfOutBufferSample == null && _useDXVA2 && _transform != null)
+                {
+                    try
+                    {
+                        ChangeColorConvertSettingAndCreateBuffer(forceSetup: true);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "Lazy NV12→YUY2 transform setup failed at frame {Frame}", frame);
+                        return 0;
+                    }
+                }
+
+                if (_mfOutBufferSample == null)
+                {
+                    // No transform available (typically because DXVA2 was off
+                    // and Source Reader's internal video processor failed to
+                    // honor the YUY2 request). Falling through would copy the
+                    // NV12 buffer as if it were YUY2; surface the cause once
+                    // every ConvertColorErrorReportThreshold frames so the
+                    // root issue (Source Reader video processing not engaged)
+                    // is visible without spamming logs.
+                    _consecutiveConvertColorErrors++;
+                    if (_consecutiveConvertColorErrors == ConvertColorErrorReportThreshold)
+                    {
+                        _logger.LogError(
+                            "Source Reader is delivering NV12 samples ({Actual} bytes) but no NV12→YUY2 transform is available ({Threshold} frames in a row). Enable UseDXVA2 in settings to engage VideoProcessorMFT.",
+                            actualLen, _consecutiveConvertColorErrors);
+                    }
+                    return 0;
+                }
+
                 ConvertColorStatus status = ConvertColor(sample);
                 if (status == ConvertColorStatus.Success)
                 {
@@ -298,6 +355,10 @@ internal sealed class MFDecoder : IDisposable
                     return 0;
                 }
             }
+            // Sample is YUY2-sized (or an unknown larger format we can't
+            // disambiguate). Skip ConvertColor — running the NV12-input
+            // transform on a YUY2 sample would fail with MF_E_INVALIDMEDIATYPE
+            // and we'd drop frames unnecessarily.
 
             return SampleUtilities.SampleCopyToBuffer(yuy2Sample, buf, _mediaInfo.OutImageBufferSize);
         }
@@ -551,7 +612,7 @@ internal sealed class MFDecoder : IDisposable
         return ConvertColorStatus.HardError;
     }
 
-    private void ChangeColorConvertSettingAndCreateBuffer()
+    private void ChangeColorConvertSettingAndCreateBuffer(bool forceSetup = false)
     {
         _mfOutBufferSample?.Dispose();
         _mfOutBufferSample = null;
@@ -566,12 +627,18 @@ internal sealed class MFDecoder : IDisposable
         Guid subType = mediaType.GetGUID(MediaTypeAttributeKeys.Subtype);
 
         string? subTypeText = VideoFormatName.GetName(subType) ?? subType.ToString();
-        _logger.LogInformation("GetCurrentMediaType subType: {SubType}", subTypeText);
+        _logger.LogInformation(
+            "GetCurrentMediaType subType: {SubType} (forceSetup={ForceSetup})",
+            subTypeText, forceSetup);
 
         // If Source Reader + its video-processing attributes already delivered
         // YUY2, VideoProcessorMFT would be an identity transform. Skip it —
         // the ProcessInput/ProcessOutput round-trip is pure overhead in that case.
-        if (subType == VideoFormatGuids.YUY2)
+        //
+        // The forceSetup escape hatch is used by funcCopyBuffer when it sees
+        // an NV12-sized sample but the reported subtype is still YUY2 (stale
+        // GetCurrentMediaType after the D3D Manager attach in DXVA2 mode).
+        if (subType == VideoFormatGuids.YUY2 && !forceSetup)
         {
             return;
         }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -236,7 +236,13 @@ internal sealed class MFDecoder : IDisposable
             IMFSample yuy2Sample = sample;
             if (_useDXVA2 && _mfOutBufferSample != null)
             {
-                ConvertColor(sample);
+                if (!ConvertColor(sample))
+                {
+                    // ProcessOutput failed (or needs more input) — _mfOutBufferSample
+                    // holds stale/incomplete data. Skip this frame instead of copying
+                    // garbage to the caller's buffer.
+                    return 0;
+                }
                 yuy2Sample = _mfOutBufferSample;
             }
 
@@ -459,21 +465,28 @@ internal sealed class MFDecoder : IDisposable
         _audioSourceReader!.SetCurrentPosition(destTimePosition);
     }
 
-    // NV12 -> YUY2
-    private void ConvertColor(IMFSample sample)
+    // MF_E_TRANSFORM_NEED_MORE_INPUT — the transform hasn't accumulated enough
+    // input for an output sample yet. Treated as a transient retry signal rather
+    // than a real error; caller skips the frame and tries again on the next read.
+    private const uint MF_E_TRANSFORM_NEED_MORE_INPUT = 0xC00D6D72;
+
+    // NV12 -> YUY2. Returns true if _mfOutBufferSample now holds valid output.
+    private bool ConvertColor(IMFSample sample)
     {
         _transform!.ProcessInput(0, sample, 0);
 
         OutputDataBuffer mftOutputDataBuffer = new() { Sample = _mfOutBufferSample };
-        // MF_E_TRANSFORM_NEED_MORE_INPUT (0xC00D6D72) is benign — the transform
-        // hasn't accumulated enough input for an output sample yet. Anything else
-        // is a real failure that would otherwise leave the output buffer with
-        // stale/garbage data and propagate as wrong colors downstream.
         Result result = _transform.ProcessOutput(ProcessOutputFlags.None, 1, ref mftOutputDataBuffer, out _);
-        if (result.Failure && (uint)result.Code != 0xC00D6D72)
+        if (result.Success)
+        {
+            return true;
+        }
+
+        if ((uint)result.Code != MF_E_TRANSFORM_NEED_MORE_INPUT)
         {
             _logger.LogError("VideoProcessorMFT.ProcessOutput failed: HRESULT 0x{HResult:X8}", (uint)result.Code);
         }
+        return false;
     }
 
     private void ChangeColorConvertSettingAndCreateBuffer()
@@ -602,7 +615,7 @@ internal sealed class MFDecoder : IDisposable
                     sourceReader.SetStreamSelection(streamIndex, false);
                 }
             }
-            catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
+            catch (Exception ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
             {
                 break;
             }
@@ -679,7 +692,7 @@ internal sealed class MFDecoder : IDisposable
                     Debug.Fail("");
                 }
             }
-            catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
+            catch (Exception ex) when ((uint)ex.HResult == MF_E_INVALIDSTREAMNUMBER)
             {
                 break;
             }
@@ -846,7 +859,7 @@ internal sealed class MFDecoder : IDisposable
             uint value = mediaType.GetUInt32(key);
             return (TEnum)Enum.ToObject(typeof(TEnum), (int)value);
         }
-        catch (SharpGenException ex) when ((uint)ex.HResult == MF_E_ATTRIBUTENOTFOUND)
+        catch (Exception ex) when ((uint)ex.HResult == MF_E_ATTRIBUTENOTFOUND)
         {
             return fallback;
         }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -68,11 +68,7 @@ internal sealed class MFDecoder : IDisposable
 
         // Honor the setting. The old code hard-coded false which silently
         // defeated the DXVA2 code path even when the user opted in.
-        // HardwareAcceleration.None also wins over UseDXVA2 to keep a
-        // consistent meaning across the two settings.
-        bool wantDxva = extension.Settings.UseDXVA2
-            && extension.Settings.HardwareAcceleration != HardwareAccelerationMode.None;
-        _useDXVA2 = InitializeDXVA2(wantDxva);
+        _useDXVA2 = InitializeDXVA2(extension.Settings.UseDXVA2);
 
         try
         {

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -20,8 +20,10 @@ using WAVEFORMATEX = Windows.Win32.Media.Audio.WAVEFORMATEX;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;
+using Beutl.Embedding.MediaFoundation;
 #else
 namespace Beutl.Extensions.MediaFoundation.Decoding;
+using Beutl.Extensions.MediaFoundation;
 #endif
 
 #pragma warning disable CA1416 // プラットフォームの互換性を検証
@@ -64,7 +66,13 @@ internal sealed class MFDecoder : IDisposable
         _sampleCache =
             new MFSampleCache(new(extension.Settings.MaxVideoBufferSize, extension.Settings.MaxAudioBufferSize));
 
-        _useDXVA2 = InitializeDXVA2(false /* extension.Settings.UseDXVA2 */);
+        // Honor the setting. The old code hard-coded false which silently
+        // defeated the DXVA2 code path even when the user opted in.
+        // HardwareAcceleration.None also wins over UseDXVA2 to keep a
+        // consistent meaning across the two settings.
+        bool wantDxva = extension.Settings.UseDXVA2
+            && extension.Settings.HardwareAcceleration != HardwareAccelerationMode.None;
+        _useDXVA2 = InitializeDXVA2(wantDxva);
 
         try
         {
@@ -478,10 +486,17 @@ internal sealed class MFDecoder : IDisposable
         using IMFMediaType mediaType = _videoSourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
 
         Guid subType = mediaType.GetGUID(MediaTypeAttributeKeys.Subtype);
-        // TODO: すでにYUY2の場合は何もしないようにする
 
         string? subTypeText = VideoFormatName.GetName(subType) ?? subType.ToString();
         _logger.LogInformation("GetCurrentMediaType subType: {SubType}", subTypeText);
+
+        // If Source Reader + its video-processing attributes already delivered
+        // YUY2, VideoProcessorMFT would be an identity transform. Skip it —
+        // the ProcessInput/ProcessOutput round-trip is pure overhead in that case.
+        if (subType == VideoFormatGuids.YUY2)
+        {
+            return;
+        }
 
         ulong aspectRatio = mediaType.GetUInt64(MediaTypeAttributeKeys.PixelAspectRatio);
         uint pixelNume = (uint)(aspectRatio >> 32);
@@ -679,6 +694,21 @@ internal sealed class MFDecoder : IDisposable
         {
             BitmapInfoHeader bih = default;
 
+            // Read color metadata from the *native* (pre-conversion) type so that
+            // HDR tags survive even though we configure YUY2 as the output subtype.
+            // If the container doesn't tag these, leave them at Unknown — MFColorSpaceHelper
+            // will fall back to sRGB/Rec.709 defaults.
+            using (IMFMediaType nativeType = sourceReader.GetNativeMediaType(_mediaInfo.VideoStreamIndex, 0))
+            {
+                _mediaInfo.TransferFunction = TryGetEnum<VideoTransferFunction>(
+                    nativeType, MediaTypeAttributeKeys.TransferFunction, VideoTransferFunction.FuncUnknown);
+                _mediaInfo.ColorPrimaries = TryGetEnum<VideoPrimaries>(
+                    nativeType, MediaTypeAttributeKeys.VideoPrimaries, VideoPrimaries.Unknown);
+                _mediaInfo.YCbCrMatrix = TryGetEnum<VideoTransferMatrix>(
+                    nativeType, MediaTypeAttributeKeys.YuvMatrix, VideoTransferMatrix.Unknown);
+                _mediaInfo.IsHdr = MFColorSpaceHelper.IsHdrTransfer(_mediaInfo.TransferFunction);
+            }
+
             IMFMediaType mediaType = sourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
 
             MediaFactory.MFCreateMFVideoFormatFromMFMediaType(mediaType, out IntPtr pMFVF, out var pcbSize);
@@ -700,11 +730,15 @@ internal sealed class MFDecoder : IDisposable
             Marshal.FreeCoTaskMem((nint)ppMFVF);
 
             Guid subType = mediaType.GetGUID(MediaTypeAttributeKeys.Subtype);
-            // YUY2
+            // YUY2 — still the Source Reader output, even for HDR input. We do carry
+            // the original PQ/HLG transfer tag up to MFReader so Skia reinterprets the
+            // 8-bit samples in the right color space. True 10-bit preservation would
+            // need a P010 output path; that's a future extension on this code.
             bih.Compression = new FourCC("YUY2");
             bih.BitCount = 16;
 
             _mediaInfo.ImageFormat = bih;
+            _mediaInfo.OutputSubType = subType;
             _mediaInfo.TotalFrameCount =
                 TimestampUtilities.ConvertFrameFromTimeStamp(_mediaInfo.HnsDuration, _mediaInfo.Fps);
             _mediaInfo.OutImageBufferSize = bih.Width * bih.Height * (bih.BitCount / 8);
@@ -778,6 +812,23 @@ internal sealed class MFDecoder : IDisposable
 
         _firstGapTimeStamp = Math.Max(firstVideoTimeStamp, firstAudioTimeStamp);
         _logger.LogInformation("TestFirstReadSample - firstGapTimeStamp: {firstGapTimeStamp}", _firstGapTimeStamp);
+    }
+
+    // IMFMediaType.Get* throws when the attribute isn't set. For optional color
+    // metadata (a lot of legacy files lack these tags) we want a soft default
+    // rather than an exception bubbling up through the constructor.
+    private static TEnum TryGetEnum<TEnum>(IMFMediaType mediaType, Guid key, TEnum fallback)
+        where TEnum : struct, Enum
+    {
+        try
+        {
+            uint value = mediaType.GetUInt32(key);
+            return (TEnum)Enum.ToObject(typeof(TEnum), (int)value);
+        }
+        catch
+        {
+            return fallback;
+        }
     }
 
     public void Dispose()

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -60,7 +60,7 @@ internal sealed class MFDecoder : IDisposable
     // is faster to satisfy by reading-through.
     private readonly int _thresholdFrameCount = 30;
 
-    // Same as above but in audio samples — equivalent to ~0.7s at 48kHz.
+    // Same as above but in audio samples — ~0.6s at 48 kHz (30000 / 48000).
     private readonly int _thresholdSampleCount = 30000;
 
     public MFDecoder(string file, MediaOptions options, MFDecodingExtension extension)
@@ -586,9 +586,10 @@ internal sealed class MFDecoder : IDisposable
         uint destWidth = (uint)destRect.right;
         uint destHeight = (uint)destRect.bottom;
 
-        // VideoProcessorMFT requires width to be a multiple of 2 and height a
-        // multiple of 16 — otherwise SetInputType / SetOutputType returns an
-        // unsupported-type error.
+        // VideoProcessorMFT in practice rejects type pairs with width not a
+        // multiple of 2 or height not a multiple of 16 — this is observed
+        // empirically (the MSDN docs do not formalize the requirement) and
+        // matches the upstream MFVideoReader sample we forked from.
         const int AlignHeightSize = 16;
         const int AlignWidth = 2;
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -236,42 +236,28 @@ internal sealed class MFDecoder : IDisposable
             IMFSample yuy2Sample = sample;
             if (_useDXVA2 && _mfOutBufferSample != null)
             {
-                IMFSample input = sample;
-                // Hardware VideoProcessorMFTs sometimes hold a frame of latency
-                // (the first ProcessInput returns NEED_MORE_INPUT). Feed extra
-                // samples from the same stream until output is produced; bail
-                // out only on a hard error or when the stream is exhausted.
-                const int MaxFeedRetries = 4;
-                int retries = 0;
-                while (true)
+                ConvertColorStatus status = ConvertColor(sample);
+                if (status == ConvertColorStatus.Success)
                 {
-                    ConvertColorStatus status = ConvertColor(input);
-                    if (status == ConvertColorStatus.Success)
-                    {
-                        yuy2Sample = _mfOutBufferSample;
-                        break;
-                    }
-                    if (status == ConvertColorStatus.HardError)
-                    {
-                        // ConvertColor already logged the HRESULT.
-                        return 0;
-                    }
-                    if (retries++ >= MaxFeedRetries)
-                    {
-                        _logger.LogWarning(
-                            "VideoProcessorMFT still returns NEED_MORE_INPUT after {MaxRetries} feeds at frame {Frame}; dropping",
-                            MaxFeedRetries, frame);
-                        return 0;
-                    }
-                    IMFSample? next = ReadSample(_mediaInfo.VideoStreamIndex);
-                    if (next is null)
+                    yuy2Sample = _mfOutBufferSample;
+                }
+                else
+                {
+                    // VideoProcessorMFT (CLSID_VideoProcessorMFT) is documented
+                    // as a synchronous MFT, so a 1:1 ProcessInput → ProcessOutput
+                    // mapping is the contract. NEED_MORE_INPUT here implies a
+                    // non-sync hardware variant; feeding the next ReadSample
+                    // would queue it in _sampleCache and cause a duplicate
+                    // ProcessInput on the next ReadFrame call. Drop the frame
+                    // instead and surface the anomaly. HardError already
+                    // logged its HRESULT inside ConvertColor.
+                    if (status == ConvertColorStatus.NeedMoreInput)
                     {
                         _logger.LogWarning(
-                            "VideoProcessorMFT needs more input but stream ended at frame {Frame}; dropping",
+                            "VideoProcessorMFT returned NEED_MORE_INPUT for a synchronous converter at frame {Frame}; dropping",
                             frame);
-                        return 0;
                     }
-                    input = next;
+                    return 0;
                 }
             }
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -27,7 +27,7 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 using Beutl.Extensions.MediaFoundation;
 #endif
 
-#pragma warning disable CA1416 // プラットフォームの互換性を検証
+#pragma warning disable CA1416 // Validate platform compatibility (entire file is Windows-only).
 
 internal sealed class MFDecoder : IDisposable
 {
@@ -55,10 +55,12 @@ internal sealed class MFDecoder : IDisposable
 
     private readonly MFSampleCache _sampleCache;
 
-    // 現在のフレームからどれくらいの範囲ならシーケンシャル読み込みさせるかの閾値
+    // Distance (in frames) within which we keep reading sequentially instead of
+    // seeking — seeking is expensive on most codecs, so a small forward jump
+    // is faster to satisfy by reading-through.
     private readonly int _thresholdFrameCount = 30;
 
-    // 現在のサンプル数からどれくらいの範囲ならシーケンシャル読み込みさせるかの閾値
+    // Same as above but in audio samples — equivalent to ~0.7s at 48kHz.
     private readonly int _thresholdSampleCount = 30000;
 
     public MFDecoder(string file, MediaOptions options, MFDecodingExtension extension)
@@ -584,7 +586,9 @@ internal sealed class MFDecoder : IDisposable
         uint destWidth = (uint)destRect.right;
         uint destHeight = (uint)destRect.bottom;
 
-        // 高さが16の倍数、幅が2の倍数になるように調節する
+        // VideoProcessorMFT requires width to be a multiple of 2 and height a
+        // multiple of 16 — otherwise SetInputType / SetOutputType returns an
+        // unsupported-type error.
         const int AlignHeightSize = 16;
         const int AlignWidth = 2;
 
@@ -630,7 +634,6 @@ internal sealed class MFDecoder : IDisposable
 
         _transform.ProcessMessage(TMessageType.MessageNotifyBeginStreaming, 0);
 
-        // 出力先IMFSample作成
         var streamInfo = _transform.GetOutputStreamInfo(0);
 
         _mfOutBufferSample = MediaFactory.MFCreateSample();
@@ -751,7 +754,7 @@ internal sealed class MFDecoder : IDisposable
             }
         }
 
-        // 再生時間取得
+        // Stream duration from the presentation descriptor.
         if (_mediaInfo.VideoStreamIndex != -1 || _mediaInfo.AudioStreamIndex != -1)
         {
             _mediaInfo.HnsDuration = (long)(ulong)sourceReader.GetPresentationAttribute(SourceReaderIndex.MediaSource,

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
@@ -12,7 +12,6 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 public sealed class MFDecodingSettings : ExtensionSettings
 {
     public static readonly CoreProperty<bool> UseDXVA2Property;
-    public static readonly CoreProperty<HardwareAccelerationMode> HardwareAccelerationProperty;
     public static readonly CoreProperty<bool> ForceSrgbGammaProperty;
     public static readonly CoreProperty<int> ThresholdFrameCountProperty;
     public static readonly CoreProperty<int> ThresholdSampleCountProperty;
@@ -23,10 +22,6 @@ public sealed class MFDecodingSettings : ExtensionSettings
     {
         UseDXVA2Property = ConfigureProperty<bool, MFDecodingSettings>(nameof(UseDXVA2))
             .DefaultValue(true)
-            .Register();
-
-        HardwareAccelerationProperty = ConfigureProperty<HardwareAccelerationMode, MFDecodingSettings>(nameof(HardwareAcceleration))
-            .DefaultValue(HardwareAccelerationMode.Auto)
             .Register();
 
         ForceSrgbGammaProperty = ConfigureProperty<bool, MFDecodingSettings>(nameof(ForceSrgbGamma))
@@ -49,7 +44,7 @@ public sealed class MFDecodingSettings : ExtensionSettings
             .DefaultValue(20)
             .Register();
 
-        AffectsConfig<MFDecodingSettings>(UseDXVA2Property, HardwareAccelerationProperty);
+        AffectsConfig<MFDecodingSettings>(UseDXVA2Property);
     }
 
     [Display(Name = nameof(Strings.UseDXVA2), Description = nameof(Strings.UseDXVA2_Description), ResourceType = typeof(Strings))]
@@ -57,16 +52,6 @@ public sealed class MFDecodingSettings : ExtensionSettings
     {
         get => GetValue(UseDXVA2Property);
         set => SetValue(UseDXVA2Property, value);
-    }
-
-    [Display(
-        Name = nameof(Strings.HardwareAcceleration),
-        Description = nameof(Strings.HardwareAcceleration_Description),
-        ResourceType = typeof(Strings))]
-    public HardwareAccelerationMode HardwareAcceleration
-    {
-        get => GetValue(HardwareAccelerationProperty);
-        set => SetValue(HardwareAccelerationProperty, value);
     }
 
     [Display(
@@ -122,19 +107,4 @@ public sealed class MFDecodingSettings : ExtensionSettings
         get => GetValue(MaxAudioBufferSizeProperty);
         set => SetValue(MaxAudioBufferSizeProperty, value);
     }
-}
-
-public enum HardwareAccelerationMode
-{
-    // Software decode only.
-    None = 0,
-
-    // Let the decoder pick D3D11VA on Windows 10+ (preferred) and fall back to DXVA2.
-    Auto = 1,
-
-    // Force DXVA2 — older but broadest driver coverage.
-    DXVA2 = 2,
-
-    // Force D3D11VA — required for HDR / 10-bit decode paths.
-    D3D11VA = 3,
 }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 using Beutl.Extensibility;
 using Beutl.Extensions.MediaFoundation.Properties;
@@ -12,6 +12,8 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 public sealed class MFDecodingSettings : ExtensionSettings
 {
     public static readonly CoreProperty<bool> UseDXVA2Property;
+    public static readonly CoreProperty<HardwareAccelerationMode> HardwareAccelerationProperty;
+    public static readonly CoreProperty<bool> ForceSrgbGammaProperty;
     public static readonly CoreProperty<int> ThresholdFrameCountProperty;
     public static readonly CoreProperty<int> ThresholdSampleCountProperty;
     public static readonly CoreProperty<int> MaxVideoBufferSizeProperty;
@@ -20,6 +22,14 @@ public sealed class MFDecodingSettings : ExtensionSettings
     static MFDecodingSettings()
     {
         UseDXVA2Property = ConfigureProperty<bool, MFDecodingSettings>(nameof(UseDXVA2))
+            .DefaultValue(true)
+            .Register();
+
+        HardwareAccelerationProperty = ConfigureProperty<HardwareAccelerationMode, MFDecodingSettings>(nameof(HardwareAcceleration))
+            .DefaultValue(HardwareAccelerationMode.Auto)
+            .Register();
+
+        ForceSrgbGammaProperty = ConfigureProperty<bool, MFDecodingSettings>(nameof(ForceSrgbGamma))
             .DefaultValue(false)
             .Register();
 
@@ -39,7 +49,7 @@ public sealed class MFDecodingSettings : ExtensionSettings
             .DefaultValue(20)
             .Register();
 
-        AffectsConfig<MFDecodingSettings>(UseDXVA2Property);
+        AffectsConfig<MFDecodingSettings>(UseDXVA2Property, HardwareAccelerationProperty);
     }
 
     [Display(Name = nameof(Strings.UseDXVA2), Description = nameof(Strings.UseDXVA2_Description), ResourceType = typeof(Strings))]
@@ -47,6 +57,26 @@ public sealed class MFDecodingSettings : ExtensionSettings
     {
         get => GetValue(UseDXVA2Property);
         set => SetValue(UseDXVA2Property, value);
+    }
+
+    [Display(
+        Name = nameof(Strings.HardwareAcceleration),
+        Description = nameof(Strings.HardwareAcceleration_Description),
+        ResourceType = typeof(Strings))]
+    public HardwareAccelerationMode HardwareAcceleration
+    {
+        get => GetValue(HardwareAccelerationProperty);
+        set => SetValue(HardwareAccelerationProperty, value);
+    }
+
+    [Display(
+        Name = nameof(Strings.ForceSrgbGamma),
+        Description = nameof(Strings.ForceSrgbGamma_Description),
+        ResourceType = typeof(Strings))]
+    public bool ForceSrgbGamma
+    {
+        get => GetValue(ForceSrgbGammaProperty);
+        set => SetValue(ForceSrgbGammaProperty, value);
     }
 
     [Range(1, int.MaxValue)]
@@ -92,4 +122,19 @@ public sealed class MFDecodingSettings : ExtensionSettings
         get => GetValue(MaxAudioBufferSizeProperty);
         set => SetValue(MaxAudioBufferSizeProperty, value);
     }
+}
+
+public enum HardwareAccelerationMode
+{
+    // Software decode only.
+    None = 0,
+
+    // Let the decoder pick D3D11VA on Windows 10+ (preferred) and fall back to DXVA2.
+    Auto = 1,
+
+    // Force DXVA2 — older but broadest driver coverage.
+    DXVA2 = 2,
+
+    // Force D3D11VA — required for HDR / 10-bit decode paths.
+    D3D11VA = 3,
 }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecodingSettings.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 using Beutl.Extensibility;
 using Beutl.Extensions.MediaFoundation.Properties;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Text;
+using Vortice.MediaFoundation;
 using Vortice.Multimedia;
 using Vortice.Win32;
 using Windows.Win32.Media.MediaFoundation;
@@ -24,6 +25,17 @@ internal struct MFMediaInfo
     public int TotalAudioSampleCount;
     public WaveFormat AudioFormat;
 
+    // Color-space metadata extracted from the input stream's IMFMediaType.
+    // TransferFunction is the only HDR signal we trust — primaries/matrix default to
+    // Unknown when the container omits the tag, which is common for SDR files.
+    public VideoTransferFunction TransferFunction;
+    public VideoPrimaries ColorPrimaries;
+    public VideoTransferMatrix YCbCrMatrix;
+    public bool IsHdr;
+
+    // The subtype we asked Source Reader to emit (YUY2 for SDR, P010 for HDR).
+    // Decoders downstream use this to pick the right YUV→RGB conversion.
+    public Guid OutputSubType;
 
     public readonly string GetMediaInfoText()
     {
@@ -38,6 +50,10 @@ internal struct MFMediaInfo
             sb.AppendLine($"  Fps: {fps}");
             sb.AppendLine($"  TotalFrameCount: {TotalFrameCount}");
             sb.AppendLine($"  FrameSize: {ImageFormat.Width}x{ImageFormat.Height}");
+            sb.AppendLine($"  TransferFunction: {TransferFunction}");
+            sb.AppendLine($"  ColorPrimaries: {ColorPrimaries}");
+            sb.AppendLine($"  YCbCrMatrix: {YCbCrMatrix}");
+            sb.AppendLine($"  IsHdr: {IsHdr}");
         }
         if (AudioStreamIndex != -1)
         {

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Vortice.MediaFoundation;
 using Vortice.Multimedia;
 using Vortice.Win32;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFMediaInfo.cs
@@ -26,16 +26,15 @@ internal struct MFMediaInfo
     public WaveFormat AudioFormat;
 
     // Color-space metadata extracted from the input stream's IMFMediaType.
-    // TransferFunction is the only HDR signal we trust — primaries/matrix default to
-    // Unknown when the container omits the tag, which is common for SDR files.
+    // TransferFunction is the primary HDR signal we trust — primaries/matrix default
+    // to Unknown when the container omits the tag, which is common for SDR files.
+    // Note: a stream that tags only ColorPrimaries (e.g. Rec.2020) without a
+    // transfer function still reports IsHdr=false here, so HDR-by-primaries-only
+    // sources fall through the SDR path. That mirrors the FFmpeg/AVF backends.
     public VideoTransferFunction TransferFunction;
     public VideoPrimaries ColorPrimaries;
     public VideoTransferMatrix YCbCrMatrix;
     public bool IsHdr;
-
-    // The subtype we asked Source Reader to emit (YUY2 for SDR, P010 for HDR).
-    // Decoders downstream use this to pick the right YUV→RGB conversion.
-    public Guid OutputSubType;
 
     public readonly string GetMediaInfoText()
     {

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -28,8 +28,6 @@ using Beutl.Extensions.MediaFoundation;
 public class MFReader : MediaReader
 {
     private readonly ILogger _logger = Log.CreateLogger<MFReader>();
-    private readonly string _file;
-    private readonly MediaOptions _options;
 
     private readonly MFDecoder? _decoder;
     private readonly VideoStreamInfo? _videoInfo;
@@ -42,8 +40,6 @@ public class MFReader : MediaReader
 
     public MFReader(string file, MediaOptions options, MFDecodingExtension extension)
     {
-        _file = file;
-        _options = options;
         _videoColorSpace = BitmapColorSpace.Srgb;
         try
         {
@@ -92,7 +88,7 @@ public class MFReader : MediaReader
 
             if (options.StreamsToLoad.HasFlag(MediaMode.Audio))
             {
-                _audioReader = new MediaFoundationReader(_file, new MediaFoundationReaderSettings
+                _audioReader = new MediaFoundationReader(file, new MediaFoundationReaderSettings
                 {
                     RequestFloatOutput = true
                 });

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -2,12 +2,15 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
+using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
 using Beutl.Media.Pixel;
 using Beutl.Media.Source;
+
+using Microsoft.Extensions.Logging;
 
 using NAudio.Wave;
 
@@ -24,6 +27,7 @@ using Beutl.Extensions.MediaFoundation;
 
 public class MFReader : MediaReader
 {
+    private readonly ILogger _logger = Log.CreateLogger<MFReader>();
     private readonly string _file;
     private readonly MediaOptions _options;
 
@@ -52,11 +56,17 @@ public class MFReader : MediaReader
                     info.TotalFrameCount,
                     new PixelSize(info.ImageFormat.Width, info.ImageFormat.Height),
                     new Rational(info.Fps.Numerator, info.Fps.Denominator));
-                // Resolve the target color space exactly once. HDR inputs get the luminance-
-                // scaled gamut so the editor preview matches the FFmpeg/AVF paths. ForceSrgbGamma
-                // is the SDR escape hatch — the YUY2 8-bit decode path strips HDR information
-                // anyway, so labelling the bitmap as plain sRGB matches what the pixels actually
-                // carry and prevents downstream color-managed code from re-applying a PQ/HLG curve.
+                // Resolve the target color space exactly once. HDR inputs are mapped
+                // by ForceSrgbGamma, which has two modes:
+                //   • false (default): build the HDR-tagged color space (PQ/HLG +
+                //     luminance-scaled Rec.2020 gamut). Skia applies the proper EOTF
+                //     in preview, producing the intended HDR look on the editor —
+                //     but the YUY2 8-bit decode path already quantized the samples,
+                //     so the result will show some banding compared to a true HDR
+                //     viewing pipeline.
+                //   • true: clip to plain sRGB instead. Recommended when the editor
+                //     monitor is SDR; avoids the HDR EOTF being applied to 8-bit
+                //     samples in a viewer that cannot reproduce the result anyway.
                 if (info.IsHdr)
                 {
                     _videoColorSpace = extension.Settings.ForceSrgbGamma
@@ -66,6 +76,16 @@ public class MFReader : MediaReader
                 else
                 {
                     _videoColorSpace = MFColorSpaceHelper.BuildTargetColorSpace(info.TransferFunction, info.ColorPrimaries);
+                    // Surface the case where the transfer tag was present but didn't
+                    // map onto any known TRC — the helper silently falls back to
+                    // sRGB and that may look wrong for forward-looking transfers.
+                    if (info.TransferFunction != Vortice.MediaFoundation.VideoTransferFunction.FuncUnknown
+                        && !MFColorSpaceHelper.TryGetTransferFunction(info.TransferFunction, out _))
+                    {
+                        _logger.LogWarning(
+                            "Stream transfer function {Trc} is not mapped; defaulting to sRGB. Colors may look off.",
+                            info.TransferFunction);
+                    }
                 }
                 HasVideo = true;
             }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -15,8 +15,10 @@ using static NAudio.Wave.MediaFoundationReader;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;
+using Beutl.Embedding.MediaFoundation;
 #else
 namespace Beutl.Extensions.MediaFoundation.Decoding;
+using Beutl.Extensions.MediaFoundation;
 #endif
 
 public class MFReader : MediaReader
@@ -26,6 +28,7 @@ public class MFReader : MediaReader
 
     private readonly MFDecoder? _decoder;
     private readonly VideoStreamInfo? _videoInfo;
+    private readonly BitmapColorSpace _videoColorSpace;
 
     private readonly AudioStreamInfo? _audioInfo;
     private readonly MediaFoundationReader? _audioReader;
@@ -36,6 +39,7 @@ public class MFReader : MediaReader
     {
         _file = file;
         _options = options;
+        _videoColorSpace = BitmapColorSpace.Srgb;
         try
         {
             if (options.StreamsToLoad.HasFlag(MediaMode.Video))
@@ -47,6 +51,14 @@ public class MFReader : MediaReader
                     info.TotalFrameCount,
                     new PixelSize(info.ImageFormat.Width, info.ImageFormat.Height),
                     new Rational(info.Fps.Numerator, info.Fps.Denominator));
+                // Resolve the target color space exactly once. HDR inputs get the luminance-
+                // scaled gamut so the editor preview matches the FFmpeg/AVF paths. If the user
+                // opts into ForceSrgbGamma, we stay on sRGB — the YUY2 8-bit pixels stop
+                // carrying HDR information after conversion anyway and sRGB avoids surprising
+                // downstream color managed code.
+                _videoColorSpace = (info.IsHdr && !extension.Settings.ForceSrgbGamma)
+                    ? MFColorSpaceHelper.BuildHdrColorSpace(info.TransferFunction, info.ColorPrimaries)
+                    : MFColorSpaceHelper.BuildTargetColorSpace(info.TransferFunction, info.ColorPrimaries);
                 HasVideo = true;
             }
 
@@ -126,7 +138,11 @@ public class MFReader : MediaReader
 
             if (r != 0)
             {
-                var result = new Bitmap(w, h);
+                // Tag the Bitmap with the source's color space (not sRGB) so Skia
+                // applies the right transfer function on sampling. For HDR input
+                // this is PQ/HLG + Rec.2020 with luminance scaling already baked in.
+                var result = new Bitmap(w, h,
+                    BitmapColorType.Bgra8888, BitmapAlphaType.Premul, _videoColorSpace);
                 fixed (byte* srcPtr = yuy2Buffer)
                 {
                     YuvConversion.Yuy2ToBgra(srcPtr, (byte*)result.Data, result.RowBytes, w, h);

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -52,13 +52,20 @@ public class MFReader : MediaReader
                     new PixelSize(info.ImageFormat.Width, info.ImageFormat.Height),
                     new Rational(info.Fps.Numerator, info.Fps.Denominator));
                 // Resolve the target color space exactly once. HDR inputs get the luminance-
-                // scaled gamut so the editor preview matches the FFmpeg/AVF paths. If the user
-                // opts into ForceSrgbGamma, we stay on sRGB — the YUY2 8-bit pixels stop
-                // carrying HDR information after conversion anyway and sRGB avoids surprising
-                // downstream color managed code.
-                _videoColorSpace = (info.IsHdr && !extension.Settings.ForceSrgbGamma)
-                    ? MFColorSpaceHelper.BuildHdrColorSpace(info.TransferFunction, info.ColorPrimaries)
-                    : MFColorSpaceHelper.BuildTargetColorSpace(info.TransferFunction, info.ColorPrimaries);
+                // scaled gamut so the editor preview matches the FFmpeg/AVF paths. ForceSrgbGamma
+                // is the SDR escape hatch — the YUY2 8-bit decode path strips HDR information
+                // anyway, so labelling the bitmap as plain sRGB matches what the pixels actually
+                // carry and prevents downstream color-managed code from re-applying a PQ/HLG curve.
+                if (info.IsHdr)
+                {
+                    _videoColorSpace = extension.Settings.ForceSrgbGamma
+                        ? BitmapColorSpace.Srgb
+                        : MFColorSpaceHelper.BuildHdrColorSpace(info.TransferFunction, info.ColorPrimaries);
+                }
+                else
+                {
+                    _videoColorSpace = MFColorSpaceHelper.BuildTargetColorSpace(info.TransferFunction, info.ColorPrimaries);
+                }
                 HasVideo = true;
             }
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -15,6 +15,7 @@ using static NAudio.Wave.MediaFoundationReader;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;
+
 using Beutl.Embedding.MediaFoundation;
 #else
 namespace Beutl.Extensions.MediaFoundation.Decoding;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -31,6 +31,7 @@ public class MFReader : MediaReader
     private readonly MFDecoder? _decoder;
     private readonly VideoStreamInfo? _videoInfo;
     private readonly BitmapColorSpace _videoColorSpace;
+    private readonly PixelFormatConverter.InvYuvMatrix8 _yuy2Inverse;
 
     private readonly AudioStreamInfo? _audioInfo;
     private readonly MediaFoundationReader? _audioReader;
@@ -40,11 +41,27 @@ public class MFReader : MediaReader
     public MFReader(string file, MediaOptions options, MFDecodingExtension extension)
     {
         _videoColorSpace = BitmapColorSpace.Srgb;
+        bool wantsAudio = options.StreamsToLoad.HasFlag(MediaMode.Audio);
         try
         {
             if (options.StreamsToLoad.HasFlag(MediaMode.Video))
             {
-                _decoder = new MFDecoder(file, new MediaOptions(MediaMode.Video), extension);
+                // Wrap decoder creation so a broken video track does not also
+                // hide a readable audio track from the caller. When the caller
+                // asked only for video, let the exception propagate.
+                try
+                {
+                    _decoder = new MFDecoder(file, new MediaOptions(MediaMode.Video), extension);
+                }
+                catch (Exception ex) when (wantsAudio)
+                {
+                    _logger.LogWarning(ex,
+                        "Video stream could not be initialized; opening as audio-only because StreamsToLoad includes Audio");
+                }
+            }
+
+            if (_decoder != null)
+            {
                 MFMediaInfo info = _decoder.GetMediaInfo();
                 _videoInfo = new VideoStreamInfo(
                     info.VideoFormatName ?? "Unknown",
@@ -82,6 +99,18 @@ public class MFReader : MediaReader
                             info.TransferFunction);
                     }
                 }
+                // Pick the inverse YUV matrix that matches the stream tag so the
+                // YUY2 → BGRA conversion below produces the right RGB values
+                // before Skia interprets _videoColorSpace. Falling back to
+                // BT.709 mirrors what most modern decoders pick for tag-less
+                // HD-or-larger SDR content.
+                _yuy2Inverse = info.YCbCrMatrix switch
+                {
+                    Vortice.MediaFoundation.VideoTransferMatrix.Bt601 => PixelFormatConverter.InvYuvMatrix8.Bt601,
+                    Vortice.MediaFoundation.VideoTransferMatrix.Bt202010 => PixelFormatConverter.InvYuvMatrix8.Bt2020,
+                    Vortice.MediaFoundation.VideoTransferMatrix.Smpte240m => PixelFormatConverter.InvYuvMatrix8.Smpte240M,
+                    _ => PixelFormatConverter.InvYuvMatrix8.Bt709,
+                };
                 HasVideo = true;
             }
 
@@ -168,7 +197,11 @@ public class MFReader : MediaReader
                     BitmapColorType.Bgra8888, BitmapAlphaType.Premul, _videoColorSpace);
                 fixed (byte* srcPtr = yuy2Buffer)
                 {
-                    YuvConversion.Yuy2ToBgra(srcPtr, (byte*)result.Data, result.RowBytes, w, h);
+                    // YuvConversion.Yuy2ToBgra is BT.601-only; use the
+                    // matrix-aware variant so BT.709 / BT.2020 / SMPTE 240M
+                    // sources are not silently miscolored.
+                    PixelFormatConverter.Yuy2ToBgra(
+                        srcPtr, (byte*)result.Data, result.RowBytes, w, h, _yuy2Inverse);
                 }
 
                 image = Ref<Bitmap>.Create(result);

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -7,7 +7,6 @@ using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
-using Beutl.Media.Pixel;
 using Beutl.Media.Source;
 
 using Microsoft.Extensions.Logging;

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFAudioEncoderSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFAudioEncoderSettings.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Media.Encoding;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Encoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Encoding;
+#endif
+
+public sealed class MFAudioEncoderSettings : AudioEncoderSettings
+{
+    public static readonly CoreProperty<AudioCodecType> CodecProperty;
+
+    static MFAudioEncoderSettings()
+    {
+        CodecProperty = ConfigureProperty<AudioCodecType, MFAudioEncoderSettings>(nameof(Codec))
+            .DefaultValue(AudioCodecType.AAC)
+            .Register();
+    }
+
+    [Display(Name = "Codec")]
+    public AudioCodecType Codec
+    {
+        get => GetValue(CodecProperty);
+        set => SetValue(CodecProperty, value);
+    }
+
+    // Restricted to codecs the Media Foundation Sink Writer can mux into
+    // our supported containers (MP4/MOV/ASF/Wave). WMA is only meaningful
+    // inside ASF and WAV implies PCM; both are provided for completeness.
+    public enum AudioCodecType
+    {
+        [Display(Name = "AAC")] AAC = 0,
+        [Display(Name = "MP3")] MP3 = 1,
+        [Display(Name = "WMA")] WMA = 2,
+        [Display(Name = "PCM (uncompressed)")] PCM = 3,
+    }
+}

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFAudioEncoderSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFAudioEncoderSettings.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Media.Encoding;
 
 #if MF_BUILD_IN

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -52,6 +52,7 @@ public class MFEncodingController : EncodingController
         CancellationToken cancellationToken)
     {
         bool isHdr = VideoSettings.IsHdr;
+        bool audioOnly = IsAudioOnlyContainer(OutputFile);
 
         using IMFAttributes sinkAttrs = MediaFactory.MFCreateAttributes(2);
         // Lets Sink Writer pick hardware encoder MFTs (QSV / NVENC / AMD VCE).
@@ -61,13 +62,17 @@ public class MFEncodingController : EncodingController
 
         using IMFSinkWriter sinkWriter = MediaFactory.MFCreateSinkWriterFromURL(OutputFile, null, sinkAttrs);
 
-        int videoStreamIndex = ConfigureVideoStream(sinkWriter, isHdr);
-        int audioStreamIndex = ConfigureAudioStream(sinkWriter, sampleProvider.SampleRate);
+        // Audio-only containers (.wav/.mp3/.aac/.adts/.m4a) cannot mux a video stream;
+        // adding one here makes BeginWriting fail. Pure-audio outputs run through the
+        // audio path only.
+        int videoStreamIndex = audioOnly ? -1 : ConfigureVideoStream(sinkWriter, isHdr);
+        int audioChannels = ResolveAudioChannels();
+        int audioStreamIndex = ConfigureAudioStream(sinkWriter, sampleProvider.SampleRate, audioChannels);
 
         // Pre-compute the HDR target color space once per encode. Reusing the object
         // saves Skia from rebuilding the SKColorSpace on every frame convert.
         BitmapColorSpace? hdrTargetColorSpace = null;
-        if (isHdr)
+        if (!audioOnly && isHdr)
         {
             hdrTargetColorSpace = MFColorSpaceHelper.BuildHdrColorSpace(
                 MapTransferForHelper(VideoSettings.ColorTransfer),
@@ -80,7 +85,7 @@ public class MFEncodingController : EncodingController
         {
             long frameCount = 0;
             long sampleCount = 0;
-            bool encodeVideo = true;
+            bool encodeVideo = videoStreamIndex >= 0;
             bool encodeAudio = audioStreamIndex >= 0;
 
             long frameRateNum = VideoSettings.FrameRate.Numerator;
@@ -110,7 +115,7 @@ public class MFEncodingController : EncodingController
                 else if (encodeAudio)
                 {
                     WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
-                        sampleCount, AudioFrameSize, sampleRate)
+                        sampleCount, AudioFrameSize, sampleRate, audioChannels)
                         .GetAwaiter().GetResult();
                     sampleCount += AudioFrameSize;
                     if (sampleCount >= sampleProvider.SampleCount)
@@ -227,15 +232,34 @@ public class MFEncodingController : EncodingController
 
     // -------------------- Audio stream setup --------------------
 
-    private int ConfigureAudioStream(IMFSinkWriter sinkWriter, long sourceSampleRate)
+    // The renderer always hands us Pcm<Stereo32BitFloat>. We can faithfully emit mono
+    // (downmix L+R) or stereo (passthrough); anything wider than 2 has no source data
+    // to fill it, so clamping is safer than declaring a layout we cannot populate.
+    private int ResolveAudioChannels()
+    {
+        int requested = AudioSettings.Channels;
+        if (requested <= 0) return 2;
+        if (requested >= 2) return 2;
+        return 1;
+    }
+
+    private static bool IsAudioOnlyContainer(string outputFile)
+    {
+        string ext = Path.GetExtension(outputFile);
+        return ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".wav", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".aac", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".adts", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private int ConfigureAudioStream(IMFSinkWriter sinkWriter, long sourceSampleRate, int channels)
     {
         int sampleRate = AudioSettings.SampleRate > 0 ? AudioSettings.SampleRate : (int)sourceSampleRate;
         if (sampleRate <= 0)
         {
             return -1;
         }
-
-        int channels = AudioSettings.Channels > 0 ? AudioSettings.Channels : 2;
 
         using IMFMediaType outType = MediaFactory.MFCreateMediaType();
         outType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Audio);
@@ -366,10 +390,9 @@ public class MFEncodingController : EncodingController
     private static async ValueTask WriteAudioFrame(
         IMFSinkWriter sinkWriter, int streamIndex,
         ISampleProvider sampleProvider,
-        long startSample, int length, long sampleRate)
+        long startSample, int length, long sampleRate, int channels)
     {
         using Pcm<Stereo32BitFloat> floatPcm = await sampleProvider.Sample(startSample, length);
-        int channels = Stereo32BitFloat.GetNumChannels();
         int numSamples = floatPcm.NumSamples;
         int byteCount = numSamples * channels * 2; // int16
 
@@ -381,10 +404,23 @@ public class MFEncodingController : EncodingController
             try
             {
                 ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
-                for (int i = 0; i < src.Length; i++)
+                if (channels == 1)
                 {
-                    dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
-                    dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
+                    // L+R averaged into a single channel keeps both sides audible without
+                    // doubling perceived amplitude.
+                    for (int i = 0; i < src.Length; i++)
+                    {
+                        float mono = (src[i].Left + src[i].Right) * 0.5f;
+                        dst[i] = FloatToPcm16(mono);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < src.Length; i++)
+                    {
+                        dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
+                        dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
+                    }
                 }
             }
             finally

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -61,7 +61,13 @@ public class MFEncodingController : EncodingController
         // Write to a sibling temp file then rename on success. If the encode aborts
         // (cancellation, codec error, exception in RenderFrame), the partially
         // written file is deleted instead of overwriting the user's previous output.
-        string tempFile = OutputFile + ".partial";
+        //
+        // The temp file MUST keep the original extension as its suffix because
+        // MFCreateSinkWriterFromURL picks the container muxer from the file
+        // name — `clip.mp4.partial` would resolve to no recognized muxer and
+        // fail before writing begins. `clip.partial.mp4` preserves `.mp4` at
+        // the end so Sink Writer selects the MP4 sink.
+        string tempFile = BuildTempOutputPath(OutputFile);
         try { if (File.Exists(tempFile)) File.Delete(tempFile); }
         catch (Exception ex) { _logger.LogWarning(ex, "Could not remove stale temp file {Temp}", tempFile); }
 
@@ -392,6 +398,21 @@ public class MFEncodingController : EncodingController
         else resolved = 1;
         clamped = resolved != requested;
         return resolved;
+    }
+
+    // Insert a `.partial` marker before the original extension so the temp
+    // file keeps the container-identifying suffix that Sink Writer needs:
+    //   /tmp/clip.mp4 → /tmp/clip.partial.mp4
+    //   /tmp/track    → /tmp/track.partial
+    internal static string BuildTempOutputPath(string outputFile)
+    {
+        string dir = Path.GetDirectoryName(outputFile) ?? string.Empty;
+        string nameWithoutExt = Path.GetFileNameWithoutExtension(outputFile);
+        string ext = Path.GetExtension(outputFile);
+        string tempName = string.IsNullOrEmpty(ext)
+            ? nameWithoutExt + ".partial"
+            : nameWithoutExt + ".partial" + ext;
+        return Path.Combine(dir, tempName);
     }
 
     internal static bool IsAudioOnlyContainer(string outputFile)

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -1,4 +1,4 @@
-using System.Runtime.Versioning;
+﻿using System.Runtime.Versioning;
 using Beutl.Extensibility;
 using Beutl.Logging;
 using Beutl.Media;
@@ -9,6 +9,7 @@ using Vortice.MediaFoundation;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Encoding;
+
 using Beutl.Embedding.MediaFoundation;
 using Beutl.Embedding.MediaFoundation.Decoding;
 #else

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -461,6 +461,14 @@ public class MFEncodingController : EncodingController
             || ext.Equals(".asf", StringComparison.OrdinalIgnoreCase)
             || ext.Equals(".wmv", StringComparison.OrdinalIgnoreCase))
             resolved = MFAudioEncoderSettings.AudioCodecType.WMA;
+        else if (ext.Equals(".aac", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".adts", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase))
+            // Raw AAC / ADTS streams (and AAC-in-MP4 audio-only) must carry an
+            // AAC payload — Sink Writer cannot mux MP3 / WMA / PCM into these
+            // containers, so the configured subtype has to be AAC even if the
+            // user picked something else in the UI.
+            resolved = MFAudioEncoderSettings.AudioCodecType.AAC;
         else
             resolved = requested;
 

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -41,12 +41,15 @@ public class MFEncodingController : EncodingController
     {
         // Media Foundation mandates a per-thread COM apartment + MFStartup. The shared
         // dispatcher already owns that lifecycle for decoding — encoders join the same
-        // thread to avoid double-initializing MFStartup and to match MFReader's model.
+        // thread to match MFReader's COM/DXVA2 model. We pass a Func<Task> overload so
+        // awaits inside EncodeCore yield the dispatcher between RenderFrame/Sample
+        // pumps; sync-over-async (.GetAwaiter().GetResult()) on this thread would
+        // deadlock if a continuation tried to post back to it.
         await MFThread.Dispatcher.InvokeAsync(() =>
             EncodeCore(frameProvider, sampleProvider, cancellationToken));
     }
 
-    private void EncodeCore(
+    private async Task EncodeCore(
         IFrameProvider frameProvider,
         ISampleProvider sampleProvider,
         CancellationToken cancellationToken)
@@ -103,9 +106,8 @@ public class MFEncodingController : EncodingController
 
                 if (encodeVideo && videoTs <= audioTs)
                 {
-                    WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
-                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr)
-                        .GetAwaiter().GetResult();
+                    await WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
+                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr);
                     frameCount++;
                     if (frameCount >= frameProvider.FrameCount)
                     {
@@ -114,9 +116,8 @@ public class MFEncodingController : EncodingController
                 }
                 else if (encodeAudio)
                 {
-                    WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
-                        sampleCount, AudioFrameSize, sampleRate, audioChannels)
-                        .GetAwaiter().GetResult();
+                    await WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
+                        sampleCount, AudioFrameSize, sampleRate, audioChannels);
                     sampleCount += AudioFrameSize;
                     if (sampleCount >= sampleProvider.SampleCount)
                     {
@@ -144,8 +145,6 @@ public class MFEncodingController : EncodingController
             }
         }
     }
-
-    // -------------------- Video stream setup --------------------
 
     private int ConfigureVideoStream(IMFSinkWriter sinkWriter, bool isHdr)
     {
@@ -230,8 +229,6 @@ public class MFEncodingController : EncodingController
             mediaType.Set(MediaTypeAttributeKeys.YuvMatrix, (uint)matrix);
     }
 
-    // -------------------- Audio stream setup --------------------
-
     // The renderer always hands us Pcm<Stereo32BitFloat>. We can faithfully emit mono
     // (downmix L+R) or stereo (passthrough); anything wider than 2 has no source data
     // to fill it, so clamping is safer than declaring a layout we cannot populate.
@@ -307,8 +304,6 @@ public class MFEncodingController : EncodingController
         sinkWriter.SetInputMediaType(streamIndex, inType, null);
         return streamIndex;
     }
-
-    // -------------------- Frame writing --------------------
 
     private static async ValueTask WriteVideoFrame(
         IMFSinkWriter sinkWriter, int streamIndex,
@@ -452,12 +447,10 @@ public class MFEncodingController : EncodingController
 
     private static ulong PackUint64(uint hi, uint lo) => ((ulong)hi << 32) | lo;
 
-    // -------------------- Enum mapping helpers --------------------
-    // The helpers below drop into MFColorSpaceHelper's domain (for Skia color-space
-    // construction) and into Media Foundation's tag domain (for the encoder stream
-    // attributes). Keeping both mappings in this file means the encoder never has
-    // to cross-cast through a third enum representation.
-
+    // MapXxxToMF: encoder output tag domain (Vortice VideoXxx enum, used as
+    // MF_MT_* attribute values). MapXxxForHelper: input to MFColorSpaceHelper
+    // (same enum, but Default already resolved into a concrete HDR transfer/
+    // primaries so Skia gets a fully-specified color space).
     private static VideoTransferFunction MapTransferToMF(
         MFVideoEncoderSettings.ColorTransferCharacteristic t, bool isHdr)
     {

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -58,95 +58,209 @@ public class MFEncodingController : EncodingController
         bool isHdr = VideoSettings.IsHdr;
         bool audioOnly = IsAudioOnlyContainer(OutputFile);
 
-        using IMFAttributes sinkAttrs = MediaFactory.MFCreateAttributes(2);
-        // Lets Sink Writer pick hardware encoder MFTs (QSV / NVENC / AMD VCE).
-        // Without this the writer silently falls back to the software encoder.
-        sinkAttrs.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
-        sinkAttrs.Set(SinkWriterAttributeKeys.DisableThrottling, 0);
+        // Write to a sibling temp file then rename on success. If the encode aborts
+        // (cancellation, codec error, exception in RenderFrame), the partially
+        // written file is deleted instead of overwriting the user's previous output.
+        string tempFile = OutputFile + ".partial";
+        try { if (File.Exists(tempFile)) File.Delete(tempFile); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Could not remove stale temp file {Temp}", tempFile); }
 
-        using IMFSinkWriter sinkWriter = MediaFactory.MFCreateSinkWriterFromURL(OutputFile, null, sinkAttrs);
-
-        // Audio-only containers (.wav/.mp3/.aac/.adts/.m4a) cannot mux a video stream;
-        // adding one here makes BeginWriting fail. Pure-audio outputs run through the
-        // audio path only.
-        int videoStreamIndex = audioOnly ? -1 : ConfigureVideoStream(sinkWriter, isHdr);
-        int audioChannels = ResolveAudioChannels();
-        int sampleRate = ResolveOutputSampleRate((int)sampleProvider.SampleRate);
-        MFAudioEncoderSettings.AudioCodecType audioCodec = ResolveAudioCodec();
-        int audioStreamIndex = ConfigureAudioStream(sinkWriter, audioCodec, sampleRate, audioChannels);
-
-        // Pre-compute the HDR target color space once per encode. Reusing the object
-        // saves Skia from rebuilding the SKColorSpace on every frame convert.
-        BitmapColorSpace? hdrTargetColorSpace = null;
-        if (!audioOnly && isHdr)
-        {
-            hdrTargetColorSpace = MFColorSpaceHelper.BuildHdrColorSpace(
-                MapTransferForHelper(VideoSettings.ColorTransfer),
-                MapPrimariesForHelper(VideoSettings.ColorPrimaries));
-        }
-        // SDR NV12 conversion must match the matrix we tag on the output stream.
-        PixelFormatConverter.YuvMatrix8 sdrMatrix = ResolveSdrYuvMatrix(VideoSettings.YCbCrMatrix);
-
-        sinkWriter.BeginWriting();
-
+        bool encodeCompleted = false;
         try
         {
-            long frameCount = 0;
-            long sampleCount = 0;
-            bool encodeVideo = videoStreamIndex >= 0;
-            bool encodeAudio = audioStreamIndex >= 0;
+            using IMFAttributes sinkAttrs = MediaFactory.MFCreateAttributes(1);
+            // Asks Sink Writer to prefer hardware encoder MFTs (QSV / NVENC / AMD VCE)
+            // when available. If no compatible hardware MFT is installed, MF
+            // transparently falls back to the software encoder — we log the
+            // resolved MFT identity after BeginWriting so the user can see which
+            // path was chosen.
+            sinkAttrs.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
 
-            long frameRateNum = VideoSettings.FrameRate.Numerator;
-            long frameRateDen = VideoSettings.FrameRate.Denominator;
+            using IMFSinkWriter sinkWriter = MediaFactory.MFCreateSinkWriterFromURL(tempFile, null, sinkAttrs);
 
-            while ((encodeVideo || encodeAudio) && !cancellationToken.IsCancellationRequested)
+            // Audio-only containers (.wav/.mp3/.aac/.adts/.m4a) cannot mux a video stream;
+            // adding one here makes BeginWriting fail. Pure-audio outputs run through the
+            // audio path only.
+            int videoStreamIndex = audioOnly ? -1 : ConfigureVideoStream(sinkWriter, isHdr);
+            int audioChannels = ResolveAudioChannels();
+            int sampleRate = ResolveOutputSampleRate((int)sampleProvider.SampleRate);
+            MFAudioEncoderSettings.AudioCodecType audioCodec = ResolveAudioCodec();
+            int audioStreamIndex = ConfigureAudioStream(sinkWriter, audioCodec, sampleRate, audioChannels);
+
+            // SDR path needs the per-stream color space resolved from user selection,
+            // not a hard-coded sRGB conversion — otherwise the pixels we hand the
+            // encoder don't match the BT.709/BT.601/Rec.2020 tag we write into the
+            // output stream and players show a slightly off-grade SDR image.
+            BitmapColorSpace? hdrTargetColorSpace = null;
+            BitmapColorSpace sdrSourceColorSpace = BitmapColorSpace.Srgb;
+            if (!audioOnly)
             {
-                long videoTs = (encodeVideo && frameRateNum > 0)
-                    ? frameCount * frameRateDen * HnsPerSecond / frameRateNum
-                    : long.MaxValue;
-                long audioTs = (encodeAudio && sampleRate > 0)
-                    ? sampleCount * HnsPerSecond / sampleRate
-                    : long.MaxValue;
-
-                if (encodeVideo && videoTs <= audioTs)
+                if (isHdr)
                 {
-                    await WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
-                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr, sdrMatrix);
-                    frameCount++;
-                    if (frameCount >= frameProvider.FrameCount)
-                    {
-                        encodeVideo = false;
-                    }
-                }
-                else if (encodeAudio)
-                {
-                    await WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
-                        sampleCount, AudioFrameSize, sampleRate, audioChannels);
-                    sampleCount += AudioFrameSize;
-                    if (sampleCount >= sampleProvider.SampleCount)
-                    {
-                        encodeAudio = false;
-                    }
+                    hdrTargetColorSpace = MFColorSpaceHelper.BuildHdrColorSpace(
+                        MapTransferForHelper(VideoSettings.ColorTransfer),
+                        MapPrimariesForHelper(VideoSettings.ColorPrimaries));
                 }
                 else
                 {
-                    break;
+                    sdrSourceColorSpace = MFColorSpaceHelper.BuildTargetColorSpace(
+                        MapTransferForHelper(VideoSettings.ColorTransfer),
+                        MapPrimariesForHelper(VideoSettings.ColorPrimaries));
                 }
+            }
+            // SDR NV12 conversion must match the matrix we tag on the output stream.
+            PixelFormatConverter.YuvMatrix8 sdrMatrix = ResolveSdrYuvMatrix(VideoSettings.YCbCrMatrix);
+
+            sinkWriter.BeginWriting();
+            LogEncoderActivation(sinkWriter, videoStreamIndex);
+
+            Exception? loopFailure = null;
+            try
+            {
+                long frameCount = 0;
+                long sampleCount = 0;
+                bool encodeVideo = videoStreamIndex >= 0;
+                bool encodeAudio = audioStreamIndex >= 0;
+
+                long frameRateNum = VideoSettings.FrameRate.Numerator;
+                long frameRateDen = VideoSettings.FrameRate.Denominator;
+
+                while ((encodeVideo || encodeAudio) && !cancellationToken.IsCancellationRequested)
+                {
+                    long videoTs = (encodeVideo && frameRateNum > 0)
+                        ? frameCount * frameRateDen * HnsPerSecond / frameRateNum
+                        : long.MaxValue;
+                    long audioTs = (encodeAudio && sampleRate > 0)
+                        ? sampleCount * HnsPerSecond / sampleRate
+                        : long.MaxValue;
+
+                    if (encodeVideo && videoTs <= audioTs)
+                    {
+                        await WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
+                            frameCount, frameRateNum, frameRateDen,
+                            hdrTargetColorSpace, sdrSourceColorSpace, isHdr, sdrMatrix);
+                        frameCount++;
+                        if (frameCount >= frameProvider.FrameCount)
+                        {
+                            encodeVideo = false;
+                        }
+                    }
+                    else if (encodeAudio)
+                    {
+                        await WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
+                            sampleCount, AudioFrameSize, sampleRate, audioChannels);
+                        sampleCount += AudioFrameSize;
+                        if (sampleCount >= sampleProvider.SampleCount)
+                        {
+                            encodeAudio = false;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                encodeCompleted = !cancellationToken.IsCancellationRequested;
+            }
+            catch (Exception ex)
+            {
+                loopFailure = ex;
+                throw;
+            }
+            finally
+            {
+                // Finalize flushes encoder queues and writes the container footer. Skipping
+                // this produces a partial file that most demuxers refuse to open.
+                // If the encode loop already threw, prefer surfacing that exception —
+                // re-throwing a Finalize failure here would hide the real cause.
+                try
+                {
+                    sinkWriter.Finalize();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "IMFSinkWriter.Finalize failed");
+                    if (loopFailure == null)
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            if (encodeCompleted)
+            {
+                // Atomic publish: replace any prior file in one step so partial writes
+                // never appear under OutputFile.
+                if (File.Exists(OutputFile))
+                {
+                    File.Delete(OutputFile);
+                }
+                File.Move(tempFile, OutputFile);
             }
         }
         finally
         {
-            // Finalize flushes encoder queues and writes the container footer. Skipping
-            // this produces a partial file that most demuxers refuse to open.
+            if (!encodeCompleted)
+            {
+                // Encode failed or was cancelled — drop the partial container so it
+                // doesn't accumulate next to the real output.
+                try
+                {
+                    if (File.Exists(tempFile)) File.Delete(tempFile);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Could not delete partial output {Temp}; user may need to remove it manually",
+                        tempFile);
+                }
+            }
+        }
+    }
+
+    // GUIDs from mfapi.h — Vortice does not expose these as named constants, but
+    // they're stable Win32 attribute keys on the encoder MFT's IMFAttributes.
+    private static readonly Guid MFT_FRIENDLY_NAME_Attribute = new("314FFBAE-5B41-4C95-9C19-4E7D586FACE3");
+    private static readonly Guid MFT_ENUM_HARDWARE_URL_Attribute = new("2FB866AC-B078-4942-AB6C-003D05CDA674");
+
+    // Surfaces whether the Sink Writer activated a hardware or software encoder MFT
+    // for the video stream. Even with MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS=1 set,
+    // MF silently picks the software encoder when no compatible hardware MFT is
+    // installed; this introspection makes the chosen path visible in the logs so
+    // users investigating slow encodes can confirm the cause.
+    private void LogEncoderActivation(IMFSinkWriter sinkWriter, int videoStreamIndex)
+    {
+        if (videoStreamIndex < 0) return;
+        try
+        {
+            nint transformPtr = sinkWriter.GetServiceForStream(
+                videoStreamIndex, Guid.Empty, typeof(IMFTransform).GUID);
+            using var transform = new IMFTransform(transformPtr);
+            using IMFAttributes attrs = transform.Attributes;
+
+            string? friendlyName = null;
+            try { friendlyName = attrs.GetString(MFT_FRIENDLY_NAME_Attribute); }
+            catch { /* attribute optional */ }
+
+            bool isHardware = false;
             try
             {
-                sinkWriter.Finalize();
+                _ = attrs.GetString(MFT_ENUM_HARDWARE_URL_Attribute);
+                isHardware = true;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "IMFSinkWriter.Finalize failed");
-                throw;
-            }
+            catch { /* hardware attribute absent on software MFTs */ }
+
+            _logger.LogInformation(
+                "Video encoder MFT for stream {Stream}: {Name} ({Kind})",
+                videoStreamIndex,
+                friendlyName ?? "(unnamed)",
+                isHardware ? "hardware" : "software (fallback)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Could not introspect encoder MFT for stream {Stream}", videoStreamIndex);
         }
     }
 
@@ -162,6 +276,15 @@ public class MFEncodingController : EncodingController
         // AV1 / H.264 have no defined HDR10 path in Media Foundation.
         Guid outSubType;
         bool useHevcMain10 = isHdr || VideoSettings.Codec == MFVideoEncoderSettings.VideoCodec.HEVC;
+        if (isHdr && VideoSettings.Codec != MFVideoEncoderSettings.VideoCodec.HEVC)
+        {
+            // Surface the implicit promotion so users notice their Codec selection
+            // was overridden by the HDR transfer characteristic.
+            _logger.LogWarning(
+                "HDR transfer ({Transfer}) selected — promoting codec from {Codec} to HEVC Main10. " +
+                "H.264 has no Media Foundation HDR10 path.",
+                VideoSettings.ColorTransfer, VideoSettings.Codec);
+        }
         if (useHevcMain10)
         {
             outSubType = VideoFormatGuids.Hevc;
@@ -246,9 +369,21 @@ public class MFEncodingController : EncodingController
     private int ResolveAudioChannels()
     {
         int requested = AudioSettings.Channels;
-        if (requested <= 0) return 2;
-        if (requested >= 2) return 2;
-        return 1;
+        int resolved;
+        if (requested <= 0) resolved = 2;
+        else if (requested >= 2) resolved = 2;
+        else resolved = 1;
+
+        if (resolved != requested)
+        {
+            // Visible warning instead of a silent clamp — a user asking for 5.1
+            // should at least see why they got stereo so they can adjust the UI
+            // (or change the upstream sample provider).
+            _logger.LogWarning(
+                "AudioSettings.Channels {Requested} not supported by the Stereo32BitFloat source; clamping to {Resolved}",
+                requested, resolved);
+        }
+        return resolved;
     }
 
     private static bool IsAudioOnlyContainer(string outputFile)
@@ -317,7 +452,12 @@ public class MFEncodingController : EncodingController
     {
         if (sampleRate <= 0)
         {
-            return -1;
+            // The source must report a positive sample rate; silently returning -1
+            // would drop the audio track from the output file without telling the
+            // user, so we fail loudly instead.
+            throw new InvalidOperationException(
+                $"Cannot configure audio stream: resolved sample rate is {sampleRate}. " +
+                "The sample provider must report a positive SampleRate.");
         }
 
         using IMFMediaType outType = MediaFactory.MFCreateMediaType();
@@ -371,7 +511,9 @@ public class MFEncodingController : EncodingController
         IMFSinkWriter sinkWriter, int streamIndex,
         IFrameProvider frameProvider,
         long frame, long frameRateNum, long frameRateDen,
-        BitmapColorSpace? hdrTargetColorSpace, bool isHdr,
+        BitmapColorSpace? hdrTargetColorSpace,
+        BitmapColorSpace sdrSourceColorSpace,
+        bool isHdr,
         PixelFormatConverter.YuvMatrix8 sdrMatrix)
     {
         using Bitmap image = await frameProvider.RenderFrame(frame);
@@ -386,6 +528,9 @@ public class MFEncodingController : EncodingController
         if (isHdr && hdrTargetColorSpace is not null)
         {
             // 16-bit RGBA in HDR target color space → P010 (10-bit YUV 4:2:0 MSB-aligned).
+            // The HDR path always converts via BT.2020 NCL limited-range coefficients in
+            // Rgba16ToP010, so the matrix tag (Bt202010) is set by ApplyColorTags
+            // independently of VideoSettings.YCbCrMatrix — sdrMatrix is unused here.
             using Bitmap converted = image.Convert(
                 BitmapColorType.Rgba16161616, BitmapAlphaType.Unpremul, hdrTargetColorSpace);
             WriteVideoSample(sinkWriter, streamIndex, converted,
@@ -393,8 +538,13 @@ public class MFEncodingController : EncodingController
         }
         else
         {
+            // Convert to the SDR target color space matching the transfer/primaries
+            // tag we wrote into the output stream. Forcing sRGB here regardless of
+            // user selection put BT.709 pixels into an sRGB transfer (slight low-
+            // luma drift) before — sdrSourceColorSpace aligns the conversion with
+            // the on-the-wire tag.
             using Bitmap converted = image.Convert(
-                BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+                BitmapColorType.Bgra8888, BitmapAlphaType.Premul, sdrSourceColorSpace);
             WriteVideoSample(sinkWriter, streamIndex, converted,
                 BitmapColorType.Bgra8888, ptsHns, durationHns, sdrMatrix);
         }
@@ -425,6 +575,13 @@ public class MFEncodingController : EncodingController
         byte* dst = (byte*)dstPtr;
         try
         {
+            // MFCreateMemoryBuffer does not document zero-initialization, and at
+            // odd widths (e.g. 853) the Y-plane converter writes `width` bytes per
+            // row while the shared stride is `chromaWidth` (854). The trailing
+            // padding bytes would otherwise carry whatever garbage the allocator
+            // returned, which encoder MFTs may read when they walk full rows.
+            System.Runtime.InteropServices.NativeMemory.Clear(dst, (nuint)totalSize);
+
             byte* src = (byte*)converted.Data;
             int srcStride = converted.RowBytes;
             if (isP010)
@@ -456,7 +613,11 @@ public class MFEncodingController : EncodingController
     {
         if (sampleRate <= 0)
         {
-            return;
+            // Unreachable in normal flow: ConfigureAudioStream throws on <= 0, so by
+            // the time encodeAudio is true the rate is positive. If a future caller
+            // bypasses that guarantee, fail rather than silently drop frames.
+            throw new InvalidOperationException(
+                $"WriteAudioFrame invoked with non-positive sample rate {sampleRate}.");
         }
 
         using Pcm<Stereo32BitFloat> floatPcm = await sampleProvider.Sample(startSample, length);
@@ -561,8 +722,11 @@ public class MFEncodingController : EncodingController
 
     // Picks the 8-bit NV12 conversion matrix matching the tag MapMatrixToMF will
     // write. Default falls back to BT.709 (typical SDR HD); the tag side writes
-    // Unknown for Default, which players resolve to BT.709 too — so the pixel
-    // math and the on-the-wire interpretation stay aligned.
+    // Unknown for Default. Most modern players resolve missing matrix tags to
+    // BT.709, but at SD resolutions (480p / 576p) decoders frequently apply
+    // BT.601 instead — so a Default + SD-sized output may decode with a slight
+    // hue shift. Users encoding SD content should select Bt601 explicitly to
+    // pin the matrix tag and avoid this ambiguity.
     private static PixelFormatConverter.YuvMatrix8 ResolveSdrYuvMatrix(
         MFVideoEncoderSettings.YCbCrMatrixType m)
     {

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -265,20 +265,34 @@ public class MFEncodingController : EncodingController
     }
 
     // Audio codec must match what the chosen container can mux. WAV requires
-    // PCM, MP3 requires MP3, and ASF/WMV requires WMA — silently overriding
-    // here is friendlier than a cryptic AddStream/BeginWriting failure.
+    // PCM, MP3 requires MP3, and ASF/WMV requires WMA — overriding here is
+    // friendlier than a cryptic AddStream/BeginWriting failure, but the user
+    // needs visibility into the substitution so they can adjust UI selections
+    // (e.g. bitrate) that no longer apply.
     private MFAudioEncoderSettings.AudioCodecType ResolveAudioCodec()
     {
         string ext = Path.GetExtension(OutputFile);
+        MFAudioEncoderSettings.AudioCodecType requested = AudioSettings.Codec;
+        MFAudioEncoderSettings.AudioCodecType resolved;
+
         if (ext.Equals(".wav", StringComparison.OrdinalIgnoreCase))
-            return MFAudioEncoderSettings.AudioCodecType.PCM;
-        if (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase))
-            return MFAudioEncoderSettings.AudioCodecType.MP3;
-        if (ext.Equals(".wma", StringComparison.OrdinalIgnoreCase)
+            resolved = MFAudioEncoderSettings.AudioCodecType.PCM;
+        else if (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase))
+            resolved = MFAudioEncoderSettings.AudioCodecType.MP3;
+        else if (ext.Equals(".wma", StringComparison.OrdinalIgnoreCase)
             || ext.Equals(".asf", StringComparison.OrdinalIgnoreCase)
             || ext.Equals(".wmv", StringComparison.OrdinalIgnoreCase))
-            return MFAudioEncoderSettings.AudioCodecType.WMA;
-        return AudioSettings.Codec;
+            resolved = MFAudioEncoderSettings.AudioCodecType.WMA;
+        else
+            resolved = requested;
+
+        if (resolved != requested)
+        {
+            _logger.LogInformation(
+                "Audio codec overridden from {Requested} to {Resolved} for container {Ext}",
+                requested, resolved, ext);
+        }
+        return resolved;
     }
 
     private int ConfigureAudioStream(
@@ -424,6 +438,14 @@ public class MFEncodingController : EncodingController
         long sourceStartSample, int sourceLength,
         int sourceSampleRate, int outputSampleRate, int channels)
     {
+        // Defensive: ConfigureAudioStream rejects non-positive rates upstream so
+        // we shouldn't reach here with bad values, but Pcm.Resamples crashes on
+        // zero/negative frequencies — keep the assert close to the math.
+        if (sourceSampleRate <= 0 || outputSampleRate <= 0)
+        {
+            return;
+        }
+
         Pcm<Stereo32BitFloat> sourcePcm = await sampleProvider.Sample(sourceStartSample, sourceLength);
         Pcm<Stereo32BitFloat>? resampled = null;
         try
@@ -549,10 +571,10 @@ public class MFEncodingController : EncodingController
         };
     }
 
-    // Picks the 8-bit NV12 conversion matrix that matches the tag MapMatrixToMF
-    // will write to MF_MT_YUV_MATRIX. Default falls back to BT.709 to align with
-    // typical SDR HD content; SMPTE 240M is rare in 8-bit and uses BT.709 here
-    // (its tag is preserved separately if the user explicitly requested it).
+    // Picks the 8-bit NV12 conversion matrix matching the tag MapMatrixToMF will
+    // write. Default falls back to BT.709 (typical SDR HD); the tag side writes
+    // Unknown for Default, which players resolve to BT.709 too — so the pixel
+    // math and the on-the-wire interpretation stay aligned.
     private static PixelFormatConverter.YuvMatrix8 ResolveSdrYuvMatrix(
         MFVideoEncoderSettings.YCbCrMatrixType m)
     {
@@ -560,6 +582,7 @@ public class MFEncodingController : EncodingController
         {
             MFVideoEncoderSettings.YCbCrMatrixType.Bt601 => PixelFormatConverter.YuvMatrix8.Bt601,
             MFVideoEncoderSettings.YCbCrMatrixType.Rec2020 => PixelFormatConverter.YuvMatrix8.Bt2020,
+            MFVideoEncoderSettings.YCbCrMatrixType.Smpte240M => PixelFormatConverter.YuvMatrix8.Smpte240M,
             _ => PixelFormatConverter.YuvMatrix8.Bt709,
         };
     }

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -1,0 +1,504 @@
+using System.Runtime.Versioning;
+using Beutl.Extensibility;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Microsoft.Extensions.Logging;
+using Vortice.MediaFoundation;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Encoding;
+using Beutl.Embedding.MediaFoundation;
+using Beutl.Embedding.MediaFoundation.Decoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Encoding;
+using Beutl.Extensions.MediaFoundation;
+using Beutl.Extensions.MediaFoundation.Decoding;
+#endif
+
+#pragma warning disable CA1416 // Validate platform compatibility (SupportedOSPlatform on the Extension).
+
+[SupportedOSPlatform("windows")]
+public class MFEncodingController : EncodingController
+{
+    private const int AudioFrameSize = 1024;
+    // 1 second in Media Foundation's 100-ns unit base.
+    private const long HnsPerSecond = 10_000_000L;
+
+    private readonly ILogger _logger = Log.CreateLogger<MFEncodingController>();
+
+    public MFEncodingController(string outputFile) : base(outputFile) { }
+
+    public override MFVideoEncoderSettings VideoSettings { get; } = new();
+
+    public override MFAudioEncoderSettings AudioSettings { get; } = new();
+
+    public override async ValueTask Encode(
+        IFrameProvider frameProvider,
+        ISampleProvider sampleProvider,
+        CancellationToken cancellationToken)
+    {
+        // Media Foundation mandates a per-thread COM apartment + MFStartup. The shared
+        // dispatcher already owns that lifecycle for decoding — encoders join the same
+        // thread to avoid double-initializing MFStartup and to match MFReader's model.
+        await MFThread.Dispatcher.InvokeAsync(() =>
+            EncodeCore(frameProvider, sampleProvider, cancellationToken));
+    }
+
+    private void EncodeCore(
+        IFrameProvider frameProvider,
+        ISampleProvider sampleProvider,
+        CancellationToken cancellationToken)
+    {
+        bool isHdr = VideoSettings.IsHdr;
+
+        using IMFAttributes sinkAttrs = MediaFactory.MFCreateAttributes(2);
+        // Lets Sink Writer pick hardware encoder MFTs (QSV / NVENC / AMD VCE).
+        // Without this the writer silently falls back to the software encoder.
+        sinkAttrs.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
+        sinkAttrs.Set(SinkWriterAttributeKeys.DisableThrottling, 0);
+
+        using IMFSinkWriter sinkWriter = MediaFactory.MFCreateSinkWriterFromURL(OutputFile, null, sinkAttrs);
+
+        int videoStreamIndex = ConfigureVideoStream(sinkWriter, isHdr);
+        int audioStreamIndex = ConfigureAudioStream(sinkWriter, sampleProvider.SampleRate);
+
+        // Pre-compute the HDR target color space once per encode. Reusing the object
+        // saves Skia from rebuilding the SKColorSpace on every frame convert.
+        BitmapColorSpace? hdrTargetColorSpace = null;
+        if (isHdr)
+        {
+            hdrTargetColorSpace = MFColorSpaceHelper.BuildHdrColorSpace(
+                MapTransferForHelper(VideoSettings.ColorTransfer),
+                MapPrimariesForHelper(VideoSettings.ColorPrimaries));
+        }
+
+        sinkWriter.BeginWriting();
+
+        try
+        {
+            long frameCount = 0;
+            long sampleCount = 0;
+            bool encodeVideo = true;
+            bool encodeAudio = audioStreamIndex >= 0;
+
+            long frameRateNum = VideoSettings.FrameRate.Numerator;
+            long frameRateDen = VideoSettings.FrameRate.Denominator;
+            long sampleRate = sampleProvider.SampleRate;
+
+            while ((encodeVideo || encodeAudio) && !cancellationToken.IsCancellationRequested)
+            {
+                long videoTs = (encodeVideo && frameRateNum > 0)
+                    ? frameCount * frameRateDen * HnsPerSecond / frameRateNum
+                    : long.MaxValue;
+                long audioTs = (encodeAudio && sampleRate > 0)
+                    ? sampleCount * HnsPerSecond / sampleRate
+                    : long.MaxValue;
+
+                if (encodeVideo && videoTs <= audioTs)
+                {
+                    WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
+                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr)
+                        .GetAwaiter().GetResult();
+                    frameCount++;
+                    if (frameCount >= frameProvider.FrameCount)
+                    {
+                        encodeVideo = false;
+                    }
+                }
+                else if (encodeAudio)
+                {
+                    WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
+                        sampleCount, AudioFrameSize, sampleRate)
+                        .GetAwaiter().GetResult();
+                    sampleCount += AudioFrameSize;
+                    if (sampleCount >= sampleProvider.SampleCount)
+                    {
+                        encodeAudio = false;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            // Finalize flushes encoder queues and writes the container footer. Skipping
+            // this produces a partial file that most demuxers refuse to open.
+            try
+            {
+                sinkWriter.Finalize();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "IMFSinkWriter.Finalize failed");
+                throw;
+            }
+        }
+    }
+
+    // -------------------- Video stream setup --------------------
+
+    private int ConfigureVideoStream(IMFSinkWriter sinkWriter, bool isHdr)
+    {
+        int width = VideoSettings.DestinationSize.Width;
+        int height = VideoSettings.DestinationSize.Height;
+        int bitrate = VideoSettings.Bitrate;
+        long frNum = VideoSettings.FrameRate.Numerator;
+        long frDen = VideoSettings.FrameRate.Denominator;
+
+        // HDR implies HEVC Main10 even if the user left Codec at H264 / Default.
+        // AV1 / H.264 have no defined HDR10 path in Media Foundation.
+        Guid outSubType;
+        bool useHevcMain10 = isHdr || VideoSettings.Codec == MFVideoEncoderSettings.VideoCodec.HEVC;
+        if (useHevcMain10)
+        {
+            outSubType = VideoFormatGuids.Hevc;
+        }
+        else
+        {
+            outSubType = VideoFormatGuids.H264;
+        }
+
+        // Output (compressed) media type.
+        using IMFMediaType outType = MediaFactory.MFCreateMediaType();
+        outType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+        outType.Set(MediaTypeAttributeKeys.Subtype, outSubType);
+        outType.Set(MediaTypeAttributeKeys.AvgBitrate, bitrate);
+        outType.Set(MediaTypeAttributeKeys.InterlaceMode, 2u); // Progressive
+        outType.Set(MediaTypeAttributeKeys.FrameSize, PackUint64((uint)width, (uint)height));
+        outType.Set(MediaTypeAttributeKeys.FrameRate, PackUint64((uint)frNum, (uint)frDen));
+        outType.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackUint64(1, 1));
+
+        // MF_MT_MPEG2_PROFILE is reused by MF for both H.264 (eAVEncH264VProfile) and
+        // HEVC (eAVEncH265VProfile). HDR → force Main10; otherwise honor user selection.
+        if (useHevcMain10)
+        {
+            int hevcProfile = isHdr
+                ? (int)MFVideoEncoderSettings.HevcProfileType.Main10
+                : (int)VideoSettings.HevcProfile;
+            outType.Set(MediaTypeAttributeKeys.Mpeg2Profile, hevcProfile);
+        }
+        else
+        {
+            outType.Set(MediaTypeAttributeKeys.Mpeg2Profile, (int)VideoSettings.H264Profile);
+        }
+
+        // Set color tags on the output media type so downstream demuxers/players
+        // can reproduce the intended grade — this is what tells HDR TVs to switch
+        // modes, and SDR viewers to apply BT.709 instead of defaulting to sRGB.
+        ApplyColorTags(outType, isHdr);
+
+        int streamIndex = sinkWriter.AddStream(outType);
+
+        // Input (uncompressed) media type: P010 for HDR, NV12 for SDR.
+        using IMFMediaType inType = MediaFactory.MFCreateMediaType();
+        inType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+        inType.Set(MediaTypeAttributeKeys.Subtype, isHdr ? VideoFormatGuids.P010 : VideoFormatGuids.NV12);
+        inType.Set(MediaTypeAttributeKeys.InterlaceMode, 2u); // Progressive
+        inType.Set(MediaTypeAttributeKeys.FrameSize, PackUint64((uint)width, (uint)height));
+        inType.Set(MediaTypeAttributeKeys.FrameRate, PackUint64((uint)frNum, (uint)frDen));
+        inType.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackUint64(1, 1));
+        ApplyColorTags(inType, isHdr);
+
+        sinkWriter.SetInputMediaType(streamIndex, inType, null);
+        return streamIndex;
+    }
+
+    private void ApplyColorTags(IMFMediaType mediaType, bool isHdr)
+    {
+        // Defaults fire in when the user picks "Default" in the UI: for HDR we need
+        // Rec.2020/PQ (HDR10) unconditionally; for SDR we leave the field unset so
+        // the decoder picks its own default (typically BT.709 for HD, BT.601 for SD).
+        VideoTransferFunction trc = MapTransferToMF(VideoSettings.ColorTransfer, isHdr);
+        VideoPrimaries primaries = MapPrimariesToMF(VideoSettings.ColorPrimaries, isHdr);
+        VideoTransferMatrix matrix = MapMatrixToMF(VideoSettings.YCbCrMatrix, isHdr);
+
+        if (trc != VideoTransferFunction.FuncUnknown)
+            mediaType.Set(MediaTypeAttributeKeys.TransferFunction, (uint)trc);
+        if (primaries != VideoPrimaries.Unknown)
+            mediaType.Set(MediaTypeAttributeKeys.VideoPrimaries, (uint)primaries);
+        if (matrix != VideoTransferMatrix.Unknown)
+            mediaType.Set(MediaTypeAttributeKeys.YuvMatrix, (uint)matrix);
+    }
+
+    // -------------------- Audio stream setup --------------------
+
+    private int ConfigureAudioStream(IMFSinkWriter sinkWriter, long sourceSampleRate)
+    {
+        int sampleRate = AudioSettings.SampleRate > 0 ? AudioSettings.SampleRate : (int)sourceSampleRate;
+        if (sampleRate <= 0)
+        {
+            return -1;
+        }
+
+        int channels = AudioSettings.Channels > 0 ? AudioSettings.Channels : 2;
+
+        using IMFMediaType outType = MediaFactory.MFCreateMediaType();
+        outType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Audio);
+
+        switch (AudioSettings.Codec)
+        {
+            case MFAudioEncoderSettings.AudioCodecType.MP3:
+                outType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.Mp3);
+                outType.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, AudioSettings.Bitrate / 8);
+                break;
+            case MFAudioEncoderSettings.AudioCodecType.WMA:
+                outType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.WMAudioV9);
+                outType.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, AudioSettings.Bitrate / 8);
+                break;
+            case MFAudioEncoderSettings.AudioCodecType.PCM:
+                // Uncompressed 16-bit little-endian — no bitrate field needed.
+                outType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.Pcm);
+                outType.Set(MediaTypeAttributeKeys.AudioBitsPerSample, 16);
+                outType.Set(MediaTypeAttributeKeys.AudioBlockAlignment, (uint)(channels * 2));
+                outType.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, (uint)(sampleRate * channels * 2));
+                break;
+            default: // AAC
+                outType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.Aac);
+                outType.Set(MediaTypeAttributeKeys.AudioBitsPerSample, 16);
+                outType.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, AudioSettings.Bitrate / 8);
+                break;
+        }
+
+        outType.Set(MediaTypeAttributeKeys.AudioSamplesPerSecond, sampleRate);
+        outType.Set(MediaTypeAttributeKeys.AudioNumChannels, channels);
+
+        int streamIndex = sinkWriter.AddStream(outType);
+
+        // Input: 16-bit signed PCM. The MF AAC encoder MFT only supports this input
+        // shape — Stereo32BitFloat (our internal working format) must be downmixed.
+        using IMFMediaType inType = MediaFactory.MFCreateMediaType();
+        inType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Audio);
+        inType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.Pcm);
+        inType.Set(MediaTypeAttributeKeys.AudioBitsPerSample, 16);
+        inType.Set(MediaTypeAttributeKeys.AudioSamplesPerSecond, sampleRate);
+        inType.Set(MediaTypeAttributeKeys.AudioNumChannels, channels);
+        inType.Set(MediaTypeAttributeKeys.AudioBlockAlignment, (uint)(channels * 2));
+        inType.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, (uint)(sampleRate * channels * 2));
+
+        sinkWriter.SetInputMediaType(streamIndex, inType, null);
+        return streamIndex;
+    }
+
+    // -------------------- Frame writing --------------------
+
+    private static async ValueTask WriteVideoFrame(
+        IMFSinkWriter sinkWriter, int streamIndex,
+        IFrameProvider frameProvider,
+        long frame, long frameRateNum, long frameRateDen,
+        BitmapColorSpace? hdrTargetColorSpace, bool isHdr)
+    {
+        using Bitmap image = await frameProvider.RenderFrame(frame);
+
+        long ptsHns = frameRateNum > 0
+            ? frame * frameRateDen * HnsPerSecond / frameRateNum
+            : 0;
+        long durationHns = frameRateNum > 0
+            ? frameRateDen * HnsPerSecond / frameRateNum
+            : HnsPerSecond / 30;
+
+        if (isHdr && hdrTargetColorSpace is not null)
+        {
+            // 16-bit RGBA in HDR target color space → P010 (10-bit YUV 4:2:0 MSB-aligned).
+            using Bitmap converted = image.Convert(
+                BitmapColorType.Rgba16161616, BitmapAlphaType.Unpremul, hdrTargetColorSpace);
+            WriteVideoSample(sinkWriter, streamIndex, converted,
+                BitmapColorType.Rgba16161616, ptsHns, durationHns);
+        }
+        else
+        {
+            using Bitmap converted = image.Convert(
+                BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+            WriteVideoSample(sinkWriter, streamIndex, converted,
+                BitmapColorType.Bgra8888, ptsHns, durationHns);
+        }
+    }
+
+    private static unsafe void WriteVideoSample(
+        IMFSinkWriter sinkWriter, int streamIndex, Bitmap converted,
+        BitmapColorType srcKind, long ptsHns, long durationHns)
+    {
+        int width = converted.Width;
+        int height = converted.Height;
+
+        // P010 stride is width*2 bytes because each 10-bit sample is packed into
+        // 16 bits. NV12 uses 1 byte per Y sample.
+        bool isP010 = srcKind == BitmapColorType.Rgba16161616;
+        int dstStride = isP010 ? width * 2 : width;
+        int ySize = dstStride * height;
+        int uvHeight = (height + 1) / 2;
+        int uvSize = dstStride * uvHeight;
+        int totalSize = ySize + uvSize;
+
+        using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(totalSize);
+        buffer.Lock(out IntPtr dstPtr, out _, out _);
+        byte* dst = (byte*)dstPtr;
+        try
+        {
+            byte* src = (byte*)converted.Data;
+            int srcStride = converted.RowBytes;
+            if (isP010)
+            {
+                PixelFormatConverter.Rgba16ToP010(src, srcStride, dst, dstStride, width, height);
+            }
+            else
+            {
+                PixelFormatConverter.BgraToNv12(src, srcStride, dst, dstStride, width, height);
+            }
+        }
+        finally
+        {
+            buffer.Unlock();
+        }
+        buffer.CurrentLength = totalSize;
+
+        using IMFSample sample = MediaFactory.MFCreateSample();
+        sample.AddBuffer(buffer);
+        sample.SampleTime = ptsHns;
+        sample.SampleDuration = durationHns;
+        sinkWriter.WriteSample(streamIndex, sample);
+    }
+
+    private static async ValueTask WriteAudioFrame(
+        IMFSinkWriter sinkWriter, int streamIndex,
+        ISampleProvider sampleProvider,
+        long startSample, int length, long sampleRate)
+    {
+        using Pcm<Stereo32BitFloat> floatPcm = await sampleProvider.Sample(startSample, length);
+        int channels = Stereo32BitFloat.GetNumChannels();
+        int numSamples = floatPcm.NumSamples;
+        int byteCount = numSamples * channels * 2; // int16
+
+        using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(byteCount);
+        buffer.Lock(out IntPtr dstPtr, out _, out _);
+        unsafe
+        {
+            short* dst = (short*)dstPtr;
+            try
+            {
+                ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
+                for (int i = 0; i < src.Length; i++)
+                {
+                    dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
+                    dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
+                }
+            }
+            finally
+            {
+                buffer.Unlock();
+            }
+        }
+        buffer.CurrentLength = byteCount;
+
+        long ptsHns = sampleRate > 0 ? startSample * HnsPerSecond / sampleRate : 0;
+        long durationHns = sampleRate > 0 ? (long)numSamples * HnsPerSecond / sampleRate : 0;
+
+        using IMFSample sample = MediaFactory.MFCreateSample();
+        sample.AddBuffer(buffer);
+        sample.SampleTime = ptsHns;
+        sample.SampleDuration = durationHns;
+        sinkWriter.WriteSample(streamIndex, sample);
+    }
+
+    private static short FloatToPcm16(float sample)
+    {
+        // Use 32767 (not 32768) for the positive side to avoid clipping +1.0 into
+        // a wraparound. Symmetric clamp keeps the DC bias out of the output.
+        float scaled = sample * 32767f;
+        if (scaled > 32767f) scaled = 32767f;
+        else if (scaled < -32768f) scaled = -32768f;
+        return (short)scaled;
+    }
+
+    private static ulong PackUint64(uint hi, uint lo) => ((ulong)hi << 32) | lo;
+
+    // -------------------- Enum mapping helpers --------------------
+    // The helpers below drop into MFColorSpaceHelper's domain (for Skia color-space
+    // construction) and into Media Foundation's tag domain (for the encoder stream
+    // attributes). Keeping both mappings in this file means the encoder never has
+    // to cross-cast through a third enum representation.
+
+    private static VideoTransferFunction MapTransferToMF(
+        MFVideoEncoderSettings.ColorTransferCharacteristic t, bool isHdr)
+    {
+        // HDR must have a valid transfer tag — default to PQ (HDR10) when the user
+        // left the field unset. SDR leaves it Unknown (decoder default kicks in).
+        if (t == MFVideoEncoderSettings.ColorTransferCharacteristic.Default)
+            return isHdr ? VideoTransferFunction.Func2084 : VideoTransferFunction.FuncUnknown;
+
+        return t switch
+        {
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Srgb => VideoTransferFunction.FuncSRGB,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Linear => VideoTransferFunction.Func10,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Bt709 => VideoTransferFunction.Func709,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Pq => VideoTransferFunction.Func2084,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Hlg => VideoTransferFunction.FuncHlg,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Smpte240M => VideoTransferFunction.Func240m,
+            _ => VideoTransferFunction.FuncUnknown,
+        };
+    }
+
+    private static VideoPrimaries MapPrimariesToMF(
+        MFVideoEncoderSettings.ColorPrimariesType p, bool isHdr)
+    {
+        if (p == MFVideoEncoderSettings.ColorPrimariesType.Default)
+            return isHdr ? VideoPrimaries.Bt2020 : VideoPrimaries.Unknown;
+
+        return p switch
+        {
+            MFVideoEncoderSettings.ColorPrimariesType.Bt709 => VideoPrimaries.Bt709,
+            MFVideoEncoderSettings.ColorPrimariesType.Rec2020 => VideoPrimaries.Bt2020,
+            MFVideoEncoderSettings.ColorPrimariesType.Dcip3 => VideoPrimaries.DciP3,
+            MFVideoEncoderSettings.ColorPrimariesType.Smpte170M => VideoPrimaries.Smpte170m,
+            _ => VideoPrimaries.Unknown,
+        };
+    }
+
+    private static VideoTransferMatrix MapMatrixToMF(
+        MFVideoEncoderSettings.YCbCrMatrixType m, bool isHdr)
+    {
+        if (m == MFVideoEncoderSettings.YCbCrMatrixType.Default)
+            return isHdr ? VideoTransferMatrix.Bt202010 : VideoTransferMatrix.Unknown;
+
+        return m switch
+        {
+            MFVideoEncoderSettings.YCbCrMatrixType.Bt709 => VideoTransferMatrix.Bt709,
+            MFVideoEncoderSettings.YCbCrMatrixType.Bt601 => VideoTransferMatrix.Bt601,
+            MFVideoEncoderSettings.YCbCrMatrixType.Rec2020 => VideoTransferMatrix.Bt202010,
+            MFVideoEncoderSettings.YCbCrMatrixType.Smpte240M => VideoTransferMatrix.Smpte240m,
+            _ => VideoTransferMatrix.Unknown,
+        };
+    }
+
+    private static VideoTransferFunction MapTransferForHelper(
+        MFVideoEncoderSettings.ColorTransferCharacteristic t)
+    {
+        return t switch
+        {
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Pq => VideoTransferFunction.Func2084,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Hlg => VideoTransferFunction.FuncHlg,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Bt709 => VideoTransferFunction.Func709,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Srgb => VideoTransferFunction.FuncSRGB,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Linear => VideoTransferFunction.Func10,
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Smpte240M => VideoTransferFunction.Func240m,
+            _ => VideoTransferFunction.Func2084, // HDR default
+        };
+    }
+
+    private static VideoPrimaries MapPrimariesForHelper(
+        MFVideoEncoderSettings.ColorPrimariesType p)
+    {
+        return p switch
+        {
+            MFVideoEncoderSettings.ColorPrimariesType.Bt709 => VideoPrimaries.Bt709,
+            MFVideoEncoderSettings.ColorPrimariesType.Rec2020 => VideoPrimaries.Bt2020,
+            MFVideoEncoderSettings.ColorPrimariesType.Dcip3 => VideoPrimaries.DciP3,
+            MFVideoEncoderSettings.ColorPrimariesType.Smpte170M => VideoPrimaries.Smpte170m,
+            _ => VideoPrimaries.Bt2020, // HDR default
+        };
+    }
+}

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -209,6 +209,13 @@ public class MFEncodingController : EncodingController
         inType.Set(MediaTypeAttributeKeys.FrameSize, PackUint64((uint)width, (uint)height));
         inType.Set(MediaTypeAttributeKeys.FrameRate, PackUint64((uint)frNum, (uint)frDen));
         inType.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackUint64(1, 1));
+        // Tell MF the actual byte stride of the buffers we hand it. For odd
+        // widths (e.g. 853) the chroma row needs ceil(width/2)*2 bytes, which
+        // is one byte wider than width — without this attribute the encoder
+        // MFT computes stride from FrameSize and reads each row off-by-one.
+        int chromaWidth = ((width + 1) / 2) * 2;
+        int defaultStride = isHdr ? chromaWidth * 2 : chromaWidth;
+        inType.Set(MediaTypeAttributeKeys.DefaultStride, defaultStride);
         ApplyColorTags(inType, isHdr);
 
         sinkWriter.SetInputMediaType(streamIndex, inType, null);

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -98,14 +98,14 @@ public class MFEncodingController : EncodingController
                 if (isHdr)
                 {
                     hdrTargetColorSpace = MFColorSpaceHelper.BuildHdrColorSpace(
-                        MapTransferForHelper(VideoSettings.ColorTransfer),
-                        MapPrimariesForHelper(VideoSettings.ColorPrimaries));
+                        MapTransferForHelper(VideoSettings.ColorTransfer, isHdr: true),
+                        MapPrimariesForHelper(VideoSettings.ColorPrimaries, isHdr: true));
                 }
                 else
                 {
                     sdrSourceColorSpace = MFColorSpaceHelper.BuildTargetColorSpace(
-                        MapTransferForHelper(VideoSettings.ColorTransfer),
-                        MapPrimariesForHelper(VideoSettings.ColorPrimaries));
+                        MapTransferForHelper(VideoSettings.ColorTransfer, isHdr: false),
+                        MapPrimariesForHelper(VideoSettings.ColorPrimaries, isHdr: false));
                 }
             }
             // SDR NV12 conversion must match the matrix we tag on the output stream.
@@ -190,13 +190,11 @@ public class MFEncodingController : EncodingController
 
             if (encodeCompleted)
             {
-                // Atomic publish: replace any prior file in one step so partial writes
-                // never appear under OutputFile.
-                if (File.Exists(OutputFile))
-                {
-                    File.Delete(OutputFile);
-                }
-                File.Move(tempFile, OutputFile);
+                // Single-syscall replace on Windows / Linux so we never leave a window
+                // where the prior output has been deleted but the new one is not yet
+                // in place. A previous Delete + Move sequence could lose the user's
+                // existing file if the Move failed mid-way (permission, sharing).
+                File.Move(tempFile, OutputFile, overwrite: true);
             }
         }
         finally
@@ -368,25 +366,33 @@ public class MFEncodingController : EncodingController
     // to fill it, so clamping is safer than declaring a layout we cannot populate.
     private int ResolveAudioChannels()
     {
-        int requested = AudioSettings.Channels;
-        int resolved;
-        if (requested <= 0) resolved = 2;
-        else if (requested >= 2) resolved = 2;
-        else resolved = 1;
-
-        if (resolved != requested)
+        int resolved = ClampAudioChannels(AudioSettings.Channels, out bool clamped);
+        if (clamped)
         {
             // Visible warning instead of a silent clamp — a user asking for 5.1
             // should at least see why they got stereo so they can adjust the UI
             // (or change the upstream sample provider).
             _logger.LogWarning(
                 "AudioSettings.Channels {Requested} not supported by the Stereo32BitFloat source; clamping to {Resolved}",
-                requested, resolved);
+                AudioSettings.Channels, resolved);
         }
         return resolved;
     }
 
-    private static bool IsAudioOnlyContainer(string outputFile)
+    // Pure-logic split of ResolveAudioChannels so the clamp rules can be
+    // unit-tested without instantiating MFEncodingController (which requires
+    // the MF runtime on Windows).
+    internal static int ClampAudioChannels(int requested, out bool clamped)
+    {
+        int resolved;
+        if (requested <= 0) resolved = 2;
+        else if (requested >= 2) resolved = 2;
+        else resolved = 1;
+        clamped = resolved != requested;
+        return resolved;
+    }
+
+    internal static bool IsAudioOnlyContainer(string outputFile)
     {
         string ext = Path.GetExtension(outputFile);
         return ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase)
@@ -684,7 +690,7 @@ public class MFEncodingController : EncodingController
     // MF_MT_* attribute values). MapXxxForHelper: input to MFColorSpaceHelper
     // (same enum, but Default already resolved into a concrete HDR transfer/
     // primaries so Skia gets a fully-specified color space).
-    private static VideoTransferFunction MapTransferToMF(
+    internal static VideoTransferFunction MapTransferToMF(
         MFVideoEncoderSettings.ColorTransferCharacteristic t, bool isHdr)
     {
         // HDR must have a valid transfer tag — default to PQ (HDR10) when the user
@@ -704,7 +710,7 @@ public class MFEncodingController : EncodingController
         };
     }
 
-    private static VideoPrimaries MapPrimariesToMF(
+    internal static VideoPrimaries MapPrimariesToMF(
         MFVideoEncoderSettings.ColorPrimariesType p, bool isHdr)
     {
         if (p == MFVideoEncoderSettings.ColorPrimariesType.Default)
@@ -727,7 +733,7 @@ public class MFEncodingController : EncodingController
     // BT.601 instead — so a Default + SD-sized output may decode with a slight
     // hue shift. Users encoding SD content should select Bt601 explicitly to
     // pin the matrix tag and avoid this ambiguity.
-    private static PixelFormatConverter.YuvMatrix8 ResolveSdrYuvMatrix(
+    internal static PixelFormatConverter.YuvMatrix8 ResolveSdrYuvMatrix(
         MFVideoEncoderSettings.YCbCrMatrixType m)
     {
         return m switch
@@ -739,7 +745,7 @@ public class MFEncodingController : EncodingController
         };
     }
 
-    private static VideoTransferMatrix MapMatrixToMF(
+    internal static VideoTransferMatrix MapMatrixToMF(
         MFVideoEncoderSettings.YCbCrMatrixType m, bool isHdr)
     {
         if (m == MFVideoEncoderSettings.YCbCrMatrixType.Default)
@@ -755,8 +761,13 @@ public class MFEncodingController : EncodingController
         };
     }
 
-    private static VideoTransferFunction MapTransferForHelper(
-        MFVideoEncoderSettings.ColorTransferCharacteristic t)
+    // Resolve a settings enum to a Vortice transfer/primaries value with the
+    // Default branch turned into a concrete value, so MFColorSpaceHelper does
+    // not have to second-guess. `isHdr` decides which side's default applies:
+    // HDR → PQ + Rec.2020, SDR → sRGB + Bt.709. Previously the unified default
+    // mapped Default→PQ for SDR too, which produced PQ-tagged sRGB pixels.
+    internal static VideoTransferFunction MapTransferForHelper(
+        MFVideoEncoderSettings.ColorTransferCharacteristic t, bool isHdr)
     {
         return t switch
         {
@@ -766,12 +777,12 @@ public class MFEncodingController : EncodingController
             MFVideoEncoderSettings.ColorTransferCharacteristic.Srgb => VideoTransferFunction.FuncSRGB,
             MFVideoEncoderSettings.ColorTransferCharacteristic.Linear => VideoTransferFunction.Func10,
             MFVideoEncoderSettings.ColorTransferCharacteristic.Smpte240M => VideoTransferFunction.Func240m,
-            _ => VideoTransferFunction.Func2084, // HDR default
+            _ => isHdr ? VideoTransferFunction.Func2084 : VideoTransferFunction.FuncSRGB,
         };
     }
 
-    private static VideoPrimaries MapPrimariesForHelper(
-        MFVideoEncoderSettings.ColorPrimariesType p)
+    internal static VideoPrimaries MapPrimariesForHelper(
+        MFVideoEncoderSettings.ColorPrimariesType p, bool isHdr)
     {
         return p switch
         {
@@ -779,7 +790,7 @@ public class MFEncodingController : EncodingController
             MFVideoEncoderSettings.ColorPrimariesType.Rec2020 => VideoPrimaries.Bt2020,
             MFVideoEncoderSettings.ColorPrimariesType.Dcip3 => VideoPrimaries.DciP3,
             MFVideoEncoderSettings.ColorPrimariesType.Smpte170M => VideoPrimaries.Smpte170m,
-            _ => VideoPrimaries.Bt2020, // HDR default
+            _ => isHdr ? VideoPrimaries.Bt2020 : VideoPrimaries.Bt709,
         };
     }
 }

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -381,11 +381,9 @@ public class MFEncodingController : EncodingController
 
     // Pure-logic split of ResolveAudioChannels so the clamp rules can be
     // unit-tested without instantiating MFEncodingController (which requires
-    // the MF runtime on Windows). The clamp itself encodes the same contract
-    // the instance method's doc-comment describes: source is always
-    // Pcm<Stereo32BitFloat>, so mono and stereo are honored, anything wider
-    // collapses to stereo because there is no source data for the extra
-    // channels.
+    // the MF runtime on Windows). Mirrors the contract documented on
+    // ResolveAudioChannels — keep the WHY description in one place to avoid
+    // the two copies drifting apart over time.
     internal static int ClampAudioChannels(int requested, out bool clamped)
     {
         int resolved;

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -70,10 +70,9 @@ public class MFEncodingController : EncodingController
         // audio path only.
         int videoStreamIndex = audioOnly ? -1 : ConfigureVideoStream(sinkWriter, isHdr);
         int audioChannels = ResolveAudioChannels();
-        int sourceSampleRate = (int)sampleProvider.SampleRate;
-        int outputSampleRate = ResolveOutputSampleRate(sourceSampleRate);
+        int sampleRate = ResolveOutputSampleRate((int)sampleProvider.SampleRate);
         MFAudioEncoderSettings.AudioCodecType audioCodec = ResolveAudioCodec();
-        int audioStreamIndex = ConfigureAudioStream(sinkWriter, audioCodec, outputSampleRate, audioChannels);
+        int audioStreamIndex = ConfigureAudioStream(sinkWriter, audioCodec, sampleRate, audioChannels);
 
         // Pre-compute the HDR target color space once per encode. Reusing the object
         // saves Skia from rebuilding the SKColorSpace on every frame convert.
@@ -104,10 +103,8 @@ public class MFEncodingController : EncodingController
                 long videoTs = (encodeVideo && frameRateNum > 0)
                     ? frameCount * frameRateDen * HnsPerSecond / frameRateNum
                     : long.MaxValue;
-                // sampleCount is in source-rate samples (matches sampleProvider.SampleCount),
-                // so audioTs is wall-clock regardless of any rate conversion done downstream.
-                long audioTs = (encodeAudio && sourceSampleRate > 0)
-                    ? sampleCount * HnsPerSecond / sourceSampleRate
+                long audioTs = (encodeAudio && sampleRate > 0)
+                    ? sampleCount * HnsPerSecond / sampleRate
                     : long.MaxValue;
 
                 if (encodeVideo && videoTs <= audioTs)
@@ -123,7 +120,7 @@ public class MFEncodingController : EncodingController
                 else if (encodeAudio)
                 {
                     await WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
-                        sampleCount, AudioFrameSize, sourceSampleRate, outputSampleRate, audioChannels);
+                        sampleCount, AudioFrameSize, sampleRate, audioChannels);
                     sampleCount += AudioFrameSize;
                     if (sampleCount >= sampleProvider.SampleCount)
                     {
@@ -256,12 +253,21 @@ public class MFEncodingController : EncodingController
             || ext.Equals(".adts", StringComparison.OrdinalIgnoreCase);
     }
 
-    // Picks the actual output rate. AudioSettings.SampleRate is treated as a
-    // user request; the writer routes samples through Pcm.Resamples when the
-    // request differs from the source.
+    // Pcm.Resamples recomputes its fractional position from zero on every call,
+    // so resampling per 1024-sample chunk would inject sample-aligned clicks
+    // and accumulate drift. Until a stateful resampler (e.g. the MF Audio
+    // Resampler DSP) is wired up we honor the source rate and surface the
+    // override decision so the user notices their setting was ignored.
     private int ResolveOutputSampleRate(int sourceSampleRate)
     {
-        return AudioSettings.SampleRate > 0 ? AudioSettings.SampleRate : sourceSampleRate;
+        int requested = AudioSettings.SampleRate;
+        if (requested > 0 && requested != sourceSampleRate)
+        {
+            _logger.LogWarning(
+                "AudioSettings.SampleRate {Requested} differs from source {Source}; using source rate to avoid resampling artifacts",
+                requested, sourceSampleRate);
+        }
+        return sourceSampleRate;
     }
 
     // Audio codec must match what the chosen container can mux. WAV requires
@@ -394,10 +400,13 @@ public class MFEncodingController : EncodingController
         int width = converted.Width;
         int height = converted.Height;
 
-        // P010 stride is width*2 bytes because each 10-bit sample is packed into
-        // 16 bits. NV12 uses 1 byte per Y sample.
+        // 4:2:0 chroma rows hold ceil(width/2) U/V pairs (= chromaWidth bytes
+        // for NV12, 2x for P010). Y rows only need width bytes, but the plane
+        // shares dstStride, so it must accommodate the longer chroma row —
+        // otherwise odd widths (e.g. 853) write one byte past every UV row.
         bool isP010 = srcKind == BitmapColorType.Rgba16161616;
-        int dstStride = isP010 ? width * 2 : width;
+        int chromaWidth = ((width + 1) / 2) * 2;
+        int dstStride = isP010 ? chromaWidth * 2 : chromaWidth;
         int ySize = dstStride * height;
         int uvHeight = (height + 1) / 2;
         int uvSize = dstStride * uvHeight;
@@ -435,88 +444,59 @@ public class MFEncodingController : EncodingController
     private static async ValueTask WriteAudioFrame(
         IMFSinkWriter sinkWriter, int streamIndex,
         ISampleProvider sampleProvider,
-        long sourceStartSample, int sourceLength,
-        int sourceSampleRate, int outputSampleRate, int channels)
+        long startSample, int length, int sampleRate, int channels)
     {
-        // Defensive: ConfigureAudioStream rejects non-positive rates upstream so
-        // we shouldn't reach here with bad values, but Pcm.Resamples crashes on
-        // zero/negative frequencies — keep the assert close to the math.
-        if (sourceSampleRate <= 0 || outputSampleRate <= 0)
+        if (sampleRate <= 0)
         {
             return;
         }
 
-        Pcm<Stereo32BitFloat> sourcePcm = await sampleProvider.Sample(sourceStartSample, sourceLength);
-        Pcm<Stereo32BitFloat>? resampled = null;
-        try
+        using Pcm<Stereo32BitFloat> floatPcm = await sampleProvider.Sample(startSample, length);
+        int numSamples = floatPcm.NumSamples;
+        int byteCount = numSamples * channels * 2; // int16
+
+        using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(byteCount);
+        buffer.Lock(out IntPtr dstPtr, out _, out _);
+        unsafe
         {
-            // The Sink Writer was configured with outputSampleRate, so the
-            // bytes we hand it must be at that rate. Resample only when the
-            // user picked a different rate than the project.
-            Pcm<Stereo32BitFloat> floatPcm = sourcePcm;
-            if (outputSampleRate > 0 && outputSampleRate != sourceSampleRate)
+            short* dst = (short*)dstPtr;
+            try
             {
-                resampled = sourcePcm.Resamples(outputSampleRate);
-                floatPcm = resampled;
-            }
-
-            int numSamples = floatPcm.NumSamples;
-            int byteCount = numSamples * channels * 2; // int16
-
-            using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(byteCount);
-            buffer.Lock(out IntPtr dstPtr, out _, out _);
-            unsafe
-            {
-                short* dst = (short*)dstPtr;
-                try
+                ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
+                if (channels == 1)
                 {
-                    ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
-                    if (channels == 1)
+                    // L+R averaged into a single channel keeps both sides audible
+                    // without doubling perceived amplitude.
+                    for (int i = 0; i < src.Length; i++)
                     {
-                        // L+R averaged into a single channel keeps both sides audible without
-                        // doubling perceived amplitude.
-                        for (int i = 0; i < src.Length; i++)
-                        {
-                            float mono = (src[i].Left + src[i].Right) * 0.5f;
-                            dst[i] = FloatToPcm16(mono);
-                        }
-                    }
-                    else
-                    {
-                        for (int i = 0; i < src.Length; i++)
-                        {
-                            dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
-                            dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
-                        }
+                        float mono = (src[i].Left + src[i].Right) * 0.5f;
+                        dst[i] = FloatToPcm16(mono);
                     }
                 }
-                finally
+                else
                 {
-                    buffer.Unlock();
+                    for (int i = 0; i < src.Length; i++)
+                    {
+                        dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
+                        dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
+                    }
                 }
             }
-            buffer.CurrentLength = byteCount;
-
-            // PTS is wall-clock — derive it from the source-rate index so it
-            // stays interleaved correctly with video regardless of resampling.
-            long ptsHns = sourceSampleRate > 0
-                ? sourceStartSample * HnsPerSecond / sourceSampleRate
-                : 0;
-            long durationHns = outputSampleRate > 0
-                ? (long)numSamples * HnsPerSecond / outputSampleRate
-                : 0;
-
-            using IMFSample sample = MediaFactory.MFCreateSample();
-            sample.AddBuffer(buffer);
-            sample.SampleTime = ptsHns;
-            sample.SampleDuration = durationHns;
-            sinkWriter.WriteSample(streamIndex, sample);
+            finally
+            {
+                buffer.Unlock();
+            }
         }
-        finally
-        {
-            sourcePcm.Dispose();
-            resampled?.Dispose();
-        }
+        buffer.CurrentLength = byteCount;
+
+        long ptsHns = startSample * HnsPerSecond / sampleRate;
+        long durationHns = (long)numSamples * HnsPerSecond / sampleRate;
+
+        using IMFSample sample = MediaFactory.MFCreateSample();
+        sample.AddBuffer(buffer);
+        sample.SampleTime = ptsHns;
+        sample.SampleDuration = durationHns;
+        sinkWriter.WriteSample(streamIndex, sample);
     }
 
     private static short FloatToPcm16(float sample)

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -381,7 +381,11 @@ public class MFEncodingController : EncodingController
 
     // Pure-logic split of ResolveAudioChannels so the clamp rules can be
     // unit-tested without instantiating MFEncodingController (which requires
-    // the MF runtime on Windows).
+    // the MF runtime on Windows). The clamp itself encodes the same contract
+    // the instance method's doc-comment describes: source is always
+    // Pcm<Stereo32BitFloat>, so mono and stereo are honored, anything wider
+    // collapses to stereo because there is no source data for the extra
+    // channels.
     internal static int ClampAudioChannels(int requested, out bool clamped)
     {
         int resolved;

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingController.cs
@@ -70,7 +70,10 @@ public class MFEncodingController : EncodingController
         // audio path only.
         int videoStreamIndex = audioOnly ? -1 : ConfigureVideoStream(sinkWriter, isHdr);
         int audioChannels = ResolveAudioChannels();
-        int audioStreamIndex = ConfigureAudioStream(sinkWriter, sampleProvider.SampleRate, audioChannels);
+        int sourceSampleRate = (int)sampleProvider.SampleRate;
+        int outputSampleRate = ResolveOutputSampleRate(sourceSampleRate);
+        MFAudioEncoderSettings.AudioCodecType audioCodec = ResolveAudioCodec();
+        int audioStreamIndex = ConfigureAudioStream(sinkWriter, audioCodec, outputSampleRate, audioChannels);
 
         // Pre-compute the HDR target color space once per encode. Reusing the object
         // saves Skia from rebuilding the SKColorSpace on every frame convert.
@@ -81,6 +84,8 @@ public class MFEncodingController : EncodingController
                 MapTransferForHelper(VideoSettings.ColorTransfer),
                 MapPrimariesForHelper(VideoSettings.ColorPrimaries));
         }
+        // SDR NV12 conversion must match the matrix we tag on the output stream.
+        PixelFormatConverter.YuvMatrix8 sdrMatrix = ResolveSdrYuvMatrix(VideoSettings.YCbCrMatrix);
 
         sinkWriter.BeginWriting();
 
@@ -93,21 +98,22 @@ public class MFEncodingController : EncodingController
 
             long frameRateNum = VideoSettings.FrameRate.Numerator;
             long frameRateDen = VideoSettings.FrameRate.Denominator;
-            long sampleRate = sampleProvider.SampleRate;
 
             while ((encodeVideo || encodeAudio) && !cancellationToken.IsCancellationRequested)
             {
                 long videoTs = (encodeVideo && frameRateNum > 0)
                     ? frameCount * frameRateDen * HnsPerSecond / frameRateNum
                     : long.MaxValue;
-                long audioTs = (encodeAudio && sampleRate > 0)
-                    ? sampleCount * HnsPerSecond / sampleRate
+                // sampleCount is in source-rate samples (matches sampleProvider.SampleCount),
+                // so audioTs is wall-clock regardless of any rate conversion done downstream.
+                long audioTs = (encodeAudio && sourceSampleRate > 0)
+                    ? sampleCount * HnsPerSecond / sourceSampleRate
                     : long.MaxValue;
 
                 if (encodeVideo && videoTs <= audioTs)
                 {
                     await WriteVideoFrame(sinkWriter, videoStreamIndex, frameProvider,
-                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr);
+                        frameCount, frameRateNum, frameRateDen, hdrTargetColorSpace, isHdr, sdrMatrix);
                     frameCount++;
                     if (frameCount >= frameProvider.FrameCount)
                     {
@@ -117,7 +123,7 @@ public class MFEncodingController : EncodingController
                 else if (encodeAudio)
                 {
                     await WriteAudioFrame(sinkWriter, audioStreamIndex, sampleProvider,
-                        sampleCount, AudioFrameSize, sampleRate, audioChannels);
+                        sampleCount, AudioFrameSize, sourceSampleRate, outputSampleRate, audioChannels);
                     sampleCount += AudioFrameSize;
                     if (sampleCount >= sampleProvider.SampleCount)
                     {
@@ -250,9 +256,37 @@ public class MFEncodingController : EncodingController
             || ext.Equals(".adts", StringComparison.OrdinalIgnoreCase);
     }
 
-    private int ConfigureAudioStream(IMFSinkWriter sinkWriter, long sourceSampleRate, int channels)
+    // Picks the actual output rate. AudioSettings.SampleRate is treated as a
+    // user request; the writer routes samples through Pcm.Resamples when the
+    // request differs from the source.
+    private int ResolveOutputSampleRate(int sourceSampleRate)
     {
-        int sampleRate = AudioSettings.SampleRate > 0 ? AudioSettings.SampleRate : (int)sourceSampleRate;
+        return AudioSettings.SampleRate > 0 ? AudioSettings.SampleRate : sourceSampleRate;
+    }
+
+    // Audio codec must match what the chosen container can mux. WAV requires
+    // PCM, MP3 requires MP3, and ASF/WMV requires WMA — silently overriding
+    // here is friendlier than a cryptic AddStream/BeginWriting failure.
+    private MFAudioEncoderSettings.AudioCodecType ResolveAudioCodec()
+    {
+        string ext = Path.GetExtension(OutputFile);
+        if (ext.Equals(".wav", StringComparison.OrdinalIgnoreCase))
+            return MFAudioEncoderSettings.AudioCodecType.PCM;
+        if (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase))
+            return MFAudioEncoderSettings.AudioCodecType.MP3;
+        if (ext.Equals(".wma", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".asf", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".wmv", StringComparison.OrdinalIgnoreCase))
+            return MFAudioEncoderSettings.AudioCodecType.WMA;
+        return AudioSettings.Codec;
+    }
+
+    private int ConfigureAudioStream(
+        IMFSinkWriter sinkWriter,
+        MFAudioEncoderSettings.AudioCodecType codec,
+        int sampleRate,
+        int channels)
+    {
         if (sampleRate <= 0)
         {
             return -1;
@@ -261,7 +295,7 @@ public class MFEncodingController : EncodingController
         using IMFMediaType outType = MediaFactory.MFCreateMediaType();
         outType.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Audio);
 
-        switch (AudioSettings.Codec)
+        switch (codec)
         {
             case MFAudioEncoderSettings.AudioCodecType.MP3:
                 outType.Set(MediaTypeAttributeKeys.Subtype, AudioFormatGuids.Mp3);
@@ -309,7 +343,8 @@ public class MFEncodingController : EncodingController
         IMFSinkWriter sinkWriter, int streamIndex,
         IFrameProvider frameProvider,
         long frame, long frameRateNum, long frameRateDen,
-        BitmapColorSpace? hdrTargetColorSpace, bool isHdr)
+        BitmapColorSpace? hdrTargetColorSpace, bool isHdr,
+        PixelFormatConverter.YuvMatrix8 sdrMatrix)
     {
         using Bitmap image = await frameProvider.RenderFrame(frame);
 
@@ -326,20 +361,21 @@ public class MFEncodingController : EncodingController
             using Bitmap converted = image.Convert(
                 BitmapColorType.Rgba16161616, BitmapAlphaType.Unpremul, hdrTargetColorSpace);
             WriteVideoSample(sinkWriter, streamIndex, converted,
-                BitmapColorType.Rgba16161616, ptsHns, durationHns);
+                BitmapColorType.Rgba16161616, ptsHns, durationHns, sdrMatrix);
         }
         else
         {
             using Bitmap converted = image.Convert(
                 BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
             WriteVideoSample(sinkWriter, streamIndex, converted,
-                BitmapColorType.Bgra8888, ptsHns, durationHns);
+                BitmapColorType.Bgra8888, ptsHns, durationHns, sdrMatrix);
         }
     }
 
     private static unsafe void WriteVideoSample(
         IMFSinkWriter sinkWriter, int streamIndex, Bitmap converted,
-        BitmapColorType srcKind, long ptsHns, long durationHns)
+        BitmapColorType srcKind, long ptsHns, long durationHns,
+        PixelFormatConverter.YuvMatrix8 sdrMatrix)
     {
         int width = converted.Width;
         int height = converted.Height;
@@ -366,7 +402,7 @@ public class MFEncodingController : EncodingController
             }
             else
             {
-                PixelFormatConverter.BgraToNv12(src, srcStride, dst, dstStride, width, height);
+                PixelFormatConverter.BgraToNv12(src, srcStride, dst, dstStride, width, height, sdrMatrix);
             }
         }
         finally
@@ -385,54 +421,80 @@ public class MFEncodingController : EncodingController
     private static async ValueTask WriteAudioFrame(
         IMFSinkWriter sinkWriter, int streamIndex,
         ISampleProvider sampleProvider,
-        long startSample, int length, long sampleRate, int channels)
+        long sourceStartSample, int sourceLength,
+        int sourceSampleRate, int outputSampleRate, int channels)
     {
-        using Pcm<Stereo32BitFloat> floatPcm = await sampleProvider.Sample(startSample, length);
-        int numSamples = floatPcm.NumSamples;
-        int byteCount = numSamples * channels * 2; // int16
-
-        using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(byteCount);
-        buffer.Lock(out IntPtr dstPtr, out _, out _);
-        unsafe
+        Pcm<Stereo32BitFloat> sourcePcm = await sampleProvider.Sample(sourceStartSample, sourceLength);
+        Pcm<Stereo32BitFloat>? resampled = null;
+        try
         {
-            short* dst = (short*)dstPtr;
-            try
+            // The Sink Writer was configured with outputSampleRate, so the
+            // bytes we hand it must be at that rate. Resample only when the
+            // user picked a different rate than the project.
+            Pcm<Stereo32BitFloat> floatPcm = sourcePcm;
+            if (outputSampleRate > 0 && outputSampleRate != sourceSampleRate)
             {
-                ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
-                if (channels == 1)
+                resampled = sourcePcm.Resamples(outputSampleRate);
+                floatPcm = resampled;
+            }
+
+            int numSamples = floatPcm.NumSamples;
+            int byteCount = numSamples * channels * 2; // int16
+
+            using IMFMediaBuffer buffer = MediaFactory.MFCreateMemoryBuffer(byteCount);
+            buffer.Lock(out IntPtr dstPtr, out _, out _);
+            unsafe
+            {
+                short* dst = (short*)dstPtr;
+                try
                 {
-                    // L+R averaged into a single channel keeps both sides audible without
-                    // doubling perceived amplitude.
-                    for (int i = 0; i < src.Length; i++)
+                    ReadOnlySpan<Stereo32BitFloat> src = floatPcm.DataSpan;
+                    if (channels == 1)
                     {
-                        float mono = (src[i].Left + src[i].Right) * 0.5f;
-                        dst[i] = FloatToPcm16(mono);
+                        // L+R averaged into a single channel keeps both sides audible without
+                        // doubling perceived amplitude.
+                        for (int i = 0; i < src.Length; i++)
+                        {
+                            float mono = (src[i].Left + src[i].Right) * 0.5f;
+                            dst[i] = FloatToPcm16(mono);
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < src.Length; i++)
+                        {
+                            dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
+                            dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
+                        }
                     }
                 }
-                else
+                finally
                 {
-                    for (int i = 0; i < src.Length; i++)
-                    {
-                        dst[i * 2 + 0] = FloatToPcm16(src[i].Left);
-                        dst[i * 2 + 1] = FloatToPcm16(src[i].Right);
-                    }
+                    buffer.Unlock();
                 }
             }
-            finally
-            {
-                buffer.Unlock();
-            }
+            buffer.CurrentLength = byteCount;
+
+            // PTS is wall-clock — derive it from the source-rate index so it
+            // stays interleaved correctly with video regardless of resampling.
+            long ptsHns = sourceSampleRate > 0
+                ? sourceStartSample * HnsPerSecond / sourceSampleRate
+                : 0;
+            long durationHns = outputSampleRate > 0
+                ? (long)numSamples * HnsPerSecond / outputSampleRate
+                : 0;
+
+            using IMFSample sample = MediaFactory.MFCreateSample();
+            sample.AddBuffer(buffer);
+            sample.SampleTime = ptsHns;
+            sample.SampleDuration = durationHns;
+            sinkWriter.WriteSample(streamIndex, sample);
         }
-        buffer.CurrentLength = byteCount;
-
-        long ptsHns = sampleRate > 0 ? startSample * HnsPerSecond / sampleRate : 0;
-        long durationHns = sampleRate > 0 ? (long)numSamples * HnsPerSecond / sampleRate : 0;
-
-        using IMFSample sample = MediaFactory.MFCreateSample();
-        sample.AddBuffer(buffer);
-        sample.SampleTime = ptsHns;
-        sample.SampleDuration = durationHns;
-        sinkWriter.WriteSample(streamIndex, sample);
+        finally
+        {
+            sourcePcm.Dispose();
+            resampled?.Dispose();
+        }
     }
 
     private static short FloatToPcm16(float sample)
@@ -484,6 +546,21 @@ public class MFEncodingController : EncodingController
             MFVideoEncoderSettings.ColorPrimariesType.Dcip3 => VideoPrimaries.DciP3,
             MFVideoEncoderSettings.ColorPrimariesType.Smpte170M => VideoPrimaries.Smpte170m,
             _ => VideoPrimaries.Unknown,
+        };
+    }
+
+    // Picks the 8-bit NV12 conversion matrix that matches the tag MapMatrixToMF
+    // will write to MF_MT_YUV_MATRIX. Default falls back to BT.709 to align with
+    // typical SDR HD content; SMPTE 240M is rare in 8-bit and uses BT.709 here
+    // (its tag is preserved separately if the user explicitly requested it).
+    private static PixelFormatConverter.YuvMatrix8 ResolveSdrYuvMatrix(
+        MFVideoEncoderSettings.YCbCrMatrixType m)
+    {
+        return m switch
+        {
+            MFVideoEncoderSettings.YCbCrMatrixType.Bt601 => PixelFormatConverter.YuvMatrix8.Bt601,
+            MFVideoEncoderSettings.YCbCrMatrixType.Rec2020 => PixelFormatConverter.YuvMatrix8.Bt2020,
+            _ => PixelFormatConverter.YuvMatrix8.Bt709,
         };
     }
 

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingExtension.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingExtension.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Versioning;
+using Beutl.Extensibility;
+using Beutl.Extensions.MediaFoundation.Properties;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Encoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Encoding;
+#endif
+
+[Export]
+[SupportedOSPlatform("windows")]
+[Display(Name = nameof(Strings.EncodingName), ResourceType = typeof(Strings))]
+public class MFEncodingExtension : ControllableEncodingExtension
+{
+    // Subset of Sink Writer container-type coverage. Anything outside this list
+    // (e.g. .mkv, .ogg) can't be muxed by Media Foundation — users should fall
+    // back to the FFmpeg encoder extension for those.
+    public override IEnumerable<string> SupportExtensions()
+    {
+        yield return ".mp4";
+        yield return ".mov";
+        yield return ".m4v";
+        yield return ".m4a";
+        yield return ".wmv";
+        yield return ".asf";
+        yield return ".wav";
+        yield return ".mp3";
+        yield return ".aac";
+        yield return ".adts";
+        yield return ".3gp";
+        yield return ".3gp2";
+        yield return ".3gpp";
+    }
+
+    public override EncodingController CreateController(string file)
+    {
+        return new MFEncodingController(file);
+    }
+}

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingExtension.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFEncodingExtension.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Runtime.Versioning;
 using Beutl.Extensibility;
 using Beutl.Extensions.MediaFoundation.Properties;

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFVideoEncoderSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFVideoEncoderSettings.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Beutl.Media.Encoding;
 
 #if MF_BUILD_IN

--- a/src/Beutl.Extensions.MediaFoundation/Encoding/MFVideoEncoderSettings.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Encoding/MFVideoEncoderSettings.cs
@@ -1,0 +1,153 @@
+using System.ComponentModel.DataAnnotations;
+using Beutl.Media.Encoding;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Encoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Encoding;
+#endif
+
+public sealed class MFVideoEncoderSettings : VideoEncoderSettings
+{
+    public static readonly CoreProperty<VideoCodec> CodecProperty;
+    public static readonly CoreProperty<H264ProfileType> H264ProfileProperty;
+    public static readonly CoreProperty<HevcProfileType> HevcProfileProperty;
+    public static readonly CoreProperty<ColorTransferCharacteristic> ColorTransferProperty;
+    public static readonly CoreProperty<ColorPrimariesType> ColorPrimariesProperty;
+    public static readonly CoreProperty<YCbCrMatrixType> YCbCrMatrixProperty;
+
+    static MFVideoEncoderSettings()
+    {
+        CodecProperty = ConfigureProperty<VideoCodec, MFVideoEncoderSettings>(nameof(Codec))
+            .DefaultValue(VideoCodec.H264)
+            .Register();
+
+        H264ProfileProperty = ConfigureProperty<H264ProfileType, MFVideoEncoderSettings>(nameof(H264Profile))
+            .DefaultValue(H264ProfileType.High)
+            .Register();
+
+        HevcProfileProperty = ConfigureProperty<HevcProfileType, MFVideoEncoderSettings>(nameof(HevcProfile))
+            .DefaultValue(HevcProfileType.Main)
+            .Register();
+
+        ColorTransferProperty = ConfigureProperty<ColorTransferCharacteristic, MFVideoEncoderSettings>(nameof(ColorTransfer))
+            .DefaultValue(ColorTransferCharacteristic.Default)
+            .Register();
+
+        ColorPrimariesProperty = ConfigureProperty<ColorPrimariesType, MFVideoEncoderSettings>(nameof(ColorPrimaries))
+            .DefaultValue(ColorPrimariesType.Default)
+            .Register();
+
+        YCbCrMatrixProperty = ConfigureProperty<YCbCrMatrixType, MFVideoEncoderSettings>(nameof(YCbCrMatrix))
+            .DefaultValue(YCbCrMatrixType.Default)
+            .Register();
+    }
+
+    [Display(Name = "Codec")]
+    public VideoCodec Codec
+    {
+        get => GetValue(CodecProperty);
+        set => SetValue(CodecProperty, value);
+    }
+
+    [Display(Name = "H.264 Profile")]
+    public H264ProfileType H264Profile
+    {
+        get => GetValue(H264ProfileProperty);
+        set => SetValue(H264ProfileProperty, value);
+    }
+
+    [Display(Name = "HEVC Profile")]
+    public HevcProfileType HevcProfile
+    {
+        get => GetValue(HevcProfileProperty);
+        set => SetValue(HevcProfileProperty, value);
+    }
+
+    /// <summary>
+    /// Transfer characteristic embedded in the encoded stream. Setting Pq or Hlg selects the
+    /// HDR encoder path (HEVC Main10 profile, 16bpc pixel pipeline, matching the output
+    /// MF_MT_TRANSFER_FUNCTION tag).
+    /// </summary>
+    [Display(Name = "Color Transfer",
+        Description = "Pq / Hlg selects the HDR encoder path (HEVC Main10).")]
+    public ColorTransferCharacteristic ColorTransfer
+    {
+        get => GetValue(ColorTransferProperty);
+        set => SetValue(ColorTransferProperty, value);
+    }
+
+    [Display(Name = "Color Primaries")]
+    public ColorPrimariesType ColorPrimaries
+    {
+        get => GetValue(ColorPrimariesProperty);
+        set => SetValue(ColorPrimariesProperty, value);
+    }
+
+    [Display(Name = "YCbCr Matrix")]
+    public YCbCrMatrixType YCbCrMatrix
+    {
+        get => GetValue(YCbCrMatrixProperty);
+        set => SetValue(YCbCrMatrixProperty, value);
+    }
+
+    public bool IsHdr =>
+        ColorTransfer == ColorTransferCharacteristic.Pq ||
+        ColorTransfer == ColorTransferCharacteristic.Hlg;
+
+    public enum VideoCodec
+    {
+        [Display(Name = "Default (H.264)")] Default = 0,
+        [Display(Name = "H.264 / AVC")] H264 = 1,
+        [Display(Name = "H.265 / HEVC")] HEVC = 2,
+    }
+
+    // Values match eAVEncH264VProfile on Windows. Media Foundation accepts these
+    // directly via MF_MT_MPEG2_PROFILE, and they pin down what the decoder will
+    // advertise to downstream consumers (browsers, NLE transcoders, etc.).
+    public enum H264ProfileType
+    {
+        Baseline = 66,
+        Main = 77,
+        High = 100,
+    }
+
+    // Values match eAVEncH265VProfile. Main10 is *required* for any HDR output —
+    // 8-bit HEVC cannot carry PQ/HLG without quantization artifacts.
+    public enum HevcProfileType
+    {
+        Main = 1,
+        Main10 = 2,
+    }
+
+    // Numeric values align with AVFVideoEncoderSettings.ColorTransferCharacteristic
+    // so BitmapColorSpace lookup semantics stay consistent across backends.
+    public enum ColorTransferCharacteristic
+    {
+        [Display(Name = "Default (SDR)")] Default = 0,
+        [Display(Name = "sRGB")] Srgb = 1,
+        [Display(Name = "Linear")] Linear = 2,
+        [Display(Name = "BT.709")] Bt709 = 3,
+        [Display(Name = "PQ (HDR10 / SMPTE ST 2084)")] Pq = 4,
+        [Display(Name = "HLG (ITU-R BT.2100)")] Hlg = 5,
+        [Display(Name = "SMPTE 240M")] Smpte240M = 9,
+    }
+
+    public enum ColorPrimariesType
+    {
+        [Display(Name = "Default")] Default = 0,
+        [Display(Name = "BT.709")] Bt709 = 2,
+        [Display(Name = "Rec.2020 / BT.2020")] Rec2020 = 8,
+        [Display(Name = "DCI-P3 (D65)")] Dcip3 = 11,
+        [Display(Name = "SMPTE 170M")] Smpte170M = 5,
+    }
+
+    public enum YCbCrMatrixType
+    {
+        [Display(Name = "Default")] Default = 0,
+        [Display(Name = "BT.709")] Bt709 = 1,
+        [Display(Name = "BT.601")] Bt601 = 2,
+        [Display(Name = "Rec.2020 / BT.2020")] Rec2020 = 3,
+        [Display(Name = "SMPTE 240M")] Smpte240M = 4,
+    }
+}

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -1,4 +1,4 @@
-using Beutl.Media;
+﻿using Beutl.Media;
 using Vortice.MediaFoundation;
 
 #if MF_BUILD_IN

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -85,12 +85,11 @@ internal static class MFColorSpaceHelper
         float eotfValue = BitmapColorSpaceTransferFn.Hlg.Transform(hlgReferenceCode);
         if (eotfValue <= 0 || !float.IsFinite(eotfValue))
         {
-            // Fallback when Skia hasn't initialized the HLG curve. 18.0 is the
-            // empirical scale FFmpeg uses for the BT.2100 OOTF γ=3 / 1000-nit
-            // peak case (extracted from libavfilter/vf_tonemap.c). Matching it
-            // keeps cross-backend output consistent in the rare init-failure
-            // path even though the analytic derivation is not a single closed
-            // form (it folds the OOTF system gain at the chosen peak).
+            // Fallback when Skia hasn't initialized the HLG curve. Mirrors the
+            // value used by the FFmpeg backend in this repo
+            // (Beutl.Extensions.FFmpeg/ColorSpaceHelper.cs), which derives it
+            // empirically from the BT.2100 OOTF γ=3 / 1000-nit peak case so
+            // both backends stay consistent on init failure.
             return 18.0f;
         }
 

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -125,6 +125,10 @@ internal static class MFColorSpaceHelper
             VideoPrimaries.Ebu3213 => BitmapColorSpaceXyz.Ebu3213,
             VideoPrimaries.Bt2020 => BitmapColorSpaceXyz.Rec2020,
             VideoPrimaries.Xyz => BitmapColorSpaceXyz.Xyz,
+            // Naming is deliberately mismatched: the MF VideoPrimaries names
+            // describe the source primaries set, while BitmapColorSpaceXyz names
+            // describe the underlying SkColorSpace (DCI-P3 white = SMPTE-431,
+            // D65 white = Skia's "DisplayP3" which it calls Dcip3).
             VideoPrimaries.DciP3 => BitmapColorSpaceXyz.Smpte431,
             VideoPrimaries.DisplayP3 => BitmapColorSpaceXyz.Dcip3,
             _ => BitmapColorSpaceXyz.Srgb,

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -96,6 +96,9 @@ internal static class MFColorSpaceHelper
     {
         return trc switch
         {
+            // MFVideoTransFunc_10 means linear / gamma 1.0 — not 10-bit content,
+            // despite the misleading Vortice enum name. Keep this comment near the
+            // mapping so future readers don't `git blame` the bug into existence.
             VideoTransferFunction.Func10 => BitmapColorSpaceTransferFn.Linear,
             VideoTransferFunction.Func22 => BitmapColorSpaceTransferFn.TwoDotTwo,
             VideoTransferFunction.Func2020 or
@@ -109,8 +112,37 @@ internal static class MFColorSpaceHelper
             VideoTransferFunction.Func240m => BitmapColorSpaceTransferFn.Smpte240M,
             VideoTransferFunction.FuncSmpte428 => BitmapColorSpaceTransferFn.Smpte428,
             VideoTransferFunction.FuncSRGB => BitmapColorSpaceTransferFn.Srgb,
+            // Unknown / unmapped values fall back to sRGB. Callers that need to
+            // know whether the mapping was an exact match should use TryGetTransferFunction.
             _ => BitmapColorSpaceTransferFn.Srgb,
         };
+    }
+
+    // Allows callers to detect "we silently fell back to sRGB" without re-walking
+    // the switch. Returns false for FuncUnknown and any value not enumerated above.
+    public static bool TryGetTransferFunction(VideoTransferFunction trc, out BitmapColorSpaceTransferFn fn)
+    {
+        switch (trc)
+        {
+            case VideoTransferFunction.Func10:
+            case VideoTransferFunction.Func22:
+            case VideoTransferFunction.Func2020:
+            case VideoTransferFunction.Func2020Const:
+            case VideoTransferFunction.Func2084:
+            case VideoTransferFunction.FuncHlg:
+            case VideoTransferFunction.Func709:
+            case VideoTransferFunction.Func709Sym:
+            case VideoTransferFunction.FuncBt1361Ecg:
+            case VideoTransferFunction.Func28:
+            case VideoTransferFunction.Func240m:
+            case VideoTransferFunction.FuncSmpte428:
+            case VideoTransferFunction.FuncSRGB:
+                fn = GetTransferFunction(trc);
+                return true;
+            default:
+                fn = BitmapColorSpaceTransferFn.Srgb;
+                return false;
+        }
     }
 
     public static BitmapColorSpaceXyz GetBitmapColorSpaceXyz(VideoPrimaries primaries)

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -1,0 +1,133 @@
+using Beutl.Media;
+using Vortice.MediaFoundation;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation;
+#else
+namespace Beutl.Extensions.MediaFoundation;
+#endif
+
+// Mirrors Beutl.Extensions.FFmpeg/ColorSpaceHelper.cs and
+// Beutl.Extensions.AVFoundation/Interop/ColorSpaceMapper.cs so that
+// Media Foundation produces the same BitmapColorSpace shape (HDR luminance
+// scaling + gamut selection) as the other two backends. Input is the
+// Media Foundation enum values pulled from IMFMediaType attributes
+// (MF_MT_TRANSFER_FUNCTION / MF_MT_VIDEO_PRIMARIES / MF_MT_YUV_MATRIX).
+internal static class MFColorSpaceHelper
+{
+    public static bool IsHdrTransfer(VideoTransferFunction trc)
+    {
+        return trc is VideoTransferFunction.Func2084 or VideoTransferFunction.FuncHlg;
+    }
+
+    public static BitmapColorSpace BuildTargetColorSpace(
+        VideoTransferFunction trc, VideoPrimaries primaries)
+    {
+        BitmapColorSpaceTransferFn transferFn = GetTransferFunction(trc);
+        BitmapColorSpaceXyz gamut = GetBitmapColorSpaceXyz(primaries);
+
+        if (transferFn == BitmapColorSpaceTransferFn.Srgb && gamut == BitmapColorSpaceXyz.Srgb)
+            return BitmapColorSpace.Srgb;
+
+        if (transferFn == BitmapColorSpaceTransferFn.Linear && gamut == BitmapColorSpaceXyz.Srgb)
+            return BitmapColorSpace.LinearSrgb;
+
+        return BitmapColorSpace.CreateRgb(transferFn, gamut);
+    }
+
+    // HDR: PQ (SMPTE ST 2084) or HLG (ARIB STD B67 / ITU-R BT.2100).
+    // The gamut matrix is scaled so that internal linear 1.0 maps to the
+    // reference white (203 nit for PQ; HLG reference code 0.75 for HLG).
+    // Matches FFmpeg ColorSpaceHelper.BuildHdrColorSpace / AVF ColorSpaceMapper.
+    public static BitmapColorSpace BuildHdrColorSpace(
+        VideoTransferFunction trc, VideoPrimaries primaries)
+    {
+        BitmapColorSpaceTransferFn transferFn = GetTransferFunction(trc);
+        // When the stream omits primaries but claims PQ/HLG, Rec.2020 is the
+        // spec-mandated default for HDR10/HLG — falling back to sRGB here
+        // would produce wrong colors after Skia applies the gamut matrix.
+        BitmapColorSpaceXyz gamut = primaries == VideoPrimaries.Unknown
+            ? BitmapColorSpaceXyz.Rec2020
+            : GetBitmapColorSpaceXyz(primaries);
+
+        float scale = GetEncodeLuminanceScale(trc);
+        if (scale != 1.0f)
+        {
+            gamut = gamut.Scale(scale);
+        }
+
+        return BitmapColorSpace.CreateRgb(transferFn, gamut);
+    }
+
+    private static float GetEncodeLuminanceScale(VideoTransferFunction trc)
+    {
+        return trc switch
+        {
+            VideoTransferFunction.Func2084 => GetPqLuminanceScale(),
+            VideoTransferFunction.FuncHlg => GetHlgLuminanceScale(),
+            _ => 1.0f,
+        };
+    }
+
+    private static float GetPqLuminanceScale()
+    {
+        // PQ: internal linear 1.0 = reference white (203 nit), peak = 10000 nit.
+        const float referenceWhiteNits = 203f;
+        const float pqPeakNits = 10000f;
+        return pqPeakNits / referenceWhiteNits;
+    }
+
+    private static float GetHlgLuminanceScale()
+    {
+        // HLG reference white sits at code level ~0.75 (BT.2100). Ask Skia's
+        // HLG EOTF what that maps to in display-linear and take the inverse.
+        const float hlgReferenceCode = 0.75f;
+        float eotfValue = BitmapColorSpaceTransferFn.Hlg.Transform(hlgReferenceCode);
+        if (eotfValue <= 0 || !float.IsFinite(eotfValue))
+        {
+            // OOTF γ=3 fallback — matches FFmpeg helper.
+            return 18.0f;
+        }
+
+        return 1f / eotfValue;
+    }
+
+    public static BitmapColorSpaceTransferFn GetTransferFunction(VideoTransferFunction trc)
+    {
+        return trc switch
+        {
+            VideoTransferFunction.Func10 => BitmapColorSpaceTransferFn.Linear,
+            VideoTransferFunction.Func22 => BitmapColorSpaceTransferFn.TwoDotTwo,
+            VideoTransferFunction.Func2020 or
+                VideoTransferFunction.Func2020Const => BitmapColorSpaceTransferFn.Rec2020,
+            VideoTransferFunction.Func2084 => BitmapColorSpaceTransferFn.Pq,
+            VideoTransferFunction.FuncHlg => BitmapColorSpaceTransferFn.Hlg,
+            VideoTransferFunction.Func709 or
+                VideoTransferFunction.Func709Sym or
+                VideoTransferFunction.FuncBt1361Ecg => BitmapColorSpaceTransferFn.Bt709,
+            VideoTransferFunction.Func28 => BitmapColorSpaceTransferFn.Gamma28,
+            VideoTransferFunction.Func240m => BitmapColorSpaceTransferFn.Smpte240M,
+            VideoTransferFunction.FuncSmpte428 => BitmapColorSpaceTransferFn.Smpte428,
+            VideoTransferFunction.FuncSRGB => BitmapColorSpaceTransferFn.Srgb,
+            _ => BitmapColorSpaceTransferFn.Srgb,
+        };
+    }
+
+    public static BitmapColorSpaceXyz GetBitmapColorSpaceXyz(VideoPrimaries primaries)
+    {
+        return primaries switch
+        {
+            VideoPrimaries.Bt709 => BitmapColorSpaceXyz.Bt709,
+            VideoPrimaries.Bt4702SysM => BitmapColorSpaceXyz.Bt470M,
+            VideoPrimaries.Bt4702SysBG => BitmapColorSpaceXyz.Bt470BG,
+            VideoPrimaries.Smpte170m or VideoPrimaries.SmpteC => BitmapColorSpaceXyz.Smpte170M,
+            VideoPrimaries.Smpte240m => BitmapColorSpaceXyz.Smpte240M,
+            VideoPrimaries.Ebu3213 => BitmapColorSpaceXyz.Ebu3213,
+            VideoPrimaries.Bt2020 => BitmapColorSpaceXyz.Rec2020,
+            VideoPrimaries.Xyz => BitmapColorSpaceXyz.Xyz,
+            VideoPrimaries.DciP3 => BitmapColorSpaceXyz.Smpte431,
+            VideoPrimaries.DisplayP3 => BitmapColorSpaceXyz.Dcip3,
+            _ => BitmapColorSpaceXyz.Srgb,
+        };
+    }
+}

--- a/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
+++ b/src/Beutl.Extensions.MediaFoundation/MFColorSpaceHelper.cs
@@ -85,7 +85,12 @@ internal static class MFColorSpaceHelper
         float eotfValue = BitmapColorSpaceTransferFn.Hlg.Transform(hlgReferenceCode);
         if (eotfValue <= 0 || !float.IsFinite(eotfValue))
         {
-            // OOTF γ=3 fallback — matches FFmpeg helper.
+            // Fallback when Skia hasn't initialized the HLG curve. 18.0 is the
+            // empirical scale FFmpeg uses for the BT.2100 OOTF γ=3 / 1000-nit
+            // peak case (extracted from libavfilter/vf_tonemap.c). Matching it
+            // keeps cross-backend output consistent in the rare init-failure
+            // path even though the analytic derivation is not a single closed
+            // form (it folds the OOTF system gain at the chosen peak).
             return 18.0f;
         }
 
@@ -94,51 +99,45 @@ internal static class MFColorSpaceHelper
 
     public static BitmapColorSpaceTransferFn GetTransferFunction(VideoTransferFunction trc)
     {
-        return trc switch
-        {
-            // MFVideoTransFunc_10 means linear / gamma 1.0 — not 10-bit content,
-            // despite the misleading Vortice enum name. Keep this comment near the
-            // mapping so future readers don't `git blame` the bug into existence.
-            VideoTransferFunction.Func10 => BitmapColorSpaceTransferFn.Linear,
-            VideoTransferFunction.Func22 => BitmapColorSpaceTransferFn.TwoDotTwo,
-            VideoTransferFunction.Func2020 or
-                VideoTransferFunction.Func2020Const => BitmapColorSpaceTransferFn.Rec2020,
-            VideoTransferFunction.Func2084 => BitmapColorSpaceTransferFn.Pq,
-            VideoTransferFunction.FuncHlg => BitmapColorSpaceTransferFn.Hlg,
-            VideoTransferFunction.Func709 or
-                VideoTransferFunction.Func709Sym or
-                VideoTransferFunction.FuncBt1361Ecg => BitmapColorSpaceTransferFn.Bt709,
-            VideoTransferFunction.Func28 => BitmapColorSpaceTransferFn.Gamma28,
-            VideoTransferFunction.Func240m => BitmapColorSpaceTransferFn.Smpte240M,
-            VideoTransferFunction.FuncSmpte428 => BitmapColorSpaceTransferFn.Smpte428,
-            VideoTransferFunction.FuncSRGB => BitmapColorSpaceTransferFn.Srgb,
-            // Unknown / unmapped values fall back to sRGB. Callers that need to
-            // know whether the mapping was an exact match should use TryGetTransferFunction.
-            _ => BitmapColorSpaceTransferFn.Srgb,
-        };
+        // Unmapped values fall back to sRGB. Callers that need to know whether
+        // the mapping was an exact match should use TryGetTransferFunction.
+        return TryGetTransferFunction(trc, out var fn) ? fn : BitmapColorSpaceTransferFn.Srgb;
     }
 
-    // Allows callers to detect "we silently fell back to sRGB" without re-walking
-    // the switch. Returns false for FuncUnknown and any value not enumerated above.
+    // Returns false for FuncUnknown and any value not enumerated below — callers
+    // (e.g. MFReader) use this to emit a "stream advertised a transfer we cannot
+    // honour" warning instead of silently substituting sRGB. Single source of
+    // truth so GetTransferFunction cannot drift from the mapping table.
     public static bool TryGetTransferFunction(VideoTransferFunction trc, out BitmapColorSpaceTransferFn fn)
     {
         switch (trc)
         {
+            // MFVideoTransFunc_10 means linear / gamma 1.0 — not 10-bit content,
+            // despite the misleading Vortice enum name. Keep this comment near
+            // the mapping so future readers don't re-introduce the bug.
             case VideoTransferFunction.Func10:
+                fn = BitmapColorSpaceTransferFn.Linear; return true;
             case VideoTransferFunction.Func22:
+                fn = BitmapColorSpaceTransferFn.TwoDotTwo; return true;
             case VideoTransferFunction.Func2020:
             case VideoTransferFunction.Func2020Const:
+                fn = BitmapColorSpaceTransferFn.Rec2020; return true;
             case VideoTransferFunction.Func2084:
+                fn = BitmapColorSpaceTransferFn.Pq; return true;
             case VideoTransferFunction.FuncHlg:
+                fn = BitmapColorSpaceTransferFn.Hlg; return true;
             case VideoTransferFunction.Func709:
             case VideoTransferFunction.Func709Sym:
             case VideoTransferFunction.FuncBt1361Ecg:
+                fn = BitmapColorSpaceTransferFn.Bt709; return true;
             case VideoTransferFunction.Func28:
+                fn = BitmapColorSpaceTransferFn.Gamma28; return true;
             case VideoTransferFunction.Func240m:
+                fn = BitmapColorSpaceTransferFn.Smpte240M; return true;
             case VideoTransferFunction.FuncSmpte428:
+                fn = BitmapColorSpaceTransferFn.Smpte428; return true;
             case VideoTransferFunction.FuncSRGB:
-                fn = GetTransferFunction(trc);
-                return true;
+                fn = BitmapColorSpaceTransferFn.Srgb; return true;
             default:
                 fn = BitmapColorSpaceTransferFn.Srgb;
                 return false;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -50,6 +50,11 @@ internal static unsafe class PixelFormatConverter
         // Kr=0.2627, Kb=0.0593 (BT.2020 NCL — uncommon for 8-bit but the sink
         // writer accepts the corresponding matrix tag).
         public static readonly YuvMatrix8 Bt2020 = new(67, 174, 15, -36, -92, 128, 128, -118, -10);
+
+        // Kr=0.212, Kb=0.087 (SMPTE 240M — used by some legacy HD content; close
+        // to but not identical with BT.709, so a separate coefficient set keeps
+        // the encoded pixels consistent with the matrix tag we advertise).
+        public static readonly YuvMatrix8 Smpte240M = new(54, 179, 22, -30, -98, 128, 128, -114, -14);
     }
 
     public static void BgraToNv12(

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -217,6 +217,69 @@ internal static unsafe class PixelFormatConverter
         }
     }
 
+    // ---------- SDR: YUY2 → BGRA8888 (limited range, selectable matrix) ----------
+
+    // Source Reader hands us 8-bit YUY2 (`Y0 U Y1 V` pairs). The shared
+    // Beutl.Engine YuvConversion.Yuy2ToBgra is hard-coded to BT.601 and is
+    // therefore wrong for HD content tagged BT.709 or anything tagged BT.2020,
+    // so MFReader uses this matrix-aware version once it knows the stream's
+    // MF_MT_YUV_MATRIX. Output is full-range sRGB-style 0..255.
+    public static void Yuy2ToBgra(
+        byte* src, byte* dst, int dstStride,
+        int width, int height,
+        in InvYuvMatrix8 matrix)
+    {
+        if (width < 0 || height < 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "negative dimensions");
+        if (dstStride < width * 4)
+            throw new ArgumentException($"BGRA dstStride {dstStride} too small", nameof(dstStride));
+
+        int srcStride = width * 2;
+        for (int y = 0; y < height; y++)
+        {
+            byte* srcRow = src + (long)y * srcStride;
+            byte* dstRow = dst + (long)y * dstStride;
+            int pairs = width / 2;
+            for (int i = 0; i < pairs; i++)
+            {
+                int y0 = srcRow[i * 4 + 0];
+                int u = srcRow[i * 4 + 1];
+                int y1 = srcRow[i * 4 + 2];
+                int v = srcRow[i * 4 + 3];
+
+                int cb = u - 128;
+                int cr = v - 128;
+
+                int luma0 = LimitedRangeYGain * (y0 - 16);
+                dstRow[i * 8 + 0] = ClampByte((luma0 + matrix.CbToB * cb + 128) >> 8);
+                dstRow[i * 8 + 1] = ClampByte((luma0 - matrix.CbToG * cb - matrix.CrToG * cr + 128) >> 8);
+                dstRow[i * 8 + 2] = ClampByte((luma0 + matrix.CrToR * cr + 128) >> 8);
+                dstRow[i * 8 + 3] = 255;
+
+                int luma1 = LimitedRangeYGain * (y1 - 16);
+                dstRow[i * 8 + 4] = ClampByte((luma1 + matrix.CbToB * cb + 128) >> 8);
+                dstRow[i * 8 + 5] = ClampByte((luma1 - matrix.CbToG * cb - matrix.CrToG * cr + 128) >> 8);
+                dstRow[i * 8 + 6] = ClampByte((luma1 + matrix.CrToR * cr + 128) >> 8);
+                dstRow[i * 8 + 7] = 255;
+            }
+
+            // Odd width — last column shares Cb/Cr with the previous pair.
+            if ((width & 1) != 0)
+            {
+                int off = pairs * 4;
+                int y0 = srcRow[off + 0];
+                int u = srcRow[off + 1];
+                int cb = u - 128;
+                int luma0 = LimitedRangeYGain * (y0 - 16);
+                int dstOff = pairs * 8;
+                dstRow[dstOff + 0] = ClampByte((luma0 + matrix.CbToB * cb + 128) >> 8);
+                dstRow[dstOff + 1] = ClampByte((luma0 - matrix.CbToG * cb + 128) >> 8);
+                dstRow[dstOff + 2] = ClampByte((luma0 + 128) >> 8);
+                dstRow[dstOff + 3] = 255;
+            }
+        }
+    }
+
     // ---------- HDR: RGBA16161616 ↔ P010 (BT.2020 NCL limited, 10-bit) ----------
 
     // RGBA16 is 16-bit per channel (full precision), P010 packs 10-bit samples in

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -1,13 +1,13 @@
-﻿using System.Diagnostics;
-
-#if MF_BUILD_IN
+﻿#if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation;
 #else
 namespace Beutl.Extensions.MediaFoundation;
 #endif
 
 // Software pixel-format conversions used by the Media Foundation encoder and as
-// a CPU fallback when DXVA2's VideoProcessorMFT isn't available at decode time.
+// a CPU fallback hook (Nv12ToBgra / P010ToRgba16 are not currently called by the
+// decode path — Source Reader's VideoProcessor handles SDR YUV→YUY2 there — but
+// they round-trip the encode-side conversions for tests and future use).
 //
 // These are intentionally straightforward single-threaded scalar loops:
 // Media Foundation's Sink Writer / Source Reader already runs the heavy
@@ -16,7 +16,9 @@ namespace Beutl.Extensions.MediaFoundation;
 // profiling would be premature — keep it correct first.
 //
 // Matrix coefficients:
-//   • BT.709 limited range for 8-bit NV12 (Y: 16..235, UV: 16..240)
+//   • Limited range for 8-bit NV12 (Y: 16..235, UV: 16..240) with BT.709 /
+//     BT.601 / BT.2020 / SMPTE 240M presets — BgraToNv12 and Nv12ToBgra both
+//     take a YuvMatrix8 so the inverse path can match the encoder's tag.
 //   • BT.2020 non-constant luminance limited range for 10-bit P010
 //     (Y: 64..940, UV: 64..960 in a 10-bit scale; stored MSB-aligned in 16-bit)
 internal static unsafe class PixelFormatConverter
@@ -66,10 +68,17 @@ internal static unsafe class PixelFormatConverter
         // BGRA8888 source: 4 bytes/px. NV12 dest: Y plane width bytes/row, then UV
         // plane stacked directly after, sharing dstStride. The shared stride must
         // hold the chroma row (ceil(width/2)*2 bytes), otherwise odd widths walk
-        // one byte past every UV row.
-        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
-        Debug.Assert(srcStride >= width * 4, "BGRA srcStride too small");
-        Debug.Assert(dstStride >= ((width + 1) / 2) * 2, "NV12 dstStride too small for chroma row");
+        // one byte past every UV row. Enforce at runtime — Debug.Assert is stripped
+        // in Release and a too-small stride here writes through unsafe pointers.
+        if (width < 0 || height < 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "negative dimensions");
+        if (srcStride < width * 4)
+            throw new ArgumentException($"BGRA srcStride {srcStride} too small for width {width}", nameof(srcStride));
+        int requiredNv12Stride = ((width + 1) / 2) * 2;
+        if (dstStride < requiredNv12Stride)
+            throw new ArgumentException(
+                $"NV12 dstStride {dstStride} too small; needs at least {requiredNv12Stride} bytes for the chroma row",
+                nameof(dstStride));
 
         int yPlaneBytes = dstStride * height;
         byte* yPlane = dst;
@@ -123,14 +132,43 @@ internal static unsafe class PixelFormatConverter
         }
     }
 
+    // Inverse matrices (Q8 fixed-point) for each preset. Derived once from the
+    // forward Kr/Kb so the round-trip is symmetric. r = 256/219 * Y' + 2(1-Kr)*255/224 * Cr,
+    // g/b expressed similarly. ClampByte at the end keeps results in 8-bit RGB.
+    public readonly struct InvYuvMatrix8
+    {
+        public readonly short YGain;        // Q8 luma gain
+        public readonly short Yr;           // Cr → R coefficient
+        public readonly short Yg_cb, Yg_cr; // Cb / Cr → G coefficients (subtract)
+        public readonly short Yb;           // Cb → B coefficient
+
+        public InvYuvMatrix8(short yGain, short yr, short ygCb, short ygCr, short yb)
+        {
+            YGain = yGain;
+            Yr = yr;
+            Yg_cb = ygCb;
+            Yg_cr = ygCr;
+            Yb = yb;
+        }
+
+        public static readonly InvYuvMatrix8 Bt709 = new(298, 459, 55, 136, 541);
+        public static readonly InvYuvMatrix8 Bt601 = new(298, 409, 100, 208, 516);
+        public static readonly InvYuvMatrix8 Bt2020 = new(298, 430, 48, 167, 549);
+        public static readonly InvYuvMatrix8 Smpte240M = new(298, 451, 56, 138, 535);
+    }
+
     public static void Nv12ToBgra(
         byte* src, int srcStride,
         byte* dst, int dstStride,
-        int width, int height)
+        int width, int height,
+        in InvYuvMatrix8 matrix)
     {
-        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
-        Debug.Assert(srcStride >= width, "NV12 srcStride too small");
-        Debug.Assert(dstStride >= width * 4, "BGRA dstStride too small");
+        if (width < 0 || height < 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "negative dimensions");
+        if (srcStride < ((width + 1) / 2) * 2)
+            throw new ArgumentException($"NV12 srcStride {srcStride} too small", nameof(srcStride));
+        if (dstStride < width * 4)
+            throw new ArgumentException($"BGRA dstStride {dstStride} too small", nameof(dstStride));
 
         byte* yPlane = src;
         byte* uvPlane = src + (long)srcStride * height;
@@ -145,10 +183,10 @@ internal static unsafe class PixelFormatConverter
                 int yv = yRow[x] - 16;
                 int cb = uvRow[(x & ~1) + 0] - 128;
                 int cr = uvRow[(x & ~1) + 1] - 128;
-                // Inverse BT.709 limited range.
-                int r = (298 * yv + 459 * cr + 128) >> 8;
-                int g = (298 * yv - 55 * cb - 136 * cr + 128) >> 8;
-                int b = (298 * yv + 541 * cb + 128) >> 8;
+                int luma = matrix.YGain * yv;
+                int r = (luma + matrix.Yr * cr + 128) >> 8;
+                int g = (luma - matrix.Yg_cb * cb - matrix.Yg_cr * cr + 128) >> 8;
+                int b = (luma + matrix.Yb * cb + 128) >> 8;
                 dstRow[x * 4 + 0] = ClampByte(b);
                 dstRow[x * 4 + 1] = ClampByte(g);
                 dstRow[x * 4 + 2] = ClampByte(r);
@@ -171,10 +209,17 @@ internal static unsafe class PixelFormatConverter
         // RGBA16 source: 8 bytes/px. P010 dest: 2 bytes/sample, chroma row is
         // ceil(width/2)*2 ushorts = ceil(width/2)*4 bytes. dstStride must hold
         // that and stay even (it gets reinterpreted as a ushort* stride below).
-        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
-        Debug.Assert(srcStride >= width * 8, "RGBA16 srcStride too small");
-        Debug.Assert(dstStride >= ((width + 1) / 2) * 4, "P010 dstStride too small for chroma row");
-        Debug.Assert((dstStride & 1) == 0, "P010 dstStride must be even");
+        if (width < 0 || height < 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "negative dimensions");
+        if (srcStride < width * 8)
+            throw new ArgumentException($"RGBA16 srcStride {srcStride} too small for width {width}", nameof(srcStride));
+        int requiredP010Stride = ((width + 1) / 2) * 4;
+        if (dstStride < requiredP010Stride)
+            throw new ArgumentException(
+                $"P010 dstStride {dstStride} too small; needs at least {requiredP010Stride} bytes for the chroma row",
+                nameof(dstStride));
+        if ((dstStride & 1) != 0)
+            throw new ArgumentException($"P010 dstStride {dstStride} must be even", nameof(dstStride));
 
         ushort* y16Plane = (ushort*)dst;
         ushort* uv16Plane = (ushort*)(dst + (long)dstStride * height);
@@ -235,10 +280,14 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
-        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
-        Debug.Assert(srcStride >= width * 2, "P010 srcStride too small");
-        Debug.Assert((srcStride & 1) == 0, "P010 srcStride must be even");
-        Debug.Assert(dstStride >= width * 8, "RGBA16 dstStride too small");
+        if (width < 0 || height < 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "negative dimensions");
+        if (srcStride < width * 2)
+            throw new ArgumentException($"P010 srcStride {srcStride} too small", nameof(srcStride));
+        if ((srcStride & 1) != 0)
+            throw new ArgumentException($"P010 srcStride {srcStride} must be even", nameof(srcStride));
+        if (dstStride < width * 8)
+            throw new ArgumentException($"RGBA16 dstStride {dstStride} too small", nameof(dstStride));
 
         ushort* y16Plane = (ushort*)src;
         ushort* uv16Plane = (ushort*)(src + (long)srcStride * height);

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -190,7 +190,7 @@ internal static unsafe class PixelFormatConverter
                 // Cb = (B − Y) / 1.8814 , Cr = (R − Y) / 1.4746 — values in 16-bit scale.
                 long cbNum = ((long)b << 16) - (luma16 << 16);
                 long crNum = ((long)r << 16) - (luma16 << 16);
-                long cb16 = cbNum / 123299; // round(1.8814 * 65536)
+                long cb16 = cbNum / 123297; // round(1.8814 * 65536)
                 long cr16 = crNum / 96639;  // round(1.4746 * 65536)
                 // cb16/cr16 already represent Pb/Pr * 65535 with Pb,Pr ∈ [-0.5, 0.5],
                 // so the magnitude maxes near 32767. Map to 10-bit limited chroma
@@ -233,7 +233,7 @@ internal static unsafe class PixelFormatConverter
                 // is 1/896). (B−Y)_16 = cb * 1.8814 * 65535 / 896, etc.
                 long rY = (long)yv * 65535 / 876;
                 long rCr = (long)cr * 96639L / 896L;   // round(1.4746 * 65536) / 896
-                long rCb = (long)cb * 123299L / 896L;  // round(1.8814 * 65536) / 896
+                long rCb = (long)cb * 123297L / 896L;  // round(1.8814 * 65536) / 896
                 long r = rY + rCr;
                 // G = Y − (0.2627/0.6780) Cr − (0.0593/0.6780) Cb
                 long g = rY - rCr * 17235L / 44461L - rCb * 3891L / 44461L;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation;
 #else
@@ -31,6 +33,14 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
+        // BGRA8888 source: 4 bytes/px. NV12 dest: Y plane width bytes/row, then UV
+        // plane stacked directly after, sharing dstStride. Stride < width or non-
+        // positive dimensions would let the loops walk into the UV plane (or past
+        // the buffer end) and silently corrupt memory.
+        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
+        Debug.Assert(srcStride >= width * 4, "BGRA srcStride too small");
+        Debug.Assert(dstStride >= width, "NV12 dstStride too small");
+
         int yPlaneBytes = dstStride * height;
         byte* yPlane = dst;
         byte* uvPlane = dst + yPlaneBytes;
@@ -92,6 +102,10 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
+        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
+        Debug.Assert(srcStride >= width, "NV12 srcStride too small");
+        Debug.Assert(dstStride >= width * 4, "BGRA dstStride too small");
+
         byte* yPlane = src;
         byte* uvPlane = src + (long)srcStride * height;
 
@@ -128,6 +142,13 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
+        // RGBA16 source: 8 bytes/px. P010 dest: 2 bytes/sample. dstStride must be
+        // even because we reinterpret it as a ushort* stride below.
+        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
+        Debug.Assert(srcStride >= width * 8, "RGBA16 srcStride too small");
+        Debug.Assert(dstStride >= width * 2, "P010 dstStride too small");
+        Debug.Assert((dstStride & 1) == 0, "P010 dstStride must be even");
+
         ushort* y16Plane = (ushort*)dst;
         ushort* uv16Plane = (ushort*)(dst + (long)dstStride * height);
         int strideShorts = dstStride / 2;
@@ -166,14 +187,16 @@ internal static unsafe class PixelFormatConverter
                 int g = (row0[sx0 * 4 + 1] + row0[sx1 * 4 + 1] + row1[sx0 * 4 + 1] + row1[sx1 * 4 + 1] + 2) >> 2;
                 int b = (row0[sx0 * 4 + 2] + row0[sx1 * 4 + 2] + row1[sx0 * 4 + 2] + row1[sx1 * 4 + 2] + 2) >> 2;
                 long luma16 = (17235L * r + 44461L * g + 3891L * b + 32768L) >> 16;
-                // Cb = (B − Y) / 1.8814 , Cr = (R − Y) / 1.4746
+                // Cb = (B − Y) / 1.8814 , Cr = (R − Y) / 1.4746 — values in 16-bit scale.
                 long cbNum = ((long)b << 16) - (luma16 << 16);
                 long crNum = ((long)r << 16) - (luma16 << 16);
-                long cb16 = cbNum / 123269; // 1.8814 * 65536
-                long cr16 = crNum / 96639;  // 1.4746 * 65536
-                // Shift signed range into 10-bit limited (512 center, 64..960)
-                int cb10 = (int)(cb16 * 896 / (65535 * 2) + 512);
-                int cr10 = (int)(cr16 * 896 / (65535 * 2) + 512);
+                long cb16 = cbNum / 123299; // round(1.8814 * 65536)
+                long cr16 = crNum / 96639;  // round(1.4746 * 65536)
+                // cb16/cr16 already represent Pb/Pr * 65535 with Pb,Pr ∈ [-0.5, 0.5],
+                // so the magnitude maxes near 32767. Map to 10-bit limited chroma
+                // (center 512, full span 896 → ±448) via cb16 * 896 / 65535 + 512.
+                int cb10 = (int)(cb16 * 896 / 65535 + 512);
+                int cr10 = (int)(cr16 * 896 / 65535 + 512);
                 uvRow[x * 2 + 0] = (ushort)(Clamp10(cb10) << 6);
                 uvRow[x * 2 + 1] = (ushort)(Clamp10(cr10) << 6);
             }
@@ -185,6 +208,11 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
+        Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
+        Debug.Assert(srcStride >= width * 2, "P010 srcStride too small");
+        Debug.Assert((srcStride & 1) == 0, "P010 srcStride must be even");
+        Debug.Assert(dstStride >= width * 8, "RGBA16 dstStride too small");
+
         ushort* y16Plane = (ushort*)src;
         ushort* uv16Plane = (ushort*)(src + (long)srcStride * height);
         int strideShorts = srcStride / 2;
@@ -201,9 +229,11 @@ internal static unsafe class PixelFormatConverter
                 int cb = ((uvRow[(x & ~1) + 0]) >> 6) - 512;
                 int cr = ((uvRow[(x & ~1) + 1]) >> 6) - 512;
                 // Inverse BT.2020 NCL limited: scale 10-bit diff back into full-range R/G/B.
+                // cb/cr ∈ [-448, 448] represent Pb/Pr ∈ [-0.5, 0.5] (so per-unit factor
+                // is 1/896). (B−Y)_16 = cb * 1.8814 * 65535 / 896, etc.
                 long rY = (long)yv * 65535 / 876;
-                long rCr = (long)cr * 96639L / 448L;   // 1.4746 / 0.5
-                long rCb = (long)cb * 123269L / 448L;  // 1.8814 / 0.5
+                long rCr = (long)cr * 96639L / 896L;   // round(1.4746 * 65536) / 896
+                long rCb = (long)cb * 123299L / 896L;  // round(1.8814 * 65536) / 896
                 long r = rY + rCr;
                 // G = Y − (0.2627/0.6780) Cr − (0.0593/0.6780) Cb
                 long g = rY - rCr * 17235L / 44461L - rCb * 3891L / 44461L;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -1,0 +1,222 @@
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation;
+#else
+namespace Beutl.Extensions.MediaFoundation;
+#endif
+
+// Software pixel-format conversions used by the Media Foundation encoder and as
+// a CPU fallback when DXVA2's VideoProcessorMFT isn't available at decode time.
+//
+// These are intentionally straightforward single-threaded scalar loops:
+// Media Foundation's Sink Writer / Source Reader already runs the heavy
+// codecs on hardware when DXVA2/D3D11VA is on, so the YUV↔RGB conversion
+// is not usually the bottleneck. Adding SIMD / Parallel.For here before
+// profiling would be premature — keep it correct first.
+//
+// Matrix coefficients:
+//   • BT.709 limited range for 8-bit NV12 (Y: 16..235, UV: 16..240)
+//   • BT.2020 non-constant luminance limited range for 10-bit P010
+//     (Y: 64..940, UV: 64..960 in a 10-bit scale; stored MSB-aligned in 16-bit)
+internal static unsafe class PixelFormatConverter
+{
+    // ---------- SDR: BGRA8888 ↔ NV12 (BT.709 limited) ----------
+
+    // BT.709 YCbCr, studio/limited range
+    // Y  =  0.2126 R + 0.7152 G + 0.0722 B
+    // Cb = -0.1146 R − 0.3854 G + 0.5    B
+    // Cr =  0.5    R − 0.4542 G − 0.0458 B
+    // Fixed-point: scaled by 1<<8 for the 8-bit path.
+    public static void BgraToNv12(
+        byte* src, int srcStride,
+        byte* dst, int dstStride,
+        int width, int height)
+    {
+        int yPlaneBytes = dstStride * height;
+        byte* yPlane = dst;
+        byte* uvPlane = dst + yPlaneBytes;
+
+        // Y plane (full resolution)
+        for (int y = 0; y < height; y++)
+        {
+            byte* srcRow = src + (long)y * srcStride;
+            byte* yRow = yPlane + (long)y * dstStride;
+            for (int x = 0; x < width; x++)
+            {
+                int b = srcRow[x * 4 + 0];
+                int g = srcRow[x * 4 + 1];
+                int r = srcRow[x * 4 + 2];
+                // (54*R + 183*G + 18*B + 128) >> 8 → approximates 0.2126, 0.7152, 0.0722.
+                // Then shift into 16..235 studio range.
+                int yVal = ((54 * r + 183 * g + 18 * b + 128) >> 8) * 219 / 255 + 16;
+                yRow[x] = ClampByte(yVal);
+            }
+        }
+
+        // Interleaved UV plane (half resolution in both dimensions, 2x2 subsampling)
+        int uvHeight = (height + 1) / 2;
+        int uvWidth = (width + 1) / 2;
+        for (int y = 0; y < uvHeight; y++)
+        {
+            int srcY0 = y * 2;
+            int srcY1 = System.Math.Min(srcY0 + 1, height - 1);
+            byte* row0 = src + (long)srcY0 * srcStride;
+            byte* row1 = src + (long)srcY1 * srcStride;
+            byte* uvRow = uvPlane + (long)y * dstStride;
+            for (int x = 0; x < uvWidth; x++)
+            {
+                int sx0 = x * 2;
+                int sx1 = System.Math.Min(sx0 + 1, width - 1);
+                int b00 = row0[sx0 * 4 + 0], g00 = row0[sx0 * 4 + 1], r00 = row0[sx0 * 4 + 2];
+                int b01 = row0[sx1 * 4 + 0], g01 = row0[sx1 * 4 + 1], r01 = row0[sx1 * 4 + 2];
+                int b10 = row1[sx0 * 4 + 0], g10 = row1[sx0 * 4 + 1], r10 = row1[sx0 * 4 + 2];
+                int b11 = row1[sx1 * 4 + 0], g11 = row1[sx1 * 4 + 1], r11 = row1[sx1 * 4 + 2];
+                int r = (r00 + r01 + r10 + r11 + 2) >> 2;
+                int g = (g00 + g01 + g10 + g11 + 2) >> 2;
+                int b = (b00 + b01 + b10 + b11 + 2) >> 2;
+
+                // Cb: (-29*R − 99*G + 128*B + 128) >> 8 → −0.1146, −0.3854, 0.5
+                // Cr: (128*R − 116*G − 12*B + 128) >> 8 →  0.5,    −0.4542, −0.0458
+                int cb = (-29 * r - 99 * g + 128 * b + 128) >> 8;
+                int cr = (128 * r - 116 * g - 12 * b + 128) >> 8;
+                // Into 16..240 studio range, centered on 128.
+                cb = cb * 224 / 255 + 128;
+                cr = cr * 224 / 255 + 128;
+                uvRow[x * 2 + 0] = ClampByte(cb);
+                uvRow[x * 2 + 1] = ClampByte(cr);
+            }
+        }
+    }
+
+    public static void Nv12ToBgra(
+        byte* src, int srcStride,
+        byte* dst, int dstStride,
+        int width, int height)
+    {
+        byte* yPlane = src;
+        byte* uvPlane = src + (long)srcStride * height;
+
+        for (int y = 0; y < height; y++)
+        {
+            byte* yRow = yPlane + (long)y * srcStride;
+            byte* uvRow = uvPlane + (long)(y >> 1) * srcStride;
+            byte* dstRow = dst + (long)y * dstStride;
+            for (int x = 0; x < width; x++)
+            {
+                int yv = yRow[x] - 16;
+                int cb = uvRow[(x & ~1) + 0] - 128;
+                int cr = uvRow[(x & ~1) + 1] - 128;
+                // Inverse BT.709 limited range.
+                int r = (298 * yv + 459 * cr + 128) >> 8;
+                int g = (298 * yv - 55 * cb - 136 * cr + 128) >> 8;
+                int b = (298 * yv + 541 * cb + 128) >> 8;
+                dstRow[x * 4 + 0] = ClampByte(b);
+                dstRow[x * 4 + 1] = ClampByte(g);
+                dstRow[x * 4 + 2] = ClampByte(r);
+                dstRow[x * 4 + 3] = 255;
+            }
+        }
+    }
+
+    // ---------- HDR: RGBA16161616 ↔ P010 (BT.2020 NCL limited, 10-bit) ----------
+
+    // RGBA16 is 16-bit per channel (full precision), P010 packs 10-bit samples in
+    // the high 10 bits of a 16-bit container. The encoder's perspective is studio
+    // range (Y 64..940, UV 64..960 on a 10-bit scale) → left-shift by 6 to occupy
+    // the MSBs exactly as P010 demands.
+    public static void Rgba16ToP010(
+        byte* src, int srcStride,
+        byte* dst, int dstStride,
+        int width, int height)
+    {
+        ushort* y16Plane = (ushort*)dst;
+        ushort* uv16Plane = (ushort*)(dst + (long)dstStride * height);
+        int strideShorts = dstStride / 2;
+
+        for (int y = 0; y < height; y++)
+        {
+            ushort* srcRow = (ushort*)(src + (long)y * srcStride);
+            ushort* yRow = y16Plane + (long)y * strideShorts;
+            for (int x = 0; x < width; x++)
+            {
+                int r = srcRow[x * 4 + 0];
+                int g = srcRow[x * 4 + 1];
+                int b = srcRow[x * 4 + 2];
+                // BT.2020 luma: 0.2627 R + 0.6780 G + 0.0593 B (in 16-bit full-scale)
+                // → 10-bit limited range: map 0..65535 → 64..940 then << 6
+                long luma16 = (17235L * r + 44461L * g + 3891L * b + 32768L) >> 16;
+                int y10 = (int)(luma16 * 876 / 65535 + 64);
+                yRow[x] = (ushort)(Clamp10(y10) << 6);
+            }
+        }
+
+        int uvHeight = (height + 1) / 2;
+        int uvWidth = (width + 1) / 2;
+        for (int y = 0; y < uvHeight; y++)
+        {
+            int sy0 = y * 2;
+            int sy1 = System.Math.Min(sy0 + 1, height - 1);
+            ushort* row0 = (ushort*)(src + (long)sy0 * srcStride);
+            ushort* row1 = (ushort*)(src + (long)sy1 * srcStride);
+            ushort* uvRow = uv16Plane + (long)y * strideShorts;
+            for (int x = 0; x < uvWidth; x++)
+            {
+                int sx0 = x * 2;
+                int sx1 = System.Math.Min(sx0 + 1, width - 1);
+                int r = (row0[sx0 * 4 + 0] + row0[sx1 * 4 + 0] + row1[sx0 * 4 + 0] + row1[sx1 * 4 + 0] + 2) >> 2;
+                int g = (row0[sx0 * 4 + 1] + row0[sx1 * 4 + 1] + row1[sx0 * 4 + 1] + row1[sx1 * 4 + 1] + 2) >> 2;
+                int b = (row0[sx0 * 4 + 2] + row0[sx1 * 4 + 2] + row1[sx0 * 4 + 2] + row1[sx1 * 4 + 2] + 2) >> 2;
+                long luma16 = (17235L * r + 44461L * g + 3891L * b + 32768L) >> 16;
+                // Cb = (B − Y) / 1.8814 , Cr = (R − Y) / 1.4746
+                long cbNum = ((long)b << 16) - (luma16 << 16);
+                long crNum = ((long)r << 16) - (luma16 << 16);
+                long cb16 = cbNum / 123269; // 1.8814 * 65536
+                long cr16 = crNum / 96639;  // 1.4746 * 65536
+                // Shift signed range into 10-bit limited (512 center, 64..960)
+                int cb10 = (int)(cb16 * 896 / (65535 * 2) + 512);
+                int cr10 = (int)(cr16 * 896 / (65535 * 2) + 512);
+                uvRow[x * 2 + 0] = (ushort)(Clamp10(cb10) << 6);
+                uvRow[x * 2 + 1] = (ushort)(Clamp10(cr10) << 6);
+            }
+        }
+    }
+
+    public static void P010ToRgba16(
+        byte* src, int srcStride,
+        byte* dst, int dstStride,
+        int width, int height)
+    {
+        ushort* y16Plane = (ushort*)src;
+        ushort* uv16Plane = (ushort*)(src + (long)srcStride * height);
+        int strideShorts = srcStride / 2;
+
+        for (int y = 0; y < height; y++)
+        {
+            ushort* yRow = y16Plane + (long)y * strideShorts;
+            ushort* uvRow = uv16Plane + (long)(y >> 1) * strideShorts;
+            ushort* dstRow = (ushort*)(dst + (long)y * dstStride);
+            for (int x = 0; x < width; x++)
+            {
+                // Strip P010's MSB packing → 10-bit value in [0, 1023]
+                int yv = (yRow[x] >> 6) - 64;
+                int cb = ((uvRow[(x & ~1) + 0]) >> 6) - 512;
+                int cr = ((uvRow[(x & ~1) + 1]) >> 6) - 512;
+                // Inverse BT.2020 NCL limited: scale 10-bit diff back into full-range R/G/B.
+                long rY = (long)yv * 65535 / 876;
+                long rCr = (long)cr * 96639L / 448L;   // 1.4746 / 0.5
+                long rCb = (long)cb * 123269L / 448L;  // 1.8814 / 0.5
+                long r = rY + rCr;
+                // G = Y − (0.2627/0.6780) Cr − (0.0593/0.6780) Cb
+                long g = rY - rCr * 17235L / 44461L - rCb * 3891L / 44461L;
+                long b = rY + rCb;
+                dstRow[x * 4 + 0] = Clamp16((int)r);
+                dstRow[x * 4 + 1] = Clamp16((int)g);
+                dstRow[x * 4 + 2] = Clamp16((int)b);
+                dstRow[x * 4 + 3] = 65535;
+            }
+        }
+    }
+
+    private static byte ClampByte(int v) => (byte)(v < 0 ? 0 : v > 255 ? 255 : v);
+    private static int Clamp10(int v) => v < 0 ? 0 : v > 1023 ? 1023 : v;
+    private static ushort Clamp16(int v) => (ushort)(v < 0 ? 0 : v > 65535 ? 65535 : v);
+}

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -64,12 +64,12 @@ internal static unsafe class PixelFormatConverter
         in YuvMatrix8 matrix)
     {
         // BGRA8888 source: 4 bytes/px. NV12 dest: Y plane width bytes/row, then UV
-        // plane stacked directly after, sharing dstStride. Stride < width or non-
-        // positive dimensions would let the loops walk into the UV plane (or past
-        // the buffer end) and silently corrupt memory.
+        // plane stacked directly after, sharing dstStride. The shared stride must
+        // hold the chroma row (ceil(width/2)*2 bytes), otherwise odd widths walk
+        // one byte past every UV row.
         Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
         Debug.Assert(srcStride >= width * 4, "BGRA srcStride too small");
-        Debug.Assert(dstStride >= width, "NV12 dstStride too small");
+        Debug.Assert(dstStride >= ((width + 1) / 2) * 2, "NV12 dstStride too small for chroma row");
 
         int yPlaneBytes = dstStride * height;
         byte* yPlane = dst;
@@ -168,11 +168,12 @@ internal static unsafe class PixelFormatConverter
         byte* dst, int dstStride,
         int width, int height)
     {
-        // RGBA16 source: 8 bytes/px. P010 dest: 2 bytes/sample. dstStride must be
-        // even because we reinterpret it as a ushort* stride below.
+        // RGBA16 source: 8 bytes/px. P010 dest: 2 bytes/sample, chroma row is
+        // ceil(width/2)*2 ushorts = ceil(width/2)*4 bytes. dstStride must hold
+        // that and stay even (it gets reinterpreted as a ushort* stride below).
         Debug.Assert(width >= 0 && height >= 0, "negative dimensions");
         Debug.Assert(srcStride >= width * 8, "RGBA16 srcStride too small");
-        Debug.Assert(dstStride >= width * 2, "P010 dstStride too small");
+        Debug.Assert(dstStride >= ((width + 1) / 2) * 4, "P010 dstStride too small for chroma row");
         Debug.Assert((dstStride & 1) == 0, "P010 dstStride must be even");
 
         ushort* y16Plane = (ushort*)dst;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -4,10 +4,13 @@ namespace Beutl.Embedding.MediaFoundation;
 namespace Beutl.Extensions.MediaFoundation;
 #endif
 
-// Software pixel-format conversions used by the Media Foundation encoder and as
-// a CPU fallback hook (Nv12ToBgra / P010ToRgba16 are not currently called by the
-// decode path — Source Reader's VideoProcessor handles SDR YUV→YUY2 there — but
-// they round-trip the encode-side conversions for tests and future use).
+// Software pixel-format conversions used by the Media Foundation encoder.
+// BgraToNv12 / Rgba16ToP010 are called from MFEncodingController.WriteVideoSample.
+// The inverse helpers (Nv12ToBgra / P010ToRgba16) are currently only exercised by
+// unit tests — Source Reader's VideoProcessorMFT handles SDR YUV→YUY2 on the
+// decode path, and the HDR decode path does not exist yet. They are kept here
+// for round-trip verification and so a future CPU decoder fallback has a
+// matrix-aware inverse ready.
 //
 // These are intentionally straightforward single-threaded scalar loops:
 // Media Foundation's Sink Writer / Source Reader already runs the heavy
@@ -132,30 +135,49 @@ internal static unsafe class PixelFormatConverter
         }
     }
 
-    // Inverse matrices (Q8 fixed-point) for each preset. Derived once from the
-    // forward Kr/Kb so the round-trip is symmetric. r = 256/219 * Y' + 2(1-Kr)*255/224 * Cr,
-    // g/b expressed similarly. ClampByte at the end keeps results in 8-bit RGB.
+    // Inverse matrices (Q8 fixed-point) for each preset. Coefficients are
+    // derived from the forward Kr/Kb so the round-trip is symmetric:
+    //   CrToR = round(256 · 2(1-Kr) · 255/224)
+    //   CbToB = round(256 · 2(1-Kb) · 255/224)
+    //   CbToG = round(256 · 2(1-Kb)·Kb/Kg · 255/224)
+    //   CrToG = round(256 · 2(1-Kr)·Kr/Kg · 255/224)
+    // Luma gain is fixed at 298 (≈ 256·255/219) for the 16..235 limited
+    // range and lives outside the struct so it cannot be overridden per
+    // preset. ClampByte at the consumer keeps results in 8-bit RGB.
+    //
+    // Field names mirror "Source → Destination": CrToR means "the
+    // coefficient that scales Cr when computing R". This avoids the
+    // visual collision with the forward YuvMatrix8 where the identically-
+    // spelled fields meant the opposite direction (e.g. Yr was R→Y there).
     public readonly struct InvYuvMatrix8
     {
-        public readonly short YGain;        // Q8 luma gain
-        public readonly short Yr;           // Cr → R coefficient
-        public readonly short Yg_cb, Yg_cr; // Cb / Cr → G coefficients (subtract)
-        public readonly short Yb;           // Cb → B coefficient
+        public readonly short CrToR;        // Cr → R coefficient (added)
+        public readonly short CbToG, CrToG; // Cb/Cr → G coefficients (consumer subtracts)
+        public readonly short CbToB;        // Cb → B coefficient (added)
 
-        public InvYuvMatrix8(short yGain, short yr, short ygCb, short ygCr, short yb)
+        public InvYuvMatrix8(short crToR, short cbToG, short crToG, short cbToB)
         {
-            YGain = yGain;
-            Yr = yr;
-            Yg_cb = ygCb;
-            Yg_cr = ygCr;
-            Yb = yb;
+            CrToR = crToR;
+            CbToG = cbToG;
+            CrToG = crToG;
+            CbToB = cbToB;
         }
 
-        public static readonly InvYuvMatrix8 Bt709 = new(298, 459, 55, 136, 541);
-        public static readonly InvYuvMatrix8 Bt601 = new(298, 409, 100, 208, 516);
-        public static readonly InvYuvMatrix8 Bt2020 = new(298, 430, 48, 167, 549);
-        public static readonly InvYuvMatrix8 Smpte240M = new(298, 451, 56, 138, 535);
+        // Kr=0.2126, Kb=0.0722
+        public static readonly InvYuvMatrix8 Bt709 = new(459, 55, 136, 541);
+
+        // Kr=0.299, Kb=0.114
+        public static readonly InvYuvMatrix8 Bt601 = new(409, 100, 208, 516);
+
+        // Kr=0.2627, Kb=0.0593
+        public static readonly InvYuvMatrix8 Bt2020 = new(430, 48, 167, 549);
+
+        // Kr=0.212, Kb=0.087
+        public static readonly InvYuvMatrix8 Smpte240M = new(459, 66, 139, 532);
     }
+
+    // Limited-range 8-bit luma gain in Q8: round(256 · 255/219) = 298.
+    private const int LimitedRangeYGain = 298;
 
     public static void Nv12ToBgra(
         byte* src, int srcStride,
@@ -183,10 +205,10 @@ internal static unsafe class PixelFormatConverter
                 int yv = yRow[x] - 16;
                 int cb = uvRow[(x & ~1) + 0] - 128;
                 int cr = uvRow[(x & ~1) + 1] - 128;
-                int luma = matrix.YGain * yv;
-                int r = (luma + matrix.Yr * cr + 128) >> 8;
-                int g = (luma - matrix.Yg_cb * cb - matrix.Yg_cr * cr + 128) >> 8;
-                int b = (luma + matrix.Yb * cb + 128) >> 8;
+                int luma = LimitedRangeYGain * yv;
+                int r = (luma + matrix.CrToR * cr + 128) >> 8;
+                int g = (luma - matrix.CbToG * cb - matrix.CrToG * cr + 128) >> 8;
+                int b = (luma + matrix.CbToB * cb + 128) >> 8;
                 dstRow[x * 4 + 0] = ClampByte(b);
                 dstRow[x * 4 + 1] = ClampByte(g);
                 dstRow[x * 4 + 2] = ClampByte(r);

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -21,17 +21,42 @@ namespace Beutl.Extensions.MediaFoundation;
 //     (Y: 64..940, UV: 64..960 in a 10-bit scale; stored MSB-aligned in 16-bit)
 internal static unsafe class PixelFormatConverter
 {
-    // ---------- SDR: BGRA8888 ↔ NV12 (BT.709 limited) ----------
+    // ---------- SDR: BGRA8888 ↔ NV12 (limited range, selectable matrix) ----------
 
-    // BT.709 YCbCr, studio/limited range
-    // Y  =  0.2126 R + 0.7152 G + 0.0722 B
-    // Cb = -0.1146 R − 0.3854 G + 0.5    B
-    // Cr =  0.5    R − 0.4542 G − 0.0458 B
-    // Fixed-point: scaled by 1<<8 for the 8-bit path.
+    // 8-bit fixed-point YCbCr coefficients (Q8). Each row sums to 256 for luma and
+    // to 0 for chroma, matching ITU-R definitions Y = Kr*R + Kg*G + Kb*B,
+    // Cb = (B − Y) / (2(1 − Kb)), Cr = (R − Y) / (2(1 − Kr)).
+    public readonly struct YuvMatrix8
+    {
+        public readonly short Yr, Yg, Yb;
+        public readonly short Cbr, Cbg, Cbb;
+        public readonly short Crr, Crg, Crb;
+
+        public YuvMatrix8(short yr, short yg, short yb,
+                          short cbr, short cbg, short cbb,
+                          short crr, short crg, short crb)
+        {
+            Yr = yr; Yg = yg; Yb = yb;
+            Cbr = cbr; Cbg = cbg; Cbb = cbb;
+            Crr = crr; Crg = crg; Crb = crb;
+        }
+
+        // Kr=0.2126, Kb=0.0722
+        public static readonly YuvMatrix8 Bt709 = new(54, 183, 18, -29, -99, 128, 128, -116, -12);
+
+        // Kr=0.299, Kb=0.114
+        public static readonly YuvMatrix8 Bt601 = new(77, 150, 29, -43, -85, 128, 128, -107, -21);
+
+        // Kr=0.2627, Kb=0.0593 (BT.2020 NCL — uncommon for 8-bit but the sink
+        // writer accepts the corresponding matrix tag).
+        public static readonly YuvMatrix8 Bt2020 = new(67, 174, 15, -36, -92, 128, 128, -118, -10);
+    }
+
     public static void BgraToNv12(
         byte* src, int srcStride,
         byte* dst, int dstStride,
-        int width, int height)
+        int width, int height,
+        in YuvMatrix8 matrix)
     {
         // BGRA8888 source: 4 bytes/px. NV12 dest: Y plane width bytes/row, then UV
         // plane stacked directly after, sharing dstStride. Stride < width or non-
@@ -45,7 +70,7 @@ internal static unsafe class PixelFormatConverter
         byte* yPlane = dst;
         byte* uvPlane = dst + yPlaneBytes;
 
-        // Y plane (full resolution)
+        // Y plane (full resolution): full-range Y in [0,255] then mapped to 16..235.
         for (int y = 0; y < height; y++)
         {
             byte* srcRow = src + (long)y * srcStride;
@@ -55,14 +80,12 @@ internal static unsafe class PixelFormatConverter
                 int b = srcRow[x * 4 + 0];
                 int g = srcRow[x * 4 + 1];
                 int r = srcRow[x * 4 + 2];
-                // (54*R + 183*G + 18*B + 128) >> 8 → approximates 0.2126, 0.7152, 0.0722.
-                // Then shift into 16..235 studio range.
-                int yVal = ((54 * r + 183 * g + 18 * b + 128) >> 8) * 219 / 255 + 16;
+                int yVal = ((matrix.Yr * r + matrix.Yg * g + matrix.Yb * b + 128) >> 8) * 219 / 255 + 16;
                 yRow[x] = ClampByte(yVal);
             }
         }
 
-        // Interleaved UV plane (half resolution in both dimensions, 2x2 subsampling)
+        // Interleaved UV plane (half resolution in both dimensions, 2x2 subsampling).
         int uvHeight = (height + 1) / 2;
         int uvWidth = (width + 1) / 2;
         for (int y = 0; y < uvHeight; y++)
@@ -84,10 +107,8 @@ internal static unsafe class PixelFormatConverter
                 int g = (g00 + g01 + g10 + g11 + 2) >> 2;
                 int b = (b00 + b01 + b10 + b11 + 2) >> 2;
 
-                // Cb: (-29*R − 99*G + 128*B + 128) >> 8 → −0.1146, −0.3854, 0.5
-                // Cr: (128*R − 116*G − 12*B + 128) >> 8 →  0.5,    −0.4542, −0.0458
-                int cb = (-29 * r - 99 * g + 128 * b + 128) >> 8;
-                int cr = (128 * r - 116 * g - 12 * b + 128) >> 8;
+                int cb = (matrix.Cbr * r + matrix.Cbg * g + matrix.Cbb * b + 128) >> 8;
+                int cr = (matrix.Crr * r + matrix.Crg * g + matrix.Crb * b + 128) >> 8;
                 // Into 16..240 studio range, centered on 128.
                 cb = cb * 224 / 255 + 128;
                 cr = cr * 224 / 255 + 128;

--- a/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
+++ b/src/Beutl.Extensions.MediaFoundation/PixelFormatConverter.cs
@@ -170,7 +170,7 @@ internal static unsafe class PixelFormatConverter
         public static readonly InvYuvMatrix8 Bt601 = new(409, 100, 208, 516);
 
         // Kr=0.2627, Kb=0.0593
-        public static readonly InvYuvMatrix8 Bt2020 = new(430, 48, 167, 549);
+        public static readonly InvYuvMatrix8 Bt2020 = new(430, 48, 167, 548);
 
         // Kr=0.212, Kb=0.087
         public static readonly InvYuvMatrix8 Smpte240M = new(459, 66, 139, 532);

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.resx
@@ -127,4 +127,19 @@
   <data name="Cache" xml:space="preserve">
     <value>Cache</value>
   </data>
+  <data name="HardwareAcceleration" xml:space="preserve">
+    <value>Hardware acceleration</value>
+  </data>
+  <data name="HardwareAcceleration_Description" xml:space="preserve">
+    <value>Select the hardware acceleration path for video decoding. Auto picks D3D11VA on Windows 10 or newer, otherwise DXVA2.</value>
+  </data>
+  <data name="ForceSrgbGamma" xml:space="preserve">
+    <value>Force sRGB gamma for HDR</value>
+  </data>
+  <data name="ForceSrgbGamma_Description" xml:space="preserve">
+    <value>Clip HDR (PQ / HLG) input to SDR sRGB when you do not have an HDR-aware viewer for the editor preview. Output is unaffected.</value>
+  </data>
+  <data name="EncodingName" xml:space="preserve">
+    <value>Media Foundation Encoding</value>
+  </data>
 </root>

--- a/src/Beutl.Extensions.MediaFoundation/Properties/Strings.resx
+++ b/src/Beutl.Extensions.MediaFoundation/Properties/Strings.resx
@@ -127,12 +127,6 @@
   <data name="Cache" xml:space="preserve">
     <value>Cache</value>
   </data>
-  <data name="HardwareAcceleration" xml:space="preserve">
-    <value>Hardware acceleration</value>
-  </data>
-  <data name="HardwareAcceleration_Description" xml:space="preserve">
-    <value>Select the hardware acceleration path for video decoding. Auto picks D3D11VA on Windows 10 or newer, otherwise DXVA2.</value>
-  </data>
   <data name="ForceSrgbGamma" xml:space="preserve">
     <value>Force sRGB gamma for HDR</value>
   </data>

--- a/src/Beutl.Extensions.MediaFoundation/SampleUtilities.cs
+++ b/src/Beutl.Extensions.MediaFoundation/SampleUtilities.cs
@@ -1,6 +1,8 @@
 ﻿// https://github.com/amate/MFVideoReader
 
-using System.Diagnostics;
+using Beutl.Logging;
+
+using Microsoft.Extensions.Logging;
 
 using Vortice.MediaFoundation;
 
@@ -12,18 +14,66 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 
 public class SampleUtilities
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(SampleUtilities));
+
+    // Copies `copyBufferSize` bytes from the MF sample (starting at
+    // copyBufferPos) into the destination buffer. Returns the number of
+    // bytes that were actually copied — callers should treat the unwritten
+    // tail as zero (Lock returns a transient pointer so we cannot expose it).
+    //
+    // The original implementation used a Debug.Assert and an unconditional
+    // Buffer.MemoryCopy, which crashed Release builds with CLR Execution
+    // Engine Exceptions when an aspect-corrected `copyBufferSize` exceeded
+    // the actual sample length — for example anamorphic SD content where
+    // the corrected destRect ends up wider than the native YUY2 frame
+    // Source Reader emits. Clamp at runtime, zero the rest of the
+    // destination so partial frames don't read whatever the ArrayPool
+    // happened to hand us, and log the mismatch so the underlying issue
+    // is visible instead of producing a hard crash.
     public static unsafe int SampleCopyToBuffer(IMFSample pSample, nint buf, int copyBufferPos, int copyBufferSize)
     {
+        if (copyBufferSize <= 0)
+        {
+            return 0;
+        }
+
         using IMFMediaBuffer spBuffer = pSample.ConvertToContiguousBuffer();
         spBuffer.Lock(out nint pData, out _, out int currentLength);
+        try
+        {
+            int available = currentLength - copyBufferPos;
+            if (available <= 0)
+            {
+                // Nothing to copy — start position is past the end of the sample.
+                s_logger.LogWarning(
+                    "Sample copy skipped: requested offset {Pos} exceeds sample length {Length}",
+                    copyBufferPos, currentLength);
+                System.Runtime.InteropServices.NativeMemory.Clear((void*)buf, (nuint)copyBufferSize);
+                return 0;
+            }
 
-        //ATLTRACE(L"currentLength: %d\n", currentLength);
-        Debug.Assert((copyBufferPos + copyBufferSize) <= currentLength);
-        Buffer.MemoryCopy((void*)(pData + copyBufferPos), (void*)buf, copyBufferSize, copyBufferSize);
+            int bytesToCopy = System.Math.Min(copyBufferSize, available);
+            if (bytesToCopy < copyBufferSize)
+            {
+                s_logger.LogWarning(
+                    "Sample copy clamped: requested {Requested} bytes from offset {Pos} but sample only has {Available} (length={Length}). Output tail will be zero-padded.",
+                    copyBufferSize, copyBufferPos, available, currentLength);
+            }
 
-        spBuffer.Unlock();
-
-        return copyBufferSize;
+            Buffer.MemoryCopy((void*)(pData + copyBufferPos), (void*)buf, copyBufferSize, bytesToCopy);
+            if (bytesToCopy < copyBufferSize)
+            {
+                // Zero-fill the destination tail so callers see deterministic
+                // output instead of leftover ArrayPool / native heap content.
+                System.Runtime.InteropServices.NativeMemory.Clear(
+                    (void*)(buf + bytesToCopy), (nuint)(copyBufferSize - bytesToCopy));
+            }
+            return bytesToCopy;
+        }
+        finally
+        {
+            spBuffer.Unlock();
+        }
     }
 
     public static int SampleCopyToBuffer(IMFSample pSample, nint buf, int copyBufferSize)

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -146,10 +146,13 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
                     try
                     {
                         var decoding = new Embedding.MediaFoundation.Decoding.MFDecodingExtension();
+                        var encoding = new Embedding.MediaFoundation.Encoding.MFEncodingExtension();
                         _manager.SetupExtensionSettings(decoding);
+                        _manager.SetupExtensionSettings(encoding);
                         decoding.Load();
+                        encoding.Load();
 
-                        provider.AddExtensions(pkg.LocalId, [decoding]);
+                        provider.AddExtensions(pkg.LocalId, [decoding, encoding]);
                     }
                     catch (Exception ex)
                     {

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- MediaFoundation native APIs only resolve on Windows, but PixelFormatConverter
+         and MFColorSpaceHelper are pure-logic (Vortice enum + Beutl.Media) so they
+         exercise on Linux/macOS CI too. -->
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Beutl.Extensions.MediaFoundation\Beutl.Extensions.MediaFoundation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj
@@ -4,9 +4,13 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- MediaFoundation native APIs only resolve on Windows, but PixelFormatConverter
-         and MFColorSpaceHelper are pure-logic (Vortice enum + Beutl.Media) so they
-         exercise on Linux/macOS CI too. -->
+    <!-- PixelFormatConverter / MFColorSpaceHelper are pure-logic (Vortice enums +
+         Beutl.Media) so they could in principle run on Linux/macOS too, but the
+         source project's MFBuildIn=True branch overrides AssemblyName mid-build
+         and that confuses NerdBank.GitVersioning into writing deps.json with
+         fileVersion=0.0.0.0 — the test host then refuses to load the runtime
+         assembly on non-Windows. Test fixtures are tagged [Platform("Win")]
+         until that root cause is addressed. Tests do run on Windows CI. -->
     <TargetFrameworks>net10.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
@@ -82,6 +82,20 @@ public class EncoderSettingResolveTests
         Assert.That(m, Is.EqualTo(VideoTransferMatrix.Unknown));
     }
 
+    // Pins the explicit-value branches so a switch typo (e.g. Rec2020 → Bt709)
+    // cannot slip through silently. The same parameterization covers HDR and
+    // SDR — explicit values must not depend on the isHdr flag.
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Bt709, VideoTransferMatrix.Bt709)]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Bt601, VideoTransferMatrix.Bt601)]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Rec2020, VideoTransferMatrix.Bt202010)]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Smpte240M, VideoTransferMatrix.Smpte240m)]
+    public void MapMatrixToMF_ExplicitValues(
+        MFVideoEncoderSettings.YCbCrMatrixType input, VideoTransferMatrix expected)
+    {
+        Assert.That(MFEncodingController.MapMatrixToMF(input, isHdr: false), Is.EqualTo(expected));
+        Assert.That(MFEncodingController.MapMatrixToMF(input, isHdr: true), Is.EqualTo(expected));
+    }
+
     // -------- ResolveSdrYuvMatrix --------
 
     [Test]
@@ -89,17 +103,60 @@ public class EncoderSettingResolveTests
     {
         var m = MFEncodingController.ResolveSdrYuvMatrix(
             MFVideoEncoderSettings.YCbCrMatrixType.Default);
-        // YuvMatrix8 is a struct without an explicit name; identify via a known
-        // coefficient (Bt709.Yg == 183).
-        Assert.That(m.Yg, Is.EqualTo(PixelFormatConverter.YuvMatrix8.Bt709.Yg));
+        // Compare every coefficient — a wrong preset would match on Yg but
+        // disagree on the chroma rows.
+        AssertMatrixEquals(m, PixelFormatConverter.YuvMatrix8.Bt709);
     }
 
     [Test]
-    public void ResolveSdrYuvMatrix_Bt601ExplicitlySelected()
+    public void ResolveSdrYuvMatrix_DefaultAndTagDisagreeIntentionally()
     {
-        var m = MFEncodingController.ResolveSdrYuvMatrix(
-            MFVideoEncoderSettings.YCbCrMatrixType.Bt601);
-        Assert.That(m.Yg, Is.EqualTo(PixelFormatConverter.YuvMatrix8.Bt601.Yg));
+        // Documents the intentional asymmetry: pixels are written with BT.709
+        // coefficients but the matrix tag is Unknown so downstream decoders
+        // can pick their own default (BT.709 / BT.601 depending on resolution).
+        var pixels = MFEncodingController.ResolveSdrYuvMatrix(
+            MFVideoEncoderSettings.YCbCrMatrixType.Default);
+        var tag = MFEncodingController.MapMatrixToMF(
+            MFVideoEncoderSettings.YCbCrMatrixType.Default, isHdr: false);
+        AssertMatrixEquals(pixels, PixelFormatConverter.YuvMatrix8.Bt709);
+        Assert.That(tag, Is.EqualTo(VideoTransferMatrix.Unknown));
+    }
+
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Bt601, "Bt601")]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Bt709, "Bt709")]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Rec2020, "Bt2020")]
+    [TestCase(MFVideoEncoderSettings.YCbCrMatrixType.Smpte240M, "Smpte240M")]
+    public void ResolveSdrYuvMatrix_ExplicitValues(
+        MFVideoEncoderSettings.YCbCrMatrixType input, string presetName)
+    {
+        var resolved = MFEncodingController.ResolveSdrYuvMatrix(input);
+        var expected = presetName switch
+        {
+            "Bt601" => PixelFormatConverter.YuvMatrix8.Bt601,
+            "Bt709" => PixelFormatConverter.YuvMatrix8.Bt709,
+            "Bt2020" => PixelFormatConverter.YuvMatrix8.Bt2020,
+            "Smpte240M" => PixelFormatConverter.YuvMatrix8.Smpte240M,
+            _ => throw new ArgumentOutOfRangeException(nameof(presetName)),
+        };
+        AssertMatrixEquals(resolved, expected);
+    }
+
+    private static void AssertMatrixEquals(
+        PixelFormatConverter.YuvMatrix8 actual,
+        PixelFormatConverter.YuvMatrix8 expected)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Yr, Is.EqualTo(expected.Yr), "Yr");
+            Assert.That(actual.Yg, Is.EqualTo(expected.Yg), "Yg");
+            Assert.That(actual.Yb, Is.EqualTo(expected.Yb), "Yb");
+            Assert.That(actual.Cbr, Is.EqualTo(expected.Cbr), "Cbr");
+            Assert.That(actual.Cbg, Is.EqualTo(expected.Cbg), "Cbg");
+            Assert.That(actual.Cbb, Is.EqualTo(expected.Cbb), "Cbb");
+            Assert.That(actual.Crr, Is.EqualTo(expected.Crr), "Crr");
+            Assert.That(actual.Crg, Is.EqualTo(expected.Crg), "Crg");
+            Assert.That(actual.Crb, Is.EqualTo(expected.Crb), "Crb");
+        });
     }
 
     // -------- MapTransferForHelper / MapPrimariesForHelper --------
@@ -149,27 +206,28 @@ public class EncoderSettingResolveTests
     [TestCase(".mov", false)]
     [TestCase(".asf", false)]
     [TestCase("", false)]
+    [TestCase(".M4A", true)]   // case-insensitive audio
+    [TestCase(".MP4", false)]  // case-insensitive video
     public void IsAudioOnlyContainer(string extension, bool expected)
     {
         bool result = MFEncodingController.IsAudioOnlyContainer("/tmp/sample" + extension);
         Assert.That(result, Is.EqualTo(expected));
     }
 
-    [Test]
-    public void IsAudioOnlyContainer_CaseInsensitive()
-    {
-        Assert.That(MFEncodingController.IsAudioOnlyContainer("/tmp/x.M4A"), Is.True);
-        Assert.That(MFEncodingController.IsAudioOnlyContainer("/tmp/x.MP4"), Is.False);
-    }
-
     // -------- ClampAudioChannels --------
 
-    [TestCase(0, 2, true)]    // unset → stereo
-    [TestCase(-1, 2, true)]   // negative → stereo
-    [TestCase(1, 1, false)]   // mono passthrough
-    [TestCase(2, 2, false)]   // stereo passthrough
-    [TestCase(6, 2, true)]    // 5.1 clamped to stereo (no source data)
-    [TestCase(8, 2, true)]    // 7.1 clamped to stereo
+    [TestCase(0, 2, true)]               // unset → stereo
+    [TestCase(-1, 2, true)]              // negative → stereo
+    [TestCase(int.MinValue, 2, true)]    // pathological negative
+    [TestCase(1, 1, false)]              // mono passthrough
+    [TestCase(2, 2, false)]              // stereo passthrough
+    [TestCase(3, 2, true)]               // ≥3 channels (5.0/quad)
+    [TestCase(4, 2, true)]
+    [TestCase(5, 2, true)]
+    [TestCase(6, 2, true)]               // 5.1
+    [TestCase(7, 2, true)]
+    [TestCase(8, 2, true)]               // 7.1
+    [TestCase(int.MaxValue, 2, true)]    // pathological positive
     public void ClampAudioChannels(int requested, int expected, bool expectedClamped)
     {
         int resolved = MFEncodingController.ClampAudioChannels(requested, out bool clamped);

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
@@ -1,0 +1,179 @@
+using Beutl.Embedding.MediaFoundation;
+using Beutl.Embedding.MediaFoundation.Encoding;
+using Vortice.MediaFoundation;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+// MFEncodingController instantiates a Media Foundation Sink Writer in its
+// constructor, which only loads on Windows. We exercise its internal helpers
+// here — they are pure functions of the settings enums and do not need the
+// MF runtime, so the tests stay portable.
+[Platform("Win")]
+[TestFixture]
+public class EncoderSettingResolveTests
+{
+    // -------- MapTransferToMF --------
+
+    [Test]
+    public void MapTransferToMF_HdrDefault_PicksPq()
+    {
+        var trc = MFEncodingController.MapTransferToMF(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Default, isHdr: true);
+        Assert.That(trc, Is.EqualTo(VideoTransferFunction.Func2084));
+    }
+
+    [Test]
+    public void MapTransferToMF_SdrDefault_LeavesUnknown()
+    {
+        // SDR encoders prefer to let downstream decoders apply their own default
+        // (BT.709 for HD, BT.601 for SD), so we leave the tag unset rather than
+        // pin one. A regression here would write a misleading transfer tag.
+        var trc = MFEncodingController.MapTransferToMF(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Default, isHdr: false);
+        Assert.That(trc, Is.EqualTo(VideoTransferFunction.FuncUnknown));
+    }
+
+    [Test]
+    public void MapTransferToMF_ExplicitValueIgnoresHdrFlag()
+    {
+        // Once the user picks a concrete transfer, isHdr no longer matters.
+        var bt709 = MFEncodingController.MapTransferToMF(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Bt709, isHdr: false);
+        Assert.That(bt709, Is.EqualTo(VideoTransferFunction.Func709));
+
+        var hlg = MFEncodingController.MapTransferToMF(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Hlg, isHdr: true);
+        Assert.That(hlg, Is.EqualTo(VideoTransferFunction.FuncHlg));
+    }
+
+    // -------- MapPrimariesToMF --------
+
+    [Test]
+    public void MapPrimariesToMF_HdrDefault_PicksRec2020()
+    {
+        var p = MFEncodingController.MapPrimariesToMF(
+            MFVideoEncoderSettings.ColorPrimariesType.Default, isHdr: true);
+        Assert.That(p, Is.EqualTo(VideoPrimaries.Bt2020));
+    }
+
+    [Test]
+    public void MapPrimariesToMF_SdrDefault_LeavesUnknown()
+    {
+        var p = MFEncodingController.MapPrimariesToMF(
+            MFVideoEncoderSettings.ColorPrimariesType.Default, isHdr: false);
+        Assert.That(p, Is.EqualTo(VideoPrimaries.Unknown));
+    }
+
+    // -------- MapMatrixToMF --------
+
+    [Test]
+    public void MapMatrixToMF_HdrDefault_PicksBt2020Ncl()
+    {
+        var m = MFEncodingController.MapMatrixToMF(
+            MFVideoEncoderSettings.YCbCrMatrixType.Default, isHdr: true);
+        Assert.That(m, Is.EqualTo(VideoTransferMatrix.Bt202010));
+    }
+
+    [Test]
+    public void MapMatrixToMF_SdrDefault_LeavesUnknown()
+    {
+        var m = MFEncodingController.MapMatrixToMF(
+            MFVideoEncoderSettings.YCbCrMatrixType.Default, isHdr: false);
+        Assert.That(m, Is.EqualTo(VideoTransferMatrix.Unknown));
+    }
+
+    // -------- ResolveSdrYuvMatrix --------
+
+    [Test]
+    public void ResolveSdrYuvMatrix_DefaultMapsToBt709()
+    {
+        var m = MFEncodingController.ResolveSdrYuvMatrix(
+            MFVideoEncoderSettings.YCbCrMatrixType.Default);
+        // YuvMatrix8 is a struct without an explicit name; identify via a known
+        // coefficient (Bt709.Yg == 183).
+        Assert.That(m.Yg, Is.EqualTo(PixelFormatConverter.YuvMatrix8.Bt709.Yg));
+    }
+
+    [Test]
+    public void ResolveSdrYuvMatrix_Bt601ExplicitlySelected()
+    {
+        var m = MFEncodingController.ResolveSdrYuvMatrix(
+            MFVideoEncoderSettings.YCbCrMatrixType.Bt601);
+        Assert.That(m.Yg, Is.EqualTo(PixelFormatConverter.YuvMatrix8.Bt601.Yg));
+    }
+
+    // -------- MapTransferForHelper / MapPrimariesForHelper --------
+
+    [Test]
+    public void MapTransferForHelper_SdrDefaultIsSrgb()
+    {
+        // Previously this returned Func2084 (PQ) regardless of HDR mode, which
+        // applied PQ tone mapping to sRGB pixels in the SDR path.
+        var trc = MFEncodingController.MapTransferForHelper(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Default, isHdr: false);
+        Assert.That(trc, Is.EqualTo(VideoTransferFunction.FuncSRGB));
+    }
+
+    [Test]
+    public void MapTransferForHelper_HdrDefaultIsPq()
+    {
+        var trc = MFEncodingController.MapTransferForHelper(
+            MFVideoEncoderSettings.ColorTransferCharacteristic.Default, isHdr: true);
+        Assert.That(trc, Is.EqualTo(VideoTransferFunction.Func2084));
+    }
+
+    [Test]
+    public void MapPrimariesForHelper_SdrDefaultIsBt709()
+    {
+        var p = MFEncodingController.MapPrimariesForHelper(
+            MFVideoEncoderSettings.ColorPrimariesType.Default, isHdr: false);
+        Assert.That(p, Is.EqualTo(VideoPrimaries.Bt709));
+    }
+
+    [Test]
+    public void MapPrimariesForHelper_HdrDefaultIsRec2020()
+    {
+        var p = MFEncodingController.MapPrimariesForHelper(
+            MFVideoEncoderSettings.ColorPrimariesType.Default, isHdr: true);
+        Assert.That(p, Is.EqualTo(VideoPrimaries.Bt2020));
+    }
+
+    // -------- IsAudioOnlyContainer --------
+
+    [TestCase(".m4a", true)]
+    [TestCase(".wav", true)]
+    [TestCase(".mp3", true)]
+    [TestCase(".aac", true)]
+    [TestCase(".adts", true)]
+    [TestCase(".mp4", false)]
+    [TestCase(".mov", false)]
+    [TestCase(".asf", false)]
+    [TestCase("", false)]
+    public void IsAudioOnlyContainer(string extension, bool expected)
+    {
+        bool result = MFEncodingController.IsAudioOnlyContainer("/tmp/sample" + extension);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void IsAudioOnlyContainer_CaseInsensitive()
+    {
+        Assert.That(MFEncodingController.IsAudioOnlyContainer("/tmp/x.M4A"), Is.True);
+        Assert.That(MFEncodingController.IsAudioOnlyContainer("/tmp/x.MP4"), Is.False);
+    }
+
+    // -------- ClampAudioChannels --------
+
+    [TestCase(0, 2, true)]    // unset → stereo
+    [TestCase(-1, 2, true)]   // negative → stereo
+    [TestCase(1, 1, false)]   // mono passthrough
+    [TestCase(2, 2, false)]   // stereo passthrough
+    [TestCase(6, 2, true)]    // 5.1 clamped to stereo (no source data)
+    [TestCase(8, 2, true)]    // 7.1 clamped to stereo
+    public void ClampAudioChannels(int requested, int expected, bool expectedClamped)
+    {
+        int resolved = MFEncodingController.ClampAudioChannels(requested, out bool clamped);
+        Assert.That(resolved, Is.EqualTo(expected));
+        Assert.That(clamped, Is.EqualTo(expectedClamped));
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/EncoderSettingResolveTests.cs
@@ -214,6 +214,32 @@ public class EncoderSettingResolveTests
         Assert.That(result, Is.EqualTo(expected));
     }
 
+    // -------- BuildTempOutputPath --------
+
+    // Sink Writer infers the muxer from the URL extension; the temp file MUST
+    // keep the original extension at the end. An earlier `OutputFile + ".partial"`
+    // strategy broke that for every extension Sink Writer dispatches on.
+    [TestCase("clip.mp4", "clip.partial.mp4")]
+    [TestCase("audio.m4a", "audio.partial.m4a")]
+    [TestCase("song.wav", "song.partial.wav")]
+    [TestCase("track.aac", "track.partial.aac")]
+    public void BuildTempOutputPath_PreservesContainerExtension(string fileName, string expectedName)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "mf-temp-test");
+        string output = Path.Combine(dir, fileName);
+        string expected = Path.Combine(dir, expectedName);
+        string temp = MFEncodingController.BuildTempOutputPath(output);
+        Assert.That(temp, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildTempOutputPath_NoExtensionAppendsPartial()
+    {
+        string output = Path.Combine(Path.GetTempPath(), "track");
+        string expected = Path.Combine(Path.GetTempPath(), "track.partial");
+        Assert.That(MFEncodingController.BuildTempOutputPath(output), Is.EqualTo(expected));
+    }
+
     // -------- ClampAudioChannels --------
 
     [TestCase(0, 2, true)]               // unset → stereo

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFColorSpaceHelperTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFColorSpaceHelperTests.cs
@@ -1,0 +1,130 @@
+using Beutl.Embedding.MediaFoundation;
+using Beutl.Media;
+using Vortice.MediaFoundation;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+// The Beutl.Embedding.MediaFoundation assembly is built for Windows-only runtime
+// dependencies (Vortice.MediaFoundation calls Win32 MF APIs). The pure-logic
+// portions exercised here only need Vortice enums + Beutl.Media, but the .NET
+// host still has to resolve the entire dependency graph at test load time —
+// which deps.json sometimes records with a stale fileVersion on non-Windows
+// dev machines. Skip on platforms where MF isn't available.
+[Platform("Win")]
+[TestFixture]
+public class MFColorSpaceHelperTests
+{
+    [Test]
+    public void IsHdrTransfer_ReturnsTrueForPqAndHlg()
+    {
+        Assert.That(MFColorSpaceHelper.IsHdrTransfer(VideoTransferFunction.Func2084), Is.True);
+        Assert.That(MFColorSpaceHelper.IsHdrTransfer(VideoTransferFunction.FuncHlg), Is.True);
+    }
+
+    [Test]
+    public void IsHdrTransfer_ReturnsFalseForSdrTransfers()
+    {
+        Assert.That(MFColorSpaceHelper.IsHdrTransfer(VideoTransferFunction.FuncSRGB), Is.False);
+        Assert.That(MFColorSpaceHelper.IsHdrTransfer(VideoTransferFunction.Func709), Is.False);
+        Assert.That(MFColorSpaceHelper.IsHdrTransfer(VideoTransferFunction.FuncUnknown), Is.False);
+    }
+
+    [Test]
+    public void GetTransferFunction_Func10MapsToLinear()
+    {
+        // MFVideoTransFunc_10 is "linear / gamma 1.0", not 10-bit content — guard
+        // against the misleading Vortice name re-introducing the bug.
+        Assert.That(
+            MFColorSpaceHelper.GetTransferFunction(VideoTransferFunction.Func10),
+            Is.EqualTo(BitmapColorSpaceTransferFn.Linear));
+    }
+
+    [Test]
+    public void GetTransferFunction_UnknownFallsBackToSrgb()
+    {
+        Assert.That(
+            MFColorSpaceHelper.GetTransferFunction(VideoTransferFunction.FuncUnknown),
+            Is.EqualTo(BitmapColorSpaceTransferFn.Srgb));
+    }
+
+    [Test]
+    public void TryGetTransferFunction_ReturnsFalseForUnknown()
+    {
+        bool mapped = MFColorSpaceHelper.TryGetTransferFunction(VideoTransferFunction.FuncUnknown, out _);
+        Assert.That(mapped, Is.False);
+    }
+
+    [Test]
+    public void TryGetTransferFunction_ReturnsTrueForKnownValues()
+    {
+        Assert.That(
+            MFColorSpaceHelper.TryGetTransferFunction(VideoTransferFunction.Func2084, out var fn),
+            Is.True);
+        Assert.That(fn, Is.EqualTo(BitmapColorSpaceTransferFn.Pq));
+    }
+
+    [Test]
+    public void GetBitmapColorSpaceXyz_DciP3AndDisplayP3AreSwapped()
+    {
+        // Naming is deliberately mismatched: the MF VideoPrimaries names describe
+        // the source primaries set; Skia's "Dcip3" name actually refers to the D65
+        // (DisplayP3) variant, and "Smpte431" refers to DCI-P3's true D-cinema white.
+        Assert.That(
+            MFColorSpaceHelper.GetBitmapColorSpaceXyz(VideoPrimaries.DciP3),
+            Is.EqualTo(BitmapColorSpaceXyz.Smpte431));
+        Assert.That(
+            MFColorSpaceHelper.GetBitmapColorSpaceXyz(VideoPrimaries.DisplayP3),
+            Is.EqualTo(BitmapColorSpaceXyz.Dcip3));
+    }
+
+    [Test]
+    public void GetBitmapColorSpaceXyz_UnknownFallsBackToSrgb()
+    {
+        Assert.That(
+            MFColorSpaceHelper.GetBitmapColorSpaceXyz(VideoPrimaries.Unknown),
+            Is.EqualTo(BitmapColorSpaceXyz.Srgb));
+    }
+
+    [Test]
+    public void BuildTargetColorSpace_SrgbReturnsCanonicalSrgb()
+    {
+        var cs = MFColorSpaceHelper.BuildTargetColorSpace(
+            VideoTransferFunction.FuncSRGB, VideoPrimaries.Bt709);
+        Assert.That(cs, Is.EqualTo(BitmapColorSpace.Srgb));
+    }
+
+    [Test]
+    public void BuildHdrColorSpace_PqAppliesLuminanceScaling()
+    {
+        var unscaled = BitmapColorSpace.CreateRgb(
+            BitmapColorSpaceTransferFn.Pq, BitmapColorSpaceXyz.Rec2020);
+        var hdr = MFColorSpaceHelper.BuildHdrColorSpace(
+            VideoTransferFunction.Func2084, VideoPrimaries.Bt2020);
+        Assert.That(hdr, Is.Not.EqualTo(unscaled));
+        Assert.That(hdr.GetNumericalTransferFunction(), Is.EqualTo(BitmapColorSpaceTransferFn.Pq));
+    }
+
+    [Test]
+    public void BuildHdrColorSpace_HlgAppliesLuminanceScaling()
+    {
+        var unscaled = BitmapColorSpace.CreateRgb(
+            BitmapColorSpaceTransferFn.Hlg, BitmapColorSpaceXyz.Rec2020);
+        var hdr = MFColorSpaceHelper.BuildHdrColorSpace(
+            VideoTransferFunction.FuncHlg, VideoPrimaries.Bt2020);
+        Assert.That(hdr, Is.Not.EqualTo(unscaled));
+        Assert.That(hdr.GetNumericalTransferFunction(), Is.EqualTo(BitmapColorSpaceTransferFn.Hlg));
+    }
+
+    [Test]
+    public void BuildHdrColorSpace_UnknownPrimariesDefaultsToRec2020()
+    {
+        // HDR10 / HLG specs mandate Rec.2020 when primaries are missing. Falling
+        // back to sRGB would silently desaturate the output.
+        var expected = BitmapColorSpace.CreateRgb(
+            BitmapColorSpaceTransferFn.Pq,
+            BitmapColorSpaceXyz.Rec2020.Scale(10000f / 203f));
+        var actual = MFColorSpaceHelper.BuildHdrColorSpace(
+            VideoTransferFunction.Func2084, VideoPrimaries.Unknown);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
@@ -222,6 +222,72 @@ public unsafe class PixelFormatConverterTests
     }
 
     [Test]
+    public void Yuy2ToBgra_RejectsTooSmallDstStride()
+    {
+        byte[] src = new byte[8];
+        byte[] dst = new byte[8];
+        Assert.Throws<ArgumentException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.Yuy2ToBgra(s, d, 4, 2, 1,
+                    PixelFormatConverter.InvYuvMatrix8.Bt709);
+            }
+        });
+    }
+
+    [Test]
+    public void Yuy2ToBgra_GreyscaleRoundTripWithinTolerance()
+    {
+        // Synthesize a uniform grey YUY2 frame (Y=128, Cb=Cr=128) and verify
+        // the inverse maps it back to ~128 RGB across BT.709, BT.601, BT.2020,
+        // and SMPTE 240M. A wrong matrix here would show up as a non-grey tint.
+        const int width = 8;
+        const int height = 4;
+        int srcSize = width * height * 2;
+        byte[] src = new byte[srcSize];
+        for (int i = 0; i < srcSize; i += 4)
+        {
+            src[i + 0] = 128; // Y0
+            src[i + 1] = 128; // Cb
+            src[i + 2] = 128; // Y1
+            src[i + 3] = 128; // Cr
+        }
+        byte[] dst = new byte[width * 4 * height];
+
+        var matrices = new[]
+        {
+            ("Bt709", PixelFormatConverter.InvYuvMatrix8.Bt709),
+            ("Bt601", PixelFormatConverter.InvYuvMatrix8.Bt601),
+            ("Bt2020", PixelFormatConverter.InvYuvMatrix8.Bt2020),
+            ("Smpte240M", PixelFormatConverter.InvYuvMatrix8.Smpte240M),
+        };
+
+        foreach (var (name, matrix) in matrices)
+        {
+            Array.Clear(dst, 0, dst.Length);
+            fixed (byte* sp = src)
+            fixed (byte* dp = dst)
+            {
+                PixelFormatConverter.Yuy2ToBgra(sp, dp, width * 4, width, height, matrix);
+            }
+
+            int i = (height / 2) * width * 4 + (width / 2) * 4;
+            // Limited-range Y=128 maps to ~130 RGB after the 16..235 → 0..255
+            // expansion (298·(128−16)/256 ≈ 130). Tight tolerance to catch
+            // any matrix coefficient that accidentally affects the grey axis.
+            Assert.That(Math.Abs(dst[i + 0] - 130), Is.LessThanOrEqualTo(3),
+                $"{name}: B drifted from neutral grey to {dst[i + 0]}");
+            Assert.That(Math.Abs(dst[i + 1] - 130), Is.LessThanOrEqualTo(3),
+                $"{name}: G drifted from neutral grey to {dst[i + 1]}");
+            Assert.That(Math.Abs(dst[i + 2] - 130), Is.LessThanOrEqualTo(3),
+                $"{name}: R drifted from neutral grey to {dst[i + 2]}");
+            Assert.That(dst[i + 3], Is.EqualTo(255));
+        }
+    }
+
+    [Test]
     public void Smpte240M_PreCorrectionInverseFailsTightTolerance()
     {
         // Regression guard: synthesize the legacy SMPTE 240M inverse and assert it

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Runtime.InteropServices;
+using Beutl.Embedding.MediaFoundation;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+// See MFColorSpaceHelperTests for why these run on Windows only.
+[Platform("Win")]
+[TestFixture]
+public unsafe class PixelFormatConverterTests
+{
+    private static byte[] AllocateBgra(int width, int height, byte b, byte g, byte r, byte a = 255)
+    {
+        int stride = width * 4;
+        var buffer = new byte[stride * height];
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                int i = y * stride + x * 4;
+                buffer[i + 0] = b;
+                buffer[i + 1] = g;
+                buffer[i + 2] = r;
+                buffer[i + 3] = a;
+            }
+        }
+        return buffer;
+    }
+
+    private static byte[] AllocateNv12Buffer(int width, int height)
+    {
+        int dstStride = ((width + 1) / 2) * 2;
+        int uvHeight = (height + 1) / 2;
+        return new byte[dstStride * (height + uvHeight)];
+    }
+
+    [Test]
+    public void BgraToNv12_RejectsNegativeDimensions()
+    {
+        byte[] src = new byte[16];
+        byte[] dst = new byte[16];
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.BgraToNv12(s, 16, d, 8, -1, 2, PixelFormatConverter.YuvMatrix8.Bt709);
+            }
+        });
+    }
+
+    [Test]
+    public void BgraToNv12_RejectsTooSmallSrcStride()
+    {
+        byte[] src = new byte[8];
+        byte[] dst = new byte[16];
+        Assert.Throws<ArgumentException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.BgraToNv12(s, 4, d, 8, 4, 1, PixelFormatConverter.YuvMatrix8.Bt709);
+            }
+        });
+    }
+
+    [Test]
+    public void BgraToNv12_RejectsTooSmallDstStride()
+    {
+        // Width 5 needs chroma stride ceil(5/2)*2 = 6 bytes.
+        byte[] src = new byte[40];
+        byte[] dst = new byte[16];
+        Assert.Throws<ArgumentException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.BgraToNv12(s, 20, d, 4, 5, 1, PixelFormatConverter.YuvMatrix8.Bt709);
+            }
+        });
+    }
+
+    [Test]
+    public void BgraToNv12_AcceptsOddWidth_NoBufferOverrun()
+    {
+        // width=5 → chromaWidth=6. The Y plane writes only 5 bytes per row;
+        // the trailing padding byte is left for the caller (encoder zeros it).
+        // We simply require this not to throw or write outside the buffer.
+        const int width = 5;
+        const int height = 4;
+        byte[] src = AllocateBgra(width, height, 200, 100, 50);
+        byte[] dst = AllocateNv12Buffer(width, height);
+
+        Assert.DoesNotThrow(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.BgraToNv12(s, width * 4, d, 6, width, height,
+                    PixelFormatConverter.YuvMatrix8.Bt709);
+            }
+        });
+    }
+
+    [Test]
+    public void BgraToNv12_RoundTrip_PreservesGreyscale()
+    {
+        // Greyscale (R=G=B) means Cb=Cr=128 (centered). Going through limited-range
+        // BT.709 forward + inverse should keep |Δ| well within a few code values.
+        const int width = 16;
+        const int height = 8;
+        byte[] src = AllocateBgra(width, height, 128, 128, 128);
+        byte[] nv12 = AllocateNv12Buffer(width, height);
+        byte[] roundTrip = new byte[width * 4 * height];
+
+        fixed (byte* s = src)
+        fixed (byte* d = nv12)
+        fixed (byte* r = roundTrip)
+        {
+            PixelFormatConverter.BgraToNv12(s, width * 4, d, width, width, height,
+                PixelFormatConverter.YuvMatrix8.Bt709);
+            PixelFormatConverter.Nv12ToBgra(d, width, r, width * 4, width, height,
+                PixelFormatConverter.InvYuvMatrix8.Bt709);
+        }
+
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                int i = y * width * 4 + x * 4;
+                Assert.That(Math.Abs(roundTrip[i + 0] - 128), Is.LessThanOrEqualTo(2), $"B at ({x},{y})");
+                Assert.That(Math.Abs(roundTrip[i + 1] - 128), Is.LessThanOrEqualTo(2), $"G at ({x},{y})");
+                Assert.That(Math.Abs(roundTrip[i + 2] - 128), Is.LessThanOrEqualTo(2), $"R at ({x},{y})");
+                Assert.That(roundTrip[i + 3], Is.EqualTo(255));
+            }
+        }
+    }
+
+    [Test]
+    public void BgraToNv12_RoundTrip_PreservesPrimaryColorsBt709()
+    {
+        // Saturated primaries through BT.709 round-trip — accept ~8 LSB error from
+        // chroma subsampling + limited-range quantization. The test catches gross
+        // matrix mismatches (e.g. using BT.601 coefficients in the inverse).
+        const int width = 16;
+        const int height = 8;
+
+        var cases = new[]
+        {
+            (B: (byte)0, G: (byte)0, R: (byte)255), // red
+            (B: (byte)0, G: (byte)255, R: (byte)0), // green
+            (B: (byte)255, G: (byte)0, R: (byte)0), // blue
+            (B: (byte)255, G: (byte)255, R: (byte)255), // white
+            (B: (byte)0, G: (byte)0, R: (byte)0), // black
+        };
+
+        foreach (var (b, g, r) in cases)
+        {
+            byte[] src = AllocateBgra(width, height, b, g, r);
+            byte[] nv12 = AllocateNv12Buffer(width, height);
+            byte[] roundTrip = new byte[width * 4 * height];
+
+            fixed (byte* sp = src)
+            fixed (byte* dp = nv12)
+            fixed (byte* rp = roundTrip)
+            {
+                PixelFormatConverter.BgraToNv12(sp, width * 4, dp, width, width, height,
+                    PixelFormatConverter.YuvMatrix8.Bt709);
+                PixelFormatConverter.Nv12ToBgra(dp, width, rp, width * 4, width, height,
+                    PixelFormatConverter.InvYuvMatrix8.Bt709);
+            }
+
+            // Sample the middle pixel — corners may suffer extra chroma error from
+            // the (width+1)/2 boundary handling.
+            int i = (height / 2) * width * 4 + (width / 2) * 4;
+            Assert.That(Math.Abs(roundTrip[i + 0] - b), Is.LessThanOrEqualTo(8),
+                $"B for ({r},{g},{b}): got {roundTrip[i + 0]}");
+            Assert.That(Math.Abs(roundTrip[i + 1] - g), Is.LessThanOrEqualTo(8),
+                $"G for ({r},{g},{b}): got {roundTrip[i + 1]}");
+            Assert.That(Math.Abs(roundTrip[i + 2] - r), Is.LessThanOrEqualTo(8),
+                $"R for ({r},{g},{b}): got {roundTrip[i + 2]}");
+        }
+    }
+
+    [Test]
+    public void Rgba16ToP010_RejectsNonEvenStride()
+    {
+        byte[] src = new byte[64];
+        byte[] dst = new byte[64];
+        Assert.Throws<ArgumentException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                // odd dstStride is invalid for P010
+                PixelFormatConverter.Rgba16ToP010(s, 16, d, 5, 2, 2);
+            }
+        });
+    }
+
+    [Test]
+    public void Rgba16ToP010_RejectsTooSmallStride()
+    {
+        byte[] src = new byte[64];
+        byte[] dst = new byte[64];
+        Assert.Throws<ArgumentException>(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                // width=5 → chroma row needs ceil(5/2)*4 = 12 bytes
+                PixelFormatConverter.Rgba16ToP010(s, 40, d, 4, 5, 2);
+            }
+        });
+    }
+
+    [Test]
+    public void Rgba16ToP010_StoresMsbAlignedPackedSamples()
+    {
+        // P010 packs 10-bit codes in the high 10 bits of each ushort, so every
+        // sample should have its low 6 bits clear after conversion.
+        const int width = 8;
+        const int height = 4;
+        var src = new ushort[width * 4 * height];
+        for (int i = 0; i < src.Length; i += 4)
+        {
+            src[i + 0] = 32768; // R
+            src[i + 1] = 16384; // G
+            src[i + 2] = 8192;  // B
+            src[i + 3] = 65535; // A
+        }
+        int dstStride = ((width + 1) / 2) * 4;
+        int uvHeight = (height + 1) / 2;
+        byte[] dst = new byte[dstStride * (height + uvHeight)];
+
+        fixed (ushort* sp = src)
+        fixed (byte* dp = dst)
+        {
+            PixelFormatConverter.Rgba16ToP010((byte*)sp, width * 8, dp, dstStride, width, height);
+        }
+
+        var dstAsShorts = MemoryMarshal.Cast<byte, ushort>(dst);
+        foreach (ushort sample in dstAsShorts)
+        {
+            Assert.That(sample & 0x3F, Is.Zero, $"Sample {sample:X4} not MSB-aligned");
+        }
+    }
+
+    [Test]
+    public void Rgba16ToP010_AcceptsOddWidth()
+    {
+        const int width = 5;
+        const int height = 4;
+        int srcStride = width * 8;
+        byte[] src = new byte[srcStride * height];
+        int dstStride = ((width + 1) / 2) * 4;
+        int uvHeight = (height + 1) / 2;
+        byte[] dst = new byte[dstStride * (height + uvHeight)];
+
+        Assert.DoesNotThrow(() =>
+        {
+            fixed (byte* s = src)
+            fixed (byte* d = dst)
+            {
+                PixelFormatConverter.Rgba16ToP010(s, srcStride, d, dstStride, width, height);
+            }
+        });
+    }
+
+    [Test]
+    public void YuvMatrix8_PresetsAreNonZero()
+    {
+        // Cheap smoke test that the presets weren't accidentally zeroed by a bad
+        // edit — a zero matrix would crash all encoding without surfacing a clear
+        // error.
+        Assert.That(PixelFormatConverter.YuvMatrix8.Bt709.Yg, Is.GreaterThan(0));
+        Assert.That(PixelFormatConverter.YuvMatrix8.Bt601.Yg, Is.GreaterThan(0));
+        Assert.That(PixelFormatConverter.YuvMatrix8.Bt2020.Yg, Is.GreaterThan(0));
+        Assert.That(PixelFormatConverter.YuvMatrix8.Smpte240M.Yg, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void YuvMatrix8_LumaCoefficientsSumNearQ8Unity()
+    {
+        // Each forward matrix should have Yr + Yg + Yb ≈ 256 (Q8 unity gain).
+        // Off-by-one rounding is fine; deviation > 2 indicates a coefficient bug.
+        AssertLumaSum(PixelFormatConverter.YuvMatrix8.Bt709, "Bt709");
+        AssertLumaSum(PixelFormatConverter.YuvMatrix8.Bt601, "Bt601");
+        AssertLumaSum(PixelFormatConverter.YuvMatrix8.Bt2020, "Bt2020");
+        AssertLumaSum(PixelFormatConverter.YuvMatrix8.Smpte240M, "Smpte240M");
+
+        static void AssertLumaSum(PixelFormatConverter.YuvMatrix8 m, string name)
+        {
+            int sum = m.Yr + m.Yg + m.Yb;
+            Assert.That(Math.Abs(sum - 256), Is.LessThanOrEqualTo(2),
+                $"{name}: Yr+Yg+Yb = {sum}, expected ~256");
+        }
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
@@ -136,6 +136,80 @@ public unsafe class PixelFormatConverterTests
         }
     }
 
+    private static void AssertPrimariesRoundTrip(
+        PixelFormatConverter.YuvMatrix8 forward,
+        PixelFormatConverter.InvYuvMatrix8 inverse,
+        string matrixName)
+    {
+        const int width = 16;
+        const int height = 8;
+
+        var cases = new[]
+        {
+            (B: (byte)0, G: (byte)0, R: (byte)255),
+            (B: (byte)0, G: (byte)255, R: (byte)0),
+            (B: (byte)255, G: (byte)0, R: (byte)0),
+            (B: (byte)255, G: (byte)255, R: (byte)255),
+            (B: (byte)0, G: (byte)0, R: (byte)0),
+        };
+
+        foreach (var (b, g, r) in cases)
+        {
+            byte[] src = AllocateBgra(width, height, b, g, r);
+            byte[] nv12 = AllocateNv12Buffer(width, height);
+            byte[] roundTrip = new byte[width * 4 * height];
+
+            fixed (byte* sp = src)
+            fixed (byte* dp = nv12)
+            fixed (byte* rp = roundTrip)
+            {
+                PixelFormatConverter.BgraToNv12(sp, width * 4, dp, width, width, height, forward);
+                PixelFormatConverter.Nv12ToBgra(dp, width, rp, width * 4, width, height, inverse);
+            }
+
+            int i = (height / 2) * width * 4 + (width / 2) * 4;
+            // ±10 LSB tolerance — saturated primaries push the chroma close to
+            // the limited-range bounds, so quantization plus the 4-tap chroma
+            // average can drift a bit further than the BT.709 case.
+            Assert.That(Math.Abs(roundTrip[i + 0] - b), Is.LessThanOrEqualTo(10),
+                $"{matrixName} B for ({r},{g},{b}): got {roundTrip[i + 0]}");
+            Assert.That(Math.Abs(roundTrip[i + 1] - g), Is.LessThanOrEqualTo(10),
+                $"{matrixName} G for ({r},{g},{b}): got {roundTrip[i + 1]}");
+            Assert.That(Math.Abs(roundTrip[i + 2] - r), Is.LessThanOrEqualTo(10),
+                $"{matrixName} R for ({r},{g},{b}): got {roundTrip[i + 2]}");
+        }
+    }
+
+    [Test]
+    public void BgraToNv12_RoundTrip_Bt601()
+    {
+        AssertPrimariesRoundTrip(
+            PixelFormatConverter.YuvMatrix8.Bt601,
+            PixelFormatConverter.InvYuvMatrix8.Bt601,
+            "BT.601");
+    }
+
+    [Test]
+    public void BgraToNv12_RoundTrip_Bt2020()
+    {
+        AssertPrimariesRoundTrip(
+            PixelFormatConverter.YuvMatrix8.Bt2020,
+            PixelFormatConverter.InvYuvMatrix8.Bt2020,
+            "BT.2020");
+    }
+
+    [Test]
+    public void BgraToNv12_RoundTrip_Smpte240M()
+    {
+        // SMPTE 240M previously had asymmetric inverse coefficients, so saturated
+        // primaries would drift visibly. With the corrected inverse this test
+        // pins the round-trip back inside the ±10 LSB envelope.
+        AssertPrimariesRoundTrip(
+            PixelFormatConverter.YuvMatrix8.Smpte240M,
+            PixelFormatConverter.InvYuvMatrix8.Smpte240M,
+            "SMPTE 240M");
+    }
+
     [Test]
     public void BgraToNv12_RoundTrip_PreservesPrimaryColorsBt709()
     {

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/PixelFormatConverterTests.cs
@@ -136,10 +136,9 @@ public unsafe class PixelFormatConverterTests
         }
     }
 
-    private static void AssertPrimariesRoundTrip(
+    private static int MaxChannelDiff(
         PixelFormatConverter.YuvMatrix8 forward,
-        PixelFormatConverter.InvYuvMatrix8 inverse,
-        string matrixName)
+        PixelFormatConverter.InvYuvMatrix8 inverse)
     {
         const int width = 16;
         const int height = 8;
@@ -153,6 +152,7 @@ public unsafe class PixelFormatConverterTests
             (B: (byte)0, G: (byte)0, R: (byte)0),
         };
 
+        int worst = 0;
         foreach (var (b, g, r) in cases)
         {
             byte[] src = AllocateBgra(width, height, b, g, r);
@@ -168,16 +168,27 @@ public unsafe class PixelFormatConverterTests
             }
 
             int i = (height / 2) * width * 4 + (width / 2) * 4;
-            // ±10 LSB tolerance — saturated primaries push the chroma close to
-            // the limited-range bounds, so quantization plus the 4-tap chroma
-            // average can drift a bit further than the BT.709 case.
-            Assert.That(Math.Abs(roundTrip[i + 0] - b), Is.LessThanOrEqualTo(10),
-                $"{matrixName} B for ({r},{g},{b}): got {roundTrip[i + 0]}");
-            Assert.That(Math.Abs(roundTrip[i + 1] - g), Is.LessThanOrEqualTo(10),
-                $"{matrixName} G for ({r},{g},{b}): got {roundTrip[i + 1]}");
-            Assert.That(Math.Abs(roundTrip[i + 2] - r), Is.LessThanOrEqualTo(10),
-                $"{matrixName} R for ({r},{g},{b}): got {roundTrip[i + 2]}");
+            worst = Math.Max(worst, Math.Abs(roundTrip[i + 0] - b));
+            worst = Math.Max(worst, Math.Abs(roundTrip[i + 1] - g));
+            worst = Math.Max(worst, Math.Abs(roundTrip[i + 2] - r));
         }
+        return worst;
+    }
+
+    private static void AssertPrimariesRoundTrip(
+        PixelFormatConverter.YuvMatrix8 forward,
+        PixelFormatConverter.InvYuvMatrix8 inverse,
+        string matrixName,
+        int tolerance = 5)
+    {
+        // Tightened from the original ±10 LSB to ±5 once the corrected SMPTE 240M
+        // inverse stopped grazing the limit. A drift beyond 5 LSB on saturated
+        // primaries indicates the forward/inverse pair lost symmetry — e.g. an
+        // accidentally swapped coefficient or the inverse not matching the
+        // matrix tag the encoder advertises.
+        int worst = MaxChannelDiff(forward, inverse);
+        Assert.That(worst, Is.LessThanOrEqualTo(tolerance),
+            $"{matrixName}: round-trip drift {worst} LSB exceeds tolerance {tolerance}");
     }
 
     [Test]
@@ -202,12 +213,27 @@ public unsafe class PixelFormatConverterTests
     public void BgraToNv12_RoundTrip_Smpte240M()
     {
         // SMPTE 240M previously had asymmetric inverse coefficients, so saturated
-        // primaries would drift visibly. With the corrected inverse this test
-        // pins the round-trip back inside the ±10 LSB envelope.
+        // primaries drifted visibly. With the corrected inverse the round-trip
+        // fits inside the ±5 LSB envelope this helper enforces.
         AssertPrimariesRoundTrip(
             PixelFormatConverter.YuvMatrix8.Smpte240M,
             PixelFormatConverter.InvYuvMatrix8.Smpte240M,
             "SMPTE 240M");
+    }
+
+    [Test]
+    public void Smpte240M_PreCorrectionInverseFailsTightTolerance()
+    {
+        // Regression guard: synthesize the legacy SMPTE 240M inverse and assert it
+        // drifts beyond the tight tolerance. If someone re-introduces those
+        // coefficients (or the round-trip becomes lax enough to mask them), this
+        // test fails before the new correctness tests do.
+        var legacyInverse = new PixelFormatConverter.InvYuvMatrix8(
+            crToR: 451, cbToG: 56, crToG: 138, cbToB: 535);
+        int worst = MaxChannelDiff(
+            PixelFormatConverter.YuvMatrix8.Smpte240M, legacyInverse);
+        Assert.That(worst, Is.GreaterThan(5),
+            $"Legacy SMPTE 240M inverse should drift past ±5 LSB; observed {worst}");
     }
 
     [Test]


### PR DESCRIPTION
## Description

- Add HDR (PQ/HLG) decoding to the Media Foundation reader so the editor preview matches the FFmpeg / AVFoundation backends, including a `ForceSrgbGamma` SDR escape hatch for users without HDR-aware viewers.
- Add a Sink Writer-based encoder covering H.264 / HEVC (with HDR10 Main10 + Rec.2020/PQ tagging), AAC / MP3 / WMA / PCM audio, and audio-only containers (`.wav` / `.mp3` / `.m4a` / `.aac` / `.adts`) so the writer no longer fails when those extensions are selected.
- Honor `AudioSettings.Channels` by clamping to mono / stereo and downmixing L+R for mono so the declared block alignment always matches the PCM bytes written.

## Breaking changes

None

## Fixed issues

None