### PR TITLE
feat: add 2D transform handles for direct preview manipulation

### DIFF
--- a/src/Beutl.Engine/Animation/KeyFrameDeltaHelper.cs
+++ b/src/Beutl.Engine/Animation/KeyFrameDeltaHelper.cs
@@ -1,0 +1,48 @@
+﻿namespace Beutl.Animation;
+
+/// <summary>
+/// Helper for writing back keyframe values during a drag. By updating the surrounding (previous/next)
+/// keyframes to "snapshot value at OnPressed + drag delta", both keyframes shift in the same direction
+/// so the animation amplitude is preserved while a global offset is applied.
+///
+/// <para>
+/// The drag delta must be the "total delta from the start of the drag to now". Because it is added
+/// directly to the snapshot, OnMoved becomes idempotent (the same delta produces the same result).
+/// </para>
+/// </summary>
+internal static class KeyFrameDeltaHelper
+{
+    /// <summary>
+    /// Returns false when both surrounding keyframes are null (= no keyframe animation, the caller should
+    /// fall back to writing CurrentValue directly).
+    /// </summary>
+    public static bool ApplyDelta<T>(
+        KeyFrame<T>? previous,
+        KeyFrame<T>? next,
+        T startPrev,
+        T startNext,
+        T delta)
+        where T : notnull, System.Numerics.IAdditionOperators<T, T, T>
+    {
+        if (previous == null && next == null) return false;
+        if (previous != null) previous.Value = startPrev + delta;
+        if (next != null) next.Value = startNext + delta;
+        return true;
+    }
+
+    /// <summary>
+    /// Snapshots and returns the surrounding keyframes' Values. The null side is filled with <paramref name="fallback"/>.
+    /// </summary>
+    public static (T prev, T next) CaptureStartValues<T>(
+        KeyFrame<T>? previous,
+        KeyFrame<T>? next,
+        T fallback)
+        where T : notnull
+    {
+        // KeyFrame<T>.Value's declared type is T?. The single current caller uses T=float (struct), so the
+        // value is never actually null and `!` is used to suppress nullability. Revisit if ref types start being accepted.
+        T prev = previous != null ? previous.Value! : fallback;
+        T nextVal = next != null ? next.Value! : fallback;
+        return (prev, nextVal);
+    }
+}

--- a/src/Beutl.Engine/Animation/KeyFrameDeltaHelper.cs
+++ b/src/Beutl.Engine/Animation/KeyFrameDeltaHelper.cs
@@ -39,8 +39,7 @@ internal static class KeyFrameDeltaHelper
         T fallback)
         where T : notnull
     {
-        // KeyFrame<T>.Value's declared type is T?. The single current caller uses T=float (struct), so the
-        // value is never actually null and `!` is used to suppress nullability. Revisit if ref types start being accepted.
+        // KeyFrame<T>.Value is T? for nullability; current callers pin T to struct types so `!` is safe.
         T prev = previous != null ? previous.Value! : fallback;
         T nextVal = next != null ? next.Value! : fallback;
         return (prev, nextVal);

--- a/src/Beutl.Engine/Graphics/Rendering/IRenderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/IRenderer.cs
@@ -26,6 +26,9 @@ public interface IRenderer : IDisposable
 
     Rect[] GetBoundaries(int zIndex);
 
+    // Provide a default implementation for source compatibility with third-party IRenderer implementations. null = not computed / cache miss.
+    Rect? GetBoundary(Drawable drawable) => null;
+
     DrawableRenderNode? FindRenderNode(Drawable drawable);
 
     RenderCacheOptions CacheOptions { get; set; }

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -1,12 +1,16 @@
 ﻿using System.Runtime.CompilerServices;
 using Beutl.Composition;
 using Beutl.Graphics.Rendering.Cache;
+using Beutl.Logging;
 using Beutl.Media;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Graphics.Rendering;
 
 public class Renderer : IRenderer
 {
+    private static readonly ILogger s_logger = Log.CreateLogger<Renderer>();
+
     private readonly ImmediateCanvas _immediateCanvas;
     private readonly RenderTarget _surface;
     private readonly FpsText _fpsText = new();
@@ -299,6 +303,35 @@ public class Renderer : IRenderer
     public Rect[] GetBoundaries(int zIndex)
     {
         return [.. _allCurrentEntries.Where(e => e.Node.Drawable?.Resource.GetOriginal().ZIndex == zIndex).Select(e => e.Bounds)];
+    }
+
+    public Rect? GetBoundary(Drawable drawable)
+    {
+        RenderThread.Dispatcher.VerifyAccess();
+        if (_nodeCache.TryGetValue(drawable, out Entry? entry))
+        {
+            if (_allCurrentEntries.Contains(entry))
+            {
+                return entry.Bounds;
+            }
+            // An entry exists but is not included in the current frame (stale). Suggests a draw-lifecycle mismatch.
+            if (s_logger.IsEnabled(LogLevel.Debug))
+            {
+                s_logger.LogDebug(
+                    "GetBoundary: stale entry for {DrawableType}#{DrawableHash:X} (cached but not in current frame).",
+                    drawable.GetType().Name, RuntimeHelpers.GetHashCode(drawable));
+            }
+            return null;
+        }
+
+        // Cache miss that also occurs in normal operation (not yet drawn or already evicted).
+        if (s_logger.IsEnabled(LogLevel.Trace))
+        {
+            s_logger.LogTrace(
+                "GetBoundary: drawable {DrawableType}#{DrawableHash:X} not in render-node cache.",
+                drawable.GetType().Name, RuntimeHelpers.GetHashCode(drawable));
+        }
+        return null;
     }
 
     public Rect[] RecalculateBoundaries(int zIndex)

--- a/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
@@ -39,10 +39,13 @@ internal static class CanonicalTransformLayout
             groupChanged = true;
         }
 
+        // Only adopt enabled T/R/S; disabled children are ignored by TransformGroup.CreateMatrix,
+        // so editing them would leave the preview unchanged. Treat absence and "disabled-only" the same way.
         int rIdx = -1, sIdx = -1, tIdx = -1;
         for (int i = 0; i < tg.Children.Count; i++)
         {
             Transform c = tg.Children[i];
+            if (!c.IsEnabled) continue;
             if (rIdx < 0 && c is RotationTransform) rIdx = i;
             if (sIdx < 0 && c is ScaleTransform) sIdx = i;
             if (tIdx < 0 && c is TranslateTransform) tIdx = i;
@@ -106,6 +109,7 @@ internal static class CanonicalTransformLayout
             for (int i = 0; i < tg.Children.Count; i++)
             {
                 Transform c = tg.Children[i];
+                if (!c.IsEnabled) continue;
                 if (rIdx < 0 && c is RotationTransform) rIdx = i;
                 if (sIdx < 0 && c is ScaleTransform) sIdx = i;
                 if (tIdx < 0 && c is TranslateTransform) tIdx = i;
@@ -117,9 +121,9 @@ internal static class CanonicalTransformLayout
         }
         return t switch
         {
-            RotationTransform r => (r, null, null),
-            ScaleTransform s => (null, s, null),
-            TranslateTransform tr => (null, null, tr),
+            RotationTransform r when r.IsEnabled => (r, null, null),
+            ScaleTransform s when s.IsEnabled => (null, s, null),
+            TranslateTransform tr when tr.IsEnabled => (null, null, tr),
             _ => (null, null, null)
         };
     }

--- a/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
@@ -1,0 +1,137 @@
+﻿using Beutl.Composition;
+
+namespace Beutl.Graphics.Transformation;
+
+/// <summary>
+/// Helper for completing the canonical [T, R, S] layout.
+///
+/// <para>
+/// <see cref="TransformGroup"/> composes its children via <c>Aggregate(I, (acc, x) => x.M * acc)</c>, so
+/// under the row-vector right-multiplication convention (<c>v' = v · M</c>), the tail of the list ends up
+/// on the left of the product (= first in application order, innermost).
+/// Therefore <c>[T, R, S]</c> means <c>M = S · R · T</c> with application order S → R → T, making
+/// Translate the outermost (scene-space) operation while Rotation/Scale act around the pivot.
+/// </para>
+///
+/// <para>
+/// If the existing list contains multiple R/S/T or non-canonical ordering, the list is not reorganized
+/// (backward compatibility with old <c>[R, S, T]</c> projects). The "first occurrence" of each type is
+/// adopted as the operative transform.
+/// </para>
+/// </summary>
+internal static class CanonicalTransformLayout
+{
+    public static CanonicalTransformLayoutResult Ensure(Drawable drawable, CompositionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(drawable);
+        ArgumentNullException.ThrowIfNull(context);
+
+        bool groupChanged = false;
+        if (drawable.Transform.CurrentValue is not TransformGroup tg)
+        {
+            var newGroup = new TransformGroup();
+            if (drawable.Transform.CurrentValue is Transform existing)
+            {
+                newGroup.Children.Add(existing);
+            }
+            drawable.Transform.CurrentValue = newGroup;
+            tg = newGroup;
+            groupChanged = true;
+        }
+
+        int rIdx = -1, sIdx = -1, tIdx = -1;
+        for (int i = 0; i < tg.Children.Count; i++)
+        {
+            Transform c = tg.Children[i];
+            if (rIdx < 0 && c is RotationTransform) rIdx = i;
+            if (sIdx < 0 && c is ScaleTransform) sIdx = i;
+            if (tIdx < 0 && c is TranslateTransform) tIdx = i;
+        }
+
+        bool added = false;
+
+        if (tIdx < 0)
+        {
+            tg.Children.Insert(0, new TranslateTransform());
+            tIdx = 0;
+            if (rIdx >= 0) rIdx++;
+            if (sIdx >= 0) sIdx++;
+            added = true;
+        }
+
+        if (rIdx < 0)
+        {
+            int insertAt = tIdx + 1;
+            tg.Children.Insert(insertAt, new RotationTransform());
+            rIdx = insertAt;
+            if (sIdx >= insertAt) sIdx++;
+            added = true;
+        }
+
+        if (sIdx < 0)
+        {
+            tg.Children.Add(new ScaleTransform());
+            sIdx = tg.Children.Count - 1;
+            added = true;
+        }
+
+        var rotation = (RotationTransform)tg.Children[rIdx];
+        var scale = (ScaleTransform)tg.Children[sIdx];
+        var translate = (TranslateTransform)tg.Children[tIdx];
+
+        // PostMatrixOfT = matrix applied after T in application order (= composition of children near the head of the list).
+        // Identity under the new [T, R, S]; S · R under the old [R, S, T].
+        Matrix postMatrixOfT = Matrix.Identity;
+        for (int i = 0; i < tIdx; i++)
+        {
+            postMatrixOfT = tg.Children[i].CreateMatrix(context) * postMatrixOfT;
+        }
+
+        bool structureChanged = groupChanged || added;
+        return new CanonicalTransformLayoutResult(translate, scale, rotation, tg, structureChanged)
+        {
+            PostMatrixOfT = postMatrixOfT,
+        };
+    }
+
+    /// <summary>
+    /// Reads the first occurrence of R/S/T each (without mutating the group). Does not return null even if the order is invalid.
+    /// </summary>
+    public static (RotationTransform? Rotation, ScaleTransform? Scale, TranslateTransform? Translate)
+        FindCanonicalTransforms(Transform? t)
+    {
+        if (t is TransformGroup tg)
+        {
+            int rIdx = -1, sIdx = -1, tIdx = -1;
+            for (int i = 0; i < tg.Children.Count; i++)
+            {
+                Transform c = tg.Children[i];
+                if (rIdx < 0 && c is RotationTransform) rIdx = i;
+                if (sIdx < 0 && c is ScaleTransform) sIdx = i;
+                if (tIdx < 0 && c is TranslateTransform) tIdx = i;
+            }
+            return (
+                rIdx >= 0 ? (RotationTransform)tg.Children[rIdx] : null,
+                sIdx >= 0 ? (ScaleTransform)tg.Children[sIdx] : null,
+                tIdx >= 0 ? (TranslateTransform)tg.Children[tIdx] : null);
+        }
+        return t switch
+        {
+            RotationTransform r => (r, null, null),
+            ScaleTransform s => (null, s, null),
+            TranslateTransform tr => (null, null, tr),
+            _ => (null, null, null)
+        };
+    }
+}
+
+internal sealed record CanonicalTransformLayoutResult(
+    TranslateTransform Translate,
+    ScaleTransform Scale,
+    RotationTransform Rotation,
+    TransformGroup Group,
+    bool StructureChanged)
+{
+    /// <summary>Matrix applied after the operative T in application order (Identity under the new [T, R, S]).</summary>
+    internal Matrix PostMatrixOfT { get; init; } = Matrix.Identity;
+}

--- a/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/CanonicalTransformLayout.cs
@@ -39,17 +39,7 @@ internal static class CanonicalTransformLayout
             groupChanged = true;
         }
 
-        // Only adopt enabled T/R/S; disabled children are ignored by TransformGroup.CreateMatrix,
-        // so editing them would leave the preview unchanged. Treat absence and "disabled-only" the same way.
-        int rIdx = -1, sIdx = -1, tIdx = -1;
-        for (int i = 0; i < tg.Children.Count; i++)
-        {
-            Transform c = tg.Children[i];
-            if (!c.IsEnabled) continue;
-            if (rIdx < 0 && c is RotationTransform) rIdx = i;
-            if (sIdx < 0 && c is ScaleTransform) sIdx = i;
-            if (tIdx < 0 && c is TranslateTransform) tIdx = i;
-        }
+        (int rIdx, int sIdx, int tIdx) = FindFirstEnabledIndices(tg.Children);
 
         bool added = false;
 
@@ -82,8 +72,8 @@ internal static class CanonicalTransformLayout
         var scale = (ScaleTransform)tg.Children[sIdx];
         var translate = (TranslateTransform)tg.Children[tIdx];
 
-        // PostMatrixOfT = matrix applied after T in application order (= composition of children near the head of the list).
-        // Identity under the new [T, R, S]; S · R under the old [R, S, T].
+        // Matrix applied after T in application order — composition of children to the left of T in the
+        // list. Identity for canonical [T, R, S] layouts; non-identity only for legacy [R, S, T] data.
         Matrix postMatrixOfT = Matrix.Identity;
         for (int i = 0; i < tIdx; i++)
         {
@@ -105,15 +95,7 @@ internal static class CanonicalTransformLayout
     {
         if (t is TransformGroup tg)
         {
-            int rIdx = -1, sIdx = -1, tIdx = -1;
-            for (int i = 0; i < tg.Children.Count; i++)
-            {
-                Transform c = tg.Children[i];
-                if (!c.IsEnabled) continue;
-                if (rIdx < 0 && c is RotationTransform) rIdx = i;
-                if (sIdx < 0 && c is ScaleTransform) sIdx = i;
-                if (tIdx < 0 && c is TranslateTransform) tIdx = i;
-            }
+            (int rIdx, int sIdx, int tIdx) = FindFirstEnabledIndices(tg.Children);
             return (
                 rIdx >= 0 ? (RotationTransform)tg.Children[rIdx] : null,
                 sIdx >= 0 ? (ScaleTransform)tg.Children[sIdx] : null,
@@ -126,6 +108,22 @@ internal static class CanonicalTransformLayout
             TranslateTransform tr when tr.IsEnabled => (null, null, tr),
             _ => (null, null, null)
         };
+    }
+
+    // Disabled children are ignored by TransformGroup.CreateMatrix, so they cannot serve as the
+    // operative T/R/S — editing them would leave the preview unchanged.
+    private static (int rIdx, int sIdx, int tIdx) FindFirstEnabledIndices(IReadOnlyList<Transform> children)
+    {
+        int rIdx = -1, sIdx = -1, tIdx = -1;
+        for (int i = 0; i < children.Count; i++)
+        {
+            Transform c = children[i];
+            if (!c.IsEnabled) continue;
+            if (rIdx < 0 && c is RotationTransform) rIdx = i;
+            if (sIdx < 0 && c is ScaleTransform) sIdx = i;
+            if (tIdx < 0 && c is TranslateTransform) tIdx = i;
+        }
+        return (rIdx, sIdx, tIdx);
     }
 }
 

--- a/src/Beutl.Engine/Graphics/Transformation/TransformHandleMath.cs
+++ b/src/Beutl.Engine/Graphics/Transformation/TransformHandleMath.cs
@@ -1,0 +1,91 @@
+﻿namespace Beutl.Graphics.Transformation;
+
+/// <summary>
+/// Pure math helper used by the transform handle operations.
+/// Assumes the canonical [T, R, S] layout (application order S → R → T, with T outermost), and computes
+/// against the following structure of <see cref="Drawable.GetTransformMatrix"/>:
+/// <code>screen = ((local - origin) * S_op * R_op) + T_op + origin + pt_alignment</code>
+/// </summary>
+internal static class TransformHandleMath
+{
+    /// <summary>
+    /// Normalizes an angle delta (in radians) into the range <c>[-π, π]</c>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="System.Math.Atan2"/> is discontinuous on the negative X axis, so when a drag crosses
+    /// to the left side of the pivot the delta (current - start) jumps by roughly ±2π. This trims it
+    /// down to the shortest-rotation form.
+    /// Inputs are assumed to be finite (callers must filter).
+    /// </remarks>
+    public static double NormalizeAngleDelta(double deltaRad)
+    {
+        return Math.IEEERemainder(deltaRad, 2 * Math.PI);
+    }
+
+    /// <summary>
+    /// Computes the ΔT to add to the operative Translate so that the anchor (opposite corner) stays
+    /// fixed on screen.
+    /// </summary>
+    /// <remarks>
+    /// <para>Derivation (canonical [T, R, S] layout, application order S → R → T):</para>
+    /// <code>
+    /// screen_anchor = (anchor - origin) * S_op * R_op + T_op + origin + pt_alignment
+    /// </code>
+    /// <para>Condition for keeping screen_anchor identical between old and new:</para>
+    /// <code>
+    /// ΔT = ((anchor - origin) * (S_old - S_new) / 100) * R_op
+    /// </code>
+    /// <para>Scale is expressed on a 100 basis. This function is specific to the new [T, R, S] layout (T outermost).</para>
+    /// </remarks>
+    /// <param name="rotation">Operative R matrix (only the 2x2 part is used).</param>
+    public static (float dx, float dy) ComputePivotTranslationDelta(
+        float startScaleX,
+        float startScaleY,
+        float newScaleX,
+        float newScaleY,
+        double anchorX,
+        double anchorY,
+        double originX,
+        double originY,
+        Matrix rotation)
+    {
+        double preRx = (anchorX - originX) * (startScaleX - newScaleX) / 100.0;
+        double preRy = (anchorY - originY) * (startScaleY - newScaleY) / 100.0;
+
+        float dx = (float)(preRx * rotation.M11 + preRy * rotation.M21);
+        float dy = (float)(preRx * rotation.M12 + preRy * rotation.M22);
+        return (dx, dy);
+    }
+
+    /// <summary>
+    /// When the rendered bounds are translated relative to the transform-derived AABB (e.g. via a FilterEffect),
+    /// computes the correction to post-translate onto userMatrix.
+    /// Returns the matrix unchanged when the center difference satisfies <c>|dx|, |dy| &lt; 0.5px</c> (absorbs numerical noise).
+    /// </summary>
+    public static Matrix AlignUserMatrixToRenderedBounds(Matrix userMatrix, Size localSize, Rect renderedBounds)
+    {
+        Point transformCenter = new Rect(localSize).TransformToAABB(userMatrix).Center;
+        Point renderedCenter = renderedBounds.Center;
+        float dx = renderedCenter.X - transformCenter.X;
+        float dy = renderedCenter.Y - transformCenter.Y;
+
+        const float Eps = 0.5f;
+        if (MathF.Abs(dx) < Eps && MathF.Abs(dy) < Eps)
+        {
+            return userMatrix;
+        }
+        return userMatrix * Matrix.CreateTranslation(dx, dy);
+    }
+
+    /// <summary>
+    /// Aspect-ratio lock used while Shift is held: snaps |rx|, |ry| to the smaller magnitude while
+    /// keeping each axis' sign.
+    /// </summary>
+    public static (double rx, double ry) LockAspect(double rx, double ry)
+    {
+        double signX = rx < 0 ? -1.0 : 1.0;
+        double signY = ry < 0 ? -1.0 : 1.0;
+        double mag = Math.Min(Math.Abs(rx), Math.Abs(ry));
+        return (signX * mag, signY * mag);
+    }
+}

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -133,6 +133,9 @@
 
                 <pathEditor:PathEditorView Name="pathEditorView"
                                            DataContext="{Binding PathEditor}" />
+
+                <local:TransformHandlesOverlay Name="transformHandlesOverlay"
+                                               IsVisible="False" />
             </Panel>
         </Player.Content>
     </Player>

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -21,6 +21,7 @@ using Beutl.Logging;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Services;
+using Beutl.Utilities;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Editors;
 using FluentAvalonia.UI.Controls;
@@ -29,21 +30,44 @@ using Microsoft.Extensions.Logging;
 using AvaImage = Avalonia.Controls.Image;
 using AvaPoint = Avalonia.Point;
 using AvaRect = Avalonia.Rect;
+using BtlMatrix = Beutl.Graphics.Matrix;
+using BtlPoint = Beutl.Graphics.Point;
+using BtlRect = Beutl.Graphics.Rect;
+using BtlSize = Beutl.Graphics.Size;
 
 namespace Beutl.Views;
 
 public partial class PlayerView
 {
-    private static double Length(AvaPoint point)
-    {
-        return Math.Sqrt((point.X * point.X) + (point.Y * point.Y));
-    }
-
     private sealed class KeyFrameState<T>(KeyFrame<T>? previous, KeyFrame<T>? next)
     {
         public KeyFrame<T>? Previous { get; } = previous;
 
         public KeyFrame<T>? Next { get; } = next;
+    }
+
+    // If localStart is non-null, convert to local time (e.g. Element/Scene3D); if null, use globalKeyTime as-is.
+    private static KeyFrameState<T>? FindKeyFramePair<T>(
+        IProperty<T> property, IEditorClock clock, Scene scene, TimeSpan? localStart)
+    {
+        int rate = scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+        TimeSpan globalKeyTime = clock.CurrentTime.Value;
+        TimeSpan localKeyTime = localStart.HasValue ? globalKeyTime - localStart.Value : globalKeyTime;
+
+        if (property.Animation is KeyFrameAnimation<T> animation)
+        {
+            TimeSpan keyTime = animation.UseGlobalClock ? globalKeyTime : localKeyTime;
+            keyTime = keyTime.RoundToRate(rate);
+
+            (IKeyFrame? prev, IKeyFrame? next) = animation.KeyFrames.GetPreviousAndNextKeyFrame(keyTime);
+
+            if (next?.KeyTime == keyTime)
+                return new(next as KeyFrame<T>, null);
+
+            return new(prev as KeyFrame<T>, next as KeyFrame<T>);
+        }
+
+        return null;
     }
 
     private interface IMouseControlHandler
@@ -134,14 +158,65 @@ public partial class PlayerView
         }
     }
 
-    private sealed class MouseControlMove : IMouseControlHandler
+    private sealed class MouseControlTransformHandles : IMouseControlHandler
     {
-        private bool _imagePressed;
-        private AvaPoint _scaledStartPosition;
-        private TranslateTransform? _translateTransform;
-        private Matrix _preMatrix = Matrix.Identity;
-        private KeyFrameState<float>? _xKeyFrame;
-        private KeyFrameState<float>? _yKeyFrame;
+        // Drag lifecycle: Press → (first OnMoved → Ensure) → Move* → Release.
+        //   _press == null  : pre-press state
+        //   _ensured == null: pre-drag (Press received but no mouse movement yet)
+
+        // When Kind == None, LocalSize/StartUserMatrix/InvStartUserMatrix/PivotLocal/PivotImage are
+        // filled with default/Identity (harmless because only HandleTranslate is invoked, which does not reference them).
+        // PressTransform: anchor for detecting whether undo/redo replaced the Transform right before the first OnMoved.
+        private sealed record PressState(
+            Drawable Drawable,
+            Element? Element,
+            double FrameScale,
+            BtlSize LocalSize,
+            BtlMatrix StartUserMatrix,
+            BtlMatrix InvStartUserMatrix,
+            BtlPoint PivotLocal,
+            AvaPoint PivotImage,
+            AvaPoint StartImagePos,
+            Transform? PressTransform);
+
+        private sealed class EnsuredState
+        {
+            public required TranslateTransform Translate { get; init; }
+            public required ScaleTransform Scale { get; init; }
+            public required RotationTransform Rotation { get; init; }
+            // Identifier used to detect undo/redo replacement via reference equality with drawable.Transform.CurrentValue.
+            public required TransformGroup Group { get; init; }
+            // null = non-invertible (HandleTranslate will abort).
+            public BtlMatrix? InvPostMatrixOfT { get; init; }
+            public required BtlMatrix RotationMatrix { get; init; }
+            public required float StartTransX { get; init; }
+            public required float StartTransY { get; init; }
+            public required float StartScaleX { get; init; }
+            public required float StartScaleY { get; init; }
+            public required float StartRotation { get; init; }
+            public KeyFrameState<float>? KfTransX { get; init; }
+            public KeyFrameState<float>? KfTransY { get; init; }
+            public KeyFrameState<float>? KfScaleX { get; init; }
+            public KeyFrameState<float>? KfScaleY { get; init; }
+            public KeyFrameState<float>? KfRotation { get; init; }
+            public required (float prev, float next) KfStartTransX { get; init; }
+            public required (float prev, float next) KfStartTransY { get; init; }
+            public required (float prev, float next) KfStartScaleX { get; init; }
+            public required (float prev, float next) KfStartScaleY { get; init; }
+            public required (float prev, float next) KfStartRotation { get; init; }
+        }
+
+        private readonly ILogger _logger = Log.CreateLogger<MouseControlTransformHandles>();
+
+        private PressState? _press;
+        private EnsuredState? _ensured;
+
+        // _changed is drag-scoped (cleared by ResetSession); _shift stays live outside of a drag too
+        // (synced from KeyDown/Up and pointer-event KeyModifiers, reset to false only in OnReleased).
+        private bool _changed;
+        private bool _shift;
+
+        public Drawable? Drawable => _press?.Drawable;
 
         public required PlayerView View { get; init; }
 
@@ -151,232 +226,648 @@ public partial class PlayerView
 
         public required IEditorSelection EditorSelection { get; init; }
 
+        public required TransformHandlesOverlay.HandleKind Kind { get; init; }
+
         public EditViewModel EditViewModel => ViewModel.EditViewModel;
-
-        public Drawable? Drawable { get; private set; }
-
-        public Element? Element { get; private set; }
 
         private Control Image => View.image;
 
-        private (TranslateTransform?, Matrix) FindOrCreateTranslation(Drawable drawable)
+        private KeyFrameState<float>? FindKf(IProperty<float> property)
+            => FindKeyFramePair(property, Clock, EditViewModel.Scene, _press?.Element?.Start);
+
+        // On invariant violation, leave a more actionable log than an NRE and short-circuit subsequent OnMoved calls via ResetSession.
+        private bool TryGetSession(
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out PressState? press,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EnsuredState? ensured)
         {
-            switch (drawable.Transform.CurrentValue)
-            {
-                case TranslateTransform translateTransform:
-                    return (translateTransform, Matrix.Identity);
-
-                case TransformGroup transformGroup:
-                    var list = transformGroup.Children;
-                    TranslateTransform? obj = null;
-                    int i;
-                    for (i = 0; i < list.Count; i++)
-                    {
-                        Transform item = list[i];
-                        if (item is TranslateTransform translate)
-                        {
-                            obj = translate;
-                            break;
-                        }
-                    }
-
-                    if (obj == null)
-                    {
-                        obj = new TranslateTransform();
-                        transformGroup.Children.Insert(0, obj);
-                        EditViewModel.HistoryManager.Commit(CommandNames.TransformElement);
-
-                        return (obj, Matrix.Identity);
-                    }
-                    else
-                    {
-                        var res = transformGroup.ToResource(new CompositionContext(Clock.CurrentTime.Value));
-
-                        return (obj, res.Matrix);
-                    }
-            }
-
-            return (null, Matrix.Identity);
+            press = _press;
+            ensured = _ensured;
+            if (press != null && ensured != null) return true;
+            _logger.LogError(
+                "MouseControlTransformHandles handler invoked without session (press={HasPress}, ensured={HasEnsured}, kind={Kind}). Aborting drag.",
+                press != null, ensured != null, Kind);
+            ResetSession();
+            press = null;
+            ensured = null;
+            return false;
         }
 
-        private KeyFrameState<float>? FindKeyFramePairOrNull(IProperty<float> property)
-        {
-            int rate = EditViewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-            TimeSpan globalkeyTime = Clock.CurrentTime.Value;
-            TimeSpan localKeyTime = Element != null ? globalkeyTime - Element.Start : globalkeyTime;
+        private static bool ApplyDelta(KeyFrameState<float>? kf, (float prev, float next) start, float delta)
+            => KeyFrameDeltaHelper.ApplyDelta(kf?.Previous, kf?.Next, start.prev, start.next, delta);
 
-            if (property.Animation is KeyFrameAnimation<float> animation)
-            {
-                TimeSpan keyTime = animation.UseGlobalClock ? globalkeyTime : localKeyTime;
-                keyTime = keyTime.RoundToRate(rate);
-
-                (IKeyFrame? prev, IKeyFrame? next) = animation.KeyFrames.GetPreviousAndNextKeyFrame(keyTime);
-
-                if (next?.KeyTime == keyTime)
-                    return new(next as KeyFrame<float>, null);
-
-                return new(prev as KeyFrame<float>, next as KeyFrame<float>);
-            }
-
-            return default;
-        }
-
-        public void OnMoved(PointerEventArgs e)
-        {
-            if (_imagePressed && Drawable != null)
-            {
-                if (!ViewModel.IsMoveMode.Value)
-                    return;
-
-                PointerPoint pointerPoint = e.GetCurrentPoint(Image);
-                AvaPoint imagePosition = pointerPoint.Position;
-                double scaleX = Image.Bounds.Size.Width / EditViewModel.Scene.FrameSize.Width;
-                AvaPoint scaledPosition = imagePosition / scaleX;
-                AvaPoint delta = scaledPosition - _scaledStartPosition;
-                if (_translateTransform == null && Length(delta) >= 1)
-                {
-                    (_translateTransform, _preMatrix) = FindOrCreateTranslation(Drawable);
-
-                    // 最初の一回だけ、キーフレームを探す
-                    if (_translateTransform != null)
-                    {
-                        // アニメーションが設定されていない場合の編集コマンドの復元に使うのでCurrentValueで良い
-                        _xKeyFrame = FindKeyFramePairOrNull(_translateTransform.X);
-                        _yKeyFrame = FindKeyFramePairOrNull(_translateTransform.Y);
-                    }
-                }
-
-                if (_preMatrix.TryInvert(out Matrix inverted))
-                {
-                    Avalonia.Matrix avaInverted = inverted.ToAvaMatrix();
-                    AvaPoint scaledPosition1 = scaledPosition * avaInverted;
-                    AvaPoint scaledStartPosition1 = _scaledStartPosition * avaInverted;
-                    delta = scaledPosition1 - scaledStartPosition1;
-                }
-
-                if (_translateTransform != null)
-                {
-                    if (!SetKeyFrameValue(_xKeyFrame, (float)delta.X))
-                    {
-                        _translateTransform.X.CurrentValue += (float)delta.X;
-                    }
-
-                    if (!SetKeyFrameValue(_yKeyFrame, (float)delta.Y))
-                    {
-                        _translateTransform.Y.CurrentValue += (float)delta.Y;
-                    }
-                }
-
-                _scaledStartPosition = scaledPosition;
-                if (Element != null)
-                {
-                    int rate = EditViewModel.Player.GetFrameRate();
-                    int st = (int)Element.Start.ToFrameNumber(rate);
-                    int ed = (int)Math.Ceiling(Element.Range.End.ToFrameNumber(rate));
-
-                    EditViewModel.FrameCacheManager.Value.DeleteAndUpdateBlocks([(st, ed)]);
-                }
-
-                e.Handled = true;
-            }
-        }
-
-        // keyframesが両方nullの場合、falseを返す
-        private static bool SetKeyFrameValue(KeyFrameState<float>? keyframes, float delta)
-        {
-            switch ((keyframes?.Previous, keyframes?.Next))
-            {
-                case (null, null):
-                    return false;
-
-                case ({ } prev, { } next):
-                    prev.Value += delta;
-                    next.Value += delta;
-                    break;
-
-                case ({ } prev, null):
-                    prev.Value += delta;
-                    break;
-
-                case (null, { } next):
-                    next.Value += delta;
-                    break;
-            }
-
-            return true;
-        }
-
-        public void OnReleased(PointerReleasedEventArgs e)
-        {
-            if (_imagePressed)
-            {
-                _imagePressed = false;
-
-                EditViewModel.HistoryManager.Commit(CommandNames.TransformElement);
-
-                Element = null;
-                _translateTransform = null;
-                Drawable = null;
-                _xKeyFrame = default;
-                _yKeyFrame = default;
-                e.Handled = true;
-            }
-        }
+        private static (float prev, float next) CaptureStartValues(KeyFrameState<float>? kf, float fallback)
+            => KeyFrameDeltaHelper.CaptureStartValues(kf?.Previous, kf?.Next, fallback);
 
         public void OnPressed(PointerPressedEventArgs e)
         {
-            Scene scene = EditViewModel.Scene;
-            PointerPoint pointerPoint = e.GetCurrentPoint(Image);
-            _imagePressed = pointerPoint.Properties.IsLeftButtonPressed;
-            AvaPoint imagePosition = pointerPoint.Position;
-            double scaleX = Image.Bounds.Size.Width / scene.FrameSize.Width;
-            _scaledStartPosition = imagePosition / scaleX;
+            PointerPoint pp = e.GetCurrentPoint(Image);
+            if (!pp.Properties.IsLeftButtonPressed) return;
 
-            Drawable = RenderThread.Dispatcher.Invoke(() =>
+            // If Shift+click happens before framePanel has focus, no KeyDown fires, so initialize
+            // _shift from the modifier state on the pointer event.
+            _shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+            if (Kind == TransformHandlesOverlay.HandleKind.None)
             {
-                var compositor = EditViewModel.Renderer.Value.Compositor;
-                var compositionFrame = compositor.EvaluateGraphics(Clock.CurrentTime.Value);
-                return EditViewModel.Renderer.Value.HitTest(compositionFrame, new((float)_scaledStartPosition.X, (float)_scaledStartPosition.Y));
-            });
-
-            if (Drawable != null)
-            {
-                // TODO: DrawableGroup以下のDrawableを拾った場合の対応
-                int zindex = Drawable.ZIndex;
-                TimeSpan time = Clock.CurrentTime.Value;
-
-                Element = scene.Children.FirstOrDefault(v =>
-                    v.IsEnabled
-                    && v.ZIndex == zindex
-                    && v.Start <= time
-                    && time < v.Range.End);
-
-                if (Element != null)
-                {
-                    EditorSelection.SelectedObject.Value = Element;
-                }
+                OnPressedHitTest(e, pp);
+                return;
             }
 
-            e.Handled = _imagePressed;
+            TransformHandlesOverlay overlay = View.transformHandlesOverlay;
+            Drawable? drawable = overlay.Drawable;
+            Element? element = overlay.Element;
+            double frameScale = overlay.FrameScale;
+            BtlSize localSize = overlay.LocalSize;
+            BtlMatrix startUserMatrix = overlay.UserMatrix;
+            BtlPoint pivotLocal = overlay.PivotLocal;
 
-            if (e.ClickCount == 2 && Drawable is Graphics.Shapes.Shape shape)
+            if (drawable == null || element == null || frameScale <= 0
+                || localSize.Width <= 0 || localSize.Height <= 0
+                || !startUserMatrix.TryInvert(out BtlMatrix invStartUserMatrix))
+            {
+                _logger.LogWarning(
+                    "Transform handle press cancelled: kind={Kind}, drawable={DrawableType}, element='{Element}', frameScale={FrameScale}",
+                    Kind, drawable?.GetType().Name ?? "null", element?.Name ?? "null", frameScale);
+                _press = null;
+                e.Handled = true;
+                return;
+            }
+
+            AvaPoint startImagePos = pp.Position;
+            AvaPoint pivotImage = overlay.PivotImage;
+
+            _press = new PressState(
+                Drawable: drawable,
+                Element: element,
+                FrameScale: frameScale,
+                LocalSize: localSize,
+                StartUserMatrix: startUserMatrix,
+                InvStartUserMatrix: invStartUserMatrix,
+                PivotLocal: pivotLocal,
+                PivotImage: pivotImage,
+                StartImagePos: startImagePos,
+                PressTransform: drawable.Transform.CurrentValue);
+
+            // Ensure (= inserting R/S/T) is a document mutation, so defer it until the first OnMoved
+            // (if the user only clicks and releases, the structure is left untouched).
+            _ensured = null;
+
+            EditorSelection.SelectedObject.Value = element;
+            View.framePanel.Cursor = TransformHandlesOverlay.GetCursorForHandle(Kind);
+
+            e.Handled = true;
+        }
+
+        // Click outside the overlay region (Kind == None). Resolve the drawable via renderer hit-test;
+        // toggle selection, launch path editor on double-click of a shape, and start a translate drag on the first OnMoved.
+        private void OnPressedHitTest(PointerPressedEventArgs e, PointerPoint pp)
+        {
+            Scene scene = EditViewModel.Scene;
+            AvaPoint imagePos = pp.Position;
+            double frameScale = Image.Bounds.Size.Width / scene.FrameSize.Width;
+            if (frameScale <= 0)
+            {
+                // Layout race: e.g. the click arrived before framePanel had laid out the image.
+                _logger.LogDebug(
+                    "OnPressedHitTest: frameScale={FrameScale} <= 0 (imageBounds={ImageBounds}, frameSize={FrameSize}), swallowing click.",
+                    frameScale, Image.Bounds.Size, scene.FrameSize);
+                _press = null;
+                e.Handled = true;
+                return;
+            }
+
+            AvaPoint scaledStartPosition = new(imagePos.X / frameScale, imagePos.Y / frameScale);
+
+            Drawable? drawable;
+            try
+            {
+                drawable = RenderThread.Dispatcher.Invoke(() =>
+                {
+                    var compositor = EditViewModel.Renderer.Value.Compositor;
+                    var compositionFrame = compositor.EvaluateGraphics(Clock.CurrentTime.Value);
+                    return EditViewModel.Renderer.Value.HitTest(compositionFrame,
+                        new((float)scaledStartPosition.X, (float)scaledStartPosition.Y));
+                });
+            }
+            catch (OperationCanceledException ocex)
+            {
+                // Pointer event delivered during shutdown. Propagating it can kill the UI thread,
+                // so log and discard the click instead.
+                _logger.LogDebug(
+                    ocex,
+                    "OnPressedHitTest: hit-test cancelled (likely shutdown). Swallowing click.");
+                _press = null;
+                e.Handled = true;
+                return;
+            }
+            catch (Exception ex) when (
+                ex is not OutOfMemoryException
+                and not StackOverflowException
+                and not System.Runtime.InteropServices.SEHException  // propagate things like GPU driver crashes
+                and not AccessViolationException)                    // CSE (defense-in-depth)
+            {
+                // Swallow the exception; propagating it would crash the editor via the pointer-event pipeline.
+                _logger.LogError(
+                    ex,
+                    "OnPressedHitTest: renderer hit-test threw at scaledPos={ScaledPos}.",
+                    scaledStartPosition);
+                _press = null;
+                e.Handled = true;
+                return;
+            }
+
+            // Fall through on an empty click so other handlers / the normal selection logic can run
+            // (setting _press=non-null + Handled=true would make the click look unresponsive).
+            if (drawable == null)
+            {
+                _press = null;
+                return;
+            }
+
+            int zindex = drawable.ZIndex;
+            TimeSpan time = Clock.CurrentTime.Value;
+            Element? element = scene.Children.FirstOrDefault(v =>
+                v.IsEnabled
+                && v.ZIndex == zindex
+                && v.Start <= time
+                && time < v.Range.End);
+
+            if (element != null)
+            {
+                EditorSelection.SelectedObject.Value = element;
+            }
+
+            _press = new PressState(
+                Drawable: drawable,
+                Element: element,
+                FrameScale: frameScale,
+                LocalSize: default,
+                StartUserMatrix: BtlMatrix.Identity,
+                InvStartUserMatrix: BtlMatrix.Identity,
+                PivotLocal: default,
+                PivotImage: default,
+                StartImagePos: imagePos,
+                PressTransform: drawable.Transform.CurrentValue);
+            _ensured = null;
+            e.Handled = true;
+
+            // Double-click on shape → path editor
+            if (e.ClickCount == 2 && drawable is Graphics.Shapes.Shape shape)
             {
                 ElementPropertyTabViewModel? tab = EditViewModel.FindToolTab<ElementPropertyTabViewModel>();
                 if (tab != null)
                 {
                     foreach (EngineObjectPropertyViewModel item in tab.Items)
                     {
-                        IPropertyEditorContext?
-                            prop = item.Properties.FirstOrDefault(v => v is GeometryEditorViewModel);
+                        IPropertyEditorContext? prop = item.Properties.FirstOrDefault(v => v is GeometryEditorViewModel);
                         if (prop is GeometryEditorViewModel geometryEditorViewModel)
                         {
-                            EditViewModel.Player.PathEditor.StartEdit(shape, geometryEditorViewModel,
-                                _scaledStartPosition);
+                            EditViewModel.Player.PathEditor.StartEdit(shape, geometryEditorViewModel, scaledStartPosition);
                             break;
                         }
                     }
                 }
             }
+        }
+
+        private void EnsureOnFirstMove()
+        {
+            if (_ensured != null || _press == null) return;
+
+            var ctx = new CompositionContext(Clock.CurrentTime.Value);
+
+            // Ensure performs a document mutation, so first take a mutation-free snapshot and verify finiteness.
+            // If any value is invalid, abort without invoking Ensure to avoid leaving a non-undoable mutation behind.
+            // The defaults used to fill missing axes must match the property defaults of the R/S/T that Ensure inserts
+            // (TranslateTransform.X/Y=0, ScaleTransform.ScaleX/Y=100, RotationTransform.Rotation=0).
+            var (probeR, probeS, probeT) = CanonicalTransformLayout.FindCanonicalTransforms(_press.Drawable.Transform.GetValue(ctx));
+            float startTransX = probeT?.X.GetValue(ctx) ?? 0f;
+            float startTransY = probeT?.Y.GetValue(ctx) ?? 0f;
+            float startScaleX = probeS?.ScaleX.GetValue(ctx) ?? 100f;
+            float startScaleY = probeS?.ScaleY.GetValue(ctx) ?? 100f;
+            float startRotation = probeR?.Rotation.GetValue(ctx) ?? 0f;
+
+            if (!float.IsFinite(startTransX) || !float.IsFinite(startTransY)
+                || !float.IsFinite(startScaleX) || !float.IsFinite(startScaleY)
+                || !float.IsFinite(startRotation))
+            {
+                AbortDrag(
+                    "EnsureOnFirstMove: non-finite snapshot (T=({Tx},{Ty}), S=({Sx},{Sy}), R={Rot}); aborting drag before structural mutation.",
+                    startTransX, startTransY, startScaleX, startScaleY, startRotation);
+                return;
+            }
+
+            CanonicalTransformLayoutResult ensured =
+                CanonicalTransformLayout.Ensure(_press.Drawable, ctx);
+
+            KeyFrameState<float>? kfTransX = FindKf(ensured.Translate.X);
+            KeyFrameState<float>? kfTransY = FindKf(ensured.Translate.Y);
+            KeyFrameState<float>? kfScaleX = FindKf(ensured.Scale.ScaleX);
+            KeyFrameState<float>? kfScaleY = FindKf(ensured.Scale.ScaleY);
+            KeyFrameState<float>? kfRotation = FindKf(ensured.Rotation.Rotation);
+
+            BtlMatrix? invPostMatrixOfT = ensured.PostMatrixOfT.TryInvert(out BtlMatrix invPostT) ? invPostT : null;
+            BtlMatrix rotationMatrix = ensured.Rotation.CreateMatrix(ctx);
+
+            _ensured = new EnsuredState
+            {
+                Translate = ensured.Translate,
+                Scale = ensured.Scale,
+                Rotation = ensured.Rotation,
+                Group = ensured.Group,
+                InvPostMatrixOfT = invPostMatrixOfT,
+                RotationMatrix = rotationMatrix,
+                StartTransX = startTransX,
+                StartTransY = startTransY,
+                StartScaleX = startScaleX,
+                StartScaleY = startScaleY,
+                StartRotation = startRotation,
+                KfTransX = kfTransX,
+                KfTransY = kfTransY,
+                KfScaleX = kfScaleX,
+                KfScaleY = kfScaleY,
+                KfRotation = kfRotation,
+                KfStartTransX = CaptureStartValues(kfTransX, startTransX),
+                KfStartTransY = CaptureStartValues(kfTransY, startTransY),
+                KfStartScaleX = CaptureStartValues(kfScaleX, startScaleX),
+                KfStartScaleY = CaptureStartValues(kfScaleY, startScaleY),
+                KfStartRotation = CaptureStartValues(kfRotation, startRotation),
+            };
+
+            // If a structural change (group wrap or R/S/T insertion) happened, commit even if delta is tiny.
+            if (ensured.StructureChanged)
+            {
+                _changed = true;
+            }
+        }
+
+        public void OnMoved(PointerEventArgs e)
+        {
+            if (_press == null) return;
+
+            // Pre-Ensure guard: detect the case where undo/redo replaces the entire Transform between
+            // OnPressed and the first OnMoved. If this is not checked before Ensure runs, structural
+            // mutations would be applied to the post-undo Transform. After Ensure, PressTransform is
+            // expected to differ, so gate on _ensured==null (the post-Ensure guard below watches _ensured.Group).
+            if (_ensured == null
+                && !ReferenceEquals(_press.Drawable.Transform.CurrentValue, _press.PressTransform))
+            {
+                AbortDrag(
+                    "OnMoved: drawable Transform replaced before first move (Drawable={DrawableType}, Kind={Kind}, oldGroup={OldGroupType}, newGroup={NewGroupType}); aborting drag.",
+                    _press.Drawable.GetType().Name,
+                    Kind,
+                    _press.PressTransform?.GetType().Name ?? "null",
+                    _press.Drawable.Transform.CurrentValue?.GetType().Name ?? "null");
+                return;
+            }
+
+            EnsureOnFirstMove();
+            if (_ensured == null) return;
+
+            // Post-Ensure guard: if undo/redo replaces the entire TransformGroup mid-drag, _ensured.Group
+            // would still point at the detached group, causing silent write loss — abort instead.
+            // Undoing a child keyframe value does not change this reference, so it still passes through the gate.
+            if (!ReferenceEquals(_press.Drawable.Transform.CurrentValue, _ensured.Group))
+            {
+                AbortDrag(
+                    "OnMoved: drawable Transform replaced mid-drag (Drawable={DrawableType}, Kind={Kind}, ensuredGroup={EnsuredGroupType}, current={CurrentType}); aborting drag.",
+                    _press.Drawable.GetType().Name,
+                    Kind,
+                    _ensured.Group.GetType().Name,
+                    _press.Drawable.Transform.CurrentValue?.GetType().Name ?? "null");
+                return;
+            }
+
+            PointerPoint pp = e.GetCurrentPoint(Image);
+            AvaPoint currentImg = pp.Position;
+
+            // KeyDown/KeyUp only fire while framePanel has focus, so losing focus causes OnKeyUp to be
+            // missed and _shift to get stuck. During a drag, treat the pointer-event KeyModifiers as
+            // authoritative.
+            _shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+            switch (Kind)
+            {
+                case TransformHandlesOverlay.HandleKind.None:
+                case TransformHandlesOverlay.HandleKind.Center:
+                    HandleTranslate(currentImg);
+                    break;
+                case TransformHandlesOverlay.HandleKind.TopLeft:
+                case TransformHandlesOverlay.HandleKind.TopRight:
+                case TransformHandlesOverlay.HandleKind.BottomRight:
+                case TransformHandlesOverlay.HandleKind.BottomLeft:
+                    HandleCorner(currentImg);
+                    break;
+                case TransformHandlesOverlay.HandleKind.Top:
+                case TransformHandlesOverlay.HandleKind.Bottom:
+                case TransformHandlesOverlay.HandleKind.Left:
+                case TransformHandlesOverlay.HandleKind.Right:
+                    HandleEdge(currentImg);
+                    break;
+                case TransformHandlesOverlay.HandleKind.Rotate:
+                    HandleRotate(currentImg);
+                    break;
+                default:
+                    // Fail-fast detection for forgotten branches when the enum is extended.
+                    throw new System.ArgumentOutOfRangeException(nameof(Kind), Kind, "Unhandled HandleKind in OnMoved switch.");
+            }
+
+            // On the frame where AbortDrag tore the session down, skip the postlude and let the
+            // pointer event flow through to the parent routing.
+            if (_press == null) return;
+
+            _changed = true;
+            InvalidateFrameCache();
+            e.Handled = true;
+        }
+
+        private void HandleTranslate(AvaPoint currentImg)
+        {
+            if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
+
+            // Convert the image-pixel delta back to scene space and map it into T's value space via InvPostMatrixOfT.
+            double scale = press.FrameScale;
+            AvaPoint scaledCurrent = new(currentImg.X / scale, currentImg.Y / scale);
+            AvaPoint scaledStart = new(press.StartImagePos.X / scale, press.StartImagePos.Y / scale);
+
+            if (ensured.InvPostMatrixOfT is not BtlMatrix inv)
+            {
+                AbortDrag(
+                    "HandleTranslate: PostMatrixOfT non-invertible (Drawable={DrawableType}); aborting drag.",
+                    press.Drawable.GetType().Name);
+                return;
+            }
+
+            BtlPoint pCurrent = inv.Transform(new BtlPoint((float)scaledCurrent.X, (float)scaledCurrent.Y));
+            BtlPoint pStart = inv.Transform(new BtlPoint((float)scaledStart.X, (float)scaledStart.Y));
+            float dx = pCurrent.X - pStart.X;
+            float dy = pCurrent.Y - pStart.Y;
+
+            float newX = ensured.StartTransX + dx;
+            float newY = ensured.StartTransY + dy;
+            // Prevent NaN/Inf from being written to Translate through an ill-conditioned PostMatrixOfT.
+            if (!float.IsFinite(newX) || !float.IsFinite(newY))
+            {
+                AbortDrag(
+                    "HandleTranslate: non-finite translate (newX={NewX}, newY={NewY}); aborting drag.",
+                    newX, newY);
+                return;
+            }
+            if (!ApplyDelta(ensured.KfTransX, ensured.KfStartTransX, dx))
+                ensured.Translate.X.CurrentValue = newX;
+            if (!ApplyDelta(ensured.KfTransY, ensured.KfStartTransY, dy))
+                ensured.Translate.Y.CurrentValue = newY;
+        }
+
+        private void HandleCorner(AvaPoint currentImg)
+        {
+            if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
+
+            // Inverse-transform with the userMatrix captured at press time (do not recompute M every frame during the drag).
+            BtlPoint currentLocal = ImagePointToStartLocal(press, currentImg);
+            (double anchorX, double anchorY) = CornerAnchorLocal(press, Kind);
+
+            // Grow the signed distance from the anchor in the "positive" direction. Crossing the
+            // diagonal makes ratio negative and flips the object, which is accepted by design.
+            bool grabLeft = Kind is TransformHandlesOverlay.HandleKind.TopLeft or TransformHandlesOverlay.HandleKind.BottomLeft;
+            bool grabTop = Kind is TransformHandlesOverlay.HandleKind.TopLeft or TransformHandlesOverlay.HandleKind.TopRight;
+
+            double newWidth = grabLeft ? (anchorX - currentLocal.X) : (currentLocal.X - anchorX);
+            double newHeight = grabTop ? (anchorY - currentLocal.Y) : (currentLocal.Y - anchorY);
+
+            double ratioX = newWidth / press.LocalSize.Width;
+            double ratioY = newHeight / press.LocalSize.Height;
+
+            if (_shift)
+            {
+                (ratioX, ratioY) = TransformHandleMath.LockAspect(ratioX, ratioY);
+            }
+
+            float newScaleX = (float)(ensured.StartScaleX * ratioX);
+            float newScaleY = (float)(ensured.StartScaleY * ratioY);
+            ApplyScaleWithPivotCorrection(press, ensured, newScaleX, newScaleY, anchorX, anchorY);
+        }
+
+        private void HandleEdge(AvaPoint currentImg)
+        {
+            if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
+
+            BtlPoint currentLocal = ImagePointToStartLocal(press, currentImg);
+            (double anchorX, double anchorY) = EdgeAnchorLocal(press, Kind);
+
+            bool horizontal = Kind is TransformHandlesOverlay.HandleKind.Left or TransformHandlesOverlay.HandleKind.Right;
+            bool grabLeft = Kind is TransformHandlesOverlay.HandleKind.Left;
+            bool grabTop = Kind is TransformHandlesOverlay.HandleKind.Top;
+
+            float newScaleX = ensured.StartScaleX;
+            float newScaleY = ensured.StartScaleY;
+
+            if (horizontal)
+            {
+                double newWidth = grabLeft ? (anchorX - currentLocal.X) : (currentLocal.X - anchorX);
+                double ratioX = newWidth / press.LocalSize.Width;
+                newScaleX = (float)(ensured.StartScaleX * ratioX);
+                if (_shift)
+                {
+                    newScaleY = (float)(ensured.StartScaleY * ratioX);
+                }
+            }
+            else
+            {
+                double newHeight = grabTop ? (anchorY - currentLocal.Y) : (currentLocal.Y - anchorY);
+                double ratioY = newHeight / press.LocalSize.Height;
+                newScaleY = (float)(ensured.StartScaleY * ratioY);
+                if (_shift)
+                {
+                    newScaleX = (float)(ensured.StartScaleX * ratioY);
+                }
+            }
+
+            ApplyScaleWithPivotCorrection(press, ensured, newScaleX, newScaleY, anchorX, anchorY);
+        }
+
+        // Centralizes LogWarning → ResetSession → cursor release. The OnMoved postlude (`_press == null`) catches the abort frame.
+        private void AbortDrag(string reasonTemplate, params object?[] args)
+        {
+            _logger.LogWarning(reasonTemplate, args);
+            ResetSession();
+            View.framePanel.Cursor = null;
+        }
+
+        private void HandleRotate(AvaPoint currentImg)
+        {
+            if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
+            double sx = press.StartImagePos.X - press.PivotImage.X;
+            double sy = press.StartImagePos.Y - press.PivotImage.Y;
+            double cx = currentImg.X - press.PivotImage.X;
+            double cy = currentImg.Y - press.PivotImage.Y;
+
+            double angleStart = Math.Atan2(sy, sx);
+            double angleCurrent = Math.Atan2(cy, cx);
+            double deltaRad = TransformHandleMath.NormalizeAngleDelta(angleCurrent - angleStart);
+            // If PivotImage is degenerate the whole drag would freeze, so abort the session and surface feedback.
+            if (!double.IsFinite(deltaRad))
+            {
+                AbortDrag(
+                    "HandleRotate: non-finite delta (pivot={Pivot}, start={Start}, current={Current}); aborting drag.",
+                    press.PivotImage, press.StartImagePos, currentImg);
+                return;
+            }
+            float deltaDeg = MathUtilities.Rad2Deg((float)deltaRad);
+
+            float newRot = ensured.StartRotation + deltaDeg;
+            if (_shift)
+            {
+                newRot = (float)(Math.Round(newRot / 15.0) * 15.0);
+            }
+
+            // newRot is invariantly finite (guaranteed by the upstream gates on StartRotation/deltaRad and by Math.Round).
+            // Derive delta from the post-Shift-snap value (deltaDeg is the pre-snap value).
+            float effectiveDelta = newRot - ensured.StartRotation;
+            if (!ApplyDelta(ensured.KfRotation, ensured.KfStartRotation, effectiveDelta))
+                ensured.Rotation.Rotation.CurrentValue = newRot;
+        }
+
+        private void ApplyScale(EnsuredState ensured, float newScaleX, float newScaleY)
+        {
+            if (!float.IsFinite(newScaleX) || !float.IsFinite(newScaleY))
+            {
+                AbortDrag(
+                    "ApplyScale: non-finite scale (sx={ScaleX}, sy={ScaleY}); aborting drag.",
+                    newScaleX, newScaleY);
+                return;
+            }
+            float deltaScaleX = newScaleX - ensured.StartScaleX;
+            float deltaScaleY = newScaleY - ensured.StartScaleY;
+            if (!ApplyDelta(ensured.KfScaleX, ensured.KfStartScaleX, deltaScaleX))
+                ensured.Scale.ScaleX.CurrentValue = newScaleX;
+            if (!ApplyDelta(ensured.KfScaleY, ensured.KfStartScaleY, deltaScaleY))
+                ensured.Scale.ScaleY.CurrentValue = newScaleY;
+        }
+
+        // Compensate the anchor shift caused by a scale change via the operative Translate.
+        // See <see cref="TransformHandleMath.ComputePivotTranslationDelta"/> for the math. Specific to the new [T, R, S] layout.
+        private void ApplyScaleWithPivotCorrection(
+            PressState press, EnsuredState ensured,
+            float newScaleX, float newScaleY, double anchorX, double anchorY)
+        {
+            ApplyScale(ensured, newScaleX, newScaleY);
+            if (_press == null) return;
+
+            (float deltaTx, float deltaTy) = TransformHandleMath.ComputePivotTranslationDelta(
+                ensured.StartScaleX, ensured.StartScaleY,
+                newScaleX, newScaleY,
+                anchorX, anchorY,
+                press.PivotLocal.X, press.PivotLocal.Y,
+                ensured.RotationMatrix);
+            float newTx = ensured.StartTransX + deltaTx;
+            float newTy = ensured.StartTransY + deltaTy;
+
+            // Block the path where an ill-conditioned anchor/origin rounds to Inf via the (float) cast.
+            if (!float.IsFinite(newTx) || !float.IsFinite(newTy))
+            {
+                AbortDrag(
+                    "ApplyScaleWithPivotCorrection: non-finite ΔT (deltaTx={Dx}, deltaTy={Dy}); aborting drag.",
+                    deltaTx, deltaTy);
+                return;
+            }
+
+            if (!ApplyDelta(ensured.KfTransX, ensured.KfStartTransX, deltaTx))
+                ensured.Translate.X.CurrentValue = newTx;
+            if (!ApplyDelta(ensured.KfTransY, ensured.KfStartTransY, deltaTy))
+                ensured.Translate.Y.CurrentValue = newTy;
+        }
+
+        private static BtlPoint ImagePointToStartLocal(PressState press, AvaPoint img)
+        {
+            double sceneX = img.X / press.FrameScale;
+            double sceneY = img.Y / press.FrameScale;
+            return press.InvStartUserMatrix.Transform(new BtlPoint((float)sceneX, (float)sceneY));
+        }
+
+        // Anchor coordinates are local-rect-relative (0,0)-(w,h). Drawable.GetTransformMatrix shares
+        // this assumption, treating the size as starting from (0,0). When a Shape has
+        // Geometry.Bounds.Position != (0,0) the overlay can misalign, but that is a limitation of the
+        // existing rendering model and out of scope for this file.
+        private static (double X, double Y) CornerAnchorLocal(PressState press, TransformHandlesOverlay.HandleKind kind)
+        {
+            BtlSize size = press.LocalSize;
+            double w = size.Width, h = size.Height;
+            return kind switch
+            {
+                TransformHandlesOverlay.HandleKind.TopLeft => (w, h),       // opposite = BottomRight
+                TransformHandlesOverlay.HandleKind.TopRight => (0, h),       // opposite = BottomLeft
+                TransformHandlesOverlay.HandleKind.BottomRight => (0, 0),    // opposite = TopLeft
+                TransformHandlesOverlay.HandleKind.BottomLeft => (w, 0),     // opposite = TopRight
+                _ => throw new System.ArgumentOutOfRangeException(nameof(kind), kind, "Corner anchor requested for non-corner HandleKind."),
+            };
+        }
+
+        private static (double X, double Y) EdgeAnchorLocal(PressState press, TransformHandlesOverlay.HandleKind kind)
+        {
+            BtlSize size = press.LocalSize;
+            double w = size.Width, h = size.Height;
+            return kind switch
+            {
+                TransformHandlesOverlay.HandleKind.Top => (0, h),     // opposite = Bottom edge
+                TransformHandlesOverlay.HandleKind.Bottom => (0, 0),  // opposite = Top edge
+                TransformHandlesOverlay.HandleKind.Left => (w, 0),    // opposite = Right edge
+                TransformHandlesOverlay.HandleKind.Right => (0, 0),   // opposite = Left edge
+                _ => throw new System.ArgumentOutOfRangeException(nameof(kind), kind, "Edge anchor requested for non-edge HandleKind."),
+            };
+        }
+
+        public void OnReleased(PointerReleasedEventArgs e)
+        {
+            if (_press == null) return;
+
+            // If the Transform was replaced between OnMoved and OnReleased, _ensured.Group now points
+            // at a detached group, so discard the pending commit. Skip this check for click-only sessions (Ensure never ran).
+            if (_ensured != null
+                && !ReferenceEquals(_press.Drawable.Transform.CurrentValue, _ensured.Group))
+            {
+                _logger.LogWarning(
+                    "OnReleased: drawable Transform replaced before release (Drawable={DrawableType}, Kind={Kind}); discarding pending commit.",
+                    _press.Drawable.GetType().Name, Kind);
+                View.framePanel.Cursor = null;
+                ResetSession();
+                _shift = false;
+                e.Handled = true;
+                return;
+            }
+
+            if (_changed)
+            {
+                EditViewModel.HistoryManager.Commit(CommandNames.TransformElement);
+            }
+
+            View.framePanel.Cursor = null;
+            ResetSession();
+            _shift = false;
+            e.Handled = true;
+        }
+
+        private void ResetSession()
+        {
+            _press = null;
+            _ensured = null;
+            _changed = false;
+        }
+
+        public void OnKeyDown(KeyEventArgs e) => SyncShift(e.KeyModifiers);
+
+        public void OnKeyUp(KeyEventArgs e) => SyncShift(e.KeyModifiers);
+
+        private void SyncShift(KeyModifiers modifiers) => _shift = modifiers.HasFlag(KeyModifiers.Shift);
+
+        private void InvalidateFrameCache()
+        {
+            Element? element = _press?.Element;
+            if (element == null) return;
+            int rate = EditViewModel.Player.GetFrameRate();
+            int st = (int)element.Start.ToFrameNumber(rate);
+            int ed = (int)Math.Ceiling(element.Range.End.ToFrameNumber(rate));
+            EditViewModel.FrameCacheManager.Value.DeleteAndUpdateBlocks([(st, ed)]);
         }
     }
 
@@ -1321,12 +1812,15 @@ public partial class PlayerView
     {
         if (viewModel.IsMoveMode.Value)
         {
-            return new MouseControlMove
+            // Mouse interactions in Move mode are routed directly to MouseControlTransformHandles in OnFramePointerPressed.
+            // Only wheel events reach this method through CreateMouseHandler, where a no-op is acceptable.
+            return new MouseControlTransformHandles
             {
+                View = this,
                 ViewModel = viewModel,
                 Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
                 EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
-                View = this
+                Kind = TransformHandlesOverlay.HandleKind.None,
             };
         }
         else if (viewModel.IsHandMode.Value)
@@ -1374,14 +1868,29 @@ public partial class PlayerView
                     viewModel.IsHandMode.Value = true;
                 }
 
-                _mouseState = CreateMouseHandler(viewModel);
-
-                _mouseState.OnPressed(e);
-                // Todo: 抽象化する
-                if (_mouseState is MouseControlMove move)
+                // In Move mode the left button funnels through MouseControlTransformHandles regardless of whether the click hit a handle.
+                // When Kind == None it takes the renderer hit-test + double-click + translate-drag path.
+                if (viewModel.IsMoveMode.Value && point.Properties.IsLeftButtonPressed)
                 {
-                    _lastSelected.SetTarget(move.Drawable);
+                    AvaPoint imagePoint = e.GetCurrentPoint(image).Position;
+                    TransformHandlesOverlay.HandleKind kind = transformHandlesOverlay.HitTest(imagePoint);
+                    var handler = new MouseControlTransformHandles
+                    {
+                        View = this,
+                        ViewModel = viewModel,
+                        Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
+                        EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
+                        Kind = kind,
+                    };
+                    _mouseState = handler;
+                    handler.OnPressed(e);
+                    _lastSelected.SetTarget(handler.Drawable);
+                    framePanel.Focus();
+                    return;
                 }
+
+                _mouseState = CreateMouseHandler(viewModel);
+                _mouseState.OnPressed(e);
             }
         }
     }

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -215,6 +215,10 @@ public partial class PlayerView
         private PressState? _press;
         private EnsuredState? _ensured;
 
+        // Stored so that ResetSession can release the capture during normal or aborted teardown.
+        // Without releasing, framePanel would keep stealing pointer events from sibling controls after the drag.
+        private IPointer? _capturedPointer;
+
         // _changed is drag-scoped (cleared by ResetSession); _shift stays live outside of a drag too
         // (synced from KeyDown/Up and pointer-event KeyModifiers, reset to false only in OnReleased).
         private bool _changed;
@@ -323,6 +327,7 @@ public partial class PlayerView
             // framePanel. Without this, releasing outside the control would leave _press dangling
             // and subsequent re-entries would mutate the Transform without a held button.
             e.Pointer.Capture(View.framePanel);
+            _capturedPointer = e.Pointer;
 
             e.Handled = true;
         }
@@ -429,6 +434,7 @@ public partial class PlayerView
             // Capture the pointer so a translate drag started here still delivers Released even when
             // the cursor leaves framePanel during the drag.
             e.Pointer.Capture(View.framePanel);
+            _capturedPointer = e.Pointer;
 
             e.Handled = true;
 
@@ -874,11 +880,23 @@ public partial class PlayerView
         //   - successful Release after Commit: Rollback becomes a no-op because Commit already cleared the current transaction.
         //   - abort/discard paths (AbortDrag, OnReleased discard branch): pending Ensure-driven structure changes and
         //     handle-applied deltas would otherwise leak into the next unrelated Commit, breaking undo grouping.
+        // Also releases any pointer capture taken in OnPressed; otherwise framePanel keeps stealing
+        // pointer events from sibling controls after the drag ends (capture does NOT auto-release on button up).
         private void ResetSession()
         {
             if (_changed || _ensured != null)
             {
                 EditViewModel.HistoryManager.Rollback();
+            }
+            if (_capturedPointer != null)
+            {
+                // Capture(null) when the captured target is still framePanel; the PointerCaptureLost
+                // path may already have done the release for us, so guard against double-clearing.
+                if (ReferenceEquals(_capturedPointer.Captured, View.framePanel))
+                {
+                    _capturedPointer.Capture(null);
+                }
+                _capturedPointer = null;
             }
             _press = null;
             _ensured = null;

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -46,7 +46,6 @@ public partial class PlayerView
         public KeyFrame<T>? Next { get; } = next;
     }
 
-    // If localStart is non-null, convert to local time (e.g. Element/Scene3D); if null, use globalKeyTime as-is.
     private static KeyFrameState<T>? FindKeyFramePair<T>(
         IProperty<T> property, IEditorClock clock, Scene scene, TimeSpan? localStart)
     {
@@ -165,12 +164,9 @@ public partial class PlayerView
     private sealed class MouseControlTransformHandles : IMouseControlHandler
     {
         // Drag lifecycle: Press → (first OnMoved → Ensure) → Move* → Release.
-        //   _press == null  : pre-press state
-        //   _ensured == null: pre-drag (Press received but no mouse movement yet)
-
-        // When Kind == None, LocalSize/StartUserMatrix/InvStartUserMatrix/PivotLocal/PivotImage are
-        // filled with default/Identity (harmless because only HandleTranslate is invoked, which does not reference them).
-        // PressTransform: anchor for detecting whether undo/redo replaced the Transform right before the first OnMoved.
+        // _ensured == null means Press fired but no mouse movement yet — Ensure (which mutates the
+        // document) is deferred to the first OnMoved so a bare click leaves the Transform alone.
+        // PressTransform anchors detection of undo/redo replacing the Transform before that first move.
         private sealed record PressState(
             Drawable Drawable,
             Element? Element,
@@ -215,12 +211,10 @@ public partial class PlayerView
         private PressState? _press;
         private EnsuredState? _ensured;
 
-        // Stored so that ResetSession can release the capture during normal or aborted teardown.
-        // Without releasing, framePanel would keep stealing pointer events from sibling controls after the drag.
+        // Avalonia does not auto-release pointer capture on button-up; without ResetSession releasing it
+        // explicitly, framePanel would keep stealing pointer events from sibling controls after the drag.
         private IPointer? _capturedPointer;
 
-        // _changed is drag-scoped (cleared by ResetSession); _shift stays live outside of a drag too
-        // (synced from KeyDown/Up and pointer-event KeyModifiers, reset to false only in OnReleased).
         private bool _changed;
         private bool _shift;
 
@@ -243,7 +237,6 @@ public partial class PlayerView
         private KeyFrameState<float>? FindKf(IProperty<float> property)
             => FindKeyFramePair(property, Clock, EditViewModel.Scene, _press?.Element?.Start);
 
-        // On invariant violation, leave a more actionable log than an NRE and short-circuit subsequent OnMoved calls via ResetSession.
         private bool TryGetSession(
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out PressState? press,
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EnsuredState? ensured)
@@ -255,8 +248,6 @@ public partial class PlayerView
                 "MouseControlTransformHandles handler invoked without session (press={HasPress}, ensured={HasEnsured}, kind={Kind}). Aborting drag.",
                 press != null, ensured != null, Kind);
             ResetSession();
-            press = null;
-            ensured = null;
             return false;
         }
 
@@ -265,6 +256,19 @@ public partial class PlayerView
 
         private static (float prev, float next) CaptureStartValues(KeyFrameState<float>? kf, float fallback)
             => KeyFrameDeltaHelper.CaptureStartValues(kf?.Previous, kf?.Next, fallback);
+
+        // Writes to surrounding keyframes when present, otherwise to CurrentValue. The two write paths
+        // are intentionally mutually exclusive so a single drag does not double-write the same axis.
+        private static void WriteScalar(
+            IProperty<float> property,
+            KeyFrameState<float>? kf,
+            (float prev, float next) kfStart,
+            float delta,
+            float newValue)
+        {
+            if (!ApplyDelta(kf, kfStart, delta))
+                property.CurrentValue = newValue;
+        }
 
         public void OnPressed(PointerPressedEventArgs e)
         {
@@ -316,8 +320,6 @@ public partial class PlayerView
                 StartImagePos: startImagePos,
                 PressTransform: drawable.Transform.CurrentValue);
 
-            // Ensure (= inserting R/S/T) is a document mutation, so defer it until the first OnMoved
-            // (if the user only clicks and releases, the structure is left untouched).
             _ensured = null;
 
             EditorSelection.SelectedObject.Value = element;
@@ -332,8 +334,7 @@ public partial class PlayerView
             e.Handled = true;
         }
 
-        // Click outside the overlay region (Kind == None). Resolve the drawable via renderer hit-test;
-        // toggle selection, launch path editor on double-click of a shape, and start a translate drag on the first OnMoved.
+        // Kind == None path: resolve the drawable via renderer hit-test instead of consuming a handle.
         private void OnPressedHitTest(PointerPressedEventArgs e, PointerPoint pp)
         {
             Scene scene = EditViewModel.Scene;
@@ -341,7 +342,7 @@ public partial class PlayerView
             double frameScale = Image.Bounds.Size.Width / scene.FrameSize.Width;
             if (frameScale <= 0)
             {
-                // Layout race: e.g. the click arrived before framePanel had laid out the image.
+                // Click arrived before framePanel laid out the image (layout race) — swallow it.
                 _logger.LogDebug(
                     "OnPressedHitTest: frameScale={FrameScale} <= 0 (imageBounds={ImageBounds}, frameSize={FrameSize}), swallowing click.",
                     frameScale, Image.Bounds.Size, scene.FrameSize);
@@ -365,8 +366,7 @@ public partial class PlayerView
             }
             catch (OperationCanceledException ocex)
             {
-                // Pointer event delivered during shutdown. Propagating it can kill the UI thread,
-                // so log and discard the click instead.
+                // Likely shutdown — propagating would crash the UI-thread pointer pipeline.
                 _logger.LogDebug(
                     ocex,
                     "OnPressedHitTest: hit-test cancelled (likely shutdown). Swallowing click.");
@@ -377,10 +377,10 @@ public partial class PlayerView
             catch (Exception ex) when (
                 ex is not OutOfMemoryException
                 and not StackOverflowException
-                and not System.Runtime.InteropServices.SEHException  // propagate things like GPU driver crashes
-                and not AccessViolationException)                    // CSE (defense-in-depth)
+                and not System.Runtime.InteropServices.SEHException  // propagate GPU driver crashes
+                and not AccessViolationException)                    // CSE defense-in-depth
             {
-                // Swallow the exception; propagating it would crash the editor via the pointer-event pipeline.
+                // Avoid crashing the editor via the pointer-event pipeline.
                 _logger.LogError(
                     ex,
                     "OnPressedHitTest: renderer hit-test threw at scaledPos={ScaledPos}.",
@@ -390,17 +390,16 @@ public partial class PlayerView
                 return;
             }
 
-            // Fall through on an empty click so other handlers / the normal selection logic can run
-            // (setting _press=non-null + Handled=true would make the click look unresponsive).
+            // Empty click: let normal selection logic run instead of swallowing it.
             if (drawable == null)
             {
                 _press = null;
                 return;
             }
 
-            // Resolve the owning Element via the hierarchical parent chain so that overlapping
-            // ZIndex elements do not alias to each other. Fall back to a ZIndex/time-window search
-            // only when the drawable's parent is outside this scene (e.g. nested SceneDrawable).
+            // Walk hierarchical parents so overlapping ZIndex elements don't alias to each other; fall
+            // back to a ZIndex/time-window search only when the drawable's parent is outside this scene
+            // (e.g. nested SceneDrawable).
             Element? element = drawable.FindHierarchicalParent<Element>();
             if (element == null || !scene.Children.Contains(element))
             {
@@ -463,10 +462,9 @@ public partial class PlayerView
 
             var ctx = new CompositionContext(Clock.CurrentTime.Value);
 
-            // Ensure performs a document mutation, so first take a mutation-free snapshot and verify finiteness.
-            // If any value is invalid, abort without invoking Ensure to avoid leaving a non-undoable mutation behind.
-            // The defaults used to fill missing axes must match the property defaults of the R/S/T that Ensure inserts
-            // (TranslateTransform.X/Y=0, ScaleTransform.ScaleX/Y=100, RotationTransform.Rotation=0).
+            // Snapshot before Ensure mutates the document — a non-finite value here aborts the drag so
+            // we don't leave a structural mutation that the user can't fix via undo. Fallbacks must match
+            // the property defaults of the R/S/T inserted by Ensure (T=0, S=100, R=0).
             var (probeR, probeS, probeT) = CanonicalTransformLayout.FindCanonicalTransforms(_press.Drawable.Transform.GetValue(ctx));
             float startTransX = probeT?.X.GetValue(ctx) ?? 0f;
             float startTransY = probeT?.Y.GetValue(ctx) ?? 0f;
@@ -521,7 +519,7 @@ public partial class PlayerView
                 KfStartRotation = CaptureStartValues(kfRotation, startRotation),
             };
 
-            // If a structural change (group wrap or R/S/T insertion) happened, commit even if delta is tiny.
+            // Commit even on a zero-delta drag so the structural change is undoable on its own.
             if (ensured.StructureChanged)
             {
                 _changed = true;
@@ -532,10 +530,9 @@ public partial class PlayerView
         {
             if (_press == null) return;
 
-            // Pre-Ensure guard: detect the case where undo/redo replaces the entire Transform between
-            // OnPressed and the first OnMoved. If this is not checked before Ensure runs, structural
-            // mutations would be applied to the post-undo Transform. After Ensure, PressTransform is
-            // expected to differ, so gate on _ensured==null (the post-Ensure guard below watches _ensured.Group).
+            // If undo/redo replaced the Transform between OnPressed and the first OnMoved, run Ensure
+            // against the wrong instance — abort the drag instead. After Ensure, PressTransform may
+            // legitimately differ, so the post-Ensure guard below watches _ensured.Group instead.
             if (_ensured == null
                 && !ReferenceEquals(_press.Drawable.Transform.CurrentValue, _press.PressTransform))
             {
@@ -551,9 +548,9 @@ public partial class PlayerView
             EnsureOnFirstMove();
             if (_ensured == null) return;
 
-            // Post-Ensure guard: if undo/redo replaces the entire TransformGroup mid-drag, _ensured.Group
-            // would still point at the detached group, causing silent write loss — abort instead.
-            // Undoing a child keyframe value does not change this reference, so it still passes through the gate.
+            // If undo/redo replaces the TransformGroup mid-drag, _ensured.Group is now detached and
+            // writes would be silently dropped. Undoing a child keyframe value keeps the group ref,
+            // so this only catches whole-Transform replacements.
             if (!ReferenceEquals(_press.Drawable.Transform.CurrentValue, _ensured.Group))
             {
                 AbortDrag(
@@ -595,12 +592,11 @@ public partial class PlayerView
                     HandleRotate(currentImg);
                     break;
                 default:
-                    // Fail-fast detection for forgotten branches when the enum is extended.
                     throw new System.ArgumentOutOfRangeException(nameof(Kind), Kind, "Unhandled HandleKind in OnMoved switch.");
             }
 
-            // On the frame where AbortDrag tore the session down, skip the postlude and let the
-            // pointer event flow through to the parent routing.
+            // AbortDrag in any branch nulls _press; in that case the pointer event should bubble up
+            // to the parent routing rather than be marked as handled.
             if (_press == null) return;
 
             _changed = true;
@@ -612,7 +608,6 @@ public partial class PlayerView
         {
             if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
 
-            // Convert the image-pixel delta back to scene space and map it into T's value space via InvPostMatrixOfT.
             double scale = press.FrameScale;
             AvaPoint scaledCurrent = new(currentImg.X / scale, currentImg.Y / scale);
             AvaPoint scaledStart = new(press.StartImagePos.X / scale, press.StartImagePos.Y / scale);
@@ -632,7 +627,6 @@ public partial class PlayerView
 
             float newX = ensured.StartTransX + dx;
             float newY = ensured.StartTransY + dy;
-            // Prevent NaN/Inf from being written to Translate through an ill-conditioned PostMatrixOfT.
             if (!float.IsFinite(newX) || !float.IsFinite(newY))
             {
                 AbortDrag(
@@ -640,22 +634,18 @@ public partial class PlayerView
                     newX, newY);
                 return;
             }
-            if (!ApplyDelta(ensured.KfTransX, ensured.KfStartTransX, dx))
-                ensured.Translate.X.CurrentValue = newX;
-            if (!ApplyDelta(ensured.KfTransY, ensured.KfStartTransY, dy))
-                ensured.Translate.Y.CurrentValue = newY;
+            WriteScalar(ensured.Translate.X, ensured.KfTransX, ensured.KfStartTransX, dx, newX);
+            WriteScalar(ensured.Translate.Y, ensured.KfTransY, ensured.KfStartTransY, dy, newY);
         }
 
         private void HandleCorner(AvaPoint currentImg)
         {
             if (!TryGetSession(out PressState? press, out EnsuredState? ensured)) return;
 
-            // Inverse-transform with the userMatrix captured at press time (do not recompute M every frame during the drag).
             BtlPoint currentLocal = ImagePointToStartLocal(press, currentImg);
             (double anchorX, double anchorY) = CornerAnchorLocal(press, Kind);
 
-            // Grow the signed distance from the anchor in the "positive" direction. Crossing the
-            // diagonal makes ratio negative and flips the object, which is accepted by design.
+            // Crossing the diagonal flips ratio sign and so flips the object — accepted by design.
             bool grabLeft = Kind is TransformHandlesOverlay.HandleKind.TopLeft or TransformHandlesOverlay.HandleKind.BottomLeft;
             bool grabTop = Kind is TransformHandlesOverlay.HandleKind.TopLeft or TransformHandlesOverlay.HandleKind.TopRight;
 
@@ -713,7 +703,6 @@ public partial class PlayerView
             ApplyScaleWithPivotCorrection(press, ensured, newScaleX, newScaleY, anchorX, anchorY);
         }
 
-        // Centralizes LogWarning → ResetSession → cursor release. The OnMoved postlude (`_press == null`) catches the abort frame.
         private void AbortDrag(string reasonTemplate, params object?[] args)
         {
             _logger.LogWarning(reasonTemplate, args);
@@ -732,7 +721,6 @@ public partial class PlayerView
             double angleStart = Math.Atan2(sy, sx);
             double angleCurrent = Math.Atan2(cy, cx);
             double deltaRad = TransformHandleMath.NormalizeAngleDelta(angleCurrent - angleStart);
-            // If PivotImage is degenerate the whole drag would freeze, so abort the session and surface feedback.
             if (!double.IsFinite(deltaRad))
             {
                 AbortDrag(
@@ -748,11 +736,9 @@ public partial class PlayerView
                 newRot = (float)(Math.Round(newRot / 15.0) * 15.0);
             }
 
-            // newRot is invariantly finite (guaranteed by the upstream gates on StartRotation/deltaRad and by Math.Round).
             // Derive delta from the post-Shift-snap value (deltaDeg is the pre-snap value).
             float effectiveDelta = newRot - ensured.StartRotation;
-            if (!ApplyDelta(ensured.KfRotation, ensured.KfStartRotation, effectiveDelta))
-                ensured.Rotation.Rotation.CurrentValue = newRot;
+            WriteScalar(ensured.Rotation.Rotation, ensured.KfRotation, ensured.KfStartRotation, effectiveDelta, newRot);
         }
 
         private void ApplyScale(EnsuredState ensured, float newScaleX, float newScaleY)
@@ -766,14 +752,12 @@ public partial class PlayerView
             }
             float deltaScaleX = newScaleX - ensured.StartScaleX;
             float deltaScaleY = newScaleY - ensured.StartScaleY;
-            if (!ApplyDelta(ensured.KfScaleX, ensured.KfStartScaleX, deltaScaleX))
-                ensured.Scale.ScaleX.CurrentValue = newScaleX;
-            if (!ApplyDelta(ensured.KfScaleY, ensured.KfStartScaleY, deltaScaleY))
-                ensured.Scale.ScaleY.CurrentValue = newScaleY;
+            WriteScalar(ensured.Scale.ScaleX, ensured.KfScaleX, ensured.KfStartScaleX, deltaScaleX, newScaleX);
+            WriteScalar(ensured.Scale.ScaleY, ensured.KfScaleY, ensured.KfStartScaleY, deltaScaleY, newScaleY);
         }
 
-        // Compensate the anchor shift caused by a scale change via the operative Translate.
-        // See <see cref="TransformHandleMath.ComputePivotTranslationDelta"/> for the math. Specific to the new [T, R, S] layout.
+        // Compensate the anchor shift caused by a scale change via the operative Translate; see
+        // <see cref="TransformHandleMath.ComputePivotTranslationDelta"/> for the derivation.
         private void ApplyScaleWithPivotCorrection(
             PressState press, EnsuredState ensured,
             float newScaleX, float newScaleY, double anchorX, double anchorY)
@@ -790,7 +774,6 @@ public partial class PlayerView
             float newTx = ensured.StartTransX + deltaTx;
             float newTy = ensured.StartTransY + deltaTy;
 
-            // Block the path where an ill-conditioned anchor/origin rounds to Inf via the (float) cast.
             if (!float.IsFinite(newTx) || !float.IsFinite(newTy))
             {
                 AbortDrag(
@@ -799,10 +782,8 @@ public partial class PlayerView
                 return;
             }
 
-            if (!ApplyDelta(ensured.KfTransX, ensured.KfStartTransX, deltaTx))
-                ensured.Translate.X.CurrentValue = newTx;
-            if (!ApplyDelta(ensured.KfTransY, ensured.KfStartTransY, deltaTy))
-                ensured.Translate.Y.CurrentValue = newTy;
+            WriteScalar(ensured.Translate.X, ensured.KfTransX, ensured.KfStartTransX, deltaTx, newTx);
+            WriteScalar(ensured.Translate.Y, ensured.KfTransY, ensured.KfStartTransY, deltaTy, newTy);
         }
 
         private static BtlPoint ImagePointToStartLocal(PressState press, AvaPoint img)
@@ -812,36 +793,36 @@ public partial class PlayerView
             return press.InvStartUserMatrix.Transform(new BtlPoint((float)sceneX, (float)sceneY));
         }
 
-        // Anchor coordinates are local-rect-relative (0,0)-(w,h). Drawable.GetTransformMatrix shares
-        // this assumption, treating the size as starting from (0,0). When a Shape has
-        // Geometry.Bounds.Position != (0,0) the overlay can misalign, but that is a limitation of the
-        // existing rendering model and out of scope for this file.
+        // Anchors are local-rect coordinates (0,0)-(w,h). Drawable.GetTransformMatrix assumes the same
+        // origin; for Shapes whose Geometry.Bounds.Position != (0,0) the overlay can misalign — that is
+        // a rendering-model limitation, out of scope here. Each anchor is the OPPOSITE corner/edge of
+        // the grabbed handle (so the grabbed side moves while the anchor stays put).
         private static (double X, double Y) CornerAnchorLocal(PressState press, TransformHandlesOverlay.HandleKind kind)
         {
             BtlSize size = press.LocalSize;
             double w = size.Width, h = size.Height;
             return kind switch
             {
-                TransformHandlesOverlay.HandleKind.TopLeft => (w, h),       // opposite = BottomRight
-                TransformHandlesOverlay.HandleKind.TopRight => (0, h),       // opposite = BottomLeft
-                TransformHandlesOverlay.HandleKind.BottomRight => (0, 0),    // opposite = TopLeft
-                TransformHandlesOverlay.HandleKind.BottomLeft => (w, 0),     // opposite = TopRight
+                TransformHandlesOverlay.HandleKind.TopLeft => (w, h),
+                TransformHandlesOverlay.HandleKind.TopRight => (0, h),
+                TransformHandlesOverlay.HandleKind.BottomRight => (0, 0),
+                TransformHandlesOverlay.HandleKind.BottomLeft => (w, 0),
                 _ => throw new System.ArgumentOutOfRangeException(nameof(kind), kind, "Corner anchor requested for non-corner HandleKind."),
             };
         }
 
-        // Anchor at the center of the opposite edge so that proportional (Shift) edge-resize stays centered
-        // on the orthogonal axis. Using a corner here makes Shift-dragging an edge introduce sideways drift.
+        // Edge anchors are at the OPPOSITE edge's center, not a corner — using a corner would make
+        // Shift-dragging an edge introduce sideways drift on the orthogonal axis.
         private static (double X, double Y) EdgeAnchorLocal(PressState press, TransformHandlesOverlay.HandleKind kind)
         {
             BtlSize size = press.LocalSize;
             double w = size.Width, h = size.Height;
             return kind switch
             {
-                TransformHandlesOverlay.HandleKind.Top => (w * 0.5, h),       // opposite = Bottom edge center
-                TransformHandlesOverlay.HandleKind.Bottom => (w * 0.5, 0),    // opposite = Top edge center
-                TransformHandlesOverlay.HandleKind.Left => (w, h * 0.5),      // opposite = Right edge center
-                TransformHandlesOverlay.HandleKind.Right => (0, h * 0.5),     // opposite = Left edge center
+                TransformHandlesOverlay.HandleKind.Top => (w * 0.5, h),
+                TransformHandlesOverlay.HandleKind.Bottom => (w * 0.5, 0),
+                TransformHandlesOverlay.HandleKind.Left => (w, h * 0.5),
+                TransformHandlesOverlay.HandleKind.Right => (0, h * 0.5),
                 _ => throw new System.ArgumentOutOfRangeException(nameof(kind), kind, "Edge anchor requested for non-edge HandleKind."),
             };
         }
@@ -850,8 +831,9 @@ public partial class PlayerView
         {
             if (_press == null) return;
 
-            // If the Transform was replaced between OnMoved and OnReleased, _ensured.Group now points
-            // at a detached group, so discard the pending commit. Skip this check for click-only sessions (Ensure never ran).
+            // If undo/redo replaced the Transform mid-drag (after the post-Ensure guard already ran),
+            // _ensured.Group is detached — discard the pending commit. Click-only sessions skip this
+            // since Ensure never ran.
             if (_ensured != null
                 && !ReferenceEquals(_press.Drawable.Transform.CurrentValue, _ensured.Group))
             {
@@ -876,12 +858,9 @@ public partial class PlayerView
             e.Handled = true;
         }
 
-        // Always roll back any pending operations recorded during the drag. ResetSession is reached on:
-        //   - successful Release after Commit: Rollback becomes a no-op because Commit already cleared the current transaction.
-        //   - abort/discard paths (AbortDrag, OnReleased discard branch): pending Ensure-driven structure changes and
-        //     handle-applied deltas would otherwise leak into the next unrelated Commit, breaking undo grouping.
-        // Also releases any pointer capture taken in OnPressed; otherwise framePanel keeps stealing
-        // pointer events from sibling controls after the drag ends (capture does NOT auto-release on button up).
+        // Rollback is a no-op after Commit (Commit clears the current transaction), but on abort/discard
+        // paths it must run so pending Ensure-driven structural changes and handle deltas don't leak into
+        // an unrelated next Commit.
         private void ResetSession()
         {
             if (_changed || _ensured != null)
@@ -890,8 +869,7 @@ public partial class PlayerView
             }
             if (_capturedPointer != null)
             {
-                // Capture(null) when the captured target is still framePanel; the PointerCaptureLost
-                // path may already have done the release for us, so guard against double-clearing.
+                // PointerCaptureLost may have already released for us; guard against double-clearing.
                 if (ReferenceEquals(_capturedPointer.Captured, View.framePanel))
                 {
                     _capturedPointer.Capture(null);
@@ -909,8 +887,8 @@ public partial class PlayerView
 
         public void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
         {
-            // In the normal Release flow, OnReleased clears _press before this fires, so this is a no-op.
-            // It only does work when capture was taken away externally (focus stolen, system event, etc.).
+            // OnReleased clears _press on the normal path, so this only fires when capture was taken
+            // away externally (focus stolen, system event, etc.).
             if (_press == null) return;
             _logger.LogDebug(
                 "OnPointerCaptureLost: capture lost mid-drag (Drawable={DrawableType}, Kind={Kind}); discarding pending changes.",
@@ -1858,8 +1836,8 @@ public partial class PlayerView
 
     private void OnFramePointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
-        // On a normal Release, OnFramePointerReleased already nulled out _mouseState, so this is a no-op.
-        // It only does work when capture was taken away externally before Release reached us.
+        // OnFramePointerReleased nulls _mouseState on the normal path; this only fires when capture
+        // was taken away externally before Release reached us.
         if (_mouseState == null) return;
         _mouseState.OnPointerCaptureLost(e);
         _mouseState = null;
@@ -1883,8 +1861,8 @@ public partial class PlayerView
     {
         if (viewModel.IsMoveMode.Value)
         {
-            // Mouse interactions in Move mode are routed directly to MouseControlTransformHandles in OnFramePointerPressed.
-            // Only wheel events reach this method through CreateMouseHandler, where a no-op is acceptable.
+            // Move-mode pointer-down is handled directly in OnFramePointerPressed; this path only
+            // serves wheel events, where a no-op handler is fine.
             return new MouseControlTransformHandles
             {
                 View = this,
@@ -1939,8 +1917,8 @@ public partial class PlayerView
                     viewModel.IsHandMode.Value = true;
                 }
 
-                // In Move mode the left button funnels through MouseControlTransformHandles regardless of whether the click hit a handle.
-                // When Kind == None it takes the renderer hit-test + double-click + translate-drag path.
+                // In Move mode, left button funnels through MouseControlTransformHandles whether or not
+                // it hit a handle (Kind == None takes the hit-test/double-click/translate-drag path).
                 if (viewModel.IsMoveMode.Value && point.Properties.IsLeftButtonPressed)
                 {
                     AvaPoint imagePoint = e.GetCurrentPoint(image).Position;

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -89,6 +89,10 @@ public partial class PlayerView
         void OnKeyUp(KeyEventArgs e)
         {
         }
+
+        void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+        }
     }
 
     private class MouseControlHand : IMouseControlHandler
@@ -315,6 +319,11 @@ public partial class PlayerView
             EditorSelection.SelectedObject.Value = element;
             View.framePanel.Cursor = TransformHandlesOverlay.GetCursorForHandle(Kind);
 
+            // Capture the pointer so handle drags receive Released even when the cursor leaves
+            // framePanel. Without this, releasing outside the control would leave _press dangling
+            // and subsequent re-entries would mutate the Transform without a held button.
+            e.Pointer.Capture(View.framePanel);
+
             e.Handled = true;
         }
 
@@ -384,13 +393,20 @@ public partial class PlayerView
                 return;
             }
 
-            int zindex = drawable.ZIndex;
-            TimeSpan time = Clock.CurrentTime.Value;
-            Element? element = scene.Children.FirstOrDefault(v =>
-                v.IsEnabled
-                && v.ZIndex == zindex
-                && v.Start <= time
-                && time < v.Range.End);
+            // Resolve the owning Element via the hierarchical parent chain so that overlapping
+            // ZIndex elements do not alias to each other. Fall back to a ZIndex/time-window search
+            // only when the drawable's parent is outside this scene (e.g. nested SceneDrawable).
+            Element? element = drawable.FindHierarchicalParent<Element>();
+            if (element == null || !scene.Children.Contains(element))
+            {
+                int zindex = drawable.ZIndex;
+                TimeSpan time = Clock.CurrentTime.Value;
+                element = scene.Children.FirstOrDefault(v =>
+                    v.IsEnabled
+                    && v.ZIndex == zindex
+                    && v.Start <= time
+                    && time < v.Range.End);
+            }
 
             if (element != null)
             {
@@ -409,6 +425,11 @@ public partial class PlayerView
                 StartImagePos: imagePos,
                 PressTransform: drawable.Transform.CurrentValue);
             _ensured = null;
+
+            // Capture the pointer so a translate drag started here still delivers Released even when
+            // the cursor leaves framePanel during the drag.
+            e.Pointer.Capture(View.framePanel);
+
             e.Handled = true;
 
             // Double-click on shape → path editor
@@ -803,16 +824,18 @@ public partial class PlayerView
             };
         }
 
+        // Anchor at the center of the opposite edge so that proportional (Shift) edge-resize stays centered
+        // on the orthogonal axis. Using a corner here makes Shift-dragging an edge introduce sideways drift.
         private static (double X, double Y) EdgeAnchorLocal(PressState press, TransformHandlesOverlay.HandleKind kind)
         {
             BtlSize size = press.LocalSize;
             double w = size.Width, h = size.Height;
             return kind switch
             {
-                TransformHandlesOverlay.HandleKind.Top => (0, h),     // opposite = Bottom edge
-                TransformHandlesOverlay.HandleKind.Bottom => (0, 0),  // opposite = Top edge
-                TransformHandlesOverlay.HandleKind.Left => (w, 0),    // opposite = Right edge
-                TransformHandlesOverlay.HandleKind.Right => (0, 0),   // opposite = Left edge
+                TransformHandlesOverlay.HandleKind.Top => (w * 0.5, h),       // opposite = Bottom edge center
+                TransformHandlesOverlay.HandleKind.Bottom => (w * 0.5, 0),    // opposite = Top edge center
+                TransformHandlesOverlay.HandleKind.Left => (w, h * 0.5),      // opposite = Right edge center
+                TransformHandlesOverlay.HandleKind.Right => (0, h * 0.5),     // opposite = Left edge center
                 _ => throw new System.ArgumentOutOfRangeException(nameof(kind), kind, "Edge anchor requested for non-edge HandleKind."),
             };
         }
@@ -847,8 +870,16 @@ public partial class PlayerView
             e.Handled = true;
         }
 
+        // Always roll back any pending operations recorded during the drag. ResetSession is reached on:
+        //   - successful Release after Commit: Rollback becomes a no-op because Commit already cleared the current transaction.
+        //   - abort/discard paths (AbortDrag, OnReleased discard branch): pending Ensure-driven structure changes and
+        //     handle-applied deltas would otherwise leak into the next unrelated Commit, breaking undo grouping.
         private void ResetSession()
         {
+            if (_changed || _ensured != null)
+            {
+                EditViewModel.HistoryManager.Rollback();
+            }
             _press = null;
             _ensured = null;
             _changed = false;
@@ -857,6 +888,19 @@ public partial class PlayerView
         public void OnKeyDown(KeyEventArgs e) => SyncShift(e.KeyModifiers);
 
         public void OnKeyUp(KeyEventArgs e) => SyncShift(e.KeyModifiers);
+
+        public void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            // In the normal Release flow, OnReleased clears _press before this fires, so this is a no-op.
+            // It only does work when capture was taken away externally (focus stolen, system event, etc.).
+            if (_press == null) return;
+            _logger.LogDebug(
+                "OnPointerCaptureLost: capture lost mid-drag (Drawable={DrawableType}, Kind={Kind}); discarding pending changes.",
+                _press.Drawable.GetType().Name, Kind);
+            View.framePanel.Cursor = null;
+            ResetSession();
+            _shift = false;
+        }
 
         private void SyncShift(KeyModifiers modifiers) => _shift = modifiers.HasFlag(KeyModifiers.Shift);
 
@@ -1792,6 +1836,15 @@ public partial class PlayerView
     private void OnFramePointerMoved(object? sender, PointerEventArgs e)
     {
         _mouseState?.OnMoved(e);
+    }
+
+    private void OnFramePointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        // On a normal Release, OnFramePointerReleased already nulled out _mouseState, so this is a no-op.
+        // It only does work when capture was taken away externally before Release reached us.
+        if (_mouseState == null) return;
+        _mouseState.OnPointerCaptureLost(e);
+        _mouseState = null;
     }
 
     private void OnFramePointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -282,32 +282,37 @@ public partial class PlayerView : UserControl
         }
 
         double frameScale = image.Bounds.Width / scene.FrameSize.Width;
-        // An Element with multiple Drawables can have the overlay and OnPressedHitTest (zindex resolution)
-        // pick different Drawables, so leave a Debug log so this is observable.
-        var drawables = element.Objects.OfType<BtlDrawable>();
+        // Prefer the last hit-tested drawable so the overlay tracks the visual object the user actually
+        // clicked on. Without this, an Element with multiple drawables would always show handles around
+        // the first one, even after hit-testing resolves a different one.
+        BtlDrawable? hitTested = null;
+        if (_lastSelected.TryGetTarget(out BtlDrawable? cached))
+        {
+            hitTested = cached;
+        }
         BtlDrawable? drawable = null;
         int drawableCount = 0;
-        foreach (BtlDrawable d in drawables)
+        foreach (BtlDrawable d in element.Objects.OfType<BtlDrawable>())
         {
             if (drawableCount == 0) drawable = d;
+            if (ReferenceEquals(d, hitTested))
+            {
+                drawable = d;
+                drawableCount = -1; // marker: matched the cached selection, no need to keep iterating
+                break;
+            }
             drawableCount++;
-            if (drawableCount > 1) break;
+            if (drawableCount > 16) break; // cap iteration; multi-drawable elements rarely exceed this
         }
         if (drawable == null)
         {
             ClearTransformHandleOverlay();
             return;
         }
-        if (drawableCount > 1 && _logger.IsEnabled(LogLevel.Debug))
-        {
-            _logger.LogDebug(
-                "UpdateTransformHandles: element '{Element}' has multiple Drawables; overlay uses the first ({DrawableType}). hit-test may target a different one.",
-                element.Name, drawable.GetType().Name);
-        }
 
         // Build an independent Resource on RenderThread and compute userMatrix / localSize / pivot
         // (evaluate animations against the ctx time, without depending on the renderer's cached render node).
-        (BtlSize localSize, BtlMatrix userMatrix, BtlPoint pivotLocal)? snap = null;
+        (BtlSize localSize, BtlMatrix userMatrix, BtlPoint pivotLocal)? snap;
         try
         {
             BtlDrawable target = drawable;
@@ -319,11 +324,10 @@ public partial class PlayerView : UserControl
                 if (bounds is not { Width: > 0, Height: > 0 }) return null;
 
                 var ctx = new CompositionContext(ctxTime);
-                BtlDrawable.Resource resource;
                 if (_transformHandleResource == null || _transformHandleResourceTarget != target)
                 {
                     _transformHandleResource?.Dispose();
-                    _transformHandleResource = (BtlDrawable.Resource)target.ToResource(ctx);
+                    _transformHandleResource = target.ToResource(ctx);
                     _transformHandleResourceTarget = target;
                 }
                 else
@@ -332,7 +336,7 @@ public partial class PlayerView : UserControl
                     bool updateOnly = true;
                     _transformHandleResource.Update(target, ctx, ref updateOnly);
                 }
-                resource = _transformHandleResource;
+                BtlDrawable.Resource? resource = _transformHandleResource;
 
                 BtlSize localSize = target.MeasureInternal(availableSize, resource);
                 if (localSize.Width <= 0 || localSize.Height <= 0) return null;

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -8,16 +8,29 @@ using Avalonia.Media.Imaging;
 using Avalonia.Media.Immutable;
 using Avalonia.Threading;
 
+using Beutl.Composition;
 using Beutl.Configuration;
 using Beutl.Controls;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PathEditorTab.ViewModels;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Transformation;
 using Beutl.Logging;
+using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Reactive.Bindings.Extensions;
+
+using BtlDrawable = Beutl.Graphics.Drawable;
+using BtlMatrix = Beutl.Graphics.Matrix;
+using BtlPoint = Beutl.Graphics.Point;
+using BtlRect = Beutl.Graphics.Rect;
+using BtlSize = Beutl.Graphics.Size;
 
 namespace Beutl.Views;
 
@@ -28,6 +41,11 @@ public partial class PlayerView : UserControl
     private IDisposable? _imageConfigSubscription;
     private IDisposable? _boundsSubscription;
     internal Control image = null!;
+
+    // Resource snapshot for the TransformHandle overlay (access only from inside RenderThread.Dispatcher).
+    // Reuses Update for in-place refresh on the same Drawable; recreates via ToResource when the Drawable changes.
+    private BtlDrawable.Resource? _transformHandleResource;
+    private BtlDrawable? _transformHandleResourceTarget;
 
     public PlayerView()
     {
@@ -103,6 +121,9 @@ public partial class PlayerView : UserControl
                 imageBackground.Height = bounds.Height;
                 pathEditorView.Width = bounds.Width;
                 pathEditorView.Height = bounds.Height;
+                transformHandlesOverlay.Width = bounds.Width;
+                transformHandlesOverlay.Height = bounds.Height;
+                UpdateTransformHandles();
             });
     }
 
@@ -125,6 +146,9 @@ public partial class PlayerView : UserControl
         base.OnDetachedFromVisualTree(e);
         _imageConfigSubscription?.Dispose();
         _boundsSubscription?.Dispose();
+
+        InvalidateTransformHandleResource();
+
         if (DataContext is PlayerViewModel viewModel && viewModel.IsPlaying.Value)
         {
             await viewModel.Pause();
@@ -141,7 +165,7 @@ public partial class PlayerView : UserControl
         if (DataContext is PlayerViewModel player && TopLevel.GetTopLevel(this) is { } topLevel)
         {
             var size = framePanel.Bounds.Size;
-            player.MaxFrameSize = new Beutl.Graphics.Size(
+            player.MaxFrameSize = new BtlSize(
                 (float)(size.Width * topLevel.RenderScaling),
                 (float)(size.Height * topLevel.RenderScaling));
         }
@@ -151,6 +175,9 @@ public partial class PlayerView : UserControl
     {
         base.OnDataContextChanged(e);
         _disposables.Clear();
+
+        InvalidateTransformHandleResource();
+
         if (DataContext is PlayerViewModel vm)
         {
             vm.PreviewInvalidated += Player_PreviewInvalidated;
@@ -163,7 +190,7 @@ public partial class PlayerView : UserControl
                 .Where(t => t.Item3 != null)
                 .Subscribe(t =>
                 {
-                    framePanel.RenderTransformOrigin = RelativePoint.TopLeft;
+                    framePanel.RenderTransformOrigin = Avalonia.RelativePoint.TopLeft;
                     framePanel.RenderTransform = new ImmutableTransform(t.matrix.ToAvaMatrix());
                     if (DataContext is PlayerViewModel { Scene: { } } vm)
                     {
@@ -197,6 +224,169 @@ public partial class PlayerView : UserControl
                         framePanel.Cursor = null;
                 })
                 .DisposeWith(_disposables);
+
+            var selection = vm.EditViewModel.GetRequiredService<Beutl.Editor.Services.IEditorSelection>();
+            selection.SelectedObject
+                .ObserveOnUIDispatcher()
+                .Subscribe(_ => UpdateTransformHandles())
+                .DisposeWith(_disposables);
+
+            // The overlay is only shown in Move mode AND while not playing. During playback we give up on shape tracking and suppress updates
+            // (a synchronous Invoke onto RenderThread every frame would tank playback throughput).
+            vm.IsMoveMode.CombineLatest(vm.IsPlaying, (move, playing) => (move, playing))
+                .ObserveOnUIDispatcher()
+                .Subscribe(t =>
+                {
+                    bool visible = t.move && !t.playing;
+                    transformHandlesOverlay.IsVisible = visible;
+                    if (visible) UpdateTransformHandles();
+                    else ClearTransformHandleOverlay();
+                })
+                .DisposeWith(_disposables);
+
+            // Overlay updates on time changes go through PreviewInvalidated.
+        }
+    }
+
+    private void UpdateTransformHandles()
+    {
+        if (DataContext is not PlayerViewModel vm) return;
+        if (!vm.IsMoveMode.Value)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        var selection = vm.EditViewModel.GetRequiredService<Beutl.Editor.Services.IEditorSelection>();
+        var clock = vm.EditViewModel.GetRequiredService<Beutl.Editor.Services.IEditorClock>();
+        if (selection.SelectedObject.Value is not Element element)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        TimeSpan time = clock.CurrentTime.Value;
+        if (time < element.Start || time >= element.Range.End)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        var renderer = vm.EditViewModel.Renderer.Value;
+        var scene = vm.EditViewModel.Scene;
+        if (image.Bounds.Width <= 0 || scene.FrameSize.Width <= 0)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        double frameScale = image.Bounds.Width / scene.FrameSize.Width;
+        // An Element with multiple Drawables can have the overlay and OnPressedHitTest (zindex resolution)
+        // pick different Drawables, so leave a Debug log so this is observable.
+        var drawables = element.Objects.OfType<BtlDrawable>();
+        BtlDrawable? drawable = null;
+        int drawableCount = 0;
+        foreach (BtlDrawable d in drawables)
+        {
+            if (drawableCount == 0) drawable = d;
+            drawableCount++;
+            if (drawableCount > 1) break;
+        }
+        if (drawable == null)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+        if (drawableCount > 1 && _logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "UpdateTransformHandles: element '{Element}' has multiple Drawables; overlay uses the first ({DrawableType}). hit-test may target a different one.",
+                element.Name, drawable.GetType().Name);
+        }
+
+        // Build an independent Resource on RenderThread and compute userMatrix / localSize / pivot
+        // (evaluate animations against the ctx time, without depending on the renderer's cached render node).
+        (BtlSize localSize, BtlMatrix userMatrix, BtlPoint pivotLocal)? snap = null;
+        try
+        {
+            BtlDrawable target = drawable;
+            BtlSize availableSize = scene.FrameSize.ToSize(1.0f);
+            TimeSpan ctxTime = time;
+            snap = RenderThread.Dispatcher.Invoke(() =>
+            {
+                BtlRect? bounds = renderer.GetBoundary(target);
+                if (bounds is not { Width: > 0, Height: > 0 }) return null;
+
+                var ctx = new CompositionContext(ctxTime);
+                BtlDrawable.Resource resource;
+                if (_transformHandleResource == null || _transformHandleResourceTarget != target)
+                {
+                    _transformHandleResource?.Dispose();
+                    _transformHandleResource = (BtlDrawable.Resource)target.ToResource(ctx);
+                    _transformHandleResourceTarget = target;
+                }
+                else
+                {
+                    // Used solely for overlay display, so do not propagate Version changes downstream (updateOnly=true).
+                    bool updateOnly = true;
+                    _transformHandleResource.Update(target, ctx, ref updateOnly);
+                }
+                resource = _transformHandleResource;
+
+                BtlSize localSize = target.MeasureInternal(availableSize, resource);
+                if (localSize.Width <= 0 || localSize.Height <= 0) return null;
+
+                BtlMatrix userMatrix = target.GetTransformMatrix(availableSize, localSize, resource);
+                BtlPoint pivot = resource.TransformOrigin.ToPixels(localSize);
+
+                // transform.Matrix does not include the FilterEffect offset, so correct it with the difference against bounds.
+                BtlMatrix adjusted = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds.Value);
+
+                return ((BtlSize, BtlMatrix, BtlPoint)?)(localSize, adjusted, pivot);
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(
+                ex,
+                "GetBoundary/MeasureInternal called from invalid thread for {DrawableType} on element '{Element}'.",
+                drawable.GetType().Name, element.Name);
+            // A partially-updated cache may remain, so dispose it and let it be rebuilt.
+            ClearTransformHandleOverlay();
+            return;
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            _logger.LogError(
+                ex,
+                "Unexpected exception while querying transform overlay geometry (drawable={DrawableType}, element='{Element}').",
+                drawable.GetType().Name, element.Name);
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        if (snap is not { } s)
+        {
+            ClearTransformHandleOverlay();
+            return;
+        }
+
+        transformHandlesOverlay.Update(drawable, element, s.localSize, s.userMatrix, s.pivotLocal, image.Bounds.Size, frameScale);
+    }
+
+    private void ClearTransformHandleOverlay()
+    {
+        transformHandlesOverlay.Clear();
+        InvalidateTransformHandleResource();
+    }
+
+    private void InvalidateTransformHandleResource()
+    {
+        if (_transformHandleResource != null)
+        {
+            _transformHandleResource.Dispose();
+            _transformHandleResource = null;
+            _transformHandleResourceTarget = null;
         }
     }
 
@@ -205,7 +395,16 @@ public partial class PlayerView : UserControl
         if (image == null)
             return;
 
-        Dispatcher.UIThread.InvokeAsync(image.InvalidateVisual);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            image.InvalidateVisual();
+
+            // Skip overlay updates while playing — RenderThread Invoke would block next-frame generation.
+            // When playback stops, the IsPlaying subscriber triggers it once.
+            if (DataContext is PlayerViewModel { IsPlaying.Value: true }) return;
+
+            UpdateTransformHandles();
+        });
     }
 
     private void ToggleDragModeClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -36,8 +36,6 @@ namespace Beutl.Views;
 
 public partial class PlayerView : UserControl
 {
-    private const int MaxScannedDrawablesPerElement = 16;
-
     private readonly CompositeDisposable _disposables = [];
     private readonly ILogger _logger = Log.CreateLogger<PlayerView>();
     private IDisposable? _imageConfigSubscription;
@@ -285,7 +283,6 @@ public partial class PlayerView : UserControl
         // clicked on, not just the element's first drawable.
         BtlDrawable? hitTested = _lastSelected.TryGetTarget(out BtlDrawable? cached) ? cached : null;
         BtlDrawable? drawable = null;
-        int drawableCount = 0;
         foreach (BtlDrawable d in element.Objects.OfType<BtlDrawable>())
         {
             drawable ??= d;
@@ -294,7 +291,6 @@ public partial class PlayerView : UserControl
                 drawable = d;
                 break;
             }
-            if (++drawableCount > MaxScannedDrawablesPerElement) break;
         }
         if (drawable == null)
         {

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -376,12 +376,17 @@ public partial class PlayerView : UserControl
 
     private void InvalidateTransformHandleResource()
     {
-        if (_transformHandleResource != null)
+        if (_transformHandleResource == null) return;
+
+        // _transformHandleResource is created inside RenderThread.Dispatcher.Invoke, so the matching
+        // Dispose must run there too — UI-thread paths (OnDataContextChanged, OnDetachedFromVisualTree,
+        // ClearTransformHandleOverlay) would otherwise race in-flight RenderThread updates.
+        RenderThread.Dispatcher.Invoke(() =>
         {
-            _transformHandleResource.Dispose();
+            _transformHandleResource?.Dispose();
             _transformHandleResource = null;
             _transformHandleResourceTarget = null;
-        }
+        });
     }
 
     private void Player_PreviewInvalidated(object? sender, EventArgs e)

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -36,14 +36,15 @@ namespace Beutl.Views;
 
 public partial class PlayerView : UserControl
 {
+    private const int MaxScannedDrawablesPerElement = 16;
+
     private readonly CompositeDisposable _disposables = [];
     private readonly ILogger _logger = Log.CreateLogger<PlayerView>();
     private IDisposable? _imageConfigSubscription;
     private IDisposable? _boundsSubscription;
     internal Control image = null!;
 
-    // Resource snapshot for the TransformHandle overlay (access only from inside RenderThread.Dispatcher).
-    // Reuses Update for in-place refresh on the same Drawable; recreates via ToResource when the Drawable changes.
+    // _transformHandleResource is RenderThread-owned: only mutate inside RenderThread.Dispatcher.
     private BtlDrawable.Resource? _transformHandleResource;
     private BtlDrawable? _transformHandleResourceTarget;
 
@@ -232,20 +233,18 @@ public partial class PlayerView : UserControl
                 .Subscribe(_ => UpdateTransformHandles())
                 .DisposeWith(_disposables);
 
-            // The overlay is only shown in Move mode AND while not playing. During playback we give up on shape tracking and suppress updates
-            // (a synchronous Invoke onto RenderThread every frame would tank playback throughput).
-            vm.IsMoveMode.CombineLatest(vm.IsPlaying, (move, playing) => (move, playing))
+            // RenderThread.Invoke during playback would stall frame generation, so suppress overlay
+            // updates outside Move mode + paused state.
+            vm.IsMoveMode.CombineLatest(vm.IsPlaying, (move, playing) => move && !playing)
+                .DistinctUntilChanged()
                 .ObserveOnUIDispatcher()
-                .Subscribe(t =>
+                .Subscribe(visible =>
                 {
-                    bool visible = t.move && !t.playing;
                     transformHandlesOverlay.IsVisible = visible;
                     if (visible) UpdateTransformHandles();
                     else ClearTransformHandleOverlay();
                 })
                 .DisposeWith(_disposables);
-
-            // Overlay updates on time changes go through PreviewInvalidated.
         }
     }
 
@@ -283,26 +282,19 @@ public partial class PlayerView : UserControl
 
         double frameScale = image.Bounds.Width / scene.FrameSize.Width;
         // Prefer the last hit-tested drawable so the overlay tracks the visual object the user actually
-        // clicked on. Without this, an Element with multiple drawables would always show handles around
-        // the first one, even after hit-testing resolves a different one.
-        BtlDrawable? hitTested = null;
-        if (_lastSelected.TryGetTarget(out BtlDrawable? cached))
-        {
-            hitTested = cached;
-        }
+        // clicked on, not just the element's first drawable.
+        BtlDrawable? hitTested = _lastSelected.TryGetTarget(out BtlDrawable? cached) ? cached : null;
         BtlDrawable? drawable = null;
         int drawableCount = 0;
         foreach (BtlDrawable d in element.Objects.OfType<BtlDrawable>())
         {
-            if (drawableCount == 0) drawable = d;
+            drawable ??= d;
             if (ReferenceEquals(d, hitTested))
             {
                 drawable = d;
-                drawableCount = -1; // marker: matched the cached selection, no need to keep iterating
                 break;
             }
-            drawableCount++;
-            if (drawableCount > 16) break; // cap iteration; multi-drawable elements rarely exceed this
+            if (++drawableCount > MaxScannedDrawablesPerElement) break;
         }
         if (drawable == null)
         {
@@ -310,8 +302,8 @@ public partial class PlayerView : UserControl
             return;
         }
 
-        // Build an independent Resource on RenderThread and compute userMatrix / localSize / pivot
-        // (evaluate animations against the ctx time, without depending on the renderer's cached render node).
+        // Use an independent Resource on RenderThread so we evaluate animations against ctxTime
+        // without piggybacking on the renderer's cached render node.
         (BtlSize localSize, BtlMatrix userMatrix, BtlPoint pivotLocal)? snap;
         try
         {
@@ -332,7 +324,8 @@ public partial class PlayerView : UserControl
                 }
                 else
                 {
-                    // Used solely for overlay display, so do not propagate Version changes downstream (updateOnly=true).
+                    // updateOnly=true: this is a read-only view for the overlay, so don't bump Version
+                    // and invalidate downstream consumers.
                     bool updateOnly = true;
                     _transformHandleResource.Update(target, ctx, ref updateOnly);
                 }
@@ -344,7 +337,7 @@ public partial class PlayerView : UserControl
                 BtlMatrix userMatrix = target.GetTransformMatrix(availableSize, localSize, resource);
                 BtlPoint pivot = resource.TransformOrigin.ToPixels(localSize);
 
-                // transform.Matrix does not include the FilterEffect offset, so correct it with the difference against bounds.
+                // userMatrix omits FilterEffect-induced offsets; align against rendered bounds.
                 BtlMatrix adjusted = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds.Value);
 
                 return ((BtlSize, BtlMatrix, BtlPoint)?)(localSize, adjusted, pivot);
@@ -356,7 +349,7 @@ public partial class PlayerView : UserControl
                 ex,
                 "GetBoundary/MeasureInternal called from invalid thread for {DrawableType} on element '{Element}'.",
                 drawable.GetType().Name, element.Name);
-            // A partially-updated cache may remain, so dispose it and let it be rebuilt.
+            // Partially-updated cache may remain — dispose and let it rebuild.
             ClearTransformHandleOverlay();
             return;
         }

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -57,6 +57,7 @@ public partial class PlayerView : UserControl
         framePanel.PointerPressed += OnFramePointerPressed;
         framePanel.PointerReleased += OnFramePointerReleased;
         framePanel.PointerMoved += OnFramePointerMoved;
+        framePanel.PointerCaptureLost += OnFramePointerCaptureLost;
         framePanel.AddHandler(PointerWheelChangedEvent, OnFramePointerWheelChanged, RoutingStrategies.Tunnel);
 
         framePanel.Focusable = true;

--- a/src/Beutl/Views/TransformHandlesOverlay.cs
+++ b/src/Beutl/Views/TransformHandlesOverlay.cs
@@ -26,19 +26,32 @@ internal sealed class TransformHandlesOverlay : Control
     private const double RotateOuterDistance = 18.0;
     private const double CenterMarkerRadius = 4.0;
 
-    private static readonly IBrush s_handleFill = new ImmutableSolidColorBrush(Color.FromRgb(0xF0, 0xF0, 0xF0));
-    private static readonly IPen s_handleStroke = new ImmutablePen(new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF)), 1.5);
-    private static readonly IPen s_boxStroke = new ImmutablePen(new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF)), 1.0);
-    private static readonly IBrush s_centerFill = new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF));
+    private static readonly ImmutableSolidColorBrush s_handleFill = new(Color.FromRgb(0xF0, 0xF0, 0xF0));
+    private static readonly ImmutableSolidColorBrush s_accentFill = new(Color.FromRgb(0x1E, 0x90, 0xFF));
+    private static readonly IPen s_handleStroke = new ImmutablePen(s_accentFill, 1.5);
+    private static readonly IPen s_boxStroke = new ImmutablePen(s_accentFill, 1.0);
+
+    private static readonly Cursor s_cursorCorner1 = new(StandardCursorType.TopLeftCorner);
+    private static readonly Cursor s_cursorCorner2 = new(StandardCursorType.TopRightCorner);
+    private static readonly Cursor s_cursorNS = new(StandardCursorType.SizeNorthSouth);
+    private static readonly Cursor s_cursorWE = new(StandardCursorType.SizeWestEast);
+    private static readonly Cursor s_cursorRotate = new(StandardCursorType.Hand);
+    private static readonly Cursor s_cursorMove = new(StandardCursorType.SizeAll);
 
     private BtlDrawable? _drawable;
     private Element? _element;
     private BtlSize _localSize;
     private BtlMatrix _userMatrix = BtlMatrix.Identity;
     private double _frameScale = 1.0;
-    private bool _hasShape;
     private readonly AvaPoint[] _imageCorners = new AvaPoint[4];
     private AvaPoint _pivotImage;
+
+    private bool HasShape =>
+        _drawable != null
+        && _localSize.Width > 0
+        && _localSize.Height > 0
+        && _frameScale > 0
+        && _userMatrix.HasInverse;
 
     public enum HandleKind
     {
@@ -83,20 +96,28 @@ internal sealed class TransformHandlesOverlay : Control
         AvaSize imageSize,
         double frameScale)
     {
+        if (ReferenceEquals(_drawable, drawable)
+            && ReferenceEquals(_element, element)
+            && _localSize == localSize
+            && _userMatrix == userMatrix
+            && _frameScale == frameScale
+            && PivotLocal == pivotLocal)
+        {
+            return;
+        }
+
         _drawable = drawable;
         _element = element;
         _localSize = localSize;
         _userMatrix = userMatrix;
         _frameScale = frameScale;
         PivotLocal = pivotLocal;
-        _hasShape = drawable != null && localSize.Width > 0 && localSize.Height > 0 && frameScale > 0;
 
-        if (_hasShape && !_userMatrix.HasInverse)
+        if (drawable != null && localSize.Width > 0 && localSize.Height > 0 && frameScale > 0 && !userMatrix.HasInverse)
         {
             s_logger.LogDebug(
                 "TransformHandlesOverlay: userMatrix non-invertible, hiding overlay. Drawable={DrawableType}",
-                drawable?.GetType().Name ?? "null");
-            _hasShape = false;
+                drawable.GetType().Name);
         }
 
         RecomputeImageGeometry();
@@ -109,13 +130,12 @@ internal sealed class TransformHandlesOverlay : Control
         _element = null;
         _localSize = default;
         _userMatrix = BtlMatrix.Identity;
-        _hasShape = false;
         InvalidateVisual();
     }
 
     private void RecomputeImageGeometry()
     {
-        if (!_hasShape || _drawable == null) return;
+        if (!HasShape) return;
 
         double w = _localSize.Width;
         double h = _localSize.Height;
@@ -142,7 +162,7 @@ internal sealed class TransformHandlesOverlay : Control
     public override void Render(DrawingContext context)
     {
         base.Render(context);
-        if (!_hasShape) return;
+        if (!HasShape) return;
 
         var geom = new StreamGeometry();
         using (var ctx = geom.Open())
@@ -155,7 +175,7 @@ internal sealed class TransformHandlesOverlay : Control
         }
         context.DrawGeometry(null, s_boxStroke, geom);
 
-        context.DrawEllipse(s_centerFill, null,
+        context.DrawEllipse(s_accentFill, null,
             new AvaRect(
                 _pivotImage.X - CenterMarkerRadius,
                 _pivotImage.Y - CenterMarkerRadius,
@@ -198,7 +218,7 @@ internal sealed class TransformHandlesOverlay : Control
 
     public HandleKind HitTest(AvaPoint imagePoint)
     {
-        if (!_hasShape) return HandleKind.None;
+        if (!HasShape) return HandleKind.None;
 
         double tol = HandleSize / 2 + 2;
         double centerTol = CenterMarkerRadius + 2;
@@ -265,12 +285,12 @@ internal sealed class TransformHandlesOverlay : Control
     {
         return kind switch
         {
-            HandleKind.TopLeft or HandleKind.BottomRight => new Cursor(StandardCursorType.TopLeftCorner),
-            HandleKind.TopRight or HandleKind.BottomLeft => new Cursor(StandardCursorType.TopRightCorner),
-            HandleKind.Top or HandleKind.Bottom => new Cursor(StandardCursorType.SizeNorthSouth),
-            HandleKind.Left or HandleKind.Right => new Cursor(StandardCursorType.SizeWestEast),
-            HandleKind.Rotate => new Cursor(StandardCursorType.Hand),
-            HandleKind.Center => new Cursor(StandardCursorType.SizeAll),
+            HandleKind.TopLeft or HandleKind.BottomRight => s_cursorCorner1,
+            HandleKind.TopRight or HandleKind.BottomLeft => s_cursorCorner2,
+            HandleKind.Top or HandleKind.Bottom => s_cursorNS,
+            HandleKind.Left or HandleKind.Right => s_cursorWE,
+            HandleKind.Rotate => s_cursorRotate,
+            HandleKind.Center => s_cursorMove,
             _ => Cursor.Default
         };
     }

--- a/src/Beutl/Views/TransformHandlesOverlay.cs
+++ b/src/Beutl/Views/TransformHandlesOverlay.cs
@@ -1,0 +1,278 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+using AvaPoint = Avalonia.Point;
+using AvaRect = Avalonia.Rect;
+using AvaSize = Avalonia.Size;
+using AvaVector = Avalonia.Vector;
+using BtlDrawable = Beutl.Graphics.Drawable;
+using BtlMatrix = Beutl.Graphics.Matrix;
+using BtlPoint = Beutl.Graphics.Point;
+using BtlSize = Beutl.Graphics.Size;
+using Element = Beutl.ProjectSystem.Element;
+
+namespace Beutl.Views;
+
+internal sealed class TransformHandlesOverlay : Control
+{
+    private static readonly ILogger s_logger = Log.CreateLogger<TransformHandlesOverlay>();
+
+    private const double HandleSize = 8.0;
+    private const double EdgeHandleLength = 14.0;
+    private const double RotateOuterDistance = 18.0;
+    private const double CenterMarkerRadius = 4.0;
+
+    private static readonly IBrush s_handleFill = new ImmutableSolidColorBrush(Color.FromRgb(0xF0, 0xF0, 0xF0));
+    private static readonly IPen s_handleStroke = new ImmutablePen(new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF)), 1.5);
+    private static readonly IPen s_boxStroke = new ImmutablePen(new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF)), 1.0);
+    private static readonly IBrush s_centerFill = new ImmutableSolidColorBrush(Color.FromRgb(0x1E, 0x90, 0xFF));
+
+    private BtlDrawable? _drawable;
+    private Element? _element;
+    private BtlSize _localSize;
+    private BtlMatrix _userMatrix = BtlMatrix.Identity;
+    private double _frameScale = 1.0;
+    private bool _hasShape;
+    private readonly AvaPoint[] _imageCorners = new AvaPoint[4];
+    private AvaPoint _pivotImage;
+
+    public enum HandleKind
+    {
+        None,
+        TopLeft,
+        Top,
+        TopRight,
+        Right,
+        BottomRight,
+        Bottom,
+        BottomLeft,
+        Left,
+        Rotate,
+        Center,
+    }
+
+    public TransformHandlesOverlay()
+    {
+        IsHitTestVisible = false;
+    }
+
+    public BtlDrawable? Drawable => _drawable;
+
+    public Element? Element => _element;
+
+    public BtlSize LocalSize => _localSize;
+
+    public BtlMatrix UserMatrix => _userMatrix;
+
+    public double FrameScale => _frameScale;
+
+    public BtlPoint PivotLocal { get; private set; }
+
+    public AvaPoint PivotImage => _pivotImage;
+
+    public void Update(
+        BtlDrawable? drawable,
+        Element? element,
+        BtlSize localSize,
+        BtlMatrix userMatrix,
+        BtlPoint pivotLocal,
+        AvaSize imageSize,
+        double frameScale)
+    {
+        _drawable = drawable;
+        _element = element;
+        _localSize = localSize;
+        _userMatrix = userMatrix;
+        _frameScale = frameScale;
+        PivotLocal = pivotLocal;
+        _hasShape = drawable != null && localSize.Width > 0 && localSize.Height > 0 && frameScale > 0;
+
+        if (_hasShape && !_userMatrix.HasInverse)
+        {
+            s_logger.LogDebug(
+                "TransformHandlesOverlay: userMatrix non-invertible, hiding overlay. Drawable={DrawableType}",
+                drawable?.GetType().Name ?? "null");
+            _hasShape = false;
+        }
+
+        RecomputeImageGeometry();
+        InvalidateVisual();
+    }
+
+    public void Clear()
+    {
+        _drawable = null;
+        _element = null;
+        _localSize = default;
+        _userMatrix = BtlMatrix.Identity;
+        _hasShape = false;
+        InvalidateVisual();
+    }
+
+    private void RecomputeImageGeometry()
+    {
+        if (!_hasShape || _drawable == null) return;
+
+        double w = _localSize.Width;
+        double h = _localSize.Height;
+        _imageCorners[0] = LocalToImage(0, 0);
+        _imageCorners[1] = LocalToImage(w, 0);
+        _imageCorners[2] = LocalToImage(w, h);
+        _imageCorners[3] = LocalToImage(0, h);
+        _pivotImage = LocalToImage(PivotLocal.X, PivotLocal.Y);
+    }
+
+    private AvaPoint LocalToImage(double lx, double ly)
+    {
+        BtlPoint p = _userMatrix.Transform(new BtlPoint((float)lx, (float)ly));
+        return new AvaPoint(p.X * _frameScale, p.Y * _frameScale);
+    }
+
+    private AvaPoint LocalEdgeMid(int cornerA, int cornerB)
+    {
+        AvaPoint a = _imageCorners[cornerA];
+        AvaPoint b = _imageCorners[cornerB];
+        return new AvaPoint((a.X + b.X) / 2.0, (a.Y + b.Y) / 2.0);
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        if (!_hasShape) return;
+
+        var geom = new StreamGeometry();
+        using (var ctx = geom.Open())
+        {
+            ctx.BeginFigure(_imageCorners[0], isFilled: false);
+            ctx.LineTo(_imageCorners[1]);
+            ctx.LineTo(_imageCorners[2]);
+            ctx.LineTo(_imageCorners[3]);
+            ctx.EndFigure(isClosed: true);
+        }
+        context.DrawGeometry(null, s_boxStroke, geom);
+
+        context.DrawEllipse(s_centerFill, null,
+            new AvaRect(
+                _pivotImage.X - CenterMarkerRadius,
+                _pivotImage.Y - CenterMarkerRadius,
+                CenterMarkerRadius * 2,
+                CenterMarkerRadius * 2));
+
+        for (int i = 0; i < 4; i++)
+        {
+            DrawCornerHandle(context, _imageCorners[i]);
+        }
+
+        DrawEdgeHandle(context, LocalEdgeMid(0, 1), _imageCorners[1] - _imageCorners[0]);
+        DrawEdgeHandle(context, LocalEdgeMid(1, 2), _imageCorners[2] - _imageCorners[1]);
+        DrawEdgeHandle(context, LocalEdgeMid(2, 3), _imageCorners[3] - _imageCorners[2]);
+        DrawEdgeHandle(context, LocalEdgeMid(3, 0), _imageCorners[0] - _imageCorners[3]);
+    }
+
+    private static void DrawCornerHandle(DrawingContext context, AvaPoint p)
+    {
+        var r = new AvaRect(p.X - HandleSize / 2, p.Y - HandleSize / 2, HandleSize, HandleSize);
+        context.DrawRectangle(s_handleFill, s_handleStroke, r);
+    }
+
+    // axis is the corner→corner direction vector. Draws a slim rectangle along that axis (so it tracks rotation).
+    private static void DrawEdgeHandle(DrawingContext context, AvaPoint p, Avalonia.Vector axis)
+    {
+        double len = axis.Length;
+        if (len < 1e-6)
+        {
+            DrawCornerHandle(context, p);
+            return;
+        }
+        double angle = Math.Atan2(axis.Y, axis.X);
+        using (context.PushTransform(Matrix.CreateRotation(angle) * Matrix.CreateTranslation(p.X, p.Y)))
+        {
+            var r = new AvaRect(-EdgeHandleLength / 2, -HandleSize / 2, EdgeHandleLength, HandleSize);
+            context.DrawRectangle(s_handleFill, s_handleStroke, r);
+        }
+    }
+
+    public HandleKind HitTest(AvaPoint imagePoint)
+    {
+        if (!_hasShape) return HandleKind.None;
+
+        double tol = HandleSize / 2 + 2;
+        double centerTol = CenterMarkerRadius + 2;
+
+        if (AvaPoint.Distance(imagePoint, _pivotImage) <= centerTol)
+            return HandleKind.Center;
+
+        if (AvaPoint.Distance(imagePoint, _imageCorners[0]) <= tol) return HandleKind.TopLeft;
+        if (AvaPoint.Distance(imagePoint, _imageCorners[1]) <= tol) return HandleKind.TopRight;
+        if (AvaPoint.Distance(imagePoint, _imageCorners[2]) <= tol) return HandleKind.BottomRight;
+        if (AvaPoint.Distance(imagePoint, _imageCorners[3]) <= tol) return HandleKind.BottomLeft;
+
+        if (HitEdge(imagePoint, _imageCorners[0], _imageCorners[1])) return HandleKind.Top;
+        if (HitEdge(imagePoint, _imageCorners[1], _imageCorners[2])) return HandleKind.Right;
+        if (HitEdge(imagePoint, _imageCorners[2], _imageCorners[3])) return HandleKind.Bottom;
+        if (HitEdge(imagePoint, _imageCorners[3], _imageCorners[0])) return HandleKind.Left;
+
+        // Rotate: within RotateOuterDistance from a corner and outside the polygon.
+        if (!IsPointInsidePolygon(imagePoint))
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                if (AvaPoint.Distance(imagePoint, _imageCorners[i]) <= RotateOuterDistance)
+                    return HandleKind.Rotate;
+            }
+        }
+
+        // Return None for clicks inside the polygon so they pass through to the normal renderer hit-test
+        // (toggling selection between overlapping objects, double-click on a shape to start path editing).
+        // Translate operations go through the central pivot marker (Center handle).
+        return HandleKind.None;
+    }
+
+    private static bool HitEdge(AvaPoint p, AvaPoint a, AvaPoint b)
+    {
+        AvaVector edge = b - a;
+        double len = edge.Length;
+        if (len < 1e-6) return false;
+        AvaVector u = edge / len;
+        AvaPoint mid = new((a.X + b.X) / 2, (a.Y + b.Y) / 2);
+        AvaVector d = p - mid;
+        double along = d.X * u.X + d.Y * u.Y;
+        double perp = d.X * -u.Y + d.Y * u.X;
+        return Math.Abs(along) <= EdgeHandleLength / 2 + 2 && Math.Abs(perp) <= HandleSize / 2 + 2;
+    }
+
+    private bool IsPointInsidePolygon(AvaPoint p)
+    {
+        bool inside = false;
+        for (int i = 0, j = 3; i < 4; j = i++)
+        {
+            AvaPoint pi = _imageCorners[i];
+            AvaPoint pj = _imageCorners[j];
+            if (((pi.Y > p.Y) != (pj.Y > p.Y)) &&
+                (p.X < (pj.X - pi.X) * (p.Y - pi.Y) / (pj.Y - pi.Y + 1e-12) + pi.X))
+            {
+                inside = !inside;
+            }
+        }
+        return inside;
+    }
+
+    public static Cursor GetCursorForHandle(HandleKind kind)
+    {
+        return kind switch
+        {
+            HandleKind.TopLeft or HandleKind.BottomRight => new Cursor(StandardCursorType.TopLeftCorner),
+            HandleKind.TopRight or HandleKind.BottomLeft => new Cursor(StandardCursorType.TopRightCorner),
+            HandleKind.Top or HandleKind.Bottom => new Cursor(StandardCursorType.SizeNorthSouth),
+            HandleKind.Left or HandleKind.Right => new Cursor(StandardCursorType.SizeWestEast),
+            HandleKind.Rotate => new Cursor(StandardCursorType.Hand),
+            HandleKind.Center => new Cursor(StandardCursorType.SizeAll),
+            _ => Cursor.Default
+        };
+    }
+}
+

--- a/tests/Beutl.UnitTests/Engine/Animation/KeyFrameDeltaHelperTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/KeyFrameDeltaHelperTests.cs
@@ -1,0 +1,146 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+
+namespace Beutl.UnitTests.Engine.Animation;
+
+public class KeyFrameDeltaHelperTests
+{
+    private static KeyFrame<float> CreateKeyFrame(float value, double seconds = 0)
+    {
+        return new KeyFrame<float>
+        {
+            Value = value,
+            KeyTime = TimeSpan.FromSeconds(seconds),
+            Easing = new LinearEasing(),
+        };
+    }
+
+    [Test]
+    public void ApplyDelta_BothNull_ReturnsFalse()
+    {
+        bool result = KeyFrameDeltaHelper.ApplyDelta<float>(null, null, 0f, 0f, 10f);
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ApplyDelta_BothKeyFrames_ShiftsBothByDelta()
+    {
+        var prev = CreateKeyFrame(100f, 0);
+        var next = CreateKeyFrame(200f, 1);
+
+        bool result = KeyFrameDeltaHelper.ApplyDelta(prev, next, 100f, 200f, 25f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(prev.Value, Is.EqualTo(125f));
+            Assert.That(next.Value, Is.EqualTo(225f));
+        });
+    }
+
+    [Test]
+    public void ApplyDelta_OnlyPrevious_OnlyShiftsPrevious()
+    {
+        var prev = CreateKeyFrame(100f, 0);
+
+        bool result = KeyFrameDeltaHelper.ApplyDelta(prev, null, 100f, 999f, 15f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(prev.Value, Is.EqualTo(115f));
+            // Confirms startNext = 999f is unused (next is null, so no write-back)
+        });
+    }
+
+    [Test]
+    public void ApplyDelta_OnlyNext_OnlyShiftsNext()
+    {
+        var next = CreateKeyFrame(200f, 1);
+
+        bool result = KeyFrameDeltaHelper.ApplyDelta(null, next, 999f, 200f, -30f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(next.Value, Is.EqualTo(170f));
+        });
+    }
+
+    [Test]
+    public void ApplyDelta_PreservesAmplitude()
+    {
+        // Animation-amplitude preservation invariant: (next - prev) after the shift matches the pre-shift value.
+        var prev = CreateKeyFrame(100f, 0);
+        var next = CreateKeyFrame(200f, 1);
+        float originalAmplitude = next.Value - prev.Value;
+
+        KeyFrameDeltaHelper.ApplyDelta(prev, next, prev.Value, next.Value, 75f);
+
+        Assert.That(next.Value - prev.Value, Is.EqualTo(originalAmplitude));
+    }
+
+    [Test]
+    public void ApplyDelta_UsesStartValuesNotCurrent_Idempotency()
+    {
+        // A drag triggers OnMoved repeatedly, but each call recomputes from the start snapshot,
+        // so the result is the same for the same delta no matter how many times it is invoked (idempotent).
+        var prev = CreateKeyFrame(100f, 0);
+        var next = CreateKeyFrame(200f, 1);
+
+        // 1st call: delta=10
+        KeyFrameDeltaHelper.ApplyDelta(prev, next, 100f, 200f, 10f);
+        float firstPrev = prev.Value;
+        float firstNext = next.Value;
+
+        // 2nd call with same start values and same delta should give same result.
+        KeyFrameDeltaHelper.ApplyDelta(prev, next, 100f, 200f, 10f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prev.Value, Is.EqualTo(firstPrev));
+            Assert.That(next.Value, Is.EqualTo(firstNext));
+            Assert.That(prev.Value, Is.EqualTo(110f));
+            Assert.That(next.Value, Is.EqualTo(210f));
+        });
+    }
+
+    [Test]
+    public void CaptureStartValues_BothNull_ReturnsFallback()
+    {
+        var (prev, next) = KeyFrameDeltaHelper.CaptureStartValues<float>(null, null, 42f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prev, Is.EqualTo(42f));
+            Assert.That(next, Is.EqualTo(42f));
+        });
+    }
+
+    [Test]
+    public void CaptureStartValues_OnlyPrevious_NextUsesFallback()
+    {
+        var p = CreateKeyFrame(100f, 0);
+        var (prev, next) = KeyFrameDeltaHelper.CaptureStartValues<float>(p, null, 42f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prev, Is.EqualTo(100f));
+            Assert.That(next, Is.EqualTo(42f));
+        });
+    }
+
+    [Test]
+    public void CaptureStartValues_BothKeyFrames_ReturnsValues()
+    {
+        var p = CreateKeyFrame(100f, 0);
+        var n = CreateKeyFrame(200f, 1);
+        var (prev, next) = KeyFrameDeltaHelper.CaptureStartValues<float>(p, n, 42f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prev, Is.EqualTo(100f));
+            Assert.That(next, Is.EqualTo(200f));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Transformation/CanonicalTransformLayoutTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Transformation/CanonicalTransformLayoutTests.cs
@@ -1,0 +1,531 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Transformation;
+
+namespace Beutl.UnitTests.Engine.Graphics.Transformation;
+
+public class CanonicalTransformLayoutTests
+{
+    private static CompositionContext Context => CompositionContext.Default;
+
+    private static Drawable CreateDrawable()
+    {
+        return new FallbackDrawable();
+    }
+
+    [Test]
+    public void Ensure_EmptyTransform_AppendsTRSInCanonicalOrder()
+    {
+        var drawable = CreateDrawable();
+        drawable.Transform.CurrentValue = null;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StructureChanged, Is.True);
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            // New canonical: [T, R, S]
+            Assert.That(result.Group.Children[0], Is.TypeOf<TranslateTransform>());
+            Assert.That(result.Group.Children[1], Is.TypeOf<RotationTransform>());
+            Assert.That(result.Group.Children[2], Is.TypeOf<ScaleTransform>());
+        });
+    }
+
+    [Test]
+    public void Ensure_OnlyTranslate_AppendsRotationAfterAndScaleAtEnd()
+    {
+        var drawable = CreateDrawable();
+        var existing = new TranslateTransform(50f, 0f);
+        var group = new TransformGroup();
+        group.Children.Add(existing);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // [T_existing, R_new, S_new]
+            Assert.That(result.Group, Is.SameAs(group));
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.SameAs(existing));
+            Assert.That(result.Group.Children[1], Is.TypeOf<RotationTransform>());
+            Assert.That(result.Group.Children[2], Is.TypeOf<ScaleTransform>());
+            Assert.That(result.Translate, Is.SameAs(existing));
+            Assert.That(result.StructureChanged, Is.True);
+        });
+    }
+
+    [Test]
+    public void Ensure_OnlyRotation_InsertsTranslateAtFrontAndScaleAtEnd()
+    {
+        var drawable = CreateDrawable();
+        var existing = new RotationTransform(45f);
+        var group = new TransformGroup();
+        group.Children.Add(existing);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // [T_new, R_existing, S_new]
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.TypeOf<TranslateTransform>());
+            Assert.That(result.Group.Children[1], Is.SameAs(existing));
+            Assert.That(result.Group.Children[2], Is.TypeOf<ScaleTransform>());
+            Assert.That(result.Rotation, Is.SameAs(existing));
+            Assert.That(result.StructureChanged, Is.True);
+        });
+    }
+
+    [Test]
+    public void Ensure_OnlyScale_InsertsTranslateAndRotationAtFront()
+    {
+        var drawable = CreateDrawable();
+        var existing = new ScaleTransform(200f, 200f);
+        var group = new TransformGroup();
+        group.Children.Add(existing);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // [T_new, R_new, S_existing]
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.TypeOf<TranslateTransform>());
+            Assert.That(result.Group.Children[1], Is.TypeOf<RotationTransform>());
+            Assert.That(result.Group.Children[2], Is.SameAs(existing));
+            Assert.That(result.Scale, Is.SameAs(existing));
+            Assert.That(result.StructureChanged, Is.True);
+        });
+    }
+
+    [Test]
+    public void Ensure_SkewAndTranslate_PreservesSkewAndAppendsAfterT()
+    {
+        var drawable = CreateDrawable();
+        var skew = new SkewTransform(15f, 0f);
+        var translate = new TranslateTransform(10f, 20f);
+        var group = new TransformGroup();
+        group.Children.Add(skew);
+        group.Children.Add(translate);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // [Skew, T_existing, R_new, S_new]
+            // T is at tIdx=1, R right after T (idx=2), S at the tail (idx=3). Skew is at idx=0, before T = on the post side.
+            Assert.That(result.Group.Children.Count, Is.EqualTo(4));
+            Assert.That(result.Group.Children[0], Is.SameAs(skew));
+            Assert.That(result.Group.Children[1], Is.SameAs(translate));
+            Assert.That(result.Group.Children[2], Is.TypeOf<RotationTransform>());
+            Assert.That(result.Group.Children[3], Is.TypeOf<ScaleTransform>());
+            Assert.That(result.Translate, Is.SameAs(translate));
+            Assert.That(result.StructureChanged, Is.True);
+            // Skew sits before T (idx<tIdx, near the head) = included in PostMatrixOfT.
+            Assert.That(result.PostMatrixOfT, Is.Not.EqualTo(Matrix.Identity));
+        });
+    }
+
+    [Test]
+    public void Ensure_LegacyRSTOrder_DoesNotReorder()
+    {
+        // A Drawable with the old [R, S, T] layout is not reorganized; the existing R/S/T are returned as the operative transforms.
+        // Backward compatibility: opening an existing project does not change the order of Children.
+        var drawable = CreateDrawable();
+        var r = new RotationTransform(45f);
+        var s = new ScaleTransform(150f, 150f);
+        var t = new TranslateTransform(10f, 20f);
+        var group = new TransformGroup();
+        group.Children.Add(r);
+        group.Children.Add(s);
+        group.Children.Add(t);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // Structure stays [R, S, T] with no additions.
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.SameAs(r));
+            Assert.That(result.Group.Children[1], Is.SameAs(s));
+            Assert.That(result.Group.Children[2], Is.SameAs(t));
+            Assert.That(result.Rotation, Is.SameAs(r));
+            Assert.That(result.Scale, Is.SameAs(s));
+            Assert.That(result.Translate, Is.SameAs(t));
+            Assert.That(result.StructureChanged, Is.False);
+        });
+    }
+
+    [Test]
+    public void Ensure_MultipleRotationsAndScales_DoesNotInsertReusesFirst()
+    {
+        var drawable = CreateDrawable();
+        var r1 = new RotationTransform(10f);
+        var r2 = new RotationTransform(20f);
+        var s1 = new ScaleTransform(150f, 150f);
+        var s2 = new ScaleTransform(80f, 80f);
+        var t = new TranslateTransform(5f, 5f);
+        var group = new TransformGroup();
+        group.Children.Add(r1);
+        group.Children.Add(r2);
+        group.Children.Add(s1);
+        group.Children.Add(s2);
+        group.Children.Add(t);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // Structures with duplicates are **preserved as-is**; the "first occurrence" of each type is adopted.
+            Assert.That(result.Group.Children.Count, Is.EqualTo(5));
+            Assert.That(result.Group.Children[0], Is.SameAs(r1));
+            Assert.That(result.Group.Children[1], Is.SameAs(r2));
+            Assert.That(result.Group.Children[2], Is.SameAs(s1));
+            Assert.That(result.Group.Children[3], Is.SameAs(s2));
+            Assert.That(result.Group.Children[4], Is.SameAs(t));
+            Assert.That(result.Rotation, Is.SameAs(r1));
+            Assert.That(result.Scale, Is.SameAs(s1));
+            Assert.That(result.Translate, Is.SameAs(t));
+            Assert.That(result.StructureChanged, Is.False);
+        });
+    }
+
+    [Test]
+    public void Ensure_ReverseOrder_DoesNotReorder()
+    {
+        // Even with the completely reversed [S, R, T], since all types are present no reorganization happens.
+        // The first occurrence of each type is the operative one.
+        var drawable = CreateDrawable();
+        var s = new ScaleTransform(150f, 150f);
+        var r = new RotationTransform(30f);
+        var t = new TranslateTransform(5f, 5f);
+        var group = new TransformGroup();
+        group.Children.Add(s);
+        group.Children.Add(r);
+        group.Children.Add(t);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.SameAs(s));
+            Assert.That(result.Group.Children[1], Is.SameAs(r));
+            Assert.That(result.Group.Children[2], Is.SameAs(t));
+            Assert.That(result.Scale, Is.SameAs(s));
+            Assert.That(result.Rotation, Is.SameAs(r));
+            Assert.That(result.Translate, Is.SameAs(t));
+            Assert.That(result.StructureChanged, Is.False);
+        });
+    }
+
+    [Test]
+    public void Ensure_TranslateThenScale_InsertsRotationAfterT()
+    {
+        // [T, S] is missing R. Insert R right after T(0) → [T, R_new, S].
+        var drawable = CreateDrawable();
+        var t = new TranslateTransform(10f, 20f);
+        var s = new ScaleTransform(400f, 200f);
+        var group = new TransformGroup();
+        group.Children.Add(t);
+        group.Children.Add(s);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // [T, R_new, S] = the new canonical layout
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.SameAs(t));
+            Assert.That(result.Group.Children[1], Is.TypeOf<RotationTransform>());
+            Assert.That(result.Group.Children[2], Is.SameAs(s));
+            Assert.That(result.Translate, Is.SameAs(t));
+            Assert.That(result.Scale, Is.SameAs(s));
+            Assert.That(result.StructureChanged, Is.True);
+        });
+    }
+
+    [Test]
+    public void Ensure_RotationAndTranslate_AppendsScaleAtEnd()
+    {
+        // [R, T] is missing S. Append S at the end → [R, T, S_new].
+        // The existing R(0) is honored as the operative transform (no reorganization).
+        var drawable = CreateDrawable();
+        var r = new RotationTransform(45f);
+        var t = new TranslateTransform(30f, 40f);
+        var group = new TransformGroup();
+        group.Children.Add(r);
+        group.Children.Add(t);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Group.Children[0], Is.SameAs(r));
+            Assert.That(result.Group.Children[1], Is.SameAs(t));
+            Assert.That(result.Group.Children[2], Is.TypeOf<ScaleTransform>());
+            Assert.That(result.Rotation, Is.SameAs(r));
+            Assert.That(result.Translate, Is.SameAs(t));
+        });
+    }
+
+    [Test]
+    public void Ensure_NewCanonicalTRSOrder_DoesNotInsert()
+    {
+        // [T, R, S] is already in canonical order, so nothing is added.
+        var drawable = CreateDrawable();
+        var t = new TranslateTransform(5f, 5f);
+        var r = new RotationTransform(10f);
+        var s = new ScaleTransform(150f, 150f);
+        var group = new TransformGroup();
+        group.Children.Add(t);
+        group.Children.Add(r);
+        group.Children.Add(s);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Group.Children.Count, Is.EqualTo(3));
+            Assert.That(result.Translate, Is.SameAs(t));
+            Assert.That(result.Rotation, Is.SameAs(r));
+            Assert.That(result.Scale, Is.SameAs(s));
+            Assert.That(result.StructureChanged, Is.False);
+        });
+    }
+
+    [Test]
+    public void Ensure_MultipleTranslates_UsesFirstOccurrence()
+    {
+        // When there are multiple Translates, adopt the first occurrence (closest to the head of the list).
+        // Input: [T_canonical, R, S, T_extra]
+        // Expectation: structure unchanged, operative Translate is the leading T_canonical.
+        var drawable = CreateDrawable();
+        var tCanonical = new TranslateTransform(50f, 50f);
+        var r = new RotationTransform(45f);
+        var s = new ScaleTransform(150f, 150f);
+        var tExtra = new TranslateTransform(10f, 0f);
+        var group = new TransformGroup();
+        group.Children.Add(tCanonical);
+        group.Children.Add(r);
+        group.Children.Add(s);
+        group.Children.Add(tExtra);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Group.Children.Count, Is.EqualTo(4));
+            Assert.That(result.Group.Children[0], Is.SameAs(tCanonical));
+            Assert.That(result.Group.Children[1], Is.SameAs(r));
+            Assert.That(result.Group.Children[2], Is.SameAs(s));
+            Assert.That(result.Group.Children[3], Is.SameAs(tExtra));
+            Assert.That(result.Rotation, Is.SameAs(r));
+            Assert.That(result.Scale, Is.SameAs(s));
+            Assert.That(result.Translate, Is.SameAs(tCanonical));
+            Assert.That(result.StructureChanged, Is.False);
+            // T(0), R(1), S(2) are contiguous
+        });
+    }
+
+    [Test]
+    public void Ensure_NonTransformGroupValue_WrapsInTransformGroup()
+    {
+        var drawable = CreateDrawable();
+        var existing = new TranslateTransform(7f, 3f);
+        drawable.Transform.CurrentValue = existing;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            // Wrapped in a TransformGroup, becoming [T_existing, R_new, S_new]
+            Assert.That(drawable.Transform.CurrentValue, Is.TypeOf<TransformGroup>());
+            Assert.That(result.Group.Children, Has.Member(existing));
+            Assert.That(result.Translate, Is.SameAs(existing));
+            Assert.That(result.StructureChanged, Is.True);
+        });
+    }
+
+    // ===== FindCanonicalTransforms (read-only) tests =====
+    // Returns the first occurrence of R/S/T without checking order (same policy as Ensure).
+    // The group is never mutated.
+
+    [Test]
+    public void FindCanonicalTransforms_DoesNotMutateGroup()
+    {
+        var t = new TranslateTransform(10f, 20f);
+        var s = new ScaleTransform(400f, 200f);
+        var group = new TransformGroup();
+        group.Children.Add(t);
+        group.Children.Add(s);
+
+        int countBefore = group.Children.Count;
+        _ = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.That(group.Children.Count, Is.EqualTo(countBefore));
+        Assert.That(group.Children[0], Is.SameAs(t));
+        Assert.That(group.Children[1], Is.SameAs(s));
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_CanonicalTRS_ReturnsAll()
+    {
+        // New canonical [T, R, S]
+        var t = new TranslateTransform(5f, 5f);
+        var r = new RotationTransform(45f);
+        var s = new ScaleTransform(150f, 150f);
+        var group = new TransformGroup();
+        group.Children.Add(t);
+        group.Children.Add(r);
+        group.Children.Add(s);
+
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.SameAs(r));
+            Assert.That(scale, Is.SameAs(s));
+            Assert.That(translate, Is.SameAs(t));
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_LegacyRST_ReturnsAll()
+    {
+        // Even with the old [R, S, T], return all without order checks (backward compatibility).
+        var r = new RotationTransform(45f);
+        var s = new ScaleTransform(150f, 150f);
+        var t = new TranslateTransform(5f, 5f);
+        var group = new TransformGroup();
+        group.Children.Add(r);
+        group.Children.Add(s);
+        group.Children.Add(t);
+
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.SameAs(r));
+            Assert.That(scale, Is.SameAs(s));
+            Assert.That(translate, Is.SameAs(t));
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_ReverseOrder_ReturnsAll()
+    {
+        // [S, R, T] also returns all.
+        var s = new ScaleTransform(150f, 150f);
+        var r = new RotationTransform(30f);
+        var t = new TranslateTransform(5f, 5f);
+        var group = new TransformGroup();
+        group.Children.Add(s);
+        group.Children.Add(r);
+        group.Children.Add(t);
+
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.SameAs(r));
+            Assert.That(scale, Is.SameAs(s));
+            Assert.That(translate, Is.SameAs(t));
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_PartialMissing_ReturnsNullsForMissing()
+    {
+        // [T, S] (missing R) → R is null; T and S return their first occurrences.
+        var t = new TranslateTransform(10f, 20f);
+        var s = new ScaleTransform(400f, 200f);
+        var group = new TransformGroup();
+        group.Children.Add(t);
+        group.Children.Add(s);
+
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.Null);
+            Assert.That(scale, Is.SameAs(s));
+            Assert.That(translate, Is.SameAs(t));
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_NonTransformGroup_HandlesSingleton()
+    {
+        var r = new RotationTransform(45f);
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(r);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.SameAs(r));
+            Assert.That(scale, Is.Null);
+            Assert.That(translate, Is.Null);
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_Null_ReturnsAllNull()
+    {
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.Null);
+            Assert.That(scale, Is.Null);
+            Assert.That(translate, Is.Null);
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_AgreesWithEnsureOnNewCanonical()
+    {
+        // Under the new canonical [T, R, S], Find and Ensure return the same references and do not change the structure.
+        var tForFind = new TranslateTransform(33f, 44f);
+        var rForFind = new RotationTransform(10f);
+        var sForFind = new ScaleTransform(120f, 120f);
+        var groupForFind = new TransformGroup();
+        groupForFind.Children.Add(tForFind);
+        groupForFind.Children.Add(rForFind);
+        groupForFind.Children.Add(sForFind);
+
+        var (rotF, scaleF, translateF) = CanonicalTransformLayout.FindCanonicalTransforms(groupForFind);
+
+        var drawable = CreateDrawable();
+        var tForEnsure = new TranslateTransform(33f, 44f);
+        var rForEnsure = new RotationTransform(10f);
+        var sForEnsure = new ScaleTransform(120f, 120f);
+        var groupForEnsure = new TransformGroup();
+        groupForEnsure.Children.Add(tForEnsure);
+        groupForEnsure.Children.Add(rForEnsure);
+        groupForEnsure.Children.Add(sForEnsure);
+        drawable.Transform.CurrentValue = groupForEnsure;
+
+        var ensured = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(groupForFind.Children.IndexOf(rotF!), Is.EqualTo(groupForEnsure.Children.IndexOf(ensured.Rotation)));
+            Assert.That(groupForFind.Children.IndexOf(scaleF!), Is.EqualTo(groupForEnsure.Children.IndexOf(ensured.Scale)));
+            Assert.That(groupForFind.Children.IndexOf(translateF!), Is.EqualTo(groupForEnsure.Children.IndexOf(ensured.Translate)));
+            Assert.That(ensured.StructureChanged, Is.False);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Transformation/CanonicalTransformLayoutTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Transformation/CanonicalTransformLayoutTests.cs
@@ -495,6 +495,74 @@ public class CanonicalTransformLayoutTests
     }
 
     [Test]
+    public void FindCanonicalTransforms_DisabledChildren_AreSkipped()
+    {
+        // Disabled T/R/S do not contribute to TransformGroup.CreateMatrix, so the handle code must not adopt them.
+        var disabledT = new TranslateTransform(10f, 20f) { IsEnabled = false };
+        var enabledT = new TranslateTransform(30f, 40f);
+        var disabledR = new RotationTransform(15f) { IsEnabled = false };
+        var enabledR = new RotationTransform(45f);
+        var s = new ScaleTransform(150f, 150f);
+        var group = new TransformGroup();
+        group.Children.Add(disabledT);
+        group.Children.Add(enabledT);
+        group.Children.Add(disabledR);
+        group.Children.Add(enabledR);
+        group.Children.Add(s);
+
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(group);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translate, Is.SameAs(enabledT));
+            Assert.That(rotation, Is.SameAs(enabledR));
+            Assert.That(scale, Is.SameAs(s));
+        });
+    }
+
+    [Test]
+    public void FindCanonicalTransforms_DisabledSingleton_ReturnsAllNull()
+    {
+        var r = new RotationTransform(45f) { IsEnabled = false };
+        var (rotation, scale, translate) = CanonicalTransformLayout.FindCanonicalTransforms(r);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotation, Is.Null);
+            Assert.That(scale, Is.Null);
+            Assert.That(translate, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Ensure_DisabledExisting_InsertsNewEnabledTransforms()
+    {
+        // If the existing T/R/S are all disabled, Ensure must insert fresh enabled ones rather than adopt the disabled ones.
+        var drawable = CreateDrawable();
+        var disabledT = new TranslateTransform(10f, 20f) { IsEnabled = false };
+        var disabledR = new RotationTransform(30f) { IsEnabled = false };
+        var disabledS = new ScaleTransform(200f, 200f) { IsEnabled = false };
+        var group = new TransformGroup();
+        group.Children.Add(disabledT);
+        group.Children.Add(disabledR);
+        group.Children.Add(disabledS);
+        drawable.Transform.CurrentValue = group;
+
+        CanonicalTransformLayoutResult result = CanonicalTransformLayout.Ensure(drawable, Context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StructureChanged, Is.True);
+            Assert.That(result.Translate, Is.Not.SameAs(disabledT));
+            Assert.That(result.Rotation, Is.Not.SameAs(disabledR));
+            Assert.That(result.Scale, Is.Not.SameAs(disabledS));
+            Assert.That(result.Translate.IsEnabled, Is.True);
+            Assert.That(result.Rotation.IsEnabled, Is.True);
+            Assert.That(result.Scale.IsEnabled, Is.True);
+        });
+    }
+
+    [Test]
     public void FindCanonicalTransforms_AgreesWithEnsureOnNewCanonical()
     {
         // Under the new canonical [T, R, S], Find and Ensure return the same references and do not change the structure.

--- a/tests/Beutl.UnitTests/Engine/Graphics/Transformation/TransformHandleMathTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Transformation/TransformHandleMathTests.cs
@@ -1,0 +1,523 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Transformation;
+
+namespace Beutl.UnitTests.Engine.Graphics.Transformation;
+
+public class TransformHandleMathTests
+{
+    // ===== ComputePivotTranslationDelta (based on the new [T, R, S] order) =====
+    //
+    // New formula: ΔT = ((anchor - origin) * (S_old - S_new) / 100) · R
+    //   Scale is on a 100 basis (100 = 1x effective); R is the 2x2 rotation matrix.
+    // screen_anchor invariant:
+    //   screen_anchor = (anchor - origin) * (S/100) · R + T + origin
+    //   With T_new = T_old + ΔT, the screen_anchor stays identical between old and new.
+
+    [Test]
+    public void ComputePivotTranslationDelta_AnchorAtOrigin_ReturnsZero()
+    {
+        // When the anchor coincides with the pivot, effD = 0, so ΔT = 0 even if the scale changes.
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 100f, startScaleY: 100f,
+            newScaleX: 200f, newScaleY: 200f,
+            anchorX: 50.0, anchorY: 50.0,
+            originX: 50.0, originY: 50.0,
+            rotation: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dx, Is.EqualTo(0f));
+            Assert.That(dy, Is.EqualTo(0f));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_DoublesScaleNoRotation_AnchorMovesNegative()
+    {
+        // Axis-aligned case. With anchor=(100,0), origin=(0,0) and scaleX 100→200:
+        // ΔTx = 100 * (100 - 200) / 100 = -100, ΔTy = 0.
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 100f, startScaleY: 100f,
+            newScaleX: 200f, newScaleY: 100f,
+            anchorX: 100.0, anchorY: 0.0,
+            originX: 0.0, originY: 0.0,
+            rotation: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dx, Is.EqualTo(-100f));
+            Assert.That(dy, Is.EqualTo(0f));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_HalvesScaleNoRotation_AnchorMovesPositive()
+    {
+        // scaleX 200→100 (2x→1x): ΔTx = 100 * (200 - 100) / 100 = 100.
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 200f, startScaleY: 100f,
+            newScaleX: 100f, newScaleY: 100f,
+            anchorX: 100.0, anchorY: 0.0,
+            originX: 0.0, originY: 0.0,
+            rotation: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dx, Is.EqualTo(100f));
+            Assert.That(dy, Is.EqualTo(0f));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_AccountsForOriginOffset()
+    {
+        // The closer the pivot is to the anchor, the smaller effD becomes.
+        // effD = 100 - 80 = 20, ΔTx = 20 * (100 - 200) / 100 = -20.
+        var (dx, _) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 100f, startScaleY: 100f,
+            newScaleX: 200f, newScaleY: 100f,
+            anchorX: 100.0, anchorY: 0.0,
+            originX: 80.0, originY: 0.0,
+            rotation: Matrix.Identity);
+
+        Assert.That(dx, Is.EqualTo(-20f));
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_With90DegRotation_RotatesPreRDelta()
+    {
+        // anchor=(100,0), origin=(0,0), scale 100→200.
+        // pre-R: (Δx, Δy) = (100 * -100/100, 0) = (-100, 0)
+        // R = 90° rotation: (x,y) → (-y, x) via row-vector right multiplication.
+        // Result: (-100, 0) · R(90°) = (0, -100).
+        Matrix r90 = Matrix.CreateRotation(System.MathF.PI / 2);
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 100f, startScaleY: 100f,
+            newScaleX: 200f, newScaleY: 100f,
+            anchorX: 100.0, anchorY: 0.0,
+            originX: 0.0, originY: 0.0,
+            rotation: r90);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dx, Is.EqualTo(0f).Within(1e-4));
+            Assert.That(dy, Is.EqualTo(-100f).Within(1e-4));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_AnchorFixedInScreenSpace_Invariant_NoRotation()
+    {
+        // screen_anchor invariant: with T_new = T_old + ΔT, screen_anchor matches between old and new.
+        //   screen_anchor = (anchor - origin) * (S/100) · R + T + origin
+        // Case where R = Identity.
+        float startScaleX = 100f, startScaleY = 100f;
+        float newScaleX = 300f, newScaleY = 150f;
+        double anchorX = 200.0, anchorY = 80.0;
+        double originX = 50.0, originY = 20.0;
+        float startTransX = 30f, startTransY = 10f;
+
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX, startScaleY, newScaleX, newScaleY,
+            anchorX, anchorY, originX, originY,
+            Matrix.Identity);
+        float newTransX = startTransX + dx;
+        float newTransY = startTransY + dy;
+
+        double screenAnchorOldX = (anchorX - originX) * (startScaleX / 100.0) + startTransX + originX;
+        double screenAnchorNewX = (anchorX - originX) * (newScaleX / 100.0) + newTransX + originX;
+        double screenAnchorOldY = (anchorY - originY) * (startScaleY / 100.0) + startTransY + originY;
+        double screenAnchorNewY = (anchorY - originY) * (newScaleY / 100.0) + newTransY + originY;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(screenAnchorNewX, Is.EqualTo(screenAnchorOldX).Within(1e-3));
+            Assert.That(screenAnchorNewY, Is.EqualTo(screenAnchorOldY).Within(1e-3));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_AnchorFixedInScreenSpace_Invariant_WithRotation()
+    {
+        // screen_anchor invariant when R is 45°.
+        // screen_anchor = (anchor - origin) * (S/100) · R + T + origin
+        Matrix r = Matrix.CreateRotation(System.MathF.PI / 4);
+        float startScaleX = 100f, startScaleY = 100f;
+        float newScaleX = 200f, newScaleY = 150f;
+        double anchorX = 100.0, anchorY = 60.0;
+        double originX = 20.0, originY = 10.0;
+        float startTransX = 5f, startTransY = 15f;
+
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX, startScaleY, newScaleX, newScaleY,
+            anchorX, anchorY, originX, originY,
+            r);
+        float newTransX = startTransX + dx;
+        float newTransY = startTransY + dy;
+
+        // Compute screen_anchor (axis-aligned point → R → translate) for both old and new.
+        // Per-axis vector of (anchor - origin) * (S/100):
+        double oldVx = (anchorX - originX) * (startScaleX / 100.0);
+        double oldVy = (anchorY - originY) * (startScaleY / 100.0);
+        // · R (row-vector right-multiplication, 2x2 portion)
+        double oldRx = oldVx * r.M11 + oldVy * r.M21;
+        double oldRy = oldVx * r.M12 + oldVy * r.M22;
+        double screenOldX = oldRx + startTransX + originX;
+        double screenOldY = oldRy + startTransY + originY;
+
+        double newVx = (anchorX - originX) * (newScaleX / 100.0);
+        double newVy = (anchorY - originY) * (newScaleY / 100.0);
+        double newRx = newVx * r.M11 + newVy * r.M21;
+        double newRy = newVx * r.M12 + newVy * r.M22;
+        double screenNewX = newRx + newTransX + originX;
+        double screenNewY = newRy + newTransY + originY;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(screenNewX, Is.EqualTo(screenOldX).Within(1e-3));
+            Assert.That(screenNewY, Is.EqualTo(screenOldY).Within(1e-3));
+        });
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_NegativeStartScale_Invariant_NoRotation()
+    {
+        // Confirm that the anchor stays fixed on screen even with negative (flipped) scales.
+        float startScaleX = -100f, startScaleY = -100f;
+        float newScaleX = -200f, newScaleY = -100f;
+        double anchorX = 200.0, anchorY = 0.0;
+        double originX = 50.0, originY = 0.0;
+        float startTransX = 30f;
+
+        var (dx, _) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX, startScaleY, newScaleX, newScaleY,
+            anchorX, anchorY, originX, originY,
+            Matrix.Identity);
+        float newTransX = startTransX + dx;
+
+        double screenAnchorOld = (anchorX - originX) * (startScaleX / 100.0) + startTransX + originX;
+        double screenAnchorNew = (anchorX - originX) * (newScaleX / 100.0) + newTransX + originX;
+
+        Assert.That(screenAnchorNew, Is.EqualTo(screenAnchorOld).Within(1e-3));
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_SignFlipAcrossZero_Invariant_NoRotation()
+    {
+        // Case where the scale sign flips while crossing the pivot (100 → -100).
+        float startScaleX = 100f, startScaleY = 100f;
+        float newScaleX = -100f, newScaleY = 100f;
+        double anchorX = 100.0, anchorY = 0.0;
+        double originX = 0.0, originY = 0.0;
+
+        var (dx, _) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX, startScaleY, newScaleX, newScaleY,
+            anchorX, anchorY, originX, originY,
+            Matrix.Identity);
+        float newTransX = 0f + dx;
+
+        double screenAnchorOld = (anchorX - originX) * (startScaleX / 100.0) + 0 + originX;
+        double screenAnchorNew = (anchorX - originX) * (newScaleX / 100.0) + newTransX + originX;
+
+        Assert.That(screenAnchorNew, Is.EqualTo(screenAnchorOld).Within(1e-3));
+    }
+
+    [Test]
+    public void ComputePivotTranslationDelta_FiniteAtZeroScale()
+    {
+        // ΔT remains finite even when newScale = 0, because the new formula does not divide by newScale.
+        var (dx, dy) = TransformHandleMath.ComputePivotTranslationDelta(
+            startScaleX: 100f, startScaleY: 100f,
+            newScaleX: 0f, newScaleY: 0f,
+            anchorX: 10.0, anchorY: 10.0,
+            originX: 0.0, originY: 0.0,
+            rotation: Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(float.IsFinite(dx), Is.True);
+            Assert.That(float.IsFinite(dy), Is.True);
+        });
+    }
+
+    // ===== NormalizeAngleDelta =====
+
+    [Test]
+    public void NormalizeAngleDelta_Zero_ReturnsZero()
+    {
+        Assert.That(TransformHandleMath.NormalizeAngleDelta(0), Is.EqualTo(0.0).Within(1e-12));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_SmallValue_PassThrough()
+    {
+        double d = 0.1;
+        Assert.That(TransformHandleMath.NormalizeAngleDelta(d), Is.EqualTo(d).Within(1e-12));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_NegativeSmallValue_PassThrough()
+    {
+        double d = -0.1;
+        Assert.That(TransformHandleMath.NormalizeAngleDelta(d), Is.EqualTo(d).Within(1e-12));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_BranchCutCrossing_WrapsToShortestRotation()
+    {
+        // Dragging from +179° to -179° produces a raw delta of -358° (-6.246 rad); normalize it to +2° (+0.0349 rad).
+        double startDeg = 179;
+        double endDeg = -179;
+        double rawDelta = (endDeg - startDeg) * Math.PI / 180.0; // -358°
+        double expected = 2 * Math.PI / 180.0;                     //   +2°
+
+        double normalized = TransformHandleMath.NormalizeAngleDelta(rawDelta);
+
+        Assert.That(normalized, Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_BranchCutOppositeDirection_WrapsToShortestRotation()
+    {
+        // From -179° to +179° the raw delta is +358° → normalizes to -2°.
+        double rawDelta = 358 * Math.PI / 180.0;
+        double expected = -2 * Math.PI / 180.0;
+
+        double normalized = TransformHandleMath.NormalizeAngleDelta(rawDelta);
+
+        Assert.That(normalized, Is.EqualTo(expected).Within(1e-6));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_MultipleRevolutions_WrapsToShortestRotation()
+    {
+        // Mathematical invariant: |result| <= π. 3π → -π or +π (boundary); -3π → same boundary.
+        double result3pi = TransformHandleMath.NormalizeAngleDelta(3 * Math.PI);
+        double resultNeg3pi = TransformHandleMath.NormalizeAngleDelta(-3 * Math.PI);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Math.Abs(result3pi), Is.EqualTo(Math.PI).Within(1e-9));
+            Assert.That(Math.Abs(resultNeg3pi), Is.EqualTo(Math.PI).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_Range_AlwaysWithinPi()
+    {
+        // Sweep to verify the |result| <= π invariant.
+        for (double d = -10 * Math.PI; d <= 10 * Math.PI; d += 0.1)
+        {
+            double r = TransformHandleMath.NormalizeAngleDelta(d);
+            Assert.That(Math.Abs(r), Is.LessThanOrEqualTo(Math.PI + 1e-9),
+                $"NormalizeAngleDelta({d}) = {r} should be within [-π, π]");
+        }
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_ExactPi_ReturnsPi()
+    {
+        // Exact π input. The IEEERemainder-based implementation returns either +π or -π, but |result| = π holds.
+        // The |result| == π invariant should be preserved even if the implementation changes in the future.
+        double result = TransformHandleMath.NormalizeAngleDelta(Math.PI);
+        Assert.That(Math.Abs(result), Is.EqualTo(Math.PI).Within(1e-12));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_ExactNegativePi_ReturnsAbsPi()
+    {
+        double result = TransformHandleMath.NormalizeAngleDelta(-Math.PI);
+        Assert.That(Math.Abs(result), Is.EqualTo(Math.PI).Within(1e-12));
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_NaN_Propagates()
+    {
+        // Public API contract: callers are expected to filter NaN/Infinity, but the function itself
+        // is guaranteed to propagate NaN without throwing (consistent with the upstream caller's double.IsFinite gate).
+        Assert.That(double.IsNaN(TransformHandleMath.NormalizeAngleDelta(double.NaN)), Is.True);
+    }
+
+    [Test]
+    public void NormalizeAngleDelta_Infinity_PropagatesAsNonFinite()
+    {
+        // Confirm that +∞ / -∞ also fall on the IsFinite-fail side (either NaN or ±∞).
+        double posInf = TransformHandleMath.NormalizeAngleDelta(double.PositiveInfinity);
+        double negInf = TransformHandleMath.NormalizeAngleDelta(double.NegativeInfinity);
+        Assert.Multiple(() =>
+        {
+            Assert.That(double.IsFinite(posInf), Is.False);
+            Assert.That(double.IsFinite(negInf), Is.False);
+        });
+    }
+
+    // ===== AlignUserMatrixToRenderedBounds =====
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_IdentityAndMatchingBounds_ReturnsUserMatrix()
+    {
+        // userMatrix=I, rendered bounds == local rect → centers match, no correction.
+        var userMatrix = Matrix.Identity;
+        var localSize = new Size(100, 50);
+        var bounds = new Rect(0, 0, 100, 50);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        Assert.That(result, Is.EqualTo(userMatrix));
+    }
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_OffsetEffect_AppliesPostTranslate()
+    {
+        // userMatrix=I, transform AABB center = (50, 25), rendered bounds center = (60, 30)
+        // → simulates a pure translation effect. dx=10, dy=5 are post-translated.
+        var userMatrix = Matrix.Identity;
+        var localSize = new Size(100, 50);
+        var bounds = new Rect(10, 5, 100, 50);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        // Post-translate maps the origin (0,0) to (10, 5)
+        Point origin = result.Transform(new Point(0, 0));
+        Assert.Multiple(() =>
+        {
+            Assert.That(origin.X, Is.EqualTo(10f).Within(1e-3));
+            Assert.That(origin.Y, Is.EqualTo(5f).Within(1e-3));
+        });
+    }
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_SymmetricBlur_NoChange()
+    {
+        // userMatrix=I, transform AABB = (0,0)-(100,50), center=(50,25).
+        // The bounds expand by 10px on each side to (-10,-10)-(110,60), but center=(50, 25) is unchanged. dx=dy=0 → no correction.
+        var userMatrix = Matrix.Identity;
+        var localSize = new Size(100, 50);
+        var bounds = new Rect(-10, -10, 120, 70);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        Assert.That(result, Is.EqualTo(userMatrix));
+    }
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_BelowThreshold_ReturnsUserMatrix()
+    {
+        // When the center difference is below 0.5px (e.g. 0.4px), treat it as numerical noise and do not apply a correction.
+        var userMatrix = Matrix.Identity;
+        var localSize = new Size(100, 50);
+        var bounds = new Rect(0.4f, 0.4f, 100, 50);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        Assert.That(result, Is.EqualTo(userMatrix));
+    }
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_AtThreshold_AppliesPostTranslate()
+    {
+        // At dx=0.51px (just over the 0.5 threshold), the correction is applied.
+        var userMatrix = Matrix.Identity;
+        var localSize = new Size(100, 50);
+        var bounds = new Rect(0.51f, 0, 100, 50);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        Point origin = result.Transform(new Point(0, 0));
+        Assert.That(origin.X, Is.EqualTo(0.51f).Within(1e-3));
+    }
+
+    [Test]
+    public void AlignUserMatrixToRenderedBounds_RotatedMatrix_OffsetComputedFromAabb()
+    {
+        // The AABB of a 100x100 square rotated by 45° is √2 times the size. When the rendered bounds match that AABB, no correction is applied.
+        Matrix userMatrix = Matrix.CreateRotation(System.MathF.PI / 4);
+        var localSize = new Size(100, 100);
+
+        // Compute the rotated AABB by rotating the 4 corners (0,0), (100,0), (100,100), (0,100).
+        // The center stays at (50, 50), and the AABB is roughly (-35.36, 35.36)-(35.36, 106.07). In practice
+        // the center is (35.36, 70.71)... here we assert that "no correction is applied when rendered bounds
+        // match the transform AABB".
+        System.Span<Point> corners = stackalloc Point[]
+        {
+            userMatrix.Transform(new Point(0, 0)),
+            userMatrix.Transform(new Point(100, 0)),
+            userMatrix.Transform(new Point(100, 100)),
+            userMatrix.Transform(new Point(0, 100)),
+        };
+        float minX = corners[0].X, maxX = corners[0].X, minY = corners[0].Y, maxY = corners[0].Y;
+        for (int i = 1; i < 4; i++)
+        {
+            if (corners[i].X < minX) minX = corners[i].X;
+            if (corners[i].X > maxX) maxX = corners[i].X;
+            if (corners[i].Y < minY) minY = corners[i].Y;
+            if (corners[i].Y > maxY) maxY = corners[i].Y;
+        }
+        var bounds = new Rect(minX, minY, maxX - minX, maxY - minY);
+
+        Matrix result = TransformHandleMath.AlignUserMatrixToRenderedBounds(userMatrix, localSize, bounds);
+
+        Assert.That(result, Is.EqualTo(userMatrix));
+    }
+
+    // ===== LockAspect =====
+
+    [Test]
+    public void LockAspect_BothPositive_TakesMinMagnitude()
+    {
+        var (rx, ry) = TransformHandleMath.LockAspect(2.0, 3.0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rx, Is.EqualTo(2.0));
+            Assert.That(ry, Is.EqualTo(2.0));
+        });
+    }
+
+    [Test]
+    public void LockAspect_NegativeX_PreservesSignAndMinMagnitude()
+    {
+        // |-1.5| < |2.0|, so magnitude = 1.5 with each axis' sign preserved.
+        var (rx, ry) = TransformHandleMath.LockAspect(-1.5, 2.0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rx, Is.EqualTo(-1.5));
+            Assert.That(ry, Is.EqualTo(1.5));
+        });
+    }
+
+    [Test]
+    public void LockAspect_BothNegative_PreservesBothFlips()
+    {
+        var (rx, ry) = TransformHandleMath.LockAspect(-2.0, -3.0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rx, Is.EqualTo(-2.0));
+            Assert.That(ry, Is.EqualTo(-2.0));
+        });
+    }
+
+    [Test]
+    public void LockAspect_ZeroInput_ReturnsZeroMagnitudeForBoth()
+    {
+        // If one side is 0, magnitude = 0 and the other side also becomes 0 (sign preserved = +).
+        var (rx, ry) = TransformHandleMath.LockAspect(0.0, 5.0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rx, Is.EqualTo(0.0));
+            Assert.That(ry, Is.EqualTo(0.0));
+        });
+    }
+
+    [Test]
+    public void LockAspect_NaN_Propagates()
+    {
+        // Public API contract: with NaN input, do not throw and propagate NaN to both axes
+        // (the caller is expected to gate on `IsFinite`; same pattern as NormalizeAngleDelta_NaN_Propagates).
+        var (rx, ry) = TransformHandleMath.LockAspect(double.NaN, 2.0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(double.IsNaN(rx), Is.True);
+            Assert.That(double.IsNaN(ry), Is.True);
+        });
+    }
+}


### PR DESCRIPTION
## Description
- Add an 8-handle 2D bounding box overlay on the player so users can translate, scale, and rotate the selected drawable directly from the preview without opening the property tab.
- Use the selected drawable's own bounds (via the new `IRenderer.GetBoundary` API) so siblings sharing the same ZIndex no longer expand the handle box.
- Project mouse deltas into the drawable's local axes when resizing rotated elements, and route translate/scale/rotation edits through the surrounding keyframes so animated transforms remain consistent.

## Breaking changes
- None. `IRenderer` gains a new member, `Rect? GetBoundary(Drawable)`, but it ships as a **default interface implementation that returns `null`**, so external `IRenderer` implementations remain source-compatible. Implementing the member is optional and only required to enable the transform-handle overlay for that renderer.

## Fixed issues
None