### PR TITLE
fix: surface FFmpeg install dialog when worker libraries are missing

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegDecodingExtension.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegDecodingExtension.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using Beutl.Extensibility;
 using Beutl.Extensions.FFmpeg.Properties;
+using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
 using Beutl.Logging;
@@ -28,7 +29,15 @@ public class FFmpegDecodingExtension : DecodingExtension
 #if !FFMPEG_OUT_OF_PROCESS
         FFmpegLoader.Initialize();
 #else
-        FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
+        try
+        {
+            FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
+        }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "FFmpeg libraries not found; prompting install.");
+            FFmpegInstallNotifier.NotifyMissing();
+        }
         Settings.PropertyChanged += OnSettingsPropertyChanged;
 #endif
         base.Load();

--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingControllerProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingControllerProxy.cs
@@ -3,6 +3,7 @@ using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
 using Beutl.FFmpegIpc.SharedMemory;
+using Beutl.FFmpegIpc.Transport;
 using Beutl.Logging;
 using Beutl.Media;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,16 @@ public class FFmpegEncodingControllerProxy(string outputFile, FFmpegEncodingSett
         IFrameProvider frameProvider, ISampleProvider sampleProvider, CancellationToken cancellationToken)
     {
         using var worker = FFmpegWorkerProcess.CreateForEncoding();
-        var connection = await worker.EnsureStartedAsync(cancellationToken);
+        IpcConnection connection;
+        try
+        {
+            connection = await worker.EnsureStartedAsync(cancellationToken);
+        }
+        catch (FFmpegLibrariesNotFoundException)
+        {
+            FFmpegInstallNotifier.NotifyMissing();
+            throw;
+        }
 
         // エンコード設定をシリアライズ
         var startRequest = new EncodeStartRequest

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -1,4 +1,4 @@
-using Avalonia.Threading;
+﻿using Avalonia.Threading;
 
 using Beutl.Extensions.FFmpeg.Properties;
 using Beutl.Services;

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -9,9 +9,14 @@ internal static class FFmpegInstallNotifier
 {
     private const long ThrottleMs = 10_000;
     private static long s_lastNotifiedTicks;
+    private static volatile bool s_librariesMissing;
+
+    public static bool IsLibrariesMissing => s_librariesMissing;
 
     public static void NotifyMissing()
     {
+        s_librariesMissing = true;
+
         long now = Environment.TickCount64;
         long last = Interlocked.Read(ref s_lastNotifiedTicks);
         if (last != 0 && now - last < ThrottleMs)
@@ -23,6 +28,17 @@ internal static class FFmpegInstallNotifier
             Strings.Make_sure_you_have_FFmpeg_installed,
             onActionButtonClick: ShowInstallDialog,
             actionButtonText: Strings.Install);
+    }
+
+    public static void MarkInstalled()
+    {
+        s_librariesMissing = false;
+        Interlocked.Exchange(ref s_lastNotifiedTicks, 0);
+    }
+
+    public static void MarkMissing()
+    {
+        s_librariesMissing = true;
     }
 
     private static void ShowInstallDialog()

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -7,24 +7,25 @@ namespace Beutl.Extensions.FFmpeg;
 
 internal static class FFmpegInstallNotifier
 {
-    private static int s_notified;
+    private const long ThrottleMs = 10_000;
+    private static long s_lastNotifiedTicks;
 
     public static void NotifyMissing()
     {
-        if (Interlocked.Exchange(ref s_notified, 1) == 1)
+        long now = Environment.TickCount64;
+        long last = Interlocked.Read(ref s_lastNotifiedTicks);
+        if (last != 0 && now - last < ThrottleMs)
             return;
+        Interlocked.Exchange(ref s_lastNotifiedTicks, now);
 
         NotificationService.ShowError(
             Strings.FFmpegError,
             Strings.Make_sure_you_have_FFmpeg_installed,
-            onClose: Reset,
             onActionButtonClick: ShowInstallDialog,
             actionButtonText: Strings.Install);
     }
 
-    public static void Reset() => Interlocked.Exchange(ref s_notified, 0);
-
-    public static void ShowInstallDialog()
+    private static void ShowInstallDialog()
     {
         Dispatcher.UIThread.Post(() =>
         {

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -1,0 +1,37 @@
+using Avalonia.Threading;
+
+using Beutl.Extensions.FFmpeg.Properties;
+using Beutl.Services;
+
+namespace Beutl.Extensions.FFmpeg;
+
+internal static class FFmpegInstallNotifier
+{
+    private static int s_notified;
+
+    public static void NotifyMissing()
+    {
+        if (Interlocked.Exchange(ref s_notified, 1) == 1)
+            return;
+
+        NotificationService.ShowError(
+            Strings.FFmpegError,
+            Strings.Make_sure_you_have_FFmpeg_installed,
+            onClose: Reset,
+            onActionButtonClick: ShowInstallDialog,
+            actionButtonText: Strings.Install);
+    }
+
+    public static void Reset() => Interlocked.Exchange(ref s_notified, 0);
+
+    public static void ShowInstallDialog()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            var viewModel = new FFmpegInstallDialogViewModel();
+            var dialog = new FFmpegInstallDialog { DataContext = viewModel };
+            dialog.ShowAsync();
+            viewModel.Start();
+        });
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallService.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallService.cs
@@ -678,6 +678,9 @@ public class FFmpegInstallService
         ProgressTextChanged?.Invoke(Strings.Verifying_FFmpeg_installation);
         IndeterminateChanged?.Invoke(true);
 
+        // 検証のため missing フラグを一旦クリアし、ワーカー起動を許可する
+        FFmpegInstallNotifier.MarkInstalled();
+
         bool verified = false;
 #if FFMPEG_OUT_OF_PROCESS
         // Workerプロセスを起動してFFmpegの初期化が成功するか確認
@@ -725,6 +728,8 @@ public class FFmpegInstallService
         }
         else
         {
+            // 検証に失敗したので missing フラグを立て直し、無駄な再起動を防ぐ
+            FFmpegInstallNotifier.MarkMissing();
             ProgressTextChanged?.Invoke(Strings.FFmpeg_verification_failed);
             Completed?.Invoke(false);
         }

--- a/src/Beutl.Extensions.FFmpeg/FFmpegPath.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegPath.cs
@@ -2,11 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-using Avalonia.Threading;
-
-using Beutl.Extensions.FFmpeg.Properties;
 using Beutl.Logging;
-using Beutl.Services;
 
 using FFmpeg.AutoGen.Abstractions;
 using FFmpeg.AutoGen.Bindings.DynamicallyLoaded;
@@ -63,11 +59,7 @@ public static class FFmpegLoader
         catch
         {
             s_isInitializationFailed = true;
-            NotificationService.ShowError(
-                Strings.FFmpegError,
-                Strings.Make_sure_you_have_FFmpeg_installed,
-                onActionButtonClick: ShowInstallDialog,
-                actionButtonText: Strings.Install);
+            FFmpegInstallNotifier.NotifyMissing();
         }
 
         static string GetVersionString(uint version)
@@ -96,21 +88,6 @@ public static class FFmpegLoader
                 };
                 s_ffmpegLogger.Log(convertedLevel, "{OriginalLevel} {FFmpegLog}", level, s.TrimEnd('\n').TrimEnd('\r'));
             });
-    }
-
-    private static void ShowInstallDialog()
-    {
-        Dispatcher.UIThread.Post(() =>
-        {
-            FFmpegInstallDialogViewModel viewModel = new();
-            FFmpegInstallDialog dialog = new()
-            {
-                DataContext = viewModel
-            };
-
-            dialog.ShowAsync();
-            viewModel.Start();
-        });
     }
 
     private static void FixDependencyIssue()

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -80,11 +80,13 @@ public sealed class FFmpegWorkerProcess : IDisposable
 
     private static void ThrowIfLibrariesMissing()
     {
+#if FFMPEG_OUT_OF_PROCESS
         if (FFmpegInstallNotifier.IsLibrariesMissing)
         {
             throw new FFmpegLibrariesNotFoundException(
                 "FFmpeg libraries are missing; install FFmpeg before starting the worker.");
         }
+#endif
     }
 
     private async Task StartWorkerAsync(CancellationToken ct)

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -125,6 +125,9 @@ public sealed class FFmpegWorkerProcess : IDisposable
 
             if (completed == exitTask)
             {
+                // キャンセル経由でexitTaskが完了した場合は OperationCanceledException を再スロー
+                await exitTask;
+
                 int code = _process.ExitCode;
                 pipeServer.Dispose();
                 if (code == 2)
@@ -138,6 +141,12 @@ public sealed class FFmpegWorkerProcess : IDisposable
 
             // 接続が先に成立。例外があれば伝播させる
             await connectTask;
+            // 敗者となった exitTask の例外を観測しておく（UnobservedTaskException 防止）
+            _ = exitTask.ContinueWith(
+                static t => { _ = t.Exception; },
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
         catch (OperationCanceledException)
         {

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -34,11 +34,15 @@ public sealed class FFmpegWorkerProcess : IDisposable
         if (_connection != null && _process is { HasExited: false })
             return _connection;
 
+        ThrowIfLibrariesMissing();
+
         _startLock.Wait();
         try
         {
             if (_connection != null && _process is { HasExited: false })
                 return _connection;
+
+            ThrowIfLibrariesMissing();
 
             // 同期コンテキストから非同期メソッドを呼び出す（タイムアウト付き）
             StartWorkerAsync(CancellationToken.None).GetAwaiter().GetResult();
@@ -55,11 +59,15 @@ public sealed class FFmpegWorkerProcess : IDisposable
         if (_connection != null && _process is { HasExited: false })
             return _connection;
 
+        ThrowIfLibrariesMissing();
+
         await _startLock.WaitAsync(ct);
         try
         {
             if (_connection != null && _process is { HasExited: false })
                 return _connection;
+
+            ThrowIfLibrariesMissing();
 
             await StartWorkerAsync(ct);
             return _connection!;
@@ -67,6 +75,15 @@ public sealed class FFmpegWorkerProcess : IDisposable
         finally
         {
             _startLock.Release();
+        }
+    }
+
+    private static void ThrowIfLibrariesMissing()
+    {
+        if (FFmpegInstallNotifier.IsLibrariesMissing)
+        {
+            throw new FFmpegLibrariesNotFoundException(
+                "FFmpeg libraries are missing; install FFmpeg before starting the worker.");
         }
     }
 

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -129,6 +129,15 @@ public sealed class FFmpegWorkerProcess : IDisposable
                 await exitTask;
 
                 int code = _process.ExitCode;
+
+                // 敗者となった connectTask の例外を観測しておく（UnobservedTaskException 防止）
+                connectCts.Cancel();
+                _ = connectTask.ContinueWith(
+                    static t => { _ = t.Exception; },
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
                 pipeServer.Dispose();
                 if (code == 2)
                 {

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO.Pipes;
+using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
 using Beutl.FFmpegIpc.Transport;
@@ -114,11 +115,29 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _process.BeginErrorReadLine();
             _process.BeginOutputReadLine();
 
-            // パイプ接続待機
+            // パイプ接続待機 + Worker早期終了検出
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             connectCts.CancelAfter(TimeSpan.FromSeconds(30));
 
-            await pipeServer.WaitForConnectionAsync(connectCts.Token);
+            var connectTask = pipeServer.WaitForConnectionAsync(connectCts.Token);
+            var exitTask = _process.WaitForExitAsync(connectCts.Token);
+            var completed = await Task.WhenAny(connectTask, exitTask).ConfigureAwait(false);
+
+            if (completed == exitTask)
+            {
+                int code = _process.ExitCode;
+                pipeServer.Dispose();
+                if (code == 2)
+                {
+                    throw new FFmpegLibrariesNotFoundException(
+                        "FFmpeg worker exited because the FFmpeg libraries could not be found.");
+                }
+                throw new InvalidOperationException(
+                    $"FFmpeg worker exited unexpectedly with code {code} before establishing connection.");
+            }
+
+            // 接続が先に成立。例外があれば伝播させる
+            await connectTask;
         }
         catch (OperationCanceledException)
         {

--- a/src/Beutl.FFmpegIpc/FFmpegLibrariesNotFoundException.cs
+++ b/src/Beutl.FFmpegIpc/FFmpegLibrariesNotFoundException.cs
@@ -1,0 +1,8 @@
+namespace Beutl.FFmpegIpc;
+
+public sealed class FFmpegLibrariesNotFoundException : Exception
+{
+    public FFmpegLibrariesNotFoundException(string message) : base(message)
+    {
+    }
+}

--- a/src/Beutl.FFmpegIpc/FFmpegLibrariesNotFoundException.cs
+++ b/src/Beutl.FFmpegIpc/FFmpegLibrariesNotFoundException.cs
@@ -1,4 +1,4 @@
-namespace Beutl.FFmpegIpc;
+﻿namespace Beutl.FFmpegIpc;
 
 public sealed class FFmpegLibrariesNotFoundException : Exception
 {

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using Beutl.FFmpegIpc;
 using FFmpeg.AutoGen.Abstractions;
 using FFmpeg.AutoGen.Bindings.DynamicallyLoaded;
 
@@ -97,7 +98,7 @@ internal static class FFmpegLoaderWorker
                 return path;
         }
 
-        throw new InvalidOperationException("FFmpeg libraries not found");
+        throw new FFmpegLibrariesNotFoundException("FFmpeg libraries not found");
     }
 
     private static bool LibrariesExists(string basePath)

--- a/src/Beutl.FFmpegWorker/Program.cs
+++ b/src/Beutl.FFmpegWorker/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO.Pipes;
+using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Transport;
 using Beutl.Logging;
 using Microsoft.Extensions.Logging;
@@ -58,10 +59,15 @@ internal static class Program
         {
             FFmpegLoaderWorker.Initialize();
         }
+        catch (FFmpegLibrariesNotFoundException ex)
+        {
+            Console.Error.WriteLine($"FFmpeg libraries not found: {ex.Message}");
+            return 2;
+        }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Failed to initialize FFmpeg: {ex.Message}");
-            return 2;
+            Console.Error.WriteLine($"Failed to initialize FFmpeg: {ex}");
+            return 4;
         }
 
         // 親プロセス監視（終了時はCancellationTokenでグレースフルシャットダウン）


### PR DESCRIPTION
## Description
- In OUT_OF_PROCESS mode the FFmpeg worker exits with code 2 when system FFmpeg libraries are missing, but the host waited 30s on the named pipe and only raised TimeoutException — the existing install dialog was never shown.
- Race pipe-connect against worker exit so missing libraries surface as FFmpegLibrariesNotFoundException, and route both decoding Load and encoding Start through a shared FFmpegInstallNotifier so the install dialog appears in both paths.
- Replace the broken one-shot notification flag (never reset by the InfoBar auto-expiry or Install click) with a 10s timestamp throttle, and fix a cancellation race in StartWorkerAsync that read _process.ExitCode after a cancellation completion and could leak an unobserved exitTask.

## Breaking changes
None.

## Fixed issues
- Closes #1785
