### PR TITLE
feat: route FFmpegWorker logs to host logger

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
+++ b/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
@@ -33,6 +33,7 @@
     <Compile Remove="Decoding\FFmpegReaderProxy.cs" />
     <Compile Remove="Encoding\FFmpegEncodingControllerProxy.cs" />
     <Compile Remove="FFmpegWorkerProcess.cs" />
+    <Compile Remove="FFmpegWorkerLogPump.cs" />
     <Compile Remove="FFmpegWorkerCodecCache.cs" />
   </ItemGroup>
 

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Text;
 using System.Threading.Channels;
 using Beutl.Logging;

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Channels;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Extensions.FFmpeg;
+
+// ワーカーの stdout/stderr をホスト側ロガーへ転送する。
+internal sealed class FFmpegWorkerLogPump : IDisposable
+{
+    private const int DefaultCapacity = 1024;
+
+    private static readonly ILogger s_logger = Log.CreateLogger("FFmpegWorker");
+
+    private readonly Channel<(string Channel, string Data)> _channel;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _consumer;
+    private int _disposed;
+
+    public FFmpegWorkerLogPump(int capacity = DefaultCapacity)
+    {
+        _channel = Channel.CreateBounded<(string, string)>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _consumer = Task.Run(ConsumeAsync);
+    }
+
+    public void Attach(Process process)
+    {
+        process.ErrorDataReceived += (_, e) => Enqueue("stderr", e.Data);
+        process.OutputDataReceived += (_, e) => Enqueue("stdout", e.Data);
+    }
+
+    private void Enqueue(string channel, string? data)
+    {
+        if (data == null)
+            return;
+
+        // BoundedChannel + DropOldest なら TryWrite は常に成功する。
+        // ハンドラから例外を漏らすとホストプロセスが UnhandledException で落ちるため握りつぶす。
+        try
+        {
+            _channel.Writer.TryWrite((channel, data));
+        }
+        catch
+        {
+        }
+    }
+
+    private async Task ConsumeAsync()
+    {
+        try
+        {
+            await foreach (var (channel, data) in _channel.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false))
+            {
+                Dispatch(channel, data);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            try { Console.Error.WriteLine($"[FFmpegWorker] log pump terminated unexpectedly: {ex}"); }
+            catch { }
+        }
+    }
+
+    private static void Dispatch(string channel, string data)
+    {
+        try
+        {
+            var (level, message) = ParseLevel(channel, data);
+            s_logger.Log(level, "{Channel} {Message}", channel, message);
+        }
+        catch (Exception ex)
+        {
+            try { Console.Error.WriteLine($"[FFmpegWorker:{channel}] log dispatch failed: {ex}"); }
+            catch { }
+        }
+    }
+
+    private static (LogLevel Level, string Message) ParseLevel(string channel, string data)
+    {
+        // ワーカーは ILogger / FFmpeg ネイティブログ / 自身のエラーメッセージのすべてを
+        // stdout に "[ffmpeg:<Level>] ..." 形式 (1行=1ログイベント, 改行は \n エスケープ) で書き出す。
+        // プレフィックス付き行はそのレベルを採用しメッセージを復号する。
+        // プレフィックスのない出力や想定外に stderr に流れてきたネイティブ出力は
+        // チャネルベースのフォールバック (stderr=Warning / stdout=Information) で扱う。
+        const string prefix = "[ffmpeg:";
+        if (data.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            int end = data.IndexOf(']', prefix.Length);
+            if (end > prefix.Length)
+            {
+                string levelText = data.AsSpan(prefix.Length, end - prefix.Length).ToString();
+                LogLevel level = levelText switch
+                {
+                    "Verbose" or "Trace" => LogLevel.Trace,
+                    "Debug" => LogLevel.Debug,
+                    "Info" or "Information" => LogLevel.Information,
+                    "Warning" => LogLevel.Warning,
+                    "Error" => LogLevel.Error,
+                    "Fatal" or "Panic" or "Critical" => LogLevel.Critical,
+                    _ => channel == "stderr" ? LogLevel.Warning : LogLevel.Information,
+                };
+                string message = DecodeMessage(data.AsSpan(end + 1).TrimStart());
+                return (level, message);
+            }
+        }
+
+        return (channel == "stderr" ? LogLevel.Warning : LogLevel.Information, data);
+    }
+
+    private static string DecodeMessage(ReadOnlySpan<char> encoded)
+    {
+        if (encoded.IndexOf('\\') < 0)
+            return encoded.ToString();
+
+        var sb = new StringBuilder(encoded.Length);
+        for (int i = 0; i < encoded.Length; i++)
+        {
+            char c = encoded[i];
+            if (c == '\\' && i + 1 < encoded.Length)
+            {
+                char next = encoded[++i];
+                switch (next)
+                {
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case '\\': sb.Append('\\'); break;
+                    default: sb.Append('\\').Append(next); break;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+        return sb.ToString();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _channel.Writer.TryComplete();
+        try { _consumer.Wait(TimeSpan.FromSeconds(2)); }
+        catch { }
+
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerLogPump.cs
@@ -11,8 +11,7 @@ internal sealed class FFmpegWorkerLogPump : IDisposable
 {
     private const int DefaultCapacity = 1024;
 
-    private static readonly ILogger s_logger = Log.CreateLogger("FFmpegWorker");
-
+    private readonly ILogger _logger = Log.CreateLogger("FFmpegWorker");
     private readonly Channel<(string Channel, string Data)> _channel;
     private readonly CancellationTokenSource _cts = new();
     private readonly Task _consumer;
@@ -70,12 +69,12 @@ internal sealed class FFmpegWorkerLogPump : IDisposable
         }
     }
 
-    private static void Dispatch(string channel, string data)
+    private void Dispatch(string channel, string data)
     {
         try
         {
             var (level, message) = ParseLevel(channel, data);
-            s_logger.Log(level, "{Channel} {Message}", channel, message);
+            _logger.Log(level, "{Channel} {Message}", channel, message);
         }
         catch (Exception ex)
         {

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -123,7 +123,8 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("Failed to start FFmpeg worker process");
 
-            // stderrを非同期に消費してバッファ溢れによるデッドロックを防止
+            // stdout/stderrを非同期に消費してバッファ溢れによるデッドロックを防止しつつ、
+            // 受信した出力をホスト側ロガーへ転送する
             _process.ErrorDataReceived += (_, e) => LogWorkerOutput("stderr", e.Data);
             _process.OutputDataReceived += (_, e) => LogWorkerOutput("stdout", e.Data);
             _process.BeginErrorReadLine();
@@ -211,13 +212,26 @@ public sealed class FFmpegWorkerProcess : IDisposable
         if (data == null)
             return;
 
-        var (level, message) = ParseLevel(channel, data);
-        s_logger.Log(level, "{Channel} {Message}", channel, message);
+        // Process.*DataReceived ハンドラから例外を漏らすとホストプロセスが UnhandledException で落ちるため、
+        // ロガー基盤（Serilog/OTLP）の障害は最終フォールバックの Console.Error で握りつぶす
+        try
+        {
+            var (level, message) = ParseLevel(channel, data);
+            s_logger.Log(level, "{Channel} {Message}", channel, message);
+        }
+        catch (Exception ex)
+        {
+            try { Console.Error.WriteLine($"[FFmpegWorker:{channel}] log dispatch failed: {ex}"); }
+            catch { /* stderrまで死んでいたら諦める */ }
+        }
     }
 
     private static (LogLevel Level, string Message) ParseLevel(string channel, string data)
     {
-        // FFmpegLoaderWorker.SetupLogging が "[ffmpeg:<Level>] ..." 形式で書き出すプレフィックスを解釈する
+        // ワーカー側の FFmpegLoaderWorker.SetupLogging は FFmpeg ライブラリの Warning 以上のログのみ
+        // "[ffmpeg:<Level>] ..." 形式で stderr に書き出す。プレフィックス付き行はそれを解釈し、
+        // 非プレフィックス行（バージョンバナーや handler 由来の Console.Error 出力等）は
+        // チャネルベースのフォールバック（stderr=Warning / stdout=Information）扱いにする。
         const string prefix = "[ffmpeg:";
         if (data.StartsWith(prefix, StringComparison.Ordinal))
         {

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -228,10 +228,11 @@ public sealed class FFmpegWorkerProcess : IDisposable
 
     private static (LogLevel Level, string Message) ParseLevel(string channel, string data)
     {
-        // ワーカー側の FFmpegLoaderWorker.SetupLogging は FFmpeg ライブラリの Warning 以上のログのみ
-        // "[ffmpeg:<Level>] ..." 形式で stderr に書き出す。プレフィックス付き行はそれを解釈し、
-        // 非プレフィックス行（バージョンバナーや handler 由来の Console.Error 出力等）は
-        // チャネルベースのフォールバック（stderr=Warning / stdout=Information）扱いにする。
+        // ワーカーは ILogger / FFmpeg ネイティブログ / 自身のエラーメッセージのすべてを
+        // stdout に "[ffmpeg:<Level>] ..." 形式 (1行=1ログイベント, 改行は \n エスケープ) で書き出す。
+        // プレフィックス付き行はそのレベルを採用しメッセージを復号する。
+        // プレフィックスのない出力や想定外に stderr に流れてきたネイティブ出力は
+        // チャネルベースのフォールバック（stderr=Warning / stdout=Information）で扱う。
         const string prefix = "[ffmpeg:";
         if (data.StartsWith(prefix, StringComparison.Ordinal))
         {
@@ -246,15 +247,43 @@ public sealed class FFmpegWorkerProcess : IDisposable
                     "Info" or "Information" => LogLevel.Information,
                     "Warning" => LogLevel.Warning,
                     "Error" => LogLevel.Error,
-                    "Fatal" or "Panic" => LogLevel.Critical,
+                    "Fatal" or "Panic" or "Critical" => LogLevel.Critical,
                     _ => channel == "stderr" ? LogLevel.Warning : LogLevel.Information,
                 };
-                string message = data.Substring(end + 1).TrimStart();
+                string message = DecodeMessage(data.Substring(end + 1).TrimStart());
                 return (level, message);
             }
         }
 
         return (channel == "stderr" ? LogLevel.Warning : LogLevel.Information, data);
+    }
+
+    private static string DecodeMessage(string encoded)
+    {
+        if (encoded.IndexOf('\\') < 0)
+            return encoded;
+
+        var sb = new System.Text.StringBuilder(encoded.Length);
+        for (int i = 0; i < encoded.Length; i++)
+        {
+            char c = encoded[i];
+            if (c == '\\' && i + 1 < encoded.Length)
+            {
+                char next = encoded[++i];
+                switch (next)
+                {
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case '\\': sb.Append('\\'); break;
+                    default: sb.Append('\\').Append(next); break;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+        return sb.ToString();
     }
 
     private static void ConfigureWorkerProcess(ProcessStartInfo startInfo)

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -21,6 +21,7 @@ public sealed class FFmpegWorkerProcess : IDisposable
     private readonly bool _multiplexed;
     private Process? _process;
     private IpcConnection? _connection;
+    private FFmpegWorkerLogPump? _logPump;
     private string? _pipeName;
 
     public FFmpegWorkerProcess(bool multiplexed = false)
@@ -123,10 +124,10 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("Failed to start FFmpeg worker process");
 
-            // stdout/stderrを非同期に消費してバッファ溢れによるデッドロックを防止しつつ、
-            // 受信した出力をホスト側ロガーへ転送する
-            _process.ErrorDataReceived += (_, e) => LogWorkerOutput("stderr", e.Data);
-            _process.OutputDataReceived += (_, e) => LogWorkerOutput("stdout", e.Data);
+            // stdout/stderr のドレインはストリームリーダースレッドから即時 enqueue するだけにし、
+            // ロガーシンクへの実書き込みはバックグラウンドで行う (FFmpegWorkerLogPump 参照)。
+            _logPump = new FFmpegWorkerLogPump();
+            _logPump.Attach(_process);
             _process.BeginErrorReadLine();
             _process.BeginOutputReadLine();
 
@@ -207,85 +208,6 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _connection.StartMultiplexedReceive(ct);
     }
 
-    private static void LogWorkerOutput(string channel, string? data)
-    {
-        if (data == null)
-            return;
-
-        // Process.*DataReceived ハンドラから例外を漏らすとホストプロセスが UnhandledException で落ちるため、
-        // ロガー基盤（Serilog/OTLP）の障害は最終フォールバックの Console.Error で握りつぶす
-        try
-        {
-            var (level, message) = ParseLevel(channel, data);
-            s_logger.Log(level, "{Channel} {Message}", channel, message);
-        }
-        catch (Exception ex)
-        {
-            try { Console.Error.WriteLine($"[FFmpegWorker:{channel}] log dispatch failed: {ex}"); }
-            catch { /* stderrまで死んでいたら諦める */ }
-        }
-    }
-
-    private static (LogLevel Level, string Message) ParseLevel(string channel, string data)
-    {
-        // ワーカーは ILogger / FFmpeg ネイティブログ / 自身のエラーメッセージのすべてを
-        // stdout に "[ffmpeg:<Level>] ..." 形式 (1行=1ログイベント, 改行は \n エスケープ) で書き出す。
-        // プレフィックス付き行はそのレベルを採用しメッセージを復号する。
-        // プレフィックスのない出力や想定外に stderr に流れてきたネイティブ出力は
-        // チャネルベースのフォールバック（stderr=Warning / stdout=Information）で扱う。
-        const string prefix = "[ffmpeg:";
-        if (data.StartsWith(prefix, StringComparison.Ordinal))
-        {
-            int end = data.IndexOf(']', prefix.Length);
-            if (end > prefix.Length)
-            {
-                string levelText = data.AsSpan(prefix.Length, end - prefix.Length).ToString();
-                LogLevel level = levelText switch
-                {
-                    "Verbose" or "Trace" => LogLevel.Trace,
-                    "Debug" => LogLevel.Debug,
-                    "Info" or "Information" => LogLevel.Information,
-                    "Warning" => LogLevel.Warning,
-                    "Error" => LogLevel.Error,
-                    "Fatal" or "Panic" or "Critical" => LogLevel.Critical,
-                    _ => channel == "stderr" ? LogLevel.Warning : LogLevel.Information,
-                };
-                string message = DecodeMessage(data.Substring(end + 1).TrimStart());
-                return (level, message);
-            }
-        }
-
-        return (channel == "stderr" ? LogLevel.Warning : LogLevel.Information, data);
-    }
-
-    private static string DecodeMessage(string encoded)
-    {
-        if (encoded.IndexOf('\\') < 0)
-            return encoded;
-
-        var sb = new System.Text.StringBuilder(encoded.Length);
-        for (int i = 0; i < encoded.Length; i++)
-        {
-            char c = encoded[i];
-            if (c == '\\' && i + 1 < encoded.Length)
-            {
-                char next = encoded[++i];
-                switch (next)
-                {
-                    case 'n': sb.Append('\n'); break;
-                    case 'r': sb.Append('\r'); break;
-                    case '\\': sb.Append('\\'); break;
-                    default: sb.Append('\\').Append(next); break;
-                }
-            }
-            else
-            {
-                sb.Append(c);
-            }
-        }
-        return sb.ToString();
-    }
-
     private static void ConfigureWorkerProcess(ProcessStartInfo startInfo)
     {
         string path = Path.Combine(AppContext.BaseDirectory, "Beutl.FFmpegWorker");
@@ -332,6 +254,11 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _process.Dispose();
             _process = null;
         }
+
+        // プロセス Dispose 後にポンプを破棄することで、終了直前に届いた行も
+        // バックグラウンド consumer が処理してから停止する。
+        _logPump?.Dispose();
+        _logPump = null;
     }
 
     public void Dispose()

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -4,11 +4,14 @@ using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
 using Beutl.FFmpegIpc.Transport;
+using Beutl.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Extensions.FFmpeg;
 
 public sealed class FFmpegWorkerProcess : IDisposable
 {
+    private static readonly ILogger s_logger = Log.CreateLogger("FFmpegWorker");
     private static readonly Lazy<FFmpegWorkerProcess> s_decodingInstance = new(() => new FFmpegWorkerProcess(multiplexed: true));
     public static FFmpegWorkerProcess DecodingInstance => s_decodingInstance.Value;
 
@@ -121,16 +124,8 @@ public sealed class FFmpegWorkerProcess : IDisposable
                 ?? throw new InvalidOperationException("Failed to start FFmpeg worker process");
 
             // stderrを非同期に消費してバッファ溢れによるデッドロックを防止
-            _process.ErrorDataReceived += (_, e) =>
-            {
-                if (e.Data != null)
-                    Console.WriteLine($"[FFmpegWorker] {e.Data}");
-            };
-            _process.OutputDataReceived += (_, e) =>
-            {
-                if (e.Data != null)
-                    Console.WriteLine($"[FFmpegWorker] {e.Data}");
-            };
+            _process.ErrorDataReceived += (_, e) => LogWorkerOutput("stderr", e.Data);
+            _process.OutputDataReceived += (_, e) => LogWorkerOutput("stdout", e.Data);
             _process.BeginErrorReadLine();
             _process.BeginOutputReadLine();
 
@@ -211,6 +206,43 @@ public sealed class FFmpegWorkerProcess : IDisposable
             _connection.StartMultiplexedReceive(ct);
     }
 
+    private static void LogWorkerOutput(string channel, string? data)
+    {
+        if (data == null)
+            return;
+
+        var (level, message) = ParseLevel(channel, data);
+        s_logger.Log(level, "{Channel} {Message}", channel, message);
+    }
+
+    private static (LogLevel Level, string Message) ParseLevel(string channel, string data)
+    {
+        // FFmpegLoaderWorker.SetupLogging が "[ffmpeg:<Level>] ..." 形式で書き出すプレフィックスを解釈する
+        const string prefix = "[ffmpeg:";
+        if (data.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            int end = data.IndexOf(']', prefix.Length);
+            if (end > prefix.Length)
+            {
+                string levelText = data.AsSpan(prefix.Length, end - prefix.Length).ToString();
+                LogLevel level = levelText switch
+                {
+                    "Verbose" or "Trace" => LogLevel.Trace,
+                    "Debug" => LogLevel.Debug,
+                    "Info" or "Information" => LogLevel.Information,
+                    "Warning" => LogLevel.Warning,
+                    "Error" => LogLevel.Error,
+                    "Fatal" or "Panic" => LogLevel.Critical,
+                    _ => channel == "stderr" ? LogLevel.Warning : LogLevel.Information,
+                };
+                string message = data.Substring(end + 1).TrimStart();
+                return (level, message);
+            }
+        }
+
+        return (channel == "stderr" ? LogLevel.Warning : LogLevel.Information, data);
+    }
+
     private static void ConfigureWorkerProcess(ProcessStartInfo startInfo)
     {
         string path = Path.Combine(AppContext.BaseDirectory, "Beutl.FFmpegWorker");
@@ -251,7 +283,7 @@ public sealed class FFmpegWorkerProcess : IDisposable
                 catch (InvalidOperationException) { /* プロセスが既に終了 */ }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine($"Warning: Failed to kill worker process: {ex.Message}");
+                    s_logger.LogWarning(ex, "Failed to kill worker process");
                 }
             }
             _process.Dispose();
@@ -270,7 +302,7 @@ public sealed class FFmpegWorkerProcess : IDisposable
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Warning: Graceful shutdown of FFmpeg worker failed: {ex.Message}");
+                s_logger.LogWarning(ex, "Graceful shutdown of FFmpeg worker failed");
             }
         }
 

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -43,7 +43,7 @@ internal static class FFmpegLoaderWorker
     private static void SetupLogging()
     {
         FFmpegSharp.FFmpegLog.SetupLogging(
-#if RELEASE
+#if !DEBUG
             logLevel: FFmpegSharp.LogLevel.Warning,
 #endif
             logFlags: FFmpegSharp.LogFlags.SkipRepeated | FFmpegSharp.LogFlags.PrintLevel,

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -31,7 +31,7 @@ internal static class FFmpegLoaderWorker
         sb.AppendLine($"  avutil: {GetVersionString(ffmpeg.avutil_version())}");
         sb.AppendLine($"  swresample: {GetVersionString(ffmpeg.swresample_version())}");
         sb.AppendLine($"  swscale: {GetVersionString(ffmpeg.swscale_version())}");
-        Console.Error.Write(sb.ToString());
+        WorkerLog.Information(sb.ToString());
     }
 
     private static void FixDependencyIssue()
@@ -43,13 +43,14 @@ internal static class FFmpegLoaderWorker
     private static void SetupLogging()
     {
         FFmpegSharp.FFmpegLog.SetupLogging(
+#if RELEASE
+            logLevel: FFmpegSharp.LogLevel.Warning,
+#endif
+            logFlags: FFmpegSharp.LogFlags.SkipRepeated | FFmpegSharp.LogFlags.PrintLevel,
             logWrite: (s, i) =>
             {
                 var level = (FFmpegSharp.LogLevel)i;
-                if (level >= FFmpegSharp.LogLevel.Warning)
-                {
-                    Console.Error.Write($"[ffmpeg:{level}] {s}");
-                }
+                WorkerLog.Write(level.ToString(), s, null);
             });
     }
 

--- a/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
@@ -46,7 +46,7 @@ internal sealed class CodecQueryHandler
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"QueryPixelFormats: codec-specific query failed, falling back to all formats: {ex.Message}");
+            WorkerLog.Warning($"QueryPixelFormats: codec-specific query failed, falling back to all formats: {ex.Message}", ex);
             // フォールバック: 全対応フォーマット
             var allFmts = Enum.GetValues<AVPixelFormat>()
                 .Where(f => f != AVPixelFormat.AV_PIX_FMT_NONE && (int)f >= 0 && ffmpeg.sws_isSupportedOutput(f) != 0)
@@ -76,7 +76,7 @@ internal sealed class CodecQueryHandler
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"QuerySampleRates: codec-specific query failed: {ex.Message}");
+            WorkerLog.Warning($"QuerySampleRates: codec-specific query failed: {ex.Message}", ex);
             return IpcMessage.Create(msg.Id, MessageType.QuerySampleRatesResult,
                 new QuerySampleRatesResponse { SampleRates = [] });
         }
@@ -96,7 +96,7 @@ internal sealed class CodecQueryHandler
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"QueryAudioFormats: codec-specific query failed: {ex.Message}");
+            WorkerLog.Warning($"QueryAudioFormats: codec-specific query failed: {ex.Message}", ex);
             return IpcMessage.Create(msg.Id, MessageType.QueryAudioFormatsResult,
                 new QueryAudioFormatsResponse { Formats = [] });
         }
@@ -122,7 +122,7 @@ internal sealed class CodecQueryHandler
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"QueryDefaultCodec: query failed: {ex.Message}");
+            WorkerLog.Warning($"QueryDefaultCodec: query failed: {ex.Message}", ex);
             return IpcMessage.Create(msg.Id, MessageType.QueryDefaultCodecResult,
                 new QueryDefaultCodecResponse());
         }

--- a/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
@@ -105,7 +105,7 @@ internal sealed class EncodingHandler : IDisposable
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Encoding failed: {ex}");
+            WorkerLog.Error("Encoding failed", ex);
             return IpcMessage.Create(msg.Id, MessageType.EncodeComplete,
                 new EncodeCompleteMessage { Success = false, Error = ex.Message });
         }

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -378,7 +378,7 @@ internal sealed class VideoRingBuffer : IDisposable
             catch (OperationCanceledException) { }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Prefetch error: {ex}");
+                WorkerLog.Error("Prefetch error", ex);
             }
         }, ct);
     }

--- a/src/Beutl.FFmpegWorker/Program.cs
+++ b/src/Beutl.FFmpegWorker/Program.cs
@@ -26,7 +26,7 @@ internal static class Program
                 case "--parent":
                     if (!int.TryParse(args[++i], out parentPid))
                     {
-                        Console.Error.WriteLine($"Invalid parent PID: {args[i]}");
+                        WorkerLog.Error($"Invalid parent PID: {args[i]}");
                         return 1;
                     }
                     break;
@@ -35,18 +35,14 @@ internal static class Program
 
         if (pipeName == null)
         {
-            Console.Error.WriteLine("Usage: Beutl.FFmpegWorker --pipe <name> --parent <pid>");
+            WorkerLog.Error("Usage: Beutl.FFmpegWorker --pipe <name> --parent <pid>");
             return 1;
         }
 
-        // ロギング初期化
+        // ロギング初期化: すべてのログを stdout に [ffmpeg:<Level>] プレフィックス付きで出力する
         Log.LoggerFactory = LoggerFactory.Create(builder =>
         {
-            builder.AddSimpleConsole(options =>
-            {
-                options.SingleLine = true;
-                options.TimestampFormat = "HH:mm:ss ";
-            });
+            builder.AddProvider(new StdoutLoggerProvider());
 #if DEBUG
             builder.SetMinimumLevel(LogLevel.Debug);
 #else
@@ -61,12 +57,12 @@ internal static class Program
         }
         catch (FFmpegLibrariesNotFoundException ex)
         {
-            Console.Error.WriteLine($"FFmpeg libraries not found: {ex.Message}");
+            WorkerLog.Error($"FFmpeg libraries not found: {ex.Message}", ex);
             return 2;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Failed to initialize FFmpeg: {ex}");
+            WorkerLog.Error($"Failed to initialize FFmpeg: {ex.Message}", ex);
             return 4;
         }
 
@@ -84,7 +80,7 @@ internal static class Program
         }
         catch (TimeoutException)
         {
-            Console.Error.WriteLine("Failed to connect to parent process pipe within 30 seconds.");
+            WorkerLog.Error("Failed to connect to parent process pipe within 30 seconds.");
             return 3;
         }
 
@@ -115,7 +111,7 @@ internal static class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Unexpected error monitoring parent process {parentPid}: {ex.Message}");
+            WorkerLog.Error($"Unexpected error monitoring parent process {parentPid}: {ex.Message}", ex);
         }
 
         // CancellationTokenでグレースフルにシャットダウン

--- a/src/Beutl.FFmpegWorker/StdoutLoggerProvider.cs
+++ b/src/Beutl.FFmpegWorker/StdoutLoggerProvider.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Beutl.FFmpegWorker;
+
+internal sealed class StdoutLoggerProvider : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new StdoutLogger(categoryName);
+
+    public void Dispose() { }
+
+    private sealed class StdoutLogger(string category) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            string message = formatter(state, exception);
+            WorkerLog.Write(LevelText(logLevel), $"{category}: {message}", exception);
+        }
+
+        private static string LevelText(LogLevel level) => level switch
+        {
+            LogLevel.Trace => "Trace",
+            LogLevel.Debug => "Debug",
+            LogLevel.Information => "Information",
+            LogLevel.Warning => "Warning",
+            LogLevel.Error => "Error",
+            LogLevel.Critical => "Critical",
+            _ => "Information",
+        };
+    }
+}

--- a/src/Beutl.FFmpegWorker/WorkerLog.cs
+++ b/src/Beutl.FFmpegWorker/WorkerLog.cs
@@ -1,0 +1,59 @@
+﻿using System.Text;
+
+namespace Beutl.FFmpegWorker;
+
+internal static class WorkerLog
+{
+    private static readonly object s_writeLock = new();
+
+    public static void Information(string message, Exception? exception = null)
+        => Write("Information", message, exception);
+
+    public static void Warning(string message, Exception? exception = null)
+        => Write("Warning", message, exception);
+
+    public static void Error(string message, Exception? exception = null)
+        => Write("Error", message, exception);
+
+    public static void Write(string level, string message, Exception? exception)
+    {
+        // ロガー基盤の例外でホストプロセスを巻き込まないよう例外は飲み込む
+        try
+        {
+            // ダッシュボードで1イベントとして表示できるよう、複数行は \n エスケープして1行で送る。
+            // ホスト側 (FFmpegWorkerProcess) でデコードする。
+            string payload = exception != null
+                ? $"{message}\n{exception}"
+                : message;
+
+            string encoded = Encode(payload);
+
+            lock (s_writeLock)
+            {
+                Console.Out.WriteLine($"[ffmpeg:{level}] {encoded}");
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static string Encode(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+
+        var sb = new StringBuilder(text.Length);
+        foreach (char c in text)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
+++ b/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegReaderProxy.cs" Link="Linked\FFmpegReaderProxy.cs" />
     <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\FFmpegWorkerProcess.cs" Link="Linked\FFmpegWorkerProcess.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\FFmpegWorkerLogPump.cs" Link="Linked\FFmpegWorkerLogPump.cs" />
   </ItemGroup>
 
   <!-- Worker側のFFmpegローダーをリンク -->

--- a/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
+++ b/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
@@ -40,6 +40,7 @@
   <!-- Worker側のFFmpegローダーをリンク -->
   <ItemGroup>
     <Compile Include="..\..\src\Beutl.FFmpegWorker\FFmpegLoaderWorker.cs" Link="Linked\FFmpegLoaderWorker.cs" />
+    <Compile Include="..\..\src\Beutl.FFmpegWorker\WorkerLog.cs" Link="Linked\WorkerLog.cs" />
   </ItemGroup>
 
   <!-- IPC テスト用: ビルド済みワーカーとその依存DLLを出力ディレクトリにコピー -->


### PR DESCRIPTION
## Description
- Pipe FFmpegWorker process stdout/stderr through Beutl.Logging (`FFmpegWorker` category) so worker output reaches the host's Serilog/file/OTLP pipeline instead of bare Console.WriteLine.
- Map `[ffmpeg:<Level>]` prefixes emitted by FFmpegLoaderWorker to the matching LogLevel; default stdout=Information, stderr=Warning when no prefix is present.
- Replace remaining Console.Error.WriteLine calls in Cleanup/Dispose with structured ILogger.LogWarning for consistency.

## Breaking changes
None

## Fixed issues
None