### PR TITLE
fix: dispose SKColorFilter in ParticleRenderNode

### DIFF
--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -112,10 +112,11 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
                 Color color = p.CurrentColor;
                 if (color != Colors.White)
                 {
-                    using var paint = new SKPaint();
-                    paint.ColorFilter = SKColorFilter.CreateBlendMode(
+                    using var colorFilter = SKColorFilter.CreateBlendMode(
                         new SKColor(color.R, color.G, color.B, color.A),
                         SKBlendMode.Modulate);
+                    using var paint = new SKPaint();
+                    paint.ColorFilter = colorFilter;
 
                     using (canvas.PushPaint(paint))
                     {


### PR DESCRIPTION
## Description

- `SKPaint.ColorFilter` setter only retains a reference; disposing the `SKPaint` did not free the `SKColorFilter`, so every non-white particle draw leaked a native `SKColorFilter` instance.
- Hold the filter in a `using` local declared before the `SKPaint` so it is disposed in the safe LIFO order (`paint` → `colorFilter`).
- Aligns with the existing pattern already used in `FilterEffectContext.cs`.

## Breaking changes

None

## Fixed issues

Fixes #1774