### PR TITLE
fix: avoid ObjectDisposedException on PlayerViewModel dispose

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1243,9 +1243,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     if (!token.IsCancellationRequested)
                         AfterRendered.OnNext(Unit.Default);
                 }
-                catch (ObjectDisposedException)
+                catch (ObjectDisposedException) when (token.IsCancellationRequested)
                 {
-                    // Dispose 中のレースで AfterRendered などが破棄された場合は無視する
+                    // Dispose 中のレースで AfterRendered などが破棄された場合のみ無視する。
+                    // 通常再生中の予期しない ObjectDisposedException は下の catch で表面化させる。
                 }
                 catch (Exception ex)
                 {
@@ -1296,6 +1297,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         // 進行中の QueueRender をキャンセルしてから Subject を破棄し、レンダースレッドが
         // 破棄済みの AfterRendered/_audioFramePushed に OnNext しないようにする
         _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
         Scene!.Edited -= OnSceneEdited;
         _disposables.Dispose();
         _currentFrameSubscription?.Dispose();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1239,7 +1239,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
                     UpdateImage(bitmapRef);
 
-                    AfterRendered.OnNext(Unit.Default);
+                    // Dispose と並走した場合に AfterRendered が破棄されている可能性があるためトークンを確認する
+                    if (!token.IsCancellationRequested)
+                        AfterRendered.OnNext(Unit.Default);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Dispose 中のレースで AfterRendered などが破棄された場合は無視する
                 }
                 catch (Exception ex)
                 {
@@ -1287,6 +1293,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         _logger.LogInformation("Disposing PlayerViewModel. ({SceneId})", _editViewModel.SceneId);
         await Pause();
+        // 進行中の QueueRender をキャンセルしてから Subject を破棄し、レンダースレッドが
+        // 破棄済みの AfterRendered/_audioFramePushed に OnNext しないようにする
+        _cts?.Cancel();
         Scene!.Edited -= OnSceneEdited;
         _disposables.Dispose();
         _currentFrameSubscription?.Dispose();


### PR DESCRIPTION
## Description
- Cancel the pending render CTS in DisposeAsync before disposing AfterRendered so render-thread work no longer touches a disposed Subject<Unit>.
- Guard AfterRendered.OnNext with the cancellation token and a dedicated ObjectDisposedException catch to swallow the residual race silently instead of surfacing a user-facing error notification.

## Breaking changes
None

## Fixed issues
None