### PR TITLE
fix: prevent index out-of-range when dragging gradient stops

### DIFF
--- a/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
+++ b/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
@@ -321,6 +321,7 @@ public class GradientStopsSlider : TemplatedControl
     private void ThumbDragDelta(object? sender, VectorEventArgs e)
     {
         if (sender is not Thumb { Parent: ContentPresenter presenter, DataContext: GradientStop stop } || _itemsControl == null) return;
+        if (Stops == null) return;
 
         double old = Canvas.GetLeft(presenter);
         if (!double.IsFinite(old)) old = 0;
@@ -330,26 +331,17 @@ public class GradientStopsSlider : TemplatedControl
 
         stop.Offset = x / DragWidth;
 
-        int oldIndex = _backgroundStops.IndexOf(stop);
+        int oldIndex = Stops.IndexOf(stop);
         if (oldIndex < 0) return;
 
         int newIndex = oldIndex;
-        if (oldIndex > 0)
+        if (oldIndex > 0 && Stops[oldIndex - 1].Offset > stop.Offset)
         {
-            GradientStop prev = _backgroundStops[oldIndex - 1];
-            if (prev.Offset > stop.Offset)
-            {
-                newIndex--;
-            }
+            newIndex--;
         }
-
-        if (newIndex == oldIndex && oldIndex + 1 < _backgroundStops.Count)
+        else if (oldIndex + 1 < Stops.Count && Stops[oldIndex + 1].Offset < stop.Offset)
         {
-            GradientStop next = _backgroundStops[oldIndex + 1];
-            if (next.Offset < stop.Offset)
-            {
-                newIndex++;
-            }
+            newIndex++;
         }
 
         Changed?.Invoke(this, (oldIndex, newIndex, stop));

--- a/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
+++ b/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
@@ -331,6 +331,8 @@ public class GradientStopsSlider : TemplatedControl
         stop.Offset = x / DragWidth;
 
         int oldIndex = _backgroundStops.IndexOf(stop);
+        if (oldIndex < 0) return;
+
         int newIndex = oldIndex;
         if (oldIndex > 0)
         {
@@ -340,7 +342,8 @@ public class GradientStopsSlider : TemplatedControl
                 newIndex--;
             }
         }
-        else if (oldIndex + 1 < _backgroundStops.Count)
+
+        if (newIndex == oldIndex && oldIndex + 1 < _backgroundStops.Count)
         {
             GradientStop next = _backgroundStops[oldIndex + 1];
             if (next.Offset < stop.Offset)
@@ -359,6 +362,7 @@ public class GradientStopsSlider : TemplatedControl
             && _itemsControl != null)
         {
             int index = Stops.IndexOf(stop);
+            if (index < 0 || _oldIndex < 0 || _oldIndex >= Stops.Count) return;
 
             Confirmed?.Invoke(this, (_oldIndex, index, stop, new(_oldOffset, stop.Color)));
         }

--- a/src/Beutl/Helpers/AvaloniaTypeConverter.cs
+++ b/src/Beutl/Helpers/AvaloniaTypeConverter.cs
@@ -158,13 +158,15 @@ public static class AvaloniaTypeConverter
 
                         break;
                     case NotifyCollectionChangedAction.Move:
-                        int newIndex = e.NewStartingIndex;
-                        if (newIndex > e.OldStartingIndex)
+                        if (e.OldStartingIndex >= 0
+                            && e.OldStartingIndex < stops.Count
+                            && e.NewStartingIndex >= 0
+                            && e.NewStartingIndex < stops.Count
+                            && e.OldStartingIndex != e.NewStartingIndex
+                            && e.OldItems is { Count: 1 })
                         {
-                            newIndex += e.OldItems!.Count;
+                            stops.Move(e.OldStartingIndex, e.NewStartingIndex);
                         }
-
-                        stops.MoveRange(e.OldStartingIndex, e.NewItems!.Count, newIndex);
                         break;
 
                     case NotifyCollectionChangedAction.Reset:

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -312,6 +312,10 @@ public sealed partial class BrushEditor : UserControl
         if (viewModel.Value.Value is not GradientBrush { GradientStops: { } list }) return;
         if (viewModel.IsDisposed) return;
 
+        if (e.OldIndex < 0 || e.OldIndex >= list.Count
+            || e.NewIndex < 0 || e.NewIndex >= list.Count)
+            return;
+
         if (e.NewIndex != e.OldIndex)
             list.Move(e.NewIndex, e.OldIndex);
         GradientStop obj = list[e.OldIndex];
@@ -324,6 +328,10 @@ public sealed partial class BrushEditor : UserControl
         if (DataContext is not BrushEditorViewModel viewModel) return;
         if (viewModel.Value.Value is not GradientBrush { GradientStops: { } list }) return;
         if (viewModel.IsDisposed) return;
+
+        if (e.OldIndex < 0 || e.OldIndex >= list.Count
+            || e.NewIndex < 0 || e.NewIndex >= list.Count)
+            return;
 
         GradientStop obj = list[e.OldIndex];
         obj.Offset.CurrentValue = (float)e.Object.Offset;

--- a/tests/Beutl.UnitTests/Core/CoreListAvaloniaSyncTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListAvaloniaSyncTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Specialized;
+using Avalonia.Collections;
+using Beutl.Collections;
+
+namespace Beutl.UnitTests.Core;
+
+// AvaloniaTypeConverter で行っている CoreList<T>.Move → AvaloniaList<T>.Move の同期処理が
+// 正しいセマンティクスで動作することを検証する。
+// GradientStopsSlider のドラッグで Stop が他のストップを横断する操作で発生していた
+// ArgumentOutOfRangeException の回帰を防ぐ。
+[TestFixture]
+public class CoreListAvaloniaSyncTests
+{
+    private static (CoreList<string> Source, AvaloniaList<string> Mirror) BuildPair(params string[] items)
+    {
+        var source = new CoreList<string>();
+        foreach (string s in items)
+        {
+            source.Add(s);
+        }
+
+        var mirror = new AvaloniaList<string>(items);
+
+        source.CollectionChanged += (_, e) =>
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex >= 0
+                        && e.OldStartingIndex < mirror.Count
+                        && e.NewStartingIndex >= 0
+                        && e.NewStartingIndex < mirror.Count
+                        && e.OldStartingIndex != e.NewStartingIndex
+                        && e.OldItems is { Count: 1 })
+                    {
+                        mirror.Move(e.OldStartingIndex, e.NewStartingIndex);
+                    }
+                    break;
+            }
+        };
+
+        return (source, mirror);
+    }
+
+    [Test]
+    public void Move_ForwardByOne_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "D");
+
+        source.Move(0, 1);
+
+        Assert.That(source, Is.EqualTo(new[] { "B", "A", "C", "D" }));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_ForwardAcrossMiddle_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "D");
+
+        source.Move(0, 2);
+
+        Assert.That(source, Is.EqualTo(new[] { "B", "C", "A", "D" }));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_ForwardToTail_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "D");
+
+        source.Move(0, 3);
+
+        Assert.That(source, Is.EqualTo(new[] { "B", "C", "D", "A" }));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_BackwardByOne_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "D");
+
+        source.Move(3, 2);
+
+        Assert.That(source, Is.EqualTo(new[] { "A", "B", "D", "C" }));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_BackwardToHead_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "D");
+
+        source.Move(3, 0);
+
+        Assert.That(source, Is.EqualTo(new[] { "D", "A", "B", "C" }));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_TwoElementCollection_BothDirections()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B");
+
+        source.Move(0, 1);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        source.Move(1, 0);
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Move_TailToTail_DoesNotThrow()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C");
+
+        Assert.DoesNotThrow(() => source.Move(2, 2));
+        Assert.That(mirror, Is.EqualTo(source));
+    }
+
+    // Stop が連続して隣のストップを横断するシナリオの再現。
+    // ドラッグ中の OnGradientStopChanged の連続 list.Move を模倣している。
+    [Test]
+    public void Move_ConsecutiveSwaps_AcrossAllStops_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("Drag", "B", "C", "D");
+
+        source.Move(0, 1);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        source.Move(1, 2);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        source.Move(2, 3);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        Assert.That(source, Is.EqualTo(new[] { "B", "C", "D", "Drag" }));
+    }
+
+    [Test]
+    public void Move_ConsecutiveSwapsBackwards_KeepsMirrorInSync()
+    {
+        (CoreList<string> source, AvaloniaList<string> mirror) = BuildPair("A", "B", "C", "Drag");
+
+        source.Move(3, 2);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        source.Move(2, 1);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        source.Move(1, 0);
+        Assert.That(mirror, Is.EqualTo(source));
+
+        Assert.That(source, Is.EqualTo(new[] { "Drag", "A", "B", "C" }));
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CoreListAvaloniaSyncTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListAvaloniaSyncTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using Avalonia.Collections;
 using Beutl.Collections;
 


### PR DESCRIPTION
## Description
- Add bounds checks before calling `list.Move` in `BrushEditor.OnGradientStopChanged` / `OnGradientStopConfirmed` so a stale or invalid index from the gradient slider never reaches the downstream Avalonia mirror, which previously threw `ArgumentOutOfRangeException` from `AvaloniaList.MoveRange` → `InsertRange`.
- Harden `GradientStopsSlider.ThumbDragCompleted` against `Stops.IndexOf` returning -1 and against a stale `_oldIndex`, so the `Confirmed` event is only raised with usable indices.
- Fix the reorder logic in `ThumbDragDelta`: the previous `else if` only checked the next stop when `oldIndex == 0`, leaving middle and tail stops unable to swap forward. The forward swap is now evaluated whenever the backward swap did not fire.

## Breaking changes
None.

## Fixed issues
None.