### PR TITLE
fix: protect output profiles from overwrite on restore failure

### DIFF
--- a/src/Beutl/Services/OutputPresetService.cs
+++ b/src/Beutl/Services/OutputPresetService.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.FFmpegIpc;
 using Beutl.Helpers;
@@ -151,9 +150,7 @@ public sealed class OutputPresetService
             array.Add(json);
         }
 
-        using FileStream stream = File.Create(_filePath);
-        using var writer = new Utf8JsonWriter(stream);
-        array.WriteTo(writer);
+        array.JsonSave(_filePath);
         _logger.LogInformation("Saved {Count} OutputPresetItem to file: {FilePath}", _items.Count, _filePath);
     }
 

--- a/src/Beutl/Services/OutputService.cs
+++ b/src/Beutl/Services/OutputService.cs
@@ -172,6 +172,9 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
 
     public void RestoreItems()
     {
+        // 再試行時に前回の成功状態が残ると、IO/JSON 失敗後も SaveItems が有効になり
+        // 空または不整合な _items が書き込まれてユーザーのプロファイルを消す恐れがある。
+        _isRestored = false;
         try
         {
             if (!File.Exists(_filePath))
@@ -218,7 +221,7 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception has occurred while restoring output profile file.");
+            _logger.LogError(ex, "An exception has occurred while restoring output profile file: {FilePath}", _filePath);
         }
     }
 

--- a/src/Beutl/Services/OutputService.cs
+++ b/src/Beutl/Services/OutputService.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Api.Services;
 using Beutl.Logging;
 using Beutl.Models;
@@ -167,51 +166,60 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
             array.Add(json);
         }
 
-        using FileStream stream = File.Create(_filePath);
-        using var writer = new Utf8JsonWriter(stream);
-        array.WriteTo(writer);
+        array.JsonSave(_filePath);
         _logger.LogInformation("Saved {Count} OutputProfileItems to file: {FilePath}", _items.Count, _filePath);
     }
 
     public void RestoreItems()
     {
-        _isRestored = true;
-        if (!File.Exists(_filePath))
+        try
         {
-            _logger.LogWarning("Output profile file not found: {FilePath}", _filePath);
-            return;
-        }
-
-        using FileStream stream = File.Open(_filePath, FileMode.Open);
-        var jsonNode = JsonNode.Parse(stream);
-        if (jsonNode is not JsonArray jsonArray)
-        {
-            _logger.LogWarning("Invalid JSON format in output profile file: {FilePath}", _filePath);
-            return;
-        }
-
-        var items = _items.ToArray();
-        _items.Clear();
-        _selectedItem.Value = null;
-        foreach (OutputProfileItem item in items)
-        {
-            item.Dispose();
-        }
-
-        _items.EnsureCapacity(jsonArray.Count);
-
-        foreach (JsonNode? jsonItem in jsonArray)
-        {
-            if (jsonItem == null) continue;
-
-            var item = OutputProfileItem.FromJson(editViewModel, jsonItem, _logger);
-            if (item != null)
+            if (!File.Exists(_filePath))
             {
-                _items.Add(item);
+                _logger.LogWarning("Output profile file not found: {FilePath}", _filePath);
+                _isRestored = true;
+                return;
             }
-        }
 
-        _logger.LogInformation("Restored {Count} OutputProfileItems from file: {FilePath}", _items.Count, _filePath);
+            using FileStream stream = File.Open(_filePath, FileMode.Open);
+            var jsonNode = JsonNode.Parse(stream);
+            if (jsonNode is not JsonArray jsonArray)
+            {
+                _logger.LogWarning("Invalid JSON format in output profile file: {FilePath}", _filePath);
+                return;
+            }
+
+            var items = _items.ToArray();
+            _items.Clear();
+            _selectedItem.Value = null;
+            foreach (OutputProfileItem item in items)
+            {
+                item.Dispose();
+            }
+
+            _items.EnsureCapacity(jsonArray.Count);
+
+            foreach (JsonNode? jsonItem in jsonArray)
+            {
+                if (jsonItem == null) continue;
+
+                var item = OutputProfileItem.FromJson(editViewModel, jsonItem, _logger);
+                if (item != null)
+                {
+                    _items.Add(item);
+                }
+            }
+
+            // 既存ファイルの読み込みに成功した場合のみ書き込みを許可する。
+            // try 冒頭で true にすると、IO 失敗や JSON 破損時に後続の SaveItems が
+            // 空の _items を書き込み、ユーザーの保存済みプロファイルが消える。
+            _isRestored = true;
+            _logger.LogInformation("Restored {Count} OutputProfileItems from file: {FilePath}", _items.Count, _filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while restoring output profile file.");
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Description
- `OutputService.RestoreItems` set `_isRestored = true` at the top of the method, so an IO or JSON parse failure left the flag stuck on. A subsequent `SaveItems` call then wrote an empty array over the user's `output-profile.json` and wiped their saved export profiles. Wrap the method in `try`/`catch` and only set `_isRestored` after the JSON array is parsed (or when the file is genuinely missing).
- Route `SaveItems` in both `OutputService` and `OutputPresetService` through `JsonHelper.JsonSave` (introduced in #1763) so writes go through a tmp file + `File.Move(..., overwrite: true)`. A crash, power loss, or full disk during the write can no longer leave the existing JSON file truncated.
- Mirrors the pattern previously applied to `OutputPresetService.RestoreItems` in #1753 — the sister service `OutputService` had the same defect.

## Breaking changes
None.

## Fixed issues
Fixes #1806