### PR TITLE
fix: catch JsonException in JsonRestore for corrupt config files (#1807)

### DIFF
--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -19,19 +19,22 @@ public static class JsonHelper
 
     // Program.Main は GlobalConfiguration.Restore (JsonHelper を経由) を Telemetry が
     // Log.LoggerFactory をセットするより前に呼ぶ。Release ビルドでは LoggerFactory が
-    // null のまま CreateLogger を呼ぶと TypeInitializationException で起動が落ちるため、
-    // 遅延取得 + 失敗時は NullLogger にフォールバックする。
-    private static ILogger Logger => s_logger ??= CreateLoggerSafe();
-
-    private static ILogger CreateLoggerSafe()
+    // null のまま CreateLogger を呼ぶと TypeInitializationException で起動が落ちる。
+    // 失敗時は NullLogger を返すが、その値はキャッシュしない。これにより
+    // LoggerFactory 初期化後の呼び出しでは本物のロガーを取得し直せる。
+    private static ILogger Logger
     {
-        try
+        get
         {
-            return Log.CreateLogger(typeof(JsonHelper));
-        }
-        catch
-        {
-            return NullLogger.Instance;
+            if (s_logger is not null) return s_logger;
+            try
+            {
+                return s_logger = Log.CreateLogger(typeof(JsonHelper));
+            }
+            catch
+            {
+                return NullLogger.Instance;
+            }
         }
     }
 

--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -8,13 +8,32 @@ using Beutl.JsonConverters;
 using Beutl.Logging;
 using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Beutl;
 
 public static class JsonHelper
 {
     private static readonly ConditionalWeakTable<Type, JsonConverter> s_converters = [];
-    private static readonly ILogger s_logger = Log.CreateLogger(typeof(JsonHelper));
+    private static ILogger? s_logger;
+
+    // Program.Main は GlobalConfiguration.Restore (JsonHelper を経由) を Telemetry が
+    // Log.LoggerFactory をセットするより前に呼ぶ。Release ビルドでは LoggerFactory が
+    // null のまま CreateLogger を呼ぶと TypeInitializationException で起動が落ちるため、
+    // 遅延取得 + 失敗時は NullLogger にフォールバックする。
+    private static ILogger Logger => s_logger ??= CreateLoggerSafe();
+
+    private static ILogger CreateLoggerSafe()
+    {
+        try
+        {
+            return Log.CreateLogger(typeof(JsonHelper));
+        }
+        catch
+        {
+            return NullLogger.Instance;
+        }
+    }
 
     public static JsonWriterOptions WriterOptions { get; } = new()
     {
@@ -144,7 +163,7 @@ public static class JsonHelper
         {
             // 破損ファイルは次回保存時にアトミック書き込みで上書きされるためそのまま放置。
             // ファイルを消すと調査用の証拠を失うので触らない。
-            s_logger.LogError(ex, "Failed to parse JSON file {Path}; treating as missing.", filename);
+            Logger.LogError(ex, "Failed to parse JSON file {Path}; treating as missing.", filename);
             return null;
         }
     }

--- a/src/Beutl.Core/JsonHelper.cs
+++ b/src/Beutl.Core/JsonHelper.cs
@@ -5,13 +5,16 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Beutl.JsonConverters;
+using Beutl.Logging;
 using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl;
 
 public static class JsonHelper
 {
     private static readonly ConditionalWeakTable<Type, JsonConverter> s_converters = [];
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(JsonHelper));
 
     public static JsonWriterOptions WriterOptions { get; } = new()
     {
@@ -133,7 +136,17 @@ public static class JsonHelper
     {
         if (!File.Exists(filename)) return null;
         using var stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return JsonNode.Parse(stream);
+        try
+        {
+            return JsonNode.Parse(stream);
+        }
+        catch (JsonException ex)
+        {
+            // 破損ファイルは次回保存時にアトミック書き込みで上書きされるためそのまま放置。
+            // ファイルを消すと調査用の証拠を失うので触らない。
+            s_logger.LogError(ex, "Failed to parse JSON file {Path}; treating as missing.", filename);
+            return null;
+        }
     }
 
     public static Type? GetDiscriminator(this JsonNode node)

--- a/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
+++ b/tests/Beutl.UnitTests/Core/JsonHelperTests.cs
@@ -56,6 +56,44 @@ public class JsonHelperTests
     }
 
     [Test]
+    public void JsonRestore_InvalidJson_ReturnsNull()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "{ this is not valid json");
+
+            JsonNode? result = JsonHelper.JsonRestore(path);
+
+            Assert.That(result, Is.Null);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void JsonRestore_InvalidJson_LeavesFileUntouched()
+    {
+        string path = Path.GetTempFileName();
+        const string corrupt = "{ this is not valid json";
+        try
+        {
+            File.WriteAllText(path, corrupt);
+
+            _ = JsonHelper.JsonRestore(path);
+
+            Assert.That(File.Exists(path), Is.True);
+            Assert.That(File.ReadAllText(path), Is.EqualTo(corrupt));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
     public void TryGetDiscriminator_Type_ReturnsTypeForKnownEntries()
     {
         var node = new JsonObject { ["$type"] = TypeFormat.ToString(typeof(Optional<int>)) };


### PR DESCRIPTION
## Description

- `JsonHelper.JsonRestore` did not catch `JsonException`, so a half-written `extensionsSettings.json` or `keymap.json` (e.g. left over after an abrupt termination) crashed `BeutlApiApplication` during startup and forced end users to delete config files manually.
- Catch `JsonException` centrally inside `JsonRestore`, log the failure with the file path via `Beutl.Logging`, and return `null` so corrupt files are treated as missing. All call sites (`ExtensionSettingsStore.RestoreAll`, `ContextCommandSettingsStore.RestoreAll`, `GlobalConfiguration.Restore`, and the `IJsonSerializable` / `ICoreSerializable` extension overloads) are recovered automatically without per-callsite changes.
- The broken file is intentionally left on disk so users or support can inspect it; the next atomic save (`JsonSave`) overwrites it with valid content.

## Breaking changes

None.

## Fixed issues

Fixes #1807