### PR TITLE
ci: register published release assets to beutl-reflect-release API

### DIFF
--- a/.github/workflows/reflect-release.yml
+++ b/.github/workflows/reflect-release.yml
@@ -50,6 +50,8 @@ jobs:
           WIN_INSTALLER=$(url_of "beutl-setup.exe")
           WIN_STANDALONE=$(url_of "beutl-standalone-setup.exe")
           LINUX_DEB=$(url_of_glob '\.deb$')
+          LINUX_ZIP=$(url_of "Beutl-linux_x64-$VER.zip")
+          LINUX_ZIP_STANDALONE=$(url_of "Beutl-linux_x64-standalone-$VER.zip")
           MAC_X64=$(url_of "Beutl.osx_x64.app.zip")
           MAC_ARM64=$(url_of "Beutl.osx_arm64.app.zip")
 
@@ -62,11 +64,13 @@ jobs:
               echo "$1 -> $2"
             fi
           }
-          check "beutl-setup.exe"            "$WIN_INSTALLER"
-          check "beutl-standalone-setup.exe" "$WIN_STANDALONE"
-          check "*.deb"                      "$LINUX_DEB"
-          check "Beutl.osx_x64.app.zip"      "$MAC_X64"
-          check "Beutl.osx_arm64.app.zip"    "$MAC_ARM64"
+          check "beutl-setup.exe"                       "$WIN_INSTALLER"
+          check "beutl-standalone-setup.exe"            "$WIN_STANDALONE"
+          check "*.deb"                                 "$LINUX_DEB"
+          check "Beutl-linux_x64-$VER.zip"              "$LINUX_ZIP"
+          check "Beutl-linux_x64-standalone-$VER.zip"   "$LINUX_ZIP_STANDALONE"
+          check "Beutl.osx_x64.app.zip"                 "$MAC_X64"
+          check "Beutl.osx_arm64.app.zip"               "$MAC_ARM64"
           [ "$missing" -eq 0 ] || exit 1
 
           body=$(jq -nc \
@@ -74,6 +78,8 @@ jobs:
             --arg winI "$WIN_INSTALLER" \
             --arg winS "$WIN_STANDALONE" \
             --arg deb "$LINUX_DEB" \
+            --arg linZ "$LINUX_ZIP" \
+            --arg linZS "$LINUX_ZIP_STANDALONE" \
             --arg macX "$MAC_X64" \
             --arg macA "$MAC_ARM64" \
             '{
@@ -81,6 +87,8 @@ jobs:
                 {id:"beutl-\($ver)-win-x64-installer",            version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:false, url:$winI},
                 {id:"beutl-\($ver)-win-x64-installer-standalone", version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:true,  url:$winS},
                 {id:"beutl-\($ver)-linux-x64-debian",             version:$ver, os:"linux", arch:"x64",   type:"debian",                       url:$deb},
+                {id:"beutl-\($ver)-linux-x64-zip",                version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:false, url:$linZ},
+                {id:"beutl-\($ver)-linux-x64-zip-standalone",     version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:true,  url:$linZS},
                 {id:"beutl-\($ver)-osx-x64-app",                  version:$ver, os:"osx",   arch:"x64",   type:"app",                          url:$macX},
                 {id:"beutl-\($ver)-osx-arm64-app",                version:$ver, os:"osx",   arch:"arm64", type:"app",                          url:$macA}
               ]

--- a/.github/workflows/reflect-release.yml
+++ b/.github/workflows/reflect-release.yml
@@ -1,0 +1,125 @@
+name: Reflect Release to beutl-reflect-release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  reflect:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    env:
+      API_BASE: https://release.api.beutl.beditor.net
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          echo "ver=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Get OIDC token
+        id: oidc
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('https://github.com/b-editor/beutl');
+            core.setSecret(token);
+            core.setOutput('token', token);
+
+      - name: Build asset payload
+        id: payload
+        env:
+          ASSETS: ${{ toJSON(github.event.release.assets) }}
+          VER: ${{ steps.ver.outputs.ver }}
+        run: |
+          set -euo pipefail
+
+          url_of() {
+            echo "$ASSETS" | jq -r --arg name "$1" \
+              '.[] | select(.name == $name) | .browser_download_url'
+          }
+          url_of_glob() {
+            echo "$ASSETS" | jq -r --arg pat "$1" \
+              '.[] | select(.name | test($pat)) | .browser_download_url' | head -n1
+          }
+
+          WIN_INSTALLER=$(url_of "beutl-setup.exe")
+          WIN_STANDALONE=$(url_of "beutl-standalone-setup.exe")
+          LINUX_DEB=$(url_of_glob '\.deb$')
+          MAC_X64=$(url_of "Beutl.osx_x64.app.zip")
+          MAC_ARM64=$(url_of "Beutl.osx_arm64.app.zip")
+
+          missing=0
+          check() {
+            if [ -z "$2" ]; then
+              echo "::error::missing asset: $1"
+              missing=1
+            else
+              echo "$1 -> $2"
+            fi
+          }
+          check "beutl-setup.exe"            "$WIN_INSTALLER"
+          check "beutl-standalone-setup.exe" "$WIN_STANDALONE"
+          check "*.deb"                      "$LINUX_DEB"
+          check "Beutl.osx_x64.app.zip"      "$MAC_X64"
+          check "Beutl.osx_arm64.app.zip"    "$MAC_ARM64"
+          [ "$missing" -eq 0 ] || exit 1
+
+          body=$(jq -nc \
+            --arg ver "$VER" \
+            --arg winI "$WIN_INSTALLER" \
+            --arg winS "$WIN_STANDALONE" \
+            --arg deb "$LINUX_DEB" \
+            --arg macX "$MAC_X64" \
+            --arg macA "$MAC_ARM64" \
+            '{
+              assets: [
+                {id:"beutl-\($ver)-win-x64-installer",            version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:false, url:$winI},
+                {id:"beutl-\($ver)-win-x64-installer-standalone", version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:true,  url:$winS},
+                {id:"beutl-\($ver)-linux-x64-debian",             version:$ver, os:"linux", arch:"x64",   type:"debian",                       url:$deb},
+                {id:"beutl-\($ver)-osx-x64-app",                  version:$ver, os:"osx",   arch:"x64",   type:"app",                          url:$macX},
+                {id:"beutl-\($ver)-osx-arm64-app",                version:$ver, os:"osx",   arch:"arm64", type:"app",                          url:$macA}
+              ]
+            }')
+
+          {
+            echo "body<<EOF"
+            echo "$body"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delete existing assets for version (idempotency)
+        env:
+          TOKEN: ${{ steps.oidc.outputs.token }}
+          VER: ${{ steps.ver.outputs.ver }}
+        run: |
+          status=$(curl -sS -o /tmp/del.out -w '%{http_code}' -X DELETE \
+            -H "Authorization: Bearer $TOKEN" \
+            "$API_BASE/releases/version/$VER")
+          echo "DELETE status: $status"
+          cat /tmp/del.out || true
+          case "$status" in
+            2*|404) ;;
+            *) echo "::error::unexpected DELETE status $status"; exit 1 ;;
+          esac
+
+      - name: Bulk register assets
+        env:
+          TOKEN: ${{ steps.oidc.outputs.token }}
+          BODY: ${{ steps.payload.outputs.body }}
+        run: |
+          status=$(curl -sS -o /tmp/post.out -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_BASE/releases/bulk")
+          echo "POST status: $status"
+          cat /tmp/post.out || true
+          case "$status" in
+            2*) ;;
+            *) echo "::error::bulk register failed with status $status"; exit 1 ;;
+          esac

--- a/.github/workflows/reflect-release.yml
+++ b/.github/workflows/reflect-release.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - name: Resolve version
         id: ver
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          tag="${{ github.event.release.tag_name }}"
-          echo "ver=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Get OIDC token
         id: oidc
@@ -50,8 +51,8 @@ jobs:
           WIN_INSTALLER=$(url_of "beutl-setup.exe")
           WIN_STANDALONE=$(url_of "beutl-standalone-setup.exe")
           LINUX_DEB=$(url_of_glob '\.deb$')
-          LINUX_ZIP=$(url_of "Beutl-linux_x64-$VER.zip")
-          LINUX_ZIP_STANDALONE=$(url_of "Beutl-linux_x64-standalone-$VER.zip")
+          LINUX_ZIP=$(url_of "Beutl-linux-x64-$VER.zip")
+          LINUX_ZIP_STANDALONE=$(url_of "Beutl-linux-x64-standalone-$VER.zip")
           MAC_X64=$(url_of "Beutl.osx_x64.app.zip")
           MAC_ARM64=$(url_of "Beutl.osx_arm64.app.zip")
 
@@ -67,8 +68,8 @@ jobs:
           check "beutl-setup.exe"                       "$WIN_INSTALLER"
           check "beutl-standalone-setup.exe"            "$WIN_STANDALONE"
           check "*.deb"                                 "$LINUX_DEB"
-          check "Beutl-linux_x64-$VER.zip"              "$LINUX_ZIP"
-          check "Beutl-linux_x64-standalone-$VER.zip"   "$LINUX_ZIP_STANDALONE"
+          check "Beutl-linux-x64-$VER.zip"              "$LINUX_ZIP"
+          check "Beutl-linux-x64-standalone-$VER.zip"   "$LINUX_ZIP_STANDALONE"
           check "Beutl.osx_x64.app.zip"                 "$MAC_X64"
           check "Beutl.osx_arm64.app.zip"               "$MAC_ARM64"
           [ "$missing" -eq 0 ] || exit 1
@@ -86,11 +87,11 @@ jobs:
               assets: [
                 {id:"beutl-\($ver)-win-x64-installer",            version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:false, url:$winI},
                 {id:"beutl-\($ver)-win-x64-installer-standalone", version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:true,  url:$winS},
-                {id:"beutl-\($ver)-linux-x64-debian",             version:$ver, os:"linux", arch:"x64",   type:"debian",                       url:$deb},
+                {id:"beutl-\($ver)-linux-x64-debian",             version:$ver, os:"linux", arch:"x64",   type:"debian",    standalone:true,  url:$deb},
                 {id:"beutl-\($ver)-linux-x64-zip",                version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:false, url:$linZ},
                 {id:"beutl-\($ver)-linux-x64-zip-standalone",     version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:true,  url:$linZS},
-                {id:"beutl-\($ver)-osx-x64-app",                  version:$ver, os:"osx",   arch:"x64",   type:"app",                          url:$macX},
-                {id:"beutl-\($ver)-osx-arm64-app",                version:$ver, os:"osx",   arch:"arm64", type:"app",                          url:$macA}
+                {id:"beutl-\($ver)-osx-x64-app",                  version:$ver, os:"osx",   arch:"x64",   type:"app",       standalone:true,  url:$macX},
+                {id:"beutl-\($ver)-osx-arm64-app",                version:$ver, os:"osx",   arch:"arm64", type:"app",       standalone:true,  url:$macA}
               ]
             }')
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/reflect-release.yml` to call the `release.api.beutl.beditor.net` API (the `beutl-reflect-release` Cloudflare Worker) when a GitHub Release is published.
- Registers 5 assets per release: Windows installer (normal/standalone), Linux `.deb`, and macOS `osx_x64` / `osx_arm64` app bundles. URLs are pulled from `github.event.release.assets`.
- Authenticates with GitHub Actions OIDC (audience `https://github.com/b-editor/beutl`), which is what the API expects.
- Idempotent: runs `DELETE /releases/version/{ver}` (404 tolerated) followed by `POST /releases/bulk`, so re-publishing the same release works without unique-id collisions.
- Skips pre-releases (`if: ${{ !github.event.release.prerelease }}`).
- Fails the workflow if any of the expected assets are missing, to catch incomplete releases early.

## Test plan
- [ ] Create a draft Release with a throwaway tag (e.g. `v0.0.0-test`) containing the 5 expected asset filenames and publish it; confirm the workflow runs.
- [ ] Verify `DELETE` and `POST /releases/bulk` return 2xx in the Actions log.
- [ ] `GET https://release.api.beutl.beditor.net/releases?version=<ver>` returns the 5 registered assets.
- [ ] Unpublish → republish the same Release; the workflow re-runs without errors (idempotency).
- [ ] Confirm a release missing one of the expected assets fails the workflow with a clear `::error::missing asset` message.