### PR TITLE
fix: correct TimeRange.IsEmpty for zero duration

### DIFF
--- a/src/Beutl.Engine/Media/TimeRange.cs
+++ b/src/Beutl.Engine/Media/TimeRange.cs
@@ -77,6 +77,11 @@ public readonly struct TimeRange : IEquatable<TimeRange>
 
     public bool Intersects(TimeRange time)
     {
+        if (IsEmpty || time.IsEmpty)
+        {
+            return false;
+        }
+
         return time.Start < End && Start < time.End;
     }
 

--- a/src/Beutl.Engine/Media/TimeRange.cs
+++ b/src/Beutl.Engine/Media/TimeRange.cs
@@ -28,7 +28,7 @@ public readonly struct TimeRange : IEquatable<TimeRange>
 
     public TimeSpan End => Start + Duration;
 
-    public bool IsEmpty => Start > End;
+    public bool IsEmpty => Duration <= TimeSpan.Zero;
 
     public static TimeRange FromSeconds(double start, double duration)
     {

--- a/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
@@ -41,14 +41,13 @@ public class TimeRangeExtraTests
     }
 
     [Test]
-    public void IsEmpty_TrueOnlyWhenStartGreaterThanEnd()
+    public void IsEmpty_TrueWhenDurationIsZeroOrNegative()
     {
-        // duration > 0 means End > Start, so IsEmpty stays false even at zero duration.
         var zero = new TimeRange();
         var positive = TimeRange.FromSeconds(1, 2);
         var negative = new TimeRange(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-1));
 
-        Assert.That(zero.IsEmpty, Is.False);
+        Assert.That(zero.IsEmpty, Is.True);
         Assert.That(positive.IsEmpty, Is.False);
         Assert.That(negative.IsEmpty, Is.True);
     }
@@ -111,9 +110,8 @@ public class TimeRangeExtraTests
     [Test]
     public void Union_WithIsEmptyOperand_ReturnsOther()
     {
-        // IsEmpty is defined as Start > End, so a negative-duration range is treated as empty.
         var range = TimeRange.FromSeconds(1, 2);
-        var emptyByDef = new TimeRange(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(-1));
+        var emptyByDef = new TimeRange();
 
         Assert.That(emptyByDef.IsEmpty, Is.True);
         Assert.That(emptyByDef.Union(range), Is.EqualTo(range));

--- a/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
+++ b/tests/Beutl.UnitTests/Engine/TimeRangeExtraTests.cs
@@ -128,6 +128,20 @@ public class TimeRangeExtraTests
     }
 
     [Test]
+    public void Intersects_EmptyRange_ReturnsFalse()
+    {
+        var zeroDuration = new TimeRange(TimeSpan.FromSeconds(5), TimeSpan.Zero);
+        var negativeDuration = new TimeRange(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-1));
+        var nonEmpty = TimeRange.FromSeconds(0, 10);
+
+        Assert.That(zeroDuration.Intersects(nonEmpty), Is.False);
+        Assert.That(nonEmpty.Intersects(zeroDuration), Is.False);
+        Assert.That(negativeDuration.Intersects(nonEmpty), Is.False);
+        Assert.That(nonEmpty.Intersects(negativeDuration), Is.False);
+        Assert.That(TimeRange.Empty.Intersects(TimeRange.Empty), Is.False);
+    }
+
+    [Test]
     public void Equality_OnEqualRanges_IsTrueAndHashesMatch()
     {
         var a = TimeRange.FromSeconds(2, 3);


### PR DESCRIPTION
## Summary
- treat  values with zero or negative duration as empty
- update  tests to reflect the corrected empty-range semantics
- preserve union behavior by verifying  is ignored as an empty operand

## Testing
- dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj --filter TimeRange

Closes #1777