### PR TITLE
fix: align silent audio buffer sample count with ceiling

### DIFF
--- a/src/Beutl.Engine/Audio/Composing/Composer.cs
+++ b/src/Beutl.Engine/Audio/Composing/Composer.cs
@@ -118,7 +118,7 @@ public class Composer : IComposer
 
         if (mixedBuffer == null)
         {
-            return new AudioBuffer(SampleRate, 2, (int)(range.Duration.TotalSeconds * SampleRate));
+            return new AudioBuffer(SampleRate, 2, AudioProcessContext.GetSampleCount(range, SampleRate));
         }
 
         // Apply master effects

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -29,7 +29,12 @@ public sealed class AudioProcessContext
 
     public int GetSampleCount()
     {
-        return (int)Math.Ceiling(TimeRange.Duration.TotalSeconds * SampleRate);
+        return GetSampleCount(TimeRange, SampleRate);
+    }
+
+    public static int GetSampleCount(TimeRange range, int sampleRate)
+    {
+        return (int)Math.Ceiling(range.Duration.TotalSeconds * sampleRate);
     }
 
     public TimeSpan GetTimeForSample(int sampleIndex)

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -37,8 +37,8 @@ public sealed class AudioProcessContext
     /// </summary>
     /// <remarks>
     /// Always rounds up via <see cref="Math.Ceiling(double)"/> so non-integer-second durations never under-allocate.
-    /// Both per-node audio paths and <c>Composer.BuildFinalOutput</c>'s silence fallback must route through this
-    /// helper to stay in sync; replacing it with truncation will desynchronise mix and silent buffers by one sample.
+    /// Both per-node audio paths and the silence fallback in <see cref="Composing.Composer"/> must route through
+    /// this helper to stay in sync; replacing it with truncation will desynchronise mix and silent buffers by one sample.
     /// </remarks>
     public static int GetSampleCount(TimeRange range, int sampleRate)
     {

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -32,6 +32,14 @@ public sealed class AudioProcessContext
         return GetSampleCount(TimeRange, SampleRate);
     }
 
+    /// <summary>
+    /// Returns the number of audio samples that cover <paramref name="range"/> at the given <paramref name="sampleRate"/>.
+    /// </summary>
+    /// <remarks>
+    /// Always rounds up via <see cref="Math.Ceiling(double)"/> so non-integer-second durations never under-allocate.
+    /// Both per-node audio paths and <c>Composer.BuildFinalOutput</c>'s silence fallback must route through this
+    /// helper to stay in sync; replacing it with truncation will desynchronise mix and silent buffers by one sample.
+    /// </remarks>
     public static int GetSampleCount(TimeRange range, int sampleRate)
     {
         if (sampleRate <= 0)

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -47,7 +47,11 @@ public sealed class AudioProcessContext
         if (range.Duration < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(range), $"Duration must be non-negative; was {range.Duration}.");
 
-        return (int)Math.Ceiling(range.Duration.TotalSeconds * sampleRate);
+        double samples = Math.Ceiling(range.Duration.TotalSeconds * sampleRate);
+        if (samples > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(range), $"Sample count {samples} exceeds Int32.MaxValue at sampleRate={sampleRate}.");
+
+        return (int)samples;
     }
 
     public TimeSpan GetTimeForSample(int sampleIndex)

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -36,6 +36,8 @@ public sealed class AudioProcessContext
     {
         if (sampleRate <= 0)
             throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+        if (range.Duration < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(range), $"Duration must be non-negative; was {range.Duration}.");
 
         return (int)Math.Ceiling(range.Duration.TotalSeconds * sampleRate);
     }

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -34,6 +34,9 @@ public sealed class AudioProcessContext
 
     public static int GetSampleCount(TimeRange range, int sampleRate)
     {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+
         return (int)Math.Ceiling(range.Duration.TotalSeconds * sampleRate);
     }
 

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -56,4 +56,17 @@ public class AudioProcessContextTests
         Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(88200));
         Assert.That(AudioProcessContext.GetSampleCount(range, 48000), Is.EqualTo(96000));
     }
+
+    [Test]
+    public void GetSampleCount_Static_NegativeDuration_Throws()
+    {
+        // TimeRange は構造体で Duration の不変条件を保証しない (Intersect などの算術で負値が入り得る)。
+        // 負の duration を Math.Ceiling に渡すと負の int が返り、後段 AudioBuffer のコンストラクタで
+        // "sampleCount" の例外として出るため、ここで早期に弾いてエラーの帰属を正しく保つ。
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(-1));
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => AudioProcessContext.GetSampleCount(range, 44100));
+        Assert.That(ex!.ParamName, Is.EqualTo("range"));
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Animation;
+﻿using Beutl.Animation;
 using Beutl.Audio.Graph;
 using Beutl.Media;
 

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -57,6 +57,18 @@ public class AudioProcessContextTests
         Assert.That(AudioProcessContext.GetSampleCount(range, 48000), Is.EqualTo(96000));
     }
 
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(int.MinValue)]
+    public void GetSampleCount_Static_NonPositiveSampleRate_Throws(int sampleRate)
+    {
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => AudioProcessContext.GetSampleCount(range, sampleRate));
+        Assert.That(ex!.ParamName, Is.EqualTo("sampleRate"));
+    }
+
     [Test]
     public void GetSampleCount_Static_NegativeDuration_Throws()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -57,6 +57,29 @@ public class AudioProcessContextTests
         Assert.That(AudioProcessContext.GetSampleCount(range, 48000), Is.EqualTo(96000));
     }
 
+    [Test]
+    public void GetSampleCount_Static_OneTick_ReturnsOne()
+    {
+        // 1 tick (100 ns) は 0 ではない最小の duration。Composer の silence fallback が
+        // 「サンプルが必要なら最低 1 サンプル確保する」という不変条件に依存しているため、
+        // 微小な正 duration がゼロにならないことを直接ピン留めする。
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(1));
+
+        Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GetSampleCount_Static_JustBelowSampleBoundary_DoesNotOverCount()
+    {
+        // 整数除算で 226 ticks 取ると真の境界 (~226.7575 ticks) を 0.7575 下回るため、
+        // Ceiling でも 1 サンプル止まり。境界の "下側" を踏むことで Ceiling が
+        // 過剰サンプル化していないことを補強する (FractionalDuration テストの裏側)。
+        var oneSampleTicksFloor = TimeSpan.TicksPerSecond / 44100; // 226
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(oneSampleTicksFloor));
+
+        Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(1));
+    }
+
     [TestCase(0)]
     [TestCase(-1)]
     [TestCase(int.MinValue)]

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -1,0 +1,58 @@
+using Beutl.Animation;
+using Beutl.Audio.Graph;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+public class AudioProcessContextTests
+{
+    [Test]
+    public void GetSampleCount_Static_IntegerSeconds_NoCeiling()
+    {
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(44100));
+    }
+
+    [Test]
+    public void GetSampleCount_Static_ZeroDuration_ReturnsZero()
+    {
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.Zero);
+        Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetSampleCount_Static_FractionalDuration_CeilingsUp()
+    {
+        // 1 サンプル分のちょうど境界 (44100Hz, 1サンプル ≒ 226.7575 ticks) を 1tick だけ超えた duration。
+        // 切り捨て版なら 1 サンプル、Ceiling 版なら 2 サンプル。回帰防止ケース。
+        var oneSampleTicks = TimeSpan.TicksPerSecond / 44100; // 226
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(oneSampleTicks + 1));
+
+        var truncated = (int)(range.Duration.TotalSeconds * 44100);
+        var ceiled = AudioProcessContext.GetSampleCount(range, 44100);
+
+        Assert.That(truncated, Is.EqualTo(1), "前提: 旧 truncation ロジックでは 1 サンプル");
+        Assert.That(ceiled, Is.EqualTo(2), "修正後: Ceiling で 2 サンプルになるべき");
+    }
+
+    [Test]
+    public void GetSampleCount_Static_MatchesInstanceMethod()
+    {
+        var range = new TimeRange(TimeSpan.FromSeconds(0.5), TimeSpan.FromMilliseconds(123.456));
+        const int sampleRate = 48000;
+
+        var instance = new AudioProcessContext(range, sampleRate, new AnimationSampler(), null);
+
+        Assert.That(AudioProcessContext.GetSampleCount(range, sampleRate),
+            Is.EqualTo(instance.GetSampleCount()));
+    }
+
+    [Test]
+    public void GetSampleCount_Static_DifferentSampleRates()
+    {
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+
+        Assert.That(AudioProcessContext.GetSampleCount(range, 44100), Is.EqualTo(88200));
+        Assert.That(AudioProcessContext.GetSampleCount(range, 48000), Is.EqualTo(96000));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -93,6 +93,20 @@ public class AudioProcessContextTests
     }
 
     [Test]
+    public void GetSampleCount_Static_OverflowsInt32_Throws()
+    {
+        // double で計算してから (int) キャストすると、Int32.MaxValue を超える値は
+        // 暗黙に未定義動作 (-2147483648 になる実装が多い) になり後段で気付けない。
+        // 長時間 × 高サンプルレートで int をはみ出すケースを早期に弾けることを担保する。
+        // 例: ~14 時間 @ 48000Hz は 2.4e9 サンプルで Int32.MaxValue (~2.15e9) を超える。
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromHours(14));
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => AudioProcessContext.GetSampleCount(range, 48000));
+        Assert.That(ex!.ParamName, Is.EqualTo("range"));
+    }
+
+    [Test]
     public void GetSampleCount_Static_NegativeDuration_Throws()
     {
         // TimeRange は構造体で Duration の不変条件を保証しない (コンストラクタや WithDuration /

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -23,10 +23,11 @@ public class AudioProcessContextTests
     [Test]
     public void GetSampleCount_Static_FractionalDuration_CeilingsUp()
     {
-        // 1 サンプル分のちょうど境界 (44100Hz, 1サンプル ≒ 226.7575 ticks) を 1tick だけ超えた duration。
-        // 切り捨て版なら 1 サンプル、Ceiling 版なら 2 サンプル。回帰防止ケース。
-        var oneSampleTicks = TimeSpan.TicksPerSecond / 44100; // 226
-        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(oneSampleTicks + 1));
+        // 44100Hz では 1 サンプル ≒ 226.7575 ticks。TimeSpan.TicksPerSecond / 44100 は整数除算で 226 となり、
+        // +1 した 227 ticks は 1 サンプル相当 (226.7575) をわずかに (0.2425 ticks) 超える。
+        // この duration は truncation だと 1 サンプル、Ceiling だと 2 サンプルになり、両者の差を確実に踏ませる。
+        var oneSampleTicksFloor = TimeSpan.TicksPerSecond / 44100; // 226 (true boundary is ~226.7575)
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(oneSampleTicksFloor + 1));
 
         var truncated = (int)(range.Duration.TotalSeconds * 44100);
         var ceiled = AudioProcessContext.GetSampleCount(range, 44100);

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -95,9 +95,10 @@ public class AudioProcessContextTests
     [Test]
     public void GetSampleCount_Static_NegativeDuration_Throws()
     {
-        // TimeRange は構造体で Duration の不変条件を保証しない (Intersect などの算術で負値が入り得る)。
-        // 負の duration を Math.Ceiling に渡すと負の int が返り、後段 AudioBuffer のコンストラクタで
-        // "sampleCount" の例外として出るため、ここで早期に弾いてエラーの帰属を正しく保つ。
+        // TimeRange は構造体で Duration の不変条件を保証しない (コンストラクタや WithDuration /
+        // SubtractStart などで負値が入り得る)。負の duration を Math.Ceiling に渡すと負の int が返り、
+        // 後段 AudioBuffer のコンストラクタで "sampleCount" の例外として出るため、ここで早期に弾いて
+        // エラーの帰属を正しく保つ。
         var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(-1));
 
         var ex = Assert.Throws<ArgumentOutOfRangeException>(

--- a/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
@@ -44,6 +44,8 @@ public class ComposerTests
         using AudioBuffer? buffer = composer.Compose(range, frame);
 
         Assert.That(buffer, Is.Not.Null);
-        Assert.That(buffer!.SampleCount, Is.EqualTo(sampleRate));
+        // ヘルパー経由で取得した値とそのまま比較し、Composer の silence fallback がヘルパーと
+        // 乖離した場合 (整数秒入力でも) に検出できるようにする。
+        Assert.That(buffer!.SampleCount, Is.EqualTo(AudioProcessContext.GetSampleCount(range, sampleRate)));
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/ComposerTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Immutable;
+using Beutl.Audio;
+using Beutl.Audio.Composing;
+using Beutl.Audio.Graph;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+public class ComposerTests
+{
+    [Test]
+    public void Compose_EmptyFrame_ReturnsSilentBufferWithCeilingSampleCount()
+    {
+        // Composer.BuildFinalOutput の silence fallback (mixedBuffer == null) が
+        // 他経路 (AudioProcessContext.GetSampleCount) と同じ Ceiling サンプル数で
+        // バッファを確保することを担保する回帰テスト。
+        // 226 ticks は 1 サンプル境界 (~226.7575 ticks @ 44100Hz) を下回るが、+1 した
+        // 227 ticks は境界をわずかに越えるため、truncation だと 1 サンプル / Ceiling だと 2 サンプル。
+        const int sampleRate = 44100;
+        var oneSampleTicksFloor = TimeSpan.TicksPerSecond / sampleRate;
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromTicks(oneSampleTicksFloor + 1));
+        var frame = new CompositionFrame(ImmutableArray<EngineObject.Resource>.Empty, range, default);
+
+        using var composer = new Composer { SampleRate = sampleRate };
+        using AudioBuffer? buffer = composer.Compose(range, frame);
+
+        Assert.That(buffer, Is.Not.Null);
+        Assert.That(buffer!.SampleRate, Is.EqualTo(sampleRate));
+        Assert.That(buffer.ChannelCount, Is.EqualTo(2));
+        Assert.That(buffer.SampleCount, Is.EqualTo(AudioProcessContext.GetSampleCount(range, sampleRate)));
+        Assert.That(buffer.SampleCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Compose_EmptyFrame_IntegerSecondDuration_MatchesGetSampleCount()
+    {
+        const int sampleRate = 48000;
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        var frame = new CompositionFrame(ImmutableArray<EngineObject.Resource>.Empty, range, default);
+
+        using var composer = new Composer { SampleRate = sampleRate };
+        using AudioBuffer? buffer = composer.Compose(range, frame);
+
+        Assert.That(buffer, Is.Not.Null);
+        Assert.That(buffer!.SampleCount, Is.EqualTo(sampleRate));
+    }
+}


### PR DESCRIPTION
## Description

- `Composer.BuildFinalOutput` returned the silence-fallback `AudioBuffer` with a sample count computed via `(int)` truncation, while every audio node and `AudioProcessContext.GetSampleCount()` uses `Math.Ceiling`. With non-integer-second durations this produced a one-sample shortfall in the silent buffer relative to other paths, risking discontinuities at buffer boundaries in `PlayerViewModel.FillAudioData`, `AudioVisualizerDrawable.Render`, and `SourceSound.Thumbnails`.
- Extracted `AudioProcessContext.GetSampleCount(TimeRange, int)` as a static helper so both the per-node path and the Composer fallback share the exact same ceiling-based formula.
- Added `AudioProcessContextTests` covering integer-second equivalence, the fractional regression case (truncation vs. ceiling diverge by one sample), zero duration, instance/static parity, and multiple sample rates.

## Breaking changes

None.

## Fixed issues

None.