### PR TITLE
fix: prevent crash from async void in EditorHostViewModel

### DIFF
--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -72,7 +72,8 @@ public class EditorHostViewModel
         {
             _logger.LogError(
                 ex,
-                "Unhandled exception in ProjectChanged. OldProject={OldProject} NewProject={NewProject}",
+                "Unhandled exception in {Method}. OldProject={OldProject} NewProject={NewProject}",
+                nameof(OnProjectChangedAsync),
                 old?.Uri?.LocalPath,
                 @new?.Uri?.LocalPath);
             NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
@@ -125,7 +126,8 @@ public class EditorHostViewModel
         {
             _logger.LogError(
                 ex,
-                "Unhandled exception in Project_Items_CollectionChanged. Action={Action}",
+                "Unhandled exception in {Method}. Action={Action}",
+                nameof(HandleProjectItemsChangedAsync),
                 e.Action);
             NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
         }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -74,8 +74,8 @@ public class EditorHostViewModel
                 ex,
                 "Unhandled exception in {Method}. OldProject={OldProject} NewProject={NewProject}",
                 nameof(OnProjectChangedAsync),
-                old?.Uri?.LocalPath,
-                @new?.Uri?.LocalPath);
+                SafeLocalPath(old?.Uri),
+                SafeLocalPath(@new?.Uri));
             NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
         }
     }
@@ -114,7 +114,7 @@ public class EditorHostViewModel
                         _logger.LogError(
                             ex,
                             "Failed to close tab for removed project item. FilePath={FilePath}",
-                            item.Uri?.LocalPath);
+                            SafeLocalPath(item.Uri));
                     }
                 }
             }
@@ -131,5 +131,14 @@ public class EditorHostViewModel
                 e.Action);
             NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
         }
+    }
+
+    // Uri.LocalPath throws InvalidOperationException for relative URIs; protect log
+    // formatting inside catch blocks from masking the original exception.
+    private static string? SafeLocalPath(Uri? uri)
+    {
+        if (uri is null)
+            return null;
+        return uri.IsAbsoluteUri ? uri.LocalPath : uri.OriginalString;
     }
 }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -62,6 +62,8 @@ public class EditorHostViewModel
             {
                 foreach (var item in oldItems)
                 {
+                    // Capture FilePath before DisposeAsync nulls out the underlying context.
+                    var filePath = item.FilePath.Value;
                     try
                     {
                         await item.DisposeAsync();
@@ -71,7 +73,7 @@ public class EditorHostViewModel
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", item.FilePath.Value);
+                        _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", filePath);
                     }
                 }
             }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -76,7 +76,7 @@ public class EditorHostViewModel
                 nameof(OnProjectChangedAsync),
                 old?.Uri?.LocalPath,
                 @new?.Uri?.LocalPath);
-            NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
+            NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
         }
     }
 
@@ -129,7 +129,7 @@ public class EditorHostViewModel
                 "Unhandled exception in {Method}. Action={Action}",
                 nameof(HandleProjectItemsChangedAsync),
                 e.Action);
-            NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
+            NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
         }
     }
 }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -1,65 +1,104 @@
 ﻿using System.Collections.Specialized;
+using Beutl.Logging;
 using Beutl.Services;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 
 namespace Beutl.ViewModels;
 
 public class EditorHostViewModel
 {
+    private readonly ILogger _logger = Log.CreateLogger<EditorHostViewModel>();
     private readonly ProjectService _projectService = ProjectService.Current;
     private readonly EditorService _editorService = EditorService.Current;
 
     public EditorHostViewModel()
     {
-        _projectService.ProjectObservable.Subscribe(item => ProjectChanged(item.New, item.Old));
+        _projectService.ProjectObservable
+            .ObserveOnUIDispatcher()
+            .Subscribe(item => _ = OnProjectChangedAsync(item.New, item.Old));
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
 
-    private async void ProjectChanged(Project? @new, Project? old)
+    private async Task OnProjectChangedAsync(Project? @new, Project? old)
     {
-        var oldItems = _editorService.TabItems.ToArray();
-        _editorService.TabItems.Clear();
-
-        // プロジェクトが閉じた
-        if (old != null)
+        try
         {
-            old.Items.CollectionChanged -= Project_Items_CollectionChanged;
-        }
+            var oldItems = _editorService.TabItems.ToArray();
+            _editorService.TabItems.Clear();
 
-        // プロジェクトが開いた
-        if (@new != null)
-        {
-            @new.Items.CollectionChanged += Project_Items_CollectionChanged;
-            foreach (ProjectItem item in @new.Items)
+            // プロジェクトが閉じた
+            if (old != null)
             {
-                _editorService.ActivateTabItem(item);
+                old.Items.CollectionChanged -= Project_Items_CollectionChanged;
+            }
+
+            // プロジェクトが開いた
+            if (@new != null)
+            {
+                @new.Items.CollectionChanged += Project_Items_CollectionChanged;
+                foreach (ProjectItem item in @new.Items)
+                {
+                    _editorService.ActivateTabItem(item);
+                }
+            }
+
+            foreach (var item in oldItems)
+            {
+                try
+                {
+                    await item.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to dispose editor tab item.");
+                }
             }
         }
-
-        foreach (var item in oldItems)
+        catch (Exception ex)
         {
-            await item.DisposeAsync();
+            _logger.LogError(ex, "Unhandled exception in ProjectChanged.");
         }
     }
 
-    private async void Project_Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    private void Project_Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.Action == NotifyCollectionChangedAction.Add &&
-            e.NewItems != null)
+        _ = HandleProjectItemsChangedAsync(e);
+    }
+
+    private async Task HandleProjectItemsChangedAsync(NotifyCollectionChangedEventArgs e)
+    {
+        try
         {
-            foreach (ProjectItem item in e.NewItems.OfType<ProjectItem>())
+            if (e.Action == NotifyCollectionChangedAction.Add &&
+                e.NewItems != null)
             {
-                _editorService.ActivateTabItem(item);
+                foreach (ProjectItem item in e.NewItems.OfType<ProjectItem>())
+                {
+                    _editorService.ActivateTabItem(item);
+                }
+            }
+            else if (e.Action == NotifyCollectionChangedAction.Remove &&
+                     e.OldItems != null)
+            {
+                foreach (ProjectItem item in e.OldItems.OfType<ProjectItem>())
+                {
+                    try
+                    {
+                        await _editorService.CloseTabItem(item);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to close tab for removed project item.");
+                    }
+                }
             }
         }
-        else if (e.Action == NotifyCollectionChangedAction.Remove &&
-                 e.OldItems != null)
+        catch (Exception ex)
         {
-            foreach (ProjectItem item in e.OldItems.OfType<ProjectItem>())
-            {
-                await _editorService.CloseTabItem(item);
-            }
+            _logger.LogError(ex, "Unhandled exception in Project_Items_CollectionChanged.");
         }
     }
 }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -29,34 +29,39 @@ public class EditorHostViewModel
             var oldItems = _editorService.TabItems.ToArray();
             _editorService.TabItems.Clear();
 
-            // プロジェクトが閉じた
-            if (old != null)
+            try
             {
-                old.Items.CollectionChanged -= Project_Items_CollectionChanged;
-            }
+                // プロジェクトが閉じた
+                if (old != null)
+                {
+                    old.Items.CollectionChanged -= Project_Items_CollectionChanged;
+                }
 
-            // プロジェクトが開いた
-            if (@new != null)
-            {
-                @new.Items.CollectionChanged += Project_Items_CollectionChanged;
-                foreach (ProjectItem item in @new.Items)
+                // プロジェクトが開いた
+                if (@new != null)
                 {
-                    _editorService.ActivateTabItem(item);
+                    @new.Items.CollectionChanged += Project_Items_CollectionChanged;
+                    foreach (ProjectItem item in @new.Items)
+                    {
+                        _editorService.ActivateTabItem(item);
+                    }
                 }
             }
-
-            foreach (var item in oldItems)
+            finally
             {
-                try
+                foreach (var item in oldItems)
                 {
-                    await item.DisposeAsync();
-                }
-                catch (OperationCanceledException)
-                {
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", item.FilePath.Value);
+                    try
+                    {
+                        await item.DisposeAsync();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", item.FilePath.Value);
+                    }
                 }
             }
         }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -66,6 +66,7 @@ public class EditorHostViewModel
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled exception in ProjectChanged.");
+            NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
         }
     }
 
@@ -111,6 +112,7 @@ public class EditorHostViewModel
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled exception in Project_Items_CollectionChanged.");
+            NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
         }
     }
 }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -24,13 +24,13 @@ public class EditorHostViewModel
 
     private async Task OnProjectChangedAsync(Project? @new, Project? old)
     {
+        var oldItems = _editorService.TabItems.ToArray();
         try
         {
-            var oldItems = _editorService.TabItems.ToArray();
-            _editorService.TabItems.Clear();
-
             try
             {
+                _editorService.TabItems.Clear();
+
                 // プロジェクトが閉じた
                 if (old != null)
                 {

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -56,7 +56,7 @@ public class EditorHostViewModel
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to dispose editor tab item.");
+                    _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", item.FilePath.Value);
                 }
             }
         }
@@ -65,7 +65,11 @@ public class EditorHostViewModel
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unhandled exception in ProjectChanged.");
+            _logger.LogError(
+                ex,
+                "Unhandled exception in ProjectChanged. OldProject={OldProject} NewProject={NewProject}",
+                old?.Uri?.LocalPath,
+                @new?.Uri?.LocalPath);
             NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
         }
     }
@@ -101,7 +105,10 @@ public class EditorHostViewModel
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Failed to close tab for removed project item.");
+                        _logger.LogError(
+                            ex,
+                            "Failed to close tab for removed project item. FilePath={FilePath}",
+                            item.Uri?.LocalPath);
                     }
                 }
             }
@@ -111,7 +118,10 @@ public class EditorHostViewModel
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unhandled exception in Project_Items_CollectionChanged.");
+            _logger.LogError(
+                ex,
+                "Unhandled exception in Project_Items_CollectionChanged. Action={Action}",
+                e.Action);
             NotificationService.ShowError(string.Empty, MessageStrings.OperationFailed);
         }
     }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Specialized;
+using Avalonia.Threading;
 using Beutl.Logging;
 using Beutl.Services;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
-using Reactive.Bindings.Extensions;
 
 namespace Beutl.ViewModels;
 
@@ -15,9 +15,22 @@ public class EditorHostViewModel
 
     public EditorHostViewModel()
     {
-        _projectService.ProjectObservable
-            .ObserveOnUIDispatcher()
-            .Subscribe(item => _ = OnProjectChangedAsync(item.New, item.Old));
+        _projectService.ProjectObservable.Subscribe(item => DispatchProjectChange(item.New, item.Old));
+    }
+
+    private void DispatchProjectChange(Project? @new, Project? old)
+    {
+        // Run inline when already on the UI thread so callers awaiting OpenProject
+        // (e.g. RestoreLastProjectTask) still see tabs populated on return. Post only
+        // when the notification comes from a background thread.
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            _ = OnProjectChangedAsync(@new, old);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() => _ = OnProjectChangedAsync(@new, old));
+        }
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -31,13 +31,11 @@ public class EditorHostViewModel
             {
                 _editorService.TabItems.Clear();
 
-                // プロジェクトが閉じた
                 if (old != null)
                 {
                     old.Items.CollectionChanged -= Project_Items_CollectionChanged;
                 }
 
-                // プロジェクトが開いた
                 if (@new != null)
                 {
                     @new.Items.CollectionChanged += Project_Items_CollectionChanged;

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -51,11 +51,17 @@ public class EditorHostViewModel
                 {
                     await item.DisposeAsync();
                 }
+                catch (OperationCanceledException)
+                {
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to dispose editor tab item.");
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
         }
         catch (Exception ex)
         {
@@ -89,12 +95,18 @@ public class EditorHostViewModel
                     {
                         await _editorService.CloseTabItem(item);
                     }
+                    catch (OperationCanceledException)
+                    {
+                    }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to close tab for removed project item.");
                     }
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
         }
         catch (Exception ex)
         {

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -118,6 +118,14 @@ public class EditorHostViewModel
                     }
                 }
             }
+            else
+            {
+                _logger.LogWarning(
+                    "Unhandled project items collection change. Action={Action} NewCount={NewCount} OldCount={OldCount}",
+                    e.Action,
+                    e.NewItems?.Count,
+                    e.OldItems?.Count);
+            }
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
## Description

- Convert the `async void` `ProjectChanged` handler in `EditorHostViewModel` to an `async Task` invoked through fire-and-forget, so an exception inside `await item.DisposeAsync()` no longer escapes to the SynchronizationContext and crashes the process.
- Subscribe to `ProjectService.ProjectObservable` via `ObserveOnUIDispatcher()` so the handler always runs on the Avalonia UI thread, regardless of which thread publishes the value. This protects `CoreList<EditorTabItem>` and Avalonia bindings from non-UI-thread access.
- Add per-item try/catch around `DisposeAsync` / `CloseTabItem`, plus an outer try/catch with `ILogger.LogError`, so a failure on one tab no longer aborts the rest of the open/close sequence or silently disappears.
- Apply the same hardening to `Project_Items_CollectionChanged`, which had the same `async void` pattern.

## Breaking changes

None.

## Fixed issues

None (tracked in the internal project board).