### PR TITLE
fix: harden Counter<T> against reorder and AddRef TOCTOU races

### DIFF
--- a/src/Beutl.Engine/Media/Source/Counter.cs
+++ b/src/Beutl.Engine/Media/Source/Counter.cs
@@ -1,4 +1,6 @@
-﻿namespace Beutl.Media.Source;
+﻿using System.Diagnostics;
+
+namespace Beutl.Media.Source;
 
 internal sealed class Counter<T>
     where T : class, IDisposable
@@ -46,6 +48,7 @@ internal sealed class Counter<T>
         {
             if (_refs == 0)
             {
+                Debug.WriteLine("Counter<T>.Release called past zero — possible double-release bug.");
                 return;
             }
 

--- a/src/Beutl.Engine/Media/Source/Counter.cs
+++ b/src/Beutl.Engine/Media/Source/Counter.cs
@@ -2,6 +2,21 @@
 
 namespace Beutl.Media.Source;
 
+/// <summary>
+/// Internal reference-counted owner for a disposable resource that may be
+/// shared across <see cref="MediaSource"/> resources. The instance starts
+/// with <c>RefCount = 1</c>; the constructing caller owns that initial
+/// reference and must call <see cref="Release"/> exactly once when finished.
+/// </summary>
+/// <remarks>
+/// All public members are thread-safe. <see cref="TryAddRef"/> atomically
+/// publishes the "alive" state — once it returns <see langword="true"/>, the
+/// caller is guaranteed to read a non-disposed <see cref="Value"/> until the
+/// matching <see cref="Release"/>. This contract is relied on by
+/// <c>VideoSource</c>, <c>ImageSource</c> and <c>SoundSource</c> to close the
+/// TOCTOU window between observing a live counter via
+/// <see cref="WeakReference{T}"/> and joining it.
+/// </remarks>
 internal sealed class Counter<T>
     where T : class, IDisposable
 {
@@ -17,6 +32,12 @@ internal sealed class Counter<T>
         _refs = 1;
     }
 
+    /// <summary>
+    /// Adds a reference. Throws <see cref="ObjectDisposedException"/> if the
+    /// counter has already reached zero. Use <see cref="TryAddRef"/> from
+    /// shared-cache paths where racing with the final <see cref="Release"/>
+    /// is expected.
+    /// </summary>
     public void AddRef()
     {
         if (!TryAddRef())
@@ -25,6 +46,14 @@ internal sealed class Counter<T>
         }
     }
 
+    /// <summary>
+    /// Atomically attempts to add a reference. Returns <see langword="true"/>
+    /// only when the counter was still alive at the moment of the call, in
+    /// which case the caller now owns one reference and may safely read
+    /// <see cref="Value"/> until they call <see cref="Release"/>. Returns
+    /// <see langword="false"/> if the counter has already reached zero —
+    /// callers fall back to creating a fresh resource in that case.
+    /// </summary>
     public bool TryAddRef()
     {
         lock (_lock)
@@ -39,6 +68,14 @@ internal sealed class Counter<T>
         }
     }
 
+    /// <summary>
+    /// Drops one reference. When the count reaches zero, invokes the
+    /// <c>onRelease</c> callback and then disposes the wrapped value
+    /// (in that order). Both calls happen outside the internal lock to
+    /// avoid re-entrant deadlocks. Calling <see cref="Release"/> after the
+    /// counter has already reached zero is a no-op; the surplus call is
+    /// logged via <see cref="Trace"/> to surface double-release bugs.
+    /// </summary>
     public void Release()
     {
         T? toDispose = null;
@@ -66,6 +103,12 @@ internal sealed class Counter<T>
         toDispose?.Dispose();
     }
 
+    /// <summary>
+    /// Returns the wrapped value. Throws <see cref="ObjectDisposedException"/>
+    /// when called after the final <see cref="Release"/>. Holding an
+    /// outstanding reference (acquired via the constructor, <see cref="AddRef"/>
+    /// or a successful <see cref="TryAddRef"/>) is what makes this access safe.
+    /// </summary>
     public T Value
     {
         get
@@ -78,6 +121,11 @@ internal sealed class Counter<T>
         }
     }
 
+    /// <summary>
+    /// Diagnostic snapshot of the current reference count. The value can
+    /// change immediately after the call returns and must not be used to
+    /// gate liveness decisions — use <see cref="TryAddRef"/> for that.
+    /// </summary>
     public int RefCount
     {
         get

--- a/src/Beutl.Engine/Media/Source/Counter.cs
+++ b/src/Beutl.Engine/Media/Source/Counter.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Media.Source;
+﻿namespace Beutl.Media.Source;
 
 internal sealed class Counter<T>
     where T : class, IDisposable

--- a/src/Beutl.Engine/Media/Source/Counter.cs
+++ b/src/Beutl.Engine/Media/Source/Counter.cs
@@ -1,11 +1,12 @@
-﻿namespace Beutl.Media.Source;
+namespace Beutl.Media.Source;
 
 internal sealed class Counter<T>
     where T : class, IDisposable
 {
+    private readonly Lock _lock = new();
     private T? _value;
     private Action? _onRelease;
-    private volatile int _refs;
+    private int _refs;
 
     public Counter(T value, Action? onRelease)
     {
@@ -16,50 +17,72 @@ internal sealed class Counter<T>
 
     public void AddRef()
     {
-        int old = _refs;
-        while (true)
+        if (!TryAddRef())
         {
-            ObjectDisposedException.ThrowIf(old == 0, this);
-            int current = Interlocked.CompareExchange(ref _refs, old + 1, old);
-            if (current == old)
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+    }
+
+    public bool TryAddRef()
+    {
+        lock (_lock)
+        {
+            if (_refs == 0)
             {
-                break;
+                return false;
             }
-            old = current;
+
+            _refs++;
+            return true;
         }
     }
 
     public void Release()
     {
-        int old = _refs;
-        while (true)
+        T? toDispose = null;
+        Action? onRelease = null;
+
+        lock (_lock)
         {
-            int current = Interlocked.CompareExchange(ref _refs, old - 1, old);
-
-            if (current == old)
+            if (_refs == 0)
             {
-                if (old == 1)
-                {
-                    _onRelease?.Invoke();
-                    _onRelease = null;
-
-                    _value?.Dispose();
-                    _value = null;
-                }
-                break;
+                return;
             }
-            old = current;
+
+            _refs--;
+            if (_refs == 0)
+            {
+                toDispose = _value;
+                _value = null;
+                onRelease = _onRelease;
+                _onRelease = null;
+            }
         }
+
+        onRelease?.Invoke();
+        toDispose?.Dispose();
     }
 
     public T Value
     {
         get
         {
-            ObjectDisposedException.ThrowIf(_refs == 0, this);
-            return _value!;
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_refs == 0, this);
+                return _value!;
+            }
         }
     }
 
-    public int RefCount => _refs;
+    public int RefCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _refs;
+            }
+        }
+    }
 }

--- a/src/Beutl.Engine/Media/Source/Counter.cs
+++ b/src/Beutl.Engine/Media/Source/Counter.cs
@@ -48,7 +48,7 @@ internal sealed class Counter<T>
         {
             if (_refs == 0)
             {
-                Debug.WriteLine("Counter<T>.Release called past zero — possible double-release bug.");
+                Trace.WriteLine($"Counter<{typeof(T).FullName}>.Release called past zero - possible double-release bug.{Environment.NewLine}{Environment.StackTrace}");
                 return;
             }
 

--- a/src/Beutl.Engine/Media/Source/ImageSource.cs
+++ b/src/Beutl.Engine/Media/Source/ImageSource.cs
@@ -17,6 +17,13 @@ public sealed class ImageSource : MediaSource
 
     public override void ReadFrom(Uri uri)
     {
+        if (HasUri && Uri != uri)
+        {
+            // 古い URI の Counter を別 Resource が保持していると
+            // TryAddRef が成功して新 URI でも古いビットマップを返してしまうため、
+            // URI が切り替わったタイミングで共有参照を破棄する。
+            Volatile.Write(ref _bitmapRef, null);
+        }
         Uri = uri;
     }
 

--- a/src/Beutl.Engine/Media/Source/ImageSource.cs
+++ b/src/Beutl.Engine/Media/Source/ImageSource.cs
@@ -52,14 +52,13 @@ public sealed class ImageSource : MediaSource
                 if (!context.DisableResourceShare)
                 {
                     var localRef = Volatile.Read(ref imageSource._bitmapRef);
-                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.TryAddRef())
                         shared = counter;
                 }
 
                 if (shared is not null)
                 {
                     _counter = shared;
-                    shared.AddRef();
                 }
                 else
                 {

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -109,14 +109,13 @@ public sealed class SoundSource : MediaSource
                 if (!context.DisableResourceShare)
                 {
                     var localRef = Volatile.Read(ref soundSource._mediaReaderRef);
-                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.TryAddRef())
                         shared = counter;
                 }
 
                 if (shared is not null)
                 {
                     _counter = shared;
-                    shared.AddRef();
                 }
                 else
                 {

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -21,6 +21,13 @@ public sealed class SoundSource : MediaSource
     {
         if (!uri.IsFile) throw new NotSupportedException("Only file URIs are supported.");
 
+        if (HasUri && Uri != uri)
+        {
+            // 古い URI の Counter を別 Resource が保持していると
+            // TryAddRef が成功して新 URI でも古い MediaReader を返してしまうため、
+            // URI が切り替わったタイミングで共有参照を破棄する。
+            Volatile.Write(ref _mediaReaderRef, null);
+        }
         Uri = uri;
     }
 

--- a/src/Beutl.Engine/Media/Source/VideoSource.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSource.cs
@@ -83,14 +83,13 @@ public sealed class VideoSource : MediaSource
                 if (!context.DisableResourceShare)
                 {
                     var localRef = Volatile.Read(ref videoSource._mediaReaderRef);
-                    if (localRef?.TryGetTarget(out var counter) == true && counter.RefCount > 0)
+                    if (localRef?.TryGetTarget(out var counter) == true && counter.TryAddRef())
                         shared = counter;
                 }
 
                 if (shared is not null)
                 {
                     _counter = shared;
-                    shared.AddRef();
                 }
                 else
                 {

--- a/src/Beutl.Engine/Media/Source/VideoSource.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSource.cs
@@ -20,6 +20,13 @@ public sealed class VideoSource : MediaSource
     {
         if (!uri.IsFile) throw new NotSupportedException("Only file URIs are supported.");
 
+        if (HasUri && Uri != uri)
+        {
+            // 古い URI の Counter を別 Resource が保持していると
+            // TryAddRef が成功して新 URI でも古い MediaReader を返してしまうため、
+            // URI が切り替わったタイミングで共有参照を破棄する。
+            Volatile.Write(ref _mediaReaderRef, null);
+        }
         Uri = uri;
     }
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -131,4 +131,70 @@ public class MediaSourceResourceShareTest
         Assert.That(encode.Bitmap, Is.Not.SameAs(preview.Bitmap),
             "DisableResourceShare=true では専用の Bitmap が割り当てられるはず");
     }
+
+    [Test]
+    public void ImageSource_ReadFromDifferentUri_DoesNotShareStaleCounter()
+    {
+        // 別 Resource が古い URI の Counter を握ったまま ReadFrom(newUri) → ToResource すると、
+        // _bitmapRef を破棄しないと TryAddRef が成功し新 URI でも古い Bitmap が返ってしまう。
+        var uriOld = TestMediaHelper.CreateTestImageUri(16, 16, Colors.Red);
+        var uriNew = TestMediaHelper.CreateTestImageUri(32, 32, Colors.Blue);
+
+        var imageSource = new ImageSource();
+        imageSource.ReadFrom(uriOld);
+
+        using var oldResource = imageSource.ToResource(CompositionContext.Default);
+        Assert.That(oldResource.Bitmap, Is.Not.Null);
+
+        imageSource.ReadFrom(uriNew);
+        using var newResource = imageSource.ToResource(CompositionContext.Default);
+
+        Assert.That(newResource.Bitmap, Is.Not.Null);
+        Assert.That(newResource.Bitmap, Is.Not.SameAs(oldResource.Bitmap),
+            "URI 切替後の Resource が旧 URI の Bitmap を共有してはならない");
+        Assert.That(newResource.FrameSize, Is.EqualTo(new PixelSize(32, 32)),
+            "新 URI に対応する Bitmap がロードされるはず");
+    }
+
+    [Test]
+    public void VideoSource_ReadFromDifferentUri_DoesNotShareStaleCounter()
+    {
+        var pathOld = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var pathNew = TestMediaHelper.CreateTestVideoFile(120, 120, new Rational(30, 1), 60);
+
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(pathOld));
+
+        using var oldResource = videoSource.ToResource(CompositionContext.Default);
+        Assert.That(oldResource.MediaReader, Is.Not.Null);
+
+        videoSource.ReadFrom(new Uri(pathNew));
+        using var newResource = videoSource.ToResource(CompositionContext.Default);
+
+        Assert.That(newResource.MediaReader, Is.Not.Null);
+        Assert.That(newResource.MediaReader, Is.Not.SameAs(oldResource.MediaReader),
+            "URI 切替後の Resource が旧 URI の MediaReader を共有してはならない");
+        Assert.That(newResource.MediaReader!.VideoInfo.FrameSize, Is.EqualTo(new PixelSize(120, 120)),
+            "新 URI に対応する MediaReader がロードされるはず");
+    }
+
+    [Test]
+    public void SoundSource_ReadFromDifferentUri_DoesNotShareStaleCounter()
+    {
+        var pathOld = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var pathNew = TestMediaHelper.CreateTestVideoFile(120, 120, new Rational(30, 1), 60);
+
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(pathOld));
+
+        using var oldResource = soundSource.ToResource(CompositionContext.Default);
+        Assert.That(oldResource.MediaReader, Is.Not.Null);
+
+        soundSource.ReadFrom(new Uri(pathNew));
+        using var newResource = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(newResource.MediaReader, Is.Not.Null);
+        Assert.That(newResource.MediaReader, Is.Not.SameAs(oldResource.MediaReader),
+            "URI 切替後の Resource が旧 URI の MediaReader を共有してはならない");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/MediaSourceResourceShareTest.cs
@@ -133,6 +133,40 @@ public class MediaSourceResourceShareTest
     }
 
     [Test]
+    public void ImageSource_DisableResourceShare_DoesNotContaminateSharedCache()
+    {
+        var uri = TestMediaHelper.CreateTestImageUri(16, 16, Colors.Red);
+        var imageSource = new ImageSource();
+        imageSource.ReadFrom(uri);
+
+        // エンコード側が先に Resource を生成しても、プレビュー側 (共有モード) は
+        // エンコード専用 Bitmap を掴まない
+        using var encode = imageSource.ToResource(
+            new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
+        using var preview = imageSource.ToResource(CompositionContext.Default);
+
+        Assert.That(preview.Bitmap, Is.Not.SameAs(encode.Bitmap),
+            "エンコード専用 Bitmap がプレビュー側に漏れてはならない");
+    }
+
+    [Test]
+    public void SoundSource_DisableResourceShare_DoesNotContaminateSharedCache()
+    {
+        var videoPath = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(videoPath));
+
+        // エンコード側が先に Resource を生成しても、プレビュー側 (共有モード) は
+        // エンコード専用 MediaReader を掴まない
+        using var encode = soundSource.ToResource(
+            new CompositionContext(TimeSpan.Zero) { DisableResourceShare = true });
+        using var preview = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(preview.MediaReader, Is.Not.SameAs(encode.MediaReader),
+            "エンコード専用 MediaReader がプレビュー側に漏れてはならない");
+    }
+
+    [Test]
     public void ImageSource_ReadFromDifferentUri_DoesNotShareStaleCounter()
     {
         // 別 Resource が古い URI の Counter を握ったまま ReadFrom(newUri) → ToResource すると、

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -7,8 +7,13 @@ public class CounterTests
     private sealed class Fake : IDisposable
     {
         public int DisposeCount;
+        public Action? OnDispose;
 
-        public void Dispose() => Interlocked.Increment(ref DisposeCount);
+        public void Dispose()
+        {
+            Interlocked.Increment(ref DisposeCount);
+            OnDispose?.Invoke();
+        }
     }
 
     [Test]
@@ -66,10 +71,14 @@ public class CounterTests
     [Test]
     public void TryAddRef_WhileAlive_ReturnsTrueAndIncrementsRefCount()
     {
-        var counter = new Counter<Fake>(new Fake(), null);
+        var fake = new Fake();
+        var counter = new Counter<Fake>(fake, null);
 
         Assert.That(counter.TryAddRef(), Is.True);
         Assert.That(counter.RefCount, Is.EqualTo(2));
+        // Contract used by VideoSource/ImageSource/SoundSource: a successful
+        // TryAddRef must guarantee Value is safe to read until matching Release.
+        Assert.That(counter.Value, Is.SameAs(fake));
     }
 
     [Test]
@@ -108,6 +117,19 @@ public class CounterTests
         counter.Release(); // noop
 
         Assert.That(callCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void OnRelease_InvokedBeforeUnderlyingDispose()
+    {
+        var order = new List<string>();
+        var fake = new Fake();
+        fake.OnDispose = () => { lock (order) order.Add("dispose"); };
+        var counter = new Counter<Fake>(fake, () => { lock (order) order.Add("onRelease"); });
+
+        counter.Release();
+
+        Assert.That(order, Is.EqualTo(new[] { "onRelease", "dispose" }));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Media.Source;
+﻿using Beutl.Media.Source;
 
 namespace Beutl.UnitTests.Engine.Media.Source;
 

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -1,0 +1,190 @@
+using Beutl.Media.Source;
+
+namespace Beutl.UnitTests.Engine.Media.Source;
+
+public class CounterTests
+{
+    private sealed class Fake : IDisposable
+    {
+        public int DisposeCount;
+
+        public void Dispose() => Interlocked.Increment(ref DisposeCount);
+    }
+
+    [Test]
+    public void Initial_RefCount_IsOne()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+
+        Assert.That(counter.RefCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AddRef_IncrementsRefCount()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+
+        counter.AddRef();
+        counter.AddRef();
+
+        Assert.That(counter.RefCount, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Release_DisposesValue_WhenRefCountReachesZero()
+    {
+        var fake = new Fake();
+        var counter = new Counter<Fake>(fake, null);
+
+        counter.AddRef();
+        counter.Release();
+        Assert.That(fake.DisposeCount, Is.EqualTo(0));
+
+        counter.Release();
+        Assert.That(fake.DisposeCount, Is.EqualTo(1));
+        Assert.That(counter.RefCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void AddRef_AfterFullyReleased_Throws()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+        counter.Release();
+
+        Assert.Throws<ObjectDisposedException>(() => counter.AddRef());
+    }
+
+    [Test]
+    public void TryAddRef_AfterFullyReleased_ReturnsFalse()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+        counter.Release();
+
+        Assert.That(counter.TryAddRef(), Is.False);
+    }
+
+    [Test]
+    public void TryAddRef_WhileAlive_ReturnsTrueAndIncrementsRefCount()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+
+        Assert.That(counter.TryAddRef(), Is.True);
+        Assert.That(counter.RefCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Value_AfterFullyReleased_Throws()
+    {
+        var counter = new Counter<Fake>(new Fake(), null);
+        counter.Release();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = counter.Value);
+    }
+
+    [Test]
+    public void Release_PastZero_IsNoop()
+    {
+        var fake = new Fake();
+        var counter = new Counter<Fake>(fake, null);
+
+        counter.Release();
+        counter.Release();
+        counter.Release();
+
+        Assert.That(fake.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void OnRelease_InvokedExactlyOnce()
+    {
+        int callCount = 0;
+        var counter = new Counter<Fake>(new Fake(), () => Interlocked.Increment(ref callCount));
+
+        counter.AddRef();
+        counter.Release();
+        Assert.That(callCount, Is.EqualTo(0));
+
+        counter.Release();
+        counter.Release(); // noop
+
+        Assert.That(callCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ParallelAddRefRelease_DoesNotLoseRef()
+    {
+        const int Threads = 8;
+        const int Iterations = 5_000;
+
+        var fake = new Fake();
+        var counter = new Counter<Fake>(fake, null);
+
+        await Task.WhenAll(Enumerable.Range(0, Threads).Select(_ => Task.Run(() =>
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                counter.AddRef();
+                counter.Release();
+            }
+        })));
+
+        Assert.That(counter.RefCount, Is.EqualTo(1));
+        Assert.That(fake.DisposeCount, Is.EqualTo(0));
+
+        counter.Release();
+        Assert.That(fake.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ParallelTryAddRefRace_NeverObservesDisposedValue()
+    {
+        const int Trials = 20;
+
+        for (int trial = 0; trial < Trials; trial++)
+        {
+            var fake = new Fake();
+            var counter = new Counter<Fake>(fake, null);
+
+            var ready = new ManualResetEventSlim();
+            int observedDisposed = 0;
+
+            var consumer = Task.Run(() =>
+            {
+                ready.Wait();
+                for (int i = 0; i < 2_000; i++)
+                {
+                    if (!counter.TryAddRef())
+                    {
+                        break;
+                    }
+
+                    try
+                    {
+                        Fake value = counter.Value;
+                        if (Volatile.Read(ref value.DisposeCount) != 0)
+                        {
+                            Interlocked.Increment(ref observedDisposed);
+                        }
+                    }
+                    finally
+                    {
+                        counter.Release();
+                    }
+                }
+            });
+
+            var releaser = Task.Run(() =>
+            {
+                ready.Wait();
+                Thread.Yield();
+                counter.Release();
+            });
+
+            ready.Set();
+            Task.WaitAll(consumer, releaser);
+
+            Assert.That(observedDisposed, Is.Zero, $"Trial {trial}: TryAddRef succeeded but observed disposed value");
+            Assert.That(fake.DisposeCount, Is.EqualTo(1), $"Trial {trial}: value not disposed exactly once");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -209,6 +209,11 @@ public class CounterTests
             var releaser = Task.Run(() =>
             {
                 barrier.SignalAndWait();
+                // Yield once so the consumer typically reaches its TryAddRef
+                // loop before the unbalanced Release lands. This keeps the
+                // TOCTOU window observable on schedulers that would otherwise
+                // let the releaser win the lock first on every trial.
+                Thread.Yield();
                 counter.Release();
             });
 
@@ -219,10 +224,12 @@ public class CounterTests
             totalTryAddRefSuccesses += tryAddRefSuccesses;
         }
 
-        // Per-trial scheduling can cause the releaser to win the race
-        // before the consumer enters its loop. Across 200 trials we
-        // expect many successful interleavings — if zero, the test
-        // never actually exercised the TOCTOU window.
-        Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(0), "No trial observed an alive counter — race window collapsed across all trials");
+        // The releaser yields once after the barrier, so the consumer
+        // should generally enter its TryAddRef loop before the unbalanced
+        // Release lands. Require at least Trials/2 successful hits across
+        // 200 trials: large enough to fail if the race window collapses,
+        // small enough to stay reliable under noisy CI schedulers.
+        Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(Trials / 2),
+            $"Race window collapsed: only {totalTryAddRefSuccesses} TryAddRef hits across {Trials} trials");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -160,26 +160,37 @@ public class CounterTests
     [Test]
     public void ParallelTryAddRefRace_NeverObservesDisposedValue()
     {
-        const int Trials = 20;
+        // Two threads race against each other through a Barrier so both
+        // actually contend on the same Counter:
+        //  - consumer: TryAddRef -> read Value -> Release (the call-site
+        //    pattern in VideoSource/ImageSource/SoundSource)
+        //  - releaser: drops the initial reference at an unpredictable
+        //    point during the consumer's loop, forcing the TOCTOU window
+        //    the volatile+CAS implementation could not close.
+        const int Trials = 200;
+        const int ConsumerIterations = 5_000;
+        int totalTryAddRefSuccesses = 0;
 
         for (int trial = 0; trial < Trials; trial++)
         {
             var fake = new Fake();
             var counter = new Counter<Fake>(fake, null);
 
-            var ready = new ManualResetEventSlim();
+            var barrier = new Barrier(2);
             int observedDisposed = 0;
+            int tryAddRefSuccesses = 0;
 
             var consumer = Task.Run(() =>
             {
-                ready.Wait();
-                for (int i = 0; i < 2_000; i++)
+                barrier.SignalAndWait();
+                for (int i = 0; i < ConsumerIterations; i++)
                 {
                     if (!counter.TryAddRef())
                     {
-                        break;
+                        continue;
                     }
 
+                    Interlocked.Increment(ref tryAddRefSuccesses);
                     try
                     {
                         Fake value = counter.Value;
@@ -197,16 +208,21 @@ public class CounterTests
 
             var releaser = Task.Run(() =>
             {
-                ready.Wait();
-                Thread.Yield();
+                barrier.SignalAndWait();
                 counter.Release();
             });
 
-            ready.Set();
             Task.WaitAll(consumer, releaser);
 
             Assert.That(observedDisposed, Is.Zero, $"Trial {trial}: TryAddRef succeeded but observed disposed value");
             Assert.That(fake.DisposeCount, Is.EqualTo(1), $"Trial {trial}: value not disposed exactly once");
+            totalTryAddRefSuccesses += tryAddRefSuccesses;
         }
+
+        // Per-trial scheduling can cause the releaser to win the race
+        // before the consumer enters its loop. Across 200 trials we
+        // expect many successful interleavings — if zero, the test
+        // never actually exercised the TOCTOU window.
+        Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(0), "No trial observed an alive counter — race window collapsed across all trials");
     }
 }


### PR DESCRIPTION
## Description
- Replace volatile/CAS in `Counter<T>` with a `System.Threading.Lock`-based implementation so `Value`, `AddRef`, `Release` and `RefCount` cannot reorder `_refs` against `_value`, removing a theoretical NRE/AccessViolation under weak memory models.
- Add `TryAddRef()` and use it in `VideoSource` / `ImageSource` / `SoundSource` to close the `RefCount > 0` then `AddRef` TOCTOU race when reusing counters via `WeakReference`.
- Add NUnit coverage for `Counter<T>` including a parallel TryAddRef/Release stress test that asserts a successful `TryAddRef` never returns a disposed value.

## Breaking changes
None. `Counter<T>` is `internal sealed`; `TryAddRef` is additive.

## Fixed issues
None (tracked in the AI Review project board).