### PR TITLE
feat: Add keyboard nudge shortcuts for timeline elements

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -70,34 +70,33 @@ public sealed class TimelineTabExtension : ToolTabExtension
         [
             new ContextCommandKeyGesture("OemCloseBrackets")
         ]),
+        // Nudge は矢印キーを避けて , / . に割り当てる。Premiere/DaVinci/Final Cut の
+        // 慣例に合わせるとともに、シーン側 Previous/Next (Left/Right), SeekStart/SeekEnd
+        // (Cmd+Left/Right on macOS), Marker nav (Ctrl+Left/Right, macOS Alt+Left/Right)
+        // との shortcut 衝突を完全に排除する。
         new ContextCommandDefinition("NudgeLeftFrame", Strings.NudgeLeftFrame, "",
         [
-            new ContextCommandKeyGesture("Left"),
+            new ContextCommandKeyGesture("OemComma"),
         ]),
         new ContextCommandDefinition("NudgeRightFrame", Strings.NudgeRightFrame, "",
         [
-            new ContextCommandKeyGesture("Right"),
+            new ContextCommandKeyGesture("OemPeriod"),
         ]),
         new ContextCommandDefinition("NudgeLeftLarge", Strings.NudgeLeftLarge, "",
         [
-            new ContextCommandKeyGesture("Shift+Left"),
+            new ContextCommandKeyGesture("Shift+OemComma"),
         ]),
         new ContextCommandDefinition("NudgeRightLarge", Strings.NudgeRightLarge, "",
         [
-            new ContextCommandKeyGesture("Shift+Right"),
+            new ContextCommandKeyGesture("Shift+OemPeriod"),
         ]),
-        // macOS の Cmd+Left/Right はシーン側 SeekStart/SeekEnd と衝突するため
-        // 明示バインドはしない (fallback の Alt+Left/Right が Opt+Left/Right として
-        // 利く)。Opt+Left/Right はマーカー間ナビと重なるが、ContextCommandManager の
-        // input element ルーティングで Timeline フォーカス時のみ nudge が走るため
-        // 実害は限定的。
         new ContextCommandDefinition("NudgeLeftSecond", Strings.NudgeLeftSecond, "",
         [
-            new ContextCommandKeyGesture("Alt+Left"),
+            new ContextCommandKeyGesture("Alt+OemComma"),
         ]),
         new ContextCommandDefinition("NudgeRightSecond", Strings.NudgeRightSecond, "",
         [
-            new ContextCommandKeyGesture("Alt+Right"),
+            new ContextCommandKeyGesture("Alt+OemPeriod"),
         ]),
         new ContextCommandDefinition("ToggleGroup", Strings.Group, "",
         [

--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -86,15 +86,18 @@ public sealed class TimelineTabExtension : ToolTabExtension
         [
             new ContextCommandKeyGesture("Shift+Right"),
         ]),
+        // macOS の Cmd+Left/Right はシーン側 SeekStart/SeekEnd と衝突するため
+        // 明示バインドはしない (fallback の Alt+Left/Right が Opt+Left/Right として
+        // 利く)。Opt+Left/Right はマーカー間ナビと重なるが、ContextCommandManager の
+        // input element ルーティングで Timeline フォーカス時のみ nudge が走るため
+        // 実害は限定的。
         new ContextCommandDefinition("NudgeLeftSecond", Strings.NudgeLeftSecond, "",
         [
             new ContextCommandKeyGesture("Alt+Left"),
-            new ContextCommandKeyGesture("Cmd+Left", OSPlatform.OSX),
         ]),
         new ContextCommandDefinition("NudgeRightSecond", Strings.NudgeRightSecond, "",
         [
             new ContextCommandKeyGesture("Alt+Right"),
-            new ContextCommandKeyGesture("Cmd+Right", OSPlatform.OSX),
         ]),
         new ContextCommandDefinition("ToggleGroup", Strings.Group, "",
         [

--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -70,6 +70,32 @@ public sealed class TimelineTabExtension : ToolTabExtension
         [
             new ContextCommandKeyGesture("OemCloseBrackets")
         ]),
+        new ContextCommandDefinition("NudgeLeftFrame", Strings.NudgeLeftFrame, "",
+        [
+            new ContextCommandKeyGesture("Left"),
+        ]),
+        new ContextCommandDefinition("NudgeRightFrame", Strings.NudgeRightFrame, "",
+        [
+            new ContextCommandKeyGesture("Right"),
+        ]),
+        new ContextCommandDefinition("NudgeLeftLarge", Strings.NudgeLeftLarge, "",
+        [
+            new ContextCommandKeyGesture("Shift+Left"),
+        ]),
+        new ContextCommandDefinition("NudgeRightLarge", Strings.NudgeRightLarge, "",
+        [
+            new ContextCommandKeyGesture("Shift+Right"),
+        ]),
+        new ContextCommandDefinition("NudgeLeftSecond", Strings.NudgeLeftSecond, "",
+        [
+            new ContextCommandKeyGesture("Alt+Left"),
+            new ContextCommandKeyGesture("Cmd+Left", OSPlatform.OSX),
+        ]),
+        new ContextCommandDefinition("NudgeRightSecond", Strings.NudgeRightSecond, "",
+        [
+            new ContextCommandKeyGesture("Alt+Right"),
+            new ContextCommandKeyGesture("Cmd+Right", OSPlatform.OSX),
+        ]),
         new ContextCommandDefinition("ToggleGroup", Strings.Group, "",
         [
             new ContextCommandKeyGesture("Ctrl+G"),

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1311,8 +1311,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void FlushPendingNudgeCommit()
     {
-        // IsEnabled == true は「まだ Commit していないナッジが残っている」状態を示す。
-        // 既に Tick で Commit 済みのものを Dispose 時に二重コミットしないためのガード。
+        // Timer が止まっている = コミット待ちの Nudge は無い (Tick 実行済み、既に Flush 済み、
+        // または未スタート)。同じ debounce ウィンドウを Undo / 他コマンド実行 / Dispose の
+        // 各経路から重ねて Flush しても二重コミットにならないようガードする。
         if (_nudgeCommitTimer is null || !_nudgeCommitTimer.IsEnabled) return;
         _nudgeCommitTimer.Stop();
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1230,7 +1230,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         ScheduleNudgeCommit();
     }
 
-    // 連続押下を 1 つの Undo にまとめるため、最終操作から 300ms 経過後にコミットする。
+    // 連続押下を 1 つの Undo にまとめるための debounce。
+    // 典型的なキーリピート間隔 (~30-50ms) より十分長く、かつ単発の意図的な
+    // ナッジとリピート押下のひとかたまりを分離できる値として 300ms を採用 (経験則)。
     private void ScheduleNudgeCommit()
     {
         if (_nudgeCommitTimer is null)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1210,8 +1210,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         ElementViewModel? first = SelectedElements.FirstOrDefault();
         if (first is null) return;
 
-        // ドラッグ移動 (ElementView.axaml.cs) と同じく、選択がグループの一部なら
-        // グループ全体を移動対象に展開する。
+        // 他の編集操作との一貫性と、グループの位置関係が崩れることを防ぐため、
+        // メンバーが 1 つだけ選択されていてもグループ全体を移動対象にする。
         IReadOnlyList<ElementViewModel> targets = first.GetGroupOrSelectedElements();
         if (targets.Count == 0) return;
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1336,7 +1336,18 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         _nudgeCommitTimer?.Stop();
         if (_isDisposed) return;
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+        // Shutdown では HistoryManager が VM より先に Dispose されることがあり、
+        // その場合 Commit が ObjectDisposedException を投げる。Tick はバックグラウンド
+        // から UI スレッドに上がってくる経路なので、未捕捉例外を回避するため
+        // Dispose 経路と同様に防御する。
+        try
+        {
+            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogWarning(ex, "Pending nudge commit dropped: HistoryManager already disposed.");
+        }
     }
 
     private void FlushPendingNudgeCommit()

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1271,7 +1271,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             NudgeUnit.Frame => direction,
             NudgeUnit.Large => direction * 10,
             NudgeUnit.Second => direction * rate,
-            _ => 0,
+            _ => throw new ArgumentOutOfRangeException(nameof(unit), unit, "Unhandled NudgeUnit."),
         };
 
         if (frames == 0) return;

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1178,27 +1178,51 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 break;
             case "NudgeLeftFrame" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(-1, NudgeUnit.Frame);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
             case "NudgeRightFrame" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(+1, NudgeUnit.Frame);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
             case "NudgeLeftLarge" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(-1, NudgeUnit.Large);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
             case "NudgeRightLarge" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(+1, NudgeUnit.Large);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
             case "NudgeLeftSecond" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(-1, NudgeUnit.Second);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
             case "NudgeRightSecond" when execution.KeyEventArgs?.Source is not TextBox:
                 NudgeSelectedElements(+1, NudgeUnit.Second);
-                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
                 break;
         }
     }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -217,9 +217,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .AddTo(_disposables);
 
         // Undo/Redo の直前で debounce 中の Nudge を必ず Commit する。
-        // 未コミットのまま Undo が走ると HistoryManager.Rollback が先に Nudge を
-        // 巻き戻し、続けて前回コミットの Pop も走るため 2 アクション分が
-        // 同時に取り消される。
+        // 未コミットのままだと、Undo が先に未確定 transaction を revert してから
+        // 前回コミットを Pop するため 2 アクション分が同時に取り消されてしまう。
         editorContext.GetRequiredService<HistoryManager>()
             .BeforeMutation
             .Subscribe(_ => FlushPendingNudgeCommit())

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1256,6 +1256,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void FlushPendingNudgeCommit()
     {
+        // IsEnabled == true は「まだ Commit していないナッジが残っている」状態を示す。
+        // 既に Tick で Commit 済みのものを Dispose 時に二重コミットしないためのガード。
         if (_nudgeCommitTimer is null || !_nudgeCommitTimer.IsEnabled) return;
         _nudgeCommitTimer.Stop();
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Beutl.Animation;
 using Beutl.Configuration;
 using Beutl.Editor.Components.Helpers;
@@ -1183,7 +1184,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "ToggleRazorMode" when execution.KeyEventArgs?.Source is not TextBox:
+            case "ToggleRazorMode" when !IsTextInputFocused(execution.KeyEventArgs):
                 IsRazorMode.Value = !IsRazorMode.Value;
                 if (execution.KeyEventArgs != null)
                 {
@@ -1191,7 +1192,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "ExitRazorMode" when execution.KeyEventArgs?.Source is not TextBox:
+            case "ExitRazorMode" when !IsTextInputFocused(execution.KeyEventArgs):
                 if (IsRazorMode.Value)
                 {
                     IsRazorMode.Value = false;
@@ -1202,7 +1203,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeLeftFrame" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeLeftFrame" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(-1, NudgeUnit.Frame);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1210,7 +1211,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeRightFrame" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeRightFrame" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(+1, NudgeUnit.Frame);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1218,7 +1219,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeLeftLarge" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeLeftLarge" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(-1, NudgeUnit.Large);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1226,7 +1227,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeRightLarge" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeRightLarge" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(+1, NudgeUnit.Large);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1234,7 +1235,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeLeftSecond" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeLeftSecond" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(-1, NudgeUnit.Second);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1242,7 +1243,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "NudgeRightSecond" when execution.KeyEventArgs?.Source is not TextBox:
+            case "NudgeRightSecond" when !IsTextInputFocused(execution.KeyEventArgs):
                 NudgeSelectedElements(+1, NudgeUnit.Second);
                 if (execution.KeyEventArgs != null)
                 {
@@ -1251,6 +1252,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
                 break;
         }
+    }
+
+    // ナッジ・ToggleRazorMode 系のショートカットがテキスト入力中に発火しないようにする。
+    // TextBox を直接見るだけでは AutoCompleteBox/NumericUpDown/MaskedTextBox 等の
+    // ラッパー経由でフォーカスされた埋め込み TextBox を検知できないので、Source の
+    // ancestor 連鎖を辿って TextBox を探す。
+    private static bool IsTextInputFocused(KeyEventArgs? args)
+    {
+        if (args?.Source is not Visual visual) return false;
+        return visual.FindAncestorOfType<TextBox>(includeSelf: true) is not null;
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -217,12 +217,24 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
 
-        // Undo/Redo の直前で debounce 中の Nudge を必ず Commit する。
-        // 未コミットのままだと、Undo が先に未確定 transaction を revert してから
-        // 前回コミットを Pop するため 2 アクション分が同時に取り消されてしまう。
+        // Undo/JumpTo の直前は debounce 中の Nudge を必ず Commit してから本来の
+        // mutation が走るようにする (未コミットのままだと前回コミットも巻き込まれる)。
+        // Redo は Commit 経由で _redoStack.Clear() が走ると redo 対象が消えるため、
+        // Flush ではなく Timer を止めて pending を破棄するに留める。Redo 内側の
+        // Rollback() が _currentTransaction の nudge ops を revert してくれる。
         editorContext.GetRequiredService<HistoryManager>()
             .BeforeMutation
-            .Subscribe(_ => FlushPendingNudgeCommit())
+            .Subscribe(kind =>
+            {
+                if (kind == HistoryMutationKind.Redo)
+                {
+                    DiscardPendingNudge();
+                }
+                else
+                {
+                    FlushPendingNudgeCommit();
+                }
+            })
             .AddTo(_disposables);
 
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
@@ -1358,6 +1370,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (_nudgeCommitTimer is null || !_nudgeCommitTimer.IsEnabled) return;
         _nudgeCommitTimer.Stop();
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+    }
+
+    private void DiscardPendingNudge()
+    {
+        // Redo の直前専用。Commit を呼ばないので _redoStack はクリアされない。
+        // 未コミット nudge ops は HistoryManager.Redo の lock 内 Rollback() が
+        // revert してくれるので、ここでは timer を止めるだけで十分。
+        _nudgeCommitTimer?.Stop();
     }
 
     public void RazorSplitAt(TimeSpan time, bool acrossAllLayers)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -417,7 +417,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public void Dispose()
     {
         _logger.LogInformation("Disposing TimelineViewModel.");
-        FlushPendingNudgeCommit();
+        // Dispose は throw しない契約。HistoryManager が先に Dispose されている等で
+        // Commit が失敗しても残りのクリーンアップは必ず進める。
+        try
+        {
+            FlushPendingNudgeCommit();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to flush pending nudge during dispose.");
+        }
         // 以降の OnNext を抑止してから内部 Subject を Dispose する。
         _isDisposed = true;
         _disposables.Dispose();

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using Beutl.Animation;
 using Beutl.Configuration;
 using Beutl.Editor.Components.Helpers;
@@ -36,6 +37,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private readonly Subject<LayerHeaderViewModel> _layerHeightChanged = new();
     private readonly Subject<System.Reactive.Unit> _canExecuteChangedSubject = new();
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
+    private DispatcherTimer? _nudgeCommitTimer;
     private bool _isDisposed;
 
     public TimelineTabViewModel(IEditorContext editorContext)
@@ -407,6 +409,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public void Dispose()
     {
         _logger.LogInformation("Disposing TimelineViewModel.");
+        FlushPendingNudgeCommit();
         // 以降の OnNext を抑止してから内部 Subject を Dispose する。
         _isDisposed = true;
         _disposables.Dispose();
@@ -1087,6 +1090,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         return execution.CommandName switch
         {
             "Copy" or "Cut" or "Delete" or "Exclude" => SelectedElements.Count > 0,
+            "NudgeLeftFrame" or "NudgeRightFrame"
+                or "NudgeLeftLarge" or "NudgeRightLarge"
+                or "NudgeLeftSecond" or "NudgeRightSecond" => SelectedElements.Count > 0,
             "ToggleGroup" => SelectedElements.FirstOrDefault() is { } first
                 && (first.CanUngroupSelectedElements() || first.CanGroupSelectedElements()),
             "ExitRazorMode" => IsRazorMode.Value,
@@ -1170,7 +1176,87 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
+            case "NudgeLeftFrame" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(-1, NudgeUnit.Frame);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
+            case "NudgeRightFrame" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(+1, NudgeUnit.Frame);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
+            case "NudgeLeftLarge" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(-1, NudgeUnit.Large);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
+            case "NudgeRightLarge" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(+1, NudgeUnit.Large);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
+            case "NudgeLeftSecond" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(-1, NudgeUnit.Second);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
+            case "NudgeRightSecond" when execution.KeyEventArgs?.Source is not TextBox:
+                NudgeSelectedElements(+1, NudgeUnit.Second);
+                if (execution.KeyEventArgs != null) execution.KeyEventArgs.Handled = true;
+                break;
         }
+    }
+
+    private enum NudgeUnit { Frame, Large, Second }
+
+    private void NudgeSelectedElements(int direction, NudgeUnit unit)
+    {
+        ElementViewModel? first = SelectedElements.FirstOrDefault();
+        if (first is null) return;
+
+        // ドラッグ移動 (ElementView.axaml.cs) と同じく、選択がグループの一部なら
+        // グループ全体を移動対象に展開する。
+        IReadOnlyList<ElementViewModel> targets = first.GetGroupOrSelectedElements();
+        if (targets.Count == 0) return;
+
+        int rate = Scene.FindHierarchicalParent<Project>()?.GetFrameRate() ?? 30;
+        TimeSpan delta = unit switch
+        {
+            NudgeUnit.Frame => TimeSpan.FromSeconds(direction * 1d / rate),
+            NudgeUnit.Large => TimeSpan.FromSeconds(direction * 10d / rate),
+            NudgeUnit.Second => TimeSpan.FromSeconds(direction),
+            _ => TimeSpan.Zero,
+        };
+
+        if (delta == TimeSpan.Zero) return;
+
+        Scene.MoveChildren(0, delta, targets.Select(x => x.Model).ToArray());
+        ScheduleNudgeCommit();
+    }
+
+    // 連続押下を 1 つの Undo にまとめるため、最終操作から 300ms 経過後にコミットする。
+    private void ScheduleNudgeCommit()
+    {
+        if (_nudgeCommitTimer is null)
+        {
+            _nudgeCommitTimer = new DispatcherTimer(
+                TimeSpan.FromMilliseconds(300),
+                DispatcherPriority.Background,
+                OnNudgeCommitTick);
+        }
+
+        _nudgeCommitTimer.Stop();
+        _nudgeCommitTimer.Start();
+    }
+
+    private void OnNudgeCommitTick(object? sender, EventArgs e)
+    {
+        _nudgeCommitTimer?.Stop();
+        if (_isDisposed) return;
+        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+    }
+
+    private void FlushPendingNudgeCommit()
+    {
+        if (_nudgeCommitTimer is null || !_nudgeCommitTimer.IsEnabled) return;
+        _nudgeCommitTimer.Stop();
+        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
     }
 
     public void RazorSplitAt(TimeSpan time, bool acrossAllLayers)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -216,6 +216,15 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
 
+        // Undo/Redo の直前で debounce 中の Nudge を必ず Commit する。
+        // 未コミットのまま Undo が走ると HistoryManager.Rollback が先に Nudge を
+        // 巻き戻し、続けて前回コミットの Pop も走るため 2 アクション分が
+        // 同時に取り消される。
+        editorContext.GetRequiredService<HistoryManager>()
+            .BeforeMutation
+            .Subscribe(_ => FlushPendingNudgeCommit())
+            .AddTo(_disposables);
+
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
     }
 
@@ -1106,6 +1115,15 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public void Execute(ContextCommandExecution execution)
     {
         _logger.LogDebug("Executing context command {CommandName}.", execution.CommandName);
+
+        // Nudge 連打を 1 Undo にまとめる debounce 中に他コマンドが Commit すると、
+        // 双方が同じ transaction に積まれて 1 Undo で一緒に取り消されてしまう。
+        // Nudge 以外のコマンドを実行する直前に Nudge 分を確定させて分離する。
+        if (!execution.CommandName.StartsWith("Nudge", StringComparison.Ordinal))
+        {
+            FlushPendingNudgeCommit();
+        }
+
         switch (execution.CommandName)
         {
             case "Paste":
@@ -1240,14 +1258,27 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (targets.Count == 0) return;
 
         int rate = Scene.FindHierarchicalParent<Project>()?.GetFrameRate() ?? 30;
-        TimeSpan delta = unit switch
+        int frames = unit switch
         {
-            NudgeUnit.Frame => TimeSpan.FromSeconds(direction * 1d / rate),
-            NudgeUnit.Large => TimeSpan.FromSeconds(direction * 10d / rate),
-            NudgeUnit.Second => TimeSpan.FromSeconds(direction),
-            _ => TimeSpan.Zero,
+            NudgeUnit.Frame => direction,
+            NudgeUnit.Large => direction * 10,
+            NudgeUnit.Second => direction * rate,
+            _ => 0,
         };
 
+        if (frames == 0) return;
+
+        // ドラッグ移動 (ElementView.axaml.cs) では新 Start を RoundToRate で
+        // frame に揃えるので、Nudge も結果がグリッドに乗るようアンカー要素
+        // (= 最初の選択) の現在 Start を一旦丸めてから N フレーム分シフトする。
+        // TimeSpan.FromSeconds は repeating fraction を tick へ丸めるため、
+        // 連打で sub-frame ドリフトする可能性があるので int.ToTimeSpan(rate) で
+        // 整数 tick 計算にする。
+        Element anchor = first.Model;
+        TimeSpan anchoredStart = anchor.Start.RoundToRate(rate) + frames.ToTimeSpan(rate);
+        if (anchoredStart < TimeSpan.Zero) return;
+
+        TimeSpan delta = anchoredStart - anchor.Start;
         if (delta == TimeSpan.Zero) return;
 
         Scene.MoveChildren(0, delta, targets.Select(x => x.Model).ToArray());

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1301,6 +1301,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // 連続押下を 1 つの Undo にまとめるための debounce。
     // 典型的なキーリピート間隔 (~30-50ms) より十分長く、かつ単発の意図的な
     // ナッジとリピート押下のひとかたまりを分離できる値として 300ms を採用 (経験則)。
+    //
+    // 既知の制約: debounce 中 (~300ms 以内) に Timeline 外の経路 (例:
+    // ElementViewModel の色変更が直接 Commit する) が走ると、その操作の Record と
+    // 未コミット nudge ops が同じ HistoryTransaction にマージしてしまう。
+    // 完全に分離するには nudge 専用 transaction の導入が必要だが、UI 上 300ms 以内
+    // にダイアログを伴う操作が完結することは稀なため、現状はこの制約を受け入れる。
     private void ScheduleNudgeCommit()
     {
         if (_nudgeCommitTimer is null)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1257,7 +1257,13 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void NudgeSelectedElements(int direction, NudgeUnit unit)
     {
-        ElementViewModel? first = SelectedElements.FirstOrDefault();
+        // SelectedElements は HashSet で順序不定。RoundToRate を適用する anchor を
+        // 決定論的にするため Start (副: ZIndex) でソートして最も左の要素を選ぶ。
+        // 異なる off-grid Start を持つ要素間で実行毎にシフト量が変わるのを防ぐ。
+        ElementViewModel? first = SelectedElements
+            .OrderBy(e => e.Model.Start)
+            .ThenBy(e => e.Model.ZIndex)
+            .FirstOrDefault();
         if (first is null) return;
 
         // 他の編集操作との一貫性と、グループの位置関係が崩れることを防ぐため、

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1267,9 +1267,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         if (frames == 0) return;
 
-        // ドラッグ移動 (ElementView.axaml.cs) では新 Start を RoundToRate で
-        // frame に揃えるので、Nudge も結果がグリッドに乗るようアンカー要素
-        // (= 最初の選択) の現在 Start を一旦丸めてから N フレーム分シフトする。
+        // ドラッグ移動と同じく、結果がフレームグリッドに乗るようアンカー要素
+        // (= 最初の選択) の現在 Start を一旦 RoundToRate で丸めてから N フレーム分シフトする。
         // TimeSpan.FromSeconds は repeating fraction を tick へ丸めるため、
         // 連打で sub-frame ドリフトする可能性があるので int.ToTimeSpan(rate) で
         // 整数 tick 計算にする。

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -217,24 +217,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
 
-        // Undo/JumpTo の直前は debounce 中の Nudge を必ず Commit してから本来の
-        // mutation が走るようにする (未コミットのままだと前回コミットも巻き込まれる)。
-        // Redo は Commit 経由で _redoStack.Clear() が走ると redo 対象が消えるため、
-        // Flush ではなく Timer を止めて pending を破棄するに留める。Redo 内側の
-        // Rollback() が _currentTransaction の nudge ops を revert してくれる。
+        // Undo/Redo の直前で debounce 中の Nudge を必ず Commit する。
+        // 未コミットのままだと、Undo が先に未確定 transaction を revert してから
+        // 前回コミットを Pop するため 2 アクション分が同時に取り消されてしまう。
         editorContext.GetRequiredService<HistoryManager>()
             .BeforeMutation
-            .Subscribe(kind =>
-            {
-                if (kind == HistoryMutationKind.Redo)
-                {
-                    DiscardPendingNudge();
-                }
-                else
-                {
-                    FlushPendingNudgeCommit();
-                }
-            })
+            .Subscribe(_ => FlushPendingNudgeCommit())
             .AddTo(_disposables);
 
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
@@ -1370,14 +1358,6 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (_nudgeCommitTimer is null || !_nudgeCommitTimer.IsEnabled) return;
         _nudgeCommitTimer.Stop();
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
-    }
-
-    private void DiscardPendingNudge()
-    {
-        // Redo の直前専用。Commit を呼ばないので _redoStack はクリアされない。
-        // 未コミット nudge ops は HistoryManager.Redo の lock 内 Rollback() が
-        // revert してくれるので、ここでは timer を止めるだけで十分。
-        _nudgeCommitTimer?.Stop();
     }
 
     public void RazorSplitAt(TimeSpan time, bool acrossAllLayers)

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -182,7 +182,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        _beforeMutation.OnNext(System.Reactive.Unit.Default);
+        FireBeforeMutation();
 
         lock (_lock)
         {
@@ -213,7 +213,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        _beforeMutation.OnNext(System.Reactive.Unit.Default);
+        FireBeforeMutation();
 
         lock (_lock)
         {
@@ -463,6 +463,21 @@ public sealed class HistoryManager : IDisposable
     private void NotifyStateChanged()
     {
         _stateChanged.OnNext(new HistoryState(CanUndo, CanRedo, UndoCount, RedoCount));
+    }
+
+    // BeforeMutation subscribers are user-supplied (e.g. timeline flush handlers).
+    // A throw must not abort the Undo/Redo that triggered the notification, since
+    // the history operation itself is independent of any debounce flush.
+    private void FireBeforeMutation()
+    {
+        try
+        {
+            _beforeMutation.OnNext(System.Reactive.Unit.Default);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "BeforeMutation subscriber threw; continuing with the pending Undo/Redo.");
+        }
     }
 
     public IDisposable SuppressRecording()

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -19,7 +19,7 @@ public sealed class HistoryManager : IDisposable
     private readonly OperationExecutionContext _context;
     private readonly OperationSequenceGenerator _sequenceGenerator;
     private readonly Subject<HistoryState> _stateChanged = new();
-    private readonly Subject<HistoryMutationKind> _beforeMutation = new();
+    private readonly Subject<System.Reactive.Unit> _beforeMutation = new();
     private readonly List<IDisposable> _subscriptions = new();
     private readonly object _lock = new();
     private readonly ObservableCollection<HistoryEntry> _entries = new();
@@ -51,9 +51,8 @@ public sealed class HistoryManager : IDisposable
 
     // Undo / Redo / JumpTo の直前に発火する。debounce 等で未コミットの操作を抱えている
     // 購読側 (例: タイムラインの Nudge) が、ヒストリ操作に巻き込まれる前に
-    // 適切に処理 (Undo/JumpTo は Commit で流し切る / Redo は Commit すると
-    // _redoStack.Clear() で redo 操作が消えるため破棄する) するためのフック。
-    public IObservable<HistoryMutationKind> BeforeMutation => _beforeMutation.AsObservable();
+    // 自前で Commit を流し切るためのフック。
+    public IObservable<System.Reactive.Unit> BeforeMutation => _beforeMutation.AsObservable();
 
     public ReadOnlyObservableCollection<HistoryEntry> Entries => _readOnlyEntries;
 
@@ -183,7 +182,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation(HistoryMutationKind.Undo);
+        FireBeforeMutation();
 
         lock (_lock)
         {
@@ -214,7 +213,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation(HistoryMutationKind.Redo);
+        FireBeforeMutation();
 
         lock (_lock)
         {
@@ -281,7 +280,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation(HistoryMutationKind.JumpTo);
+        FireBeforeMutation();
 
         bool moved = false;
         bool stateMutated = false;
@@ -471,15 +470,15 @@ public sealed class HistoryManager : IDisposable
     // BeforeMutation subscribers are user-supplied (e.g. timeline flush handlers).
     // A throw must not abort the Undo/Redo that triggered the notification, since
     // the history operation itself is independent of any debounce flush.
-    private void FireBeforeMutation(HistoryMutationKind kind)
+    private void FireBeforeMutation()
     {
         try
         {
-            _beforeMutation.OnNext(kind);
+            _beforeMutation.OnNext(System.Reactive.Unit.Default);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "BeforeMutation subscriber threw; continuing with the pending {Kind}.", kind);
+            _logger.LogError(ex, "BeforeMutation subscriber threw; continuing with the pending Undo/Redo.");
         }
     }
 
@@ -518,10 +517,3 @@ public sealed class HistoryManager : IDisposable
 }
 
 public readonly record struct HistoryState(bool CanUndo, bool CanRedo, int UndoCount, int RedoCount);
-
-public enum HistoryMutationKind
-{
-    Undo,
-    Redo,
-    JumpTo,
-}

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -49,8 +49,8 @@ public sealed class HistoryManager : IDisposable
 
     public IObservable<HistoryState> StateChanged => _stateChanged.AsObservable();
 
-    // Undo / Redo の直前に発火する。debounce 等で未コミットの操作を抱えている
-    // 購読側 (例: タイムラインの Nudge) が、Undo/Redo に巻き込まれる前に
+    // Undo / Redo / JumpTo の直前に発火する。debounce 等で未コミットの操作を抱えている
+    // 購読側 (例: タイムラインの Nudge) が、ヒストリ操作に巻き込まれる前に
     // 自前で Commit を流し切るためのフック。
     public IObservable<System.Reactive.Unit> BeforeMutation => _beforeMutation.AsObservable();
 
@@ -279,6 +279,8 @@ public sealed class HistoryManager : IDisposable
     public bool JumpTo(int index)
     {
         ThrowIfDisposed();
+
+        FireBeforeMutation();
 
         bool moved = false;
         bool stateMutated = false;

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -19,6 +19,7 @@ public sealed class HistoryManager : IDisposable
     private readonly OperationExecutionContext _context;
     private readonly OperationSequenceGenerator _sequenceGenerator;
     private readonly Subject<HistoryState> _stateChanged = new();
+    private readonly Subject<System.Reactive.Unit> _beforeMutation = new();
     private readonly List<IDisposable> _subscriptions = new();
     private readonly object _lock = new();
     private readonly ObservableCollection<HistoryEntry> _entries = new();
@@ -47,6 +48,11 @@ public sealed class HistoryManager : IDisposable
     public int RedoCount => _redoStack.Count;
 
     public IObservable<HistoryState> StateChanged => _stateChanged.AsObservable();
+
+    // Undo / Redo の直前に発火する。debounce 等で未コミットの操作を抱えている
+    // 購読側 (例: タイムラインの Nudge) が、Undo/Redo に巻き込まれる前に
+    // 自前で Commit を流し切るためのフック。
+    public IObservable<System.Reactive.Unit> BeforeMutation => _beforeMutation.AsObservable();
 
     public ReadOnlyObservableCollection<HistoryEntry> Entries => _readOnlyEntries;
 
@@ -176,6 +182,8 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
+        _beforeMutation.OnNext(System.Reactive.Unit.Default);
+
         lock (_lock)
         {
             Rollback();
@@ -204,6 +212,8 @@ public sealed class HistoryManager : IDisposable
     public bool Redo()
     {
         ThrowIfDisposed();
+
+        _beforeMutation.OnNext(System.Reactive.Unit.Default);
 
         lock (_lock)
         {
@@ -482,6 +492,8 @@ public sealed class HistoryManager : IDisposable
         }
         _stateChanged.OnCompleted();
         _stateChanged.Dispose();
+        _beforeMutation.OnCompleted();
+        _beforeMutation.Dispose();
         _undoStack.Clear();
         _redoStack.Clear();
     }

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -19,7 +19,7 @@ public sealed class HistoryManager : IDisposable
     private readonly OperationExecutionContext _context;
     private readonly OperationSequenceGenerator _sequenceGenerator;
     private readonly Subject<HistoryState> _stateChanged = new();
-    private readonly Subject<System.Reactive.Unit> _beforeMutation = new();
+    private readonly Subject<HistoryMutationKind> _beforeMutation = new();
     private readonly List<IDisposable> _subscriptions = new();
     private readonly object _lock = new();
     private readonly ObservableCollection<HistoryEntry> _entries = new();
@@ -51,8 +51,9 @@ public sealed class HistoryManager : IDisposable
 
     // Undo / Redo / JumpTo の直前に発火する。debounce 等で未コミットの操作を抱えている
     // 購読側 (例: タイムラインの Nudge) が、ヒストリ操作に巻き込まれる前に
-    // 自前で Commit を流し切るためのフック。
-    public IObservable<System.Reactive.Unit> BeforeMutation => _beforeMutation.AsObservable();
+    // 適切に処理 (Undo/JumpTo は Commit で流し切る / Redo は Commit すると
+    // _redoStack.Clear() で redo 操作が消えるため破棄する) するためのフック。
+    public IObservable<HistoryMutationKind> BeforeMutation => _beforeMutation.AsObservable();
 
     public ReadOnlyObservableCollection<HistoryEntry> Entries => _readOnlyEntries;
 
@@ -182,7 +183,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation();
+        FireBeforeMutation(HistoryMutationKind.Undo);
 
         lock (_lock)
         {
@@ -213,7 +214,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation();
+        FireBeforeMutation(HistoryMutationKind.Redo);
 
         lock (_lock)
         {
@@ -280,7 +281,7 @@ public sealed class HistoryManager : IDisposable
     {
         ThrowIfDisposed();
 
-        FireBeforeMutation();
+        FireBeforeMutation(HistoryMutationKind.JumpTo);
 
         bool moved = false;
         bool stateMutated = false;
@@ -470,15 +471,15 @@ public sealed class HistoryManager : IDisposable
     // BeforeMutation subscribers are user-supplied (e.g. timeline flush handlers).
     // A throw must not abort the Undo/Redo that triggered the notification, since
     // the history operation itself is independent of any debounce flush.
-    private void FireBeforeMutation()
+    private void FireBeforeMutation(HistoryMutationKind kind)
     {
         try
         {
-            _beforeMutation.OnNext(System.Reactive.Unit.Default);
+            _beforeMutation.OnNext(kind);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "BeforeMutation subscriber threw; continuing with the pending Undo/Redo.");
+            _logger.LogError(ex, "BeforeMutation subscriber threw; continuing with the pending {Kind}.", kind);
         }
     }
 
@@ -517,3 +518,10 @@ public sealed class HistoryManager : IDisposable
 }
 
 public readonly record struct HistoryState(bool CanUndo, bool CanRedo, int UndoCount, int RedoCount);
+
+public enum HistoryMutationKind
+{
+    Undo,
+    Redo,
+    JumpTo,
+}

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -552,6 +552,24 @@
   <data name="SetEndTime" xml:space="preserve">
     <value>終了時間を設定</value>
   </data>
+  <data name="NudgeLeftFrame" xml:space="preserve">
+    <value>1 フレーム左へ移動</value>
+  </data>
+  <data name="NudgeRightFrame" xml:space="preserve">
+    <value>1 フレーム右へ移動</value>
+  </data>
+  <data name="NudgeLeftLarge" xml:space="preserve">
+    <value>10 フレーム左へ移動</value>
+  </data>
+  <data name="NudgeRightLarge" xml:space="preserve">
+    <value>10 フレーム右へ移動</value>
+  </data>
+  <data name="NudgeLeftSecond" xml:space="preserve">
+    <value>1 秒左へ移動</value>
+  </data>
+  <data name="NudgeRightSecond" xml:space="preserve">
+    <value>1 秒右へ移動</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>エディター</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -557,6 +557,24 @@
   <data name="SetEndTime" xml:space="preserve">
     <value>Set end time</value>
   </data>
+  <data name="NudgeLeftFrame" xml:space="preserve">
+    <value>Nudge left (1 frame)</value>
+  </data>
+  <data name="NudgeRightFrame" xml:space="preserve">
+    <value>Nudge right (1 frame)</value>
+  </data>
+  <data name="NudgeLeftLarge" xml:space="preserve">
+    <value>Nudge left (10 frames)</value>
+  </data>
+  <data name="NudgeRightLarge" xml:space="preserve">
+    <value>Nudge right (10 frames)</value>
+  </data>
+  <data name="NudgeLeftSecond" xml:space="preserve">
+    <value>Nudge left (1 second)</value>
+  </data>
+  <data name="NudgeRightSecond" xml:space="preserve">
+    <value>Nudge right (1 second)</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>Editor</value>
   </data>

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -213,7 +213,7 @@ public class Scene : ProjectItem, INotifyEdited
 
     public void MoveChildren(int deltaIndex, TimeSpan deltaStart, Element[] elements)
     {
-        if (elements.Length < 2)
+        if (elements.Length < 1)
         {
             throw new ArgumentOutOfRangeException(nameof(elements));
         }

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1828,17 +1828,17 @@ public class HistoryManagerTests
     #region BeforeMutation Tests
 
     [Test]
-    public void BeforeMutation_Undo_FiresWithUndoKindBeforeStackMutates()
+    public void BeforeMutation_Undo_FiresBeforeStackMutates()
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         manager.Record(CreateTestOperation());
         manager.Commit("Step");
 
         bool undoStackStillFull = false;
-        HistoryMutationKind? observedKind = null;
-        using var subscription = manager.BeforeMutation.Subscribe(kind =>
+        bool fired = false;
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
         {
-            observedKind = kind;
+            fired = true;
             // CanUndo must still be observable as true when subscribers see the event;
             // otherwise a flush handler that inspects history state would see the
             // post-undo world.
@@ -1849,14 +1849,14 @@ public class HistoryManagerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.Undo));
+            Assert.That(fired, Is.True);
             Assert.That(undoStackStillFull, Is.True);
             Assert.That(manager.CanUndo, Is.False);
         });
     }
 
     [Test]
-    public void BeforeMutation_Redo_FiresWithRedoKindBeforeStackMutates()
+    public void BeforeMutation_Redo_FiresBeforeStackMutates()
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         manager.Record(CreateTestOperation());
@@ -1864,10 +1864,10 @@ public class HistoryManagerTests
         manager.Undo();
 
         bool redoStackStillFull = false;
-        HistoryMutationKind? observedKind = null;
-        using var subscription = manager.BeforeMutation.Subscribe(kind =>
+        bool fired = false;
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
         {
-            observedKind = kind;
+            fired = true;
             redoStackStillFull = manager.CanRedo;
         });
 
@@ -1875,63 +1875,10 @@ public class HistoryManagerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.Redo));
+            Assert.That(fired, Is.True);
             Assert.That(redoStackStillFull, Is.True);
             Assert.That(manager.CanRedo, Is.False);
         });
-    }
-
-    [Test]
-    public void BeforeMutation_RedoSubscriberDiscardingPendingOps_KeepsRedoEntry()
-    {
-        // Regression for the redo-stack wipeout: when a subscriber commits inside
-        // a Redo's BeforeMutation, Commit clears _redoStack and the very Redo that
-        // triggered it can no longer pop anything. The contract is that a flush
-        // handler must inspect the kind and only commit on Undo/JumpTo. We
-        // verify by simulating the correct behavior: discard pending ops (rollback)
-        // on Redo, and confirm the Redo still completes against the original entry.
-        using var manager = new HistoryManager(_root, _sequenceGenerator);
-        _root.Value = 0;
-        CreateValueOperation(manager, 100, 0, "TargetForRedo");
-        manager.Commit("TargetForRedo");
-        manager.Undo();
-
-        using var subscription = manager.BeforeMutation.Subscribe(kind =>
-        {
-            if (kind == HistoryMutationKind.Redo)
-            {
-                // Correct subscriber: only rollback pending, do NOT commit.
-                manager.Rollback();
-            }
-        });
-
-        // Simulate a pending uncommitted op (e.g. nudge in debounce).
-        manager.Record(CreateTestOperation());
-
-        bool redone = manager.Redo();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(redone, Is.True);
-            Assert.That(_root.Value, Is.EqualTo(100));
-            Assert.That(manager.CanRedo, Is.False);
-            Assert.That(manager.UndoCount, Is.EqualTo(1));
-        });
-    }
-
-    [Test]
-    public void BeforeMutation_JumpTo_FiresWithJumpToKind()
-    {
-        using var manager = new HistoryManager(_root, _sequenceGenerator);
-        manager.Record(CreateTestOperation());
-        manager.Commit("Step");
-
-        HistoryMutationKind? observedKind = null;
-        using var subscription = manager.BeforeMutation.Subscribe(kind => observedKind = kind);
-
-        manager.JumpTo(0);
-
-        Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.JumpTo));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1828,17 +1828,17 @@ public class HistoryManagerTests
     #region BeforeMutation Tests
 
     [Test]
-    public void BeforeMutation_Undo_FiresBeforeStackMutates()
+    public void BeforeMutation_Undo_FiresWithUndoKindBeforeStackMutates()
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         manager.Record(CreateTestOperation());
         manager.Commit("Step");
 
         bool undoStackStillFull = false;
-        bool fired = false;
-        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        HistoryMutationKind? observedKind = null;
+        using var subscription = manager.BeforeMutation.Subscribe(kind =>
         {
-            fired = true;
+            observedKind = kind;
             // CanUndo must still be observable as true when subscribers see the event;
             // otherwise a flush handler that inspects history state would see the
             // post-undo world.
@@ -1849,14 +1849,14 @@ public class HistoryManagerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(fired, Is.True);
+            Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.Undo));
             Assert.That(undoStackStillFull, Is.True);
             Assert.That(manager.CanUndo, Is.False);
         });
     }
 
     [Test]
-    public void BeforeMutation_Redo_FiresBeforeStackMutates()
+    public void BeforeMutation_Redo_FiresWithRedoKindBeforeStackMutates()
     {
         using var manager = new HistoryManager(_root, _sequenceGenerator);
         manager.Record(CreateTestOperation());
@@ -1864,10 +1864,10 @@ public class HistoryManagerTests
         manager.Undo();
 
         bool redoStackStillFull = false;
-        bool fired = false;
-        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        HistoryMutationKind? observedKind = null;
+        using var subscription = manager.BeforeMutation.Subscribe(kind =>
         {
-            fired = true;
+            observedKind = kind;
             redoStackStillFull = manager.CanRedo;
         });
 
@@ -1875,10 +1875,63 @@ public class HistoryManagerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(fired, Is.True);
+            Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.Redo));
             Assert.That(redoStackStillFull, Is.True);
             Assert.That(manager.CanRedo, Is.False);
         });
+    }
+
+    [Test]
+    public void BeforeMutation_RedoSubscriberDiscardingPendingOps_KeepsRedoEntry()
+    {
+        // Regression for the redo-stack wipeout: when a subscriber commits inside
+        // a Redo's BeforeMutation, Commit clears _redoStack and the very Redo that
+        // triggered it can no longer pop anything. The contract is that a flush
+        // handler must inspect the kind and only commit on Undo/JumpTo. We
+        // verify by simulating the correct behavior: discard pending ops (rollback)
+        // on Redo, and confirm the Redo still completes against the original entry.
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        _root.Value = 0;
+        CreateValueOperation(manager, 100, 0, "TargetForRedo");
+        manager.Commit("TargetForRedo");
+        manager.Undo();
+
+        using var subscription = manager.BeforeMutation.Subscribe(kind =>
+        {
+            if (kind == HistoryMutationKind.Redo)
+            {
+                // Correct subscriber: only rollback pending, do NOT commit.
+                manager.Rollback();
+            }
+        });
+
+        // Simulate a pending uncommitted op (e.g. nudge in debounce).
+        manager.Record(CreateTestOperation());
+
+        bool redone = manager.Redo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(redone, Is.True);
+            Assert.That(_root.Value, Is.EqualTo(100));
+            Assert.That(manager.CanRedo, Is.False);
+            Assert.That(manager.UndoCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void BeforeMutation_JumpTo_FiresWithJumpToKind()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("Step");
+
+        HistoryMutationKind? observedKind = null;
+        using var subscription = manager.BeforeMutation.Subscribe(kind => observedKind = kind);
+
+        manager.JumpTo(0);
+
+        Assert.That(observedKind, Is.EqualTo(HistoryMutationKind.JumpTo));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1824,4 +1824,121 @@ public class HistoryManagerTests
     }
 
     #endregion
+
+    #region BeforeMutation Tests
+
+    [Test]
+    public void BeforeMutation_Undo_FiresBeforeStackMutates()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("Step");
+
+        bool undoStackStillFull = false;
+        bool fired = false;
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        {
+            fired = true;
+            // CanUndo must still be observable as true when subscribers see the event;
+            // otherwise a flush handler that inspects history state would see the
+            // post-undo world.
+            undoStackStillFull = manager.CanUndo;
+        });
+
+        manager.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fired, Is.True);
+            Assert.That(undoStackStillFull, Is.True);
+            Assert.That(manager.CanUndo, Is.False);
+        });
+    }
+
+    [Test]
+    public void BeforeMutation_Redo_FiresBeforeStackMutates()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("Step");
+        manager.Undo();
+
+        bool redoStackStillFull = false;
+        bool fired = false;
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        {
+            fired = true;
+            redoStackStillFull = manager.CanRedo;
+        });
+
+        manager.Redo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fired, Is.True);
+            Assert.That(redoStackStillFull, Is.True);
+            Assert.That(manager.CanRedo, Is.False);
+        });
+    }
+
+    [Test]
+    public void BeforeMutation_SubscriberCommit_LandsAsSeparateUndoEntry()
+    {
+        // Reproduces the timeline-nudge flush contract: a subscriber Commit
+        // during Undo must produce an undo entry of its own that gets popped
+        // by the very Undo that triggered it, not merged with the prior entry.
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("First");
+
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        {
+            // Simulate a debounced edit that was still pending in a flush handler.
+            manager.Record(CreateTestOperation());
+            manager.Commit("Pending");
+        });
+
+        int undoCountBefore = manager.UndoCount;
+        manager.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(undoCountBefore, Is.EqualTo(1));
+            // After commit-from-subscriber (push) + Undo (pop), the user's prior
+            // commit must remain on the stack.
+            Assert.That(manager.UndoCount, Is.EqualTo(1));
+            Assert.That(manager.PeekUndo()!.DisplayName, Is.EqualTo("First"));
+        });
+    }
+
+    [Test]
+    public void BeforeMutation_SubscriberThrows_DoesNotAbortUndo()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("Step");
+
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+            throw new InvalidOperationException("subscriber blew up"));
+
+        Assert.DoesNotThrow(() => manager.Undo());
+        Assert.That(manager.CanUndo, Is.False);
+    }
+
+    [Test]
+    public void BeforeMutation_Dispose_CompletesObservable()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+
+        bool completed = false;
+        using var subscription = manager.BeforeMutation.Subscribe(
+            _ => { },
+            () => completed = true);
+
+        manager.Dispose();
+
+        Assert.That(completed, Is.True);
+    }
+
+    #endregion
 }

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1926,6 +1926,35 @@ public class HistoryManagerTests
     }
 
     [Test]
+    public void BeforeMutation_JumpTo_FiresBeforeWalkBegins()
+    {
+        // Pending nudge operations live on _currentTransaction; without a flush
+        // before JumpTo walks the stacks, those operations would silently revert
+        // and never reach the undo history.
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("First");
+
+        using var subscription = manager.BeforeMutation.Subscribe(_ =>
+        {
+            manager.Record(CreateTestOperation());
+            manager.Commit("Pending");
+        });
+
+        int undoCountBefore = manager.UndoCount;
+        manager.JumpTo(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(undoCountBefore, Is.EqualTo(1));
+            // After flush (push) + JumpTo to 0 (walks both back to redo), no
+            // entries should be on the undo stack but both should be recoverable.
+            Assert.That(manager.UndoCount, Is.EqualTo(0));
+            Assert.That(manager.RedoCount, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
     public void BeforeMutation_Dispose_CompletesObservable()
     {
         var manager = new HistoryManager(_root, _sequenceGenerator);

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
@@ -1,4 +1,4 @@
-using Beutl.ProjectSystem;
+﻿using Beutl.ProjectSystem;
 using NUnit.Framework.Legacy;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
@@ -70,6 +70,27 @@ public class SceneMoveChildrenTests
     }
 
     [Test]
+    public void MoveChildren_NonZeroDeltaIndex_ShiftsZIndex()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element element = CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+            scene.Children.Add(element);
+
+            scene.MoveChildren(+2, TimeSpan.Zero, [element]);
+
+            ClassicAssert.AreEqual(3, element.ZIndex);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(2), element.Start);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void MoveChildren_MultipleElements_AllShiftTogether()
     {
         string basePath = GetTempPath();

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
@@ -1,0 +1,94 @@
+using Beutl.ProjectSystem;
+using NUnit.Framework.Legacy;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class SceneMoveChildrenTests
+{
+    private static string GetTempPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"beutl_scene_movechildren_{Guid.NewGuid():N}");
+    }
+
+    private static Scene CreateScene(string basePath)
+    {
+        Directory.CreateDirectory(basePath);
+        return new Scene(100, 100, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(basePath, "test.scene"))
+        };
+    }
+
+    private static Element CreateElement(string basePath, TimeSpan start, TimeSpan length, int zIndex = 0)
+    {
+        return new Element
+        {
+            Start = start,
+            Length = length,
+            ZIndex = zIndex,
+            Uri = new Uri(Path.Combine(basePath, $"{Guid.NewGuid():N}.layer"))
+        };
+    }
+
+    [Test]
+    public void MoveChildren_SingleElement_ShiftsStartByDelta()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element element = CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+            scene.Children.Add(element);
+
+            scene.MoveChildren(0, TimeSpan.FromSeconds(1), [element]);
+
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(3), element.Start);
+            ClassicAssert.AreEqual(0, element.ZIndex);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void MoveChildren_EmptyArray_Throws()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+
+            ClassicAssert.Throws<ArgumentOutOfRangeException>(
+                () => scene.MoveChildren(0, TimeSpan.FromSeconds(1), []));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void MoveChildren_MultipleElements_AllShiftTogether()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1), zIndex: 1);
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+
+            scene.MoveChildren(0, TimeSpan.FromSeconds(1), [a, b]);
+
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(3), a.Start);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(5), b.Start);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneMoveChildrenTests.cs
@@ -91,6 +91,31 @@ public class SceneMoveChildrenTests
     }
 
     [Test]
+    public void MoveChildren_ConflictingShift_LeavesElementUnchanged()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element movable = CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element obstacle = CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+            scene.Children.Add(movable);
+            scene.Children.Add(obstacle);
+
+            // movable を obstacle の ZIndex に重ねようとすると衝突する。
+            // 時間方向の自動補正は効かないので no-op になる契約。
+            scene.MoveChildren(+1, TimeSpan.Zero, [movable]);
+
+            ClassicAssert.AreEqual(0, movable.ZIndex);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(2), movable.Start);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void MoveChildren_MultipleElements_AllShiftTogether()
     {
         string basePath = GetTempPath();


### PR DESCRIPTION
## Description

- Add timeline-element nudge shortcuts using the `,` / `.` keys (Premiere / DaVinci / Final Cut convention) to move the selection by 1 frame, 10 frames (Shift), or 1 second (Alt). Arrow keys were intentionally avoided to prevent collisions with SceneEditor Previous/Next, macOS `Cmd+Left/Right` SeekStart/SeekEnd, and Marker navigation (`Ctrl/Alt+Left/Right`).
- Consecutive presses are merged into a single undoable transaction via a 300 ms debounced `HistoryManager.Commit`, so rapid adjustments produce one history entry instead of dozens. The pending edit is also flushed before Undo / Redo / JumpTo so debounced state never bleeds into an unrelated history operation.
- Adds `HistoryManager.BeforeMutation` (IObservable) which fires immediately before Undo / Redo / JumpTo. Subscriber exceptions are caught and logged so a misbehaving flush handler cannot abort the history mutation that triggered it.
- Group-aware: when any member of a group is selected, the whole group moves together, mirroring the existing drag-move behaviour. The anchor element is picked deterministically from the selection so the visible move target is stable.
- Text-input guard: nudge is suppressed while focus is in a `TextBox` or any descendant text-input source (renaming etc.), not just a bare `TextBox`.
- Hardening: unknown `NudgeUnit` now fails fast instead of silently no-op; the commit-timer tick swallows `ObjectDisposedException` so a tick racing `Dispose` does not crash; and `TimelineTabViewModel.Dispose` no longer throws if the final flush fails.

## Breaking changes

- `Scene.MoveChildren(int, TimeSpan, Element[])` argument validation was relaxed from `elements.Length < 2` to `elements.Length < 1` so a single element can be moved through `MultipleMoveCommand` (used by the nudge transaction). The only in-tree caller (`ElementView.axaml.cs`) still guards with `elems.Length > 1`, so behaviour for existing callers is unchanged. Public-API consumers that depended on the previous `ArgumentOutOfRangeException` for single-element arrays will no longer see it thrown.
- New public surface on `HistoryManager`: `IObservable<Unit> BeforeMutation`. Additive only; no existing member changed signature.

## Fixed issues

- None (tracked on the AI Review project board as a Todo item; no GitHub issue is linked yet).