### PR TITLE
fix: harden cancellation handling in IpcConnection multiplexed path

### DIFF
--- a/Beutl.slnx
+++ b/Beutl.slnx
@@ -29,6 +29,7 @@
     <Project Path="tests\Beutl.Benchmarks\Beutl.Benchmarks.csproj" />
     <Project Path="tests\Beutl.Extensions.AVFoundation.Tests\Beutl.Extensions.AVFoundation.Tests.csproj" />
     <Project Path="tests\Beutl.FFmpegBenchmarks\Beutl.FFmpegBenchmarks.csproj" />
+    <Project Path="tests\Beutl.FFmpegIpc.Tests\Beutl.FFmpegIpc.Tests.csproj" />
     <Project Path="tests\Beutl.UnitTests\Beutl.UnitTests.csproj" />
     <Project Path="tests\DirectoryViewTest\DirectoryViewTest.csproj" />
     <Project Path="tests\EnumerateFontFamilies\EnumerateFontFamilies.csproj" />

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -192,11 +192,8 @@ public sealed class FFmpegWorkerProcess : IDisposable
         _connection = new IpcConnection(pipeServer)
         {
             // 受信ループ / Dispose 異常系の診断は ILogger に転送する。
-            DiagnosticLogger = (msg, ex) =>
-            {
-                if (ex != null) s_logger.LogError(ex, "{Message}", msg);
-                else s_logger.LogError("{Message}", msg);
-            },
+            // LogError(Exception?, ...) は ex が null でも受け付ける。
+            DiagnosticLogger = (msg, ex) => s_logger.LogError(ex, "{Message}", msg),
             // 現状ホスト側のリードはキャンセルトークンを渡しておらず、
             // 共有メモリは参照カウントで管理されるため通常は呼ばれない。
             // 将来 CancellationToken 対応リードを追加した際のリグレッション検知として

--- a/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegWorkerProcess.cs
@@ -189,7 +189,21 @@ public sealed class FFmpegWorkerProcess : IDisposable
             throw;
         }
 
-        _connection = new IpcConnection(pipeServer);
+        _connection = new IpcConnection(pipeServer)
+        {
+            // 受信ループ / Dispose 異常系の診断は ILogger に転送する。
+            DiagnosticLogger = (msg, ex) =>
+            {
+                if (ex != null) s_logger.LogError(ex, "{Message}", msg);
+                else s_logger.LogError("{Message}", msg);
+            },
+            // 現状ホスト側のリードはキャンセルトークンを渡しておらず、
+            // 共有メモリは参照カウントで管理されるため通常は呼ばれない。
+            // 将来 CancellationToken 対応リードを追加した際のリグレッション検知として
+            // 観測のみログに残す (実際のバッファ解放は消費側の責務とする)。
+            DroppedResponseHandler = msg => s_logger.LogWarning(
+                "Dropped IPC response Id={Id} Type={Type}; no awaiter present.", msg.Id, msg.Type)
+        };
 
         // ハンドシェイク待機（プロトコルバージョン検証）
         var handshake = await _connection.ReceiveAsync(ct)

--- a/src/Beutl.FFmpegIpc/Beutl.FFmpegIpc.csproj
+++ b/src/Beutl.FFmpegIpc/Beutl.FFmpegIpc.csproj
@@ -6,4 +6,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Beutl.FFmpegIpc.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -348,44 +348,53 @@ public sealed class IpcConnection : IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        _receiveLoopCts?.Cancel();
-
-        // 受信ループを待ってからパイプ/セマフォを破棄する。先にパイプを破棄すると
-        // 進行中の ReadMessageAsync が ObjectDisposedException で死に、自己 Dispose が
-        // 誤って "broken pipe" として pending リクエストに伝播してしまう。上限を切って
-        // 待つことで、ループ内ハング (理論上ありえない) でも Dispose は必ず進む。
+        ExceptionDispatchInfo? fatalToRethrow = null;
         try
         {
-            if (_receiveLoopTask is { } task && !task.Wait(TimeSpan.FromSeconds(5)))
+            _receiveLoopCts?.Cancel();
+
+            // 受信ループを待ってからパイプ/セマフォを破棄する。先にパイプを破棄すると
+            // 進行中の ReadMessageAsync が ObjectDisposedException で死に、自己 Dispose が
+            // 誤って "broken pipe" として pending リクエストに伝播してしまう。上限を切って
+            // 待つことで、ループ内ハング (理論上ありえない) でも Dispose は必ず進む。
+            try
             {
-                // タイムアウト = ループが停止しなかった。続行するとパイプ破棄で
-                // ObjectDisposedException を引き起こし、その先で診断が消える。
-                // 続行はするが、痕跡が残るよう Trace に出す。
-                Trace.TraceError("IpcConnection.Dispose: receive loop did not exit within 5s; proceeding with disposal.");
+                if (_receiveLoopTask is { } task && !task.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    // タイムアウト = ループが停止しなかった。続行するとパイプ破棄で
+                    // ObjectDisposedException を引き起こし、その先で診断が消える。
+                    // 続行はするが、痕跡が残るよう Trace に出す。
+                    Trace.TraceError("IpcConnection.Dispose: receive loop did not exit within 5s; proceeding with disposal.");
+                }
+            }
+            catch (AggregateException ex)
+            {
+                // 受信ループ内例外は finally で pending TCS / _receiveLoopFault へ伝播済みだが、
+                // Dispose 時の根因をたどれるよう原例外を残す。
+                Trace.TraceError($"IpcConnection.Dispose: receive loop ended with exception: {ex}");
+
+                // 受信ループの generic catch が除外している致命系 (OOM/SOE/AVE) は
+                // Dispose 経路でも握りつぶさず再 throw する。リソース解放後に投げ直すため
+                // ExceptionDispatchInfo として捕捉だけしておく。
+                var fatal = ex.InnerExceptions.FirstOrDefault(static e =>
+                    e is OutOfMemoryException or StackOverflowException or AccessViolationException);
+                if (fatal != null)
+                {
+                    fatalToRethrow = ExceptionDispatchInfo.Capture(fatal);
+                }
             }
         }
-        catch (AggregateException ex)
+        finally
         {
-            // 受信ループ内例外は finally で pending TCS / _receiveLoopFault へ伝播済みだが、
-            // Dispose 時の根因をたどれるよう原例外を残す。
-            Trace.TraceError($"IpcConnection.Dispose: receive loop ended with exception: {ex}");
-
-            // 受信ループの generic catch が除外している致命系 (OOM/SOE/AVE) は
-            // Dispose 経路でも握りつぶさず再 throw する。さもないと receive-loop の
-            // exclusion 規約がこの行で undo される。
-            var fatal = ex.InnerExceptions.FirstOrDefault(static e =>
-                e is OutOfMemoryException or StackOverflowException or AccessViolationException);
-            if (fatal != null)
-            {
-                ExceptionDispatchInfo.Capture(fatal).Throw();
-            }
+            // task.Wait が AggregateException 以外の例外 (ObjectDisposedException 等) で
+            // 抜けても、パイプ/セマフォ/CTS は必ず解放してハンドルリークを防ぐ。
+            _receiveLoopCts?.Dispose();
+            _requestLock.Dispose();
+            _writeLock.Dispose();
+            _readLock.Dispose();
+            _pipe.Dispose();
         }
 
-        _receiveLoopCts?.Dispose();
-
-        _requestLock.Dispose();
-        _writeLock.Dispose();
-        _readLock.Dispose();
-        _pipe.Dispose();
+        fatalToRethrow?.Throw();
     }
 }

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipes;
+using System.Runtime.ExceptionServices;
 using Beutl.FFmpegIpc.Protocol;
 
 namespace Beutl.FFmpegIpc.Transport;
@@ -381,6 +382,16 @@ public sealed class IpcConnection : IDisposable
             // 受信ループ内例外は finally で pending TCS / _receiveLoopFault へ伝播済みだが、
             // Dispose 時の根因をたどれるよう原例外を残す。
             Trace.TraceError($"IpcConnection.Dispose: receive loop ended with exception: {ex}");
+
+            // 受信ループの generic catch が除外している致命系 (OOM/SOE/AVE) は
+            // Dispose 経路でも握りつぶさず再 throw する。さもないと receive-loop の
+            // exclusion 規約がこの行で undo される。
+            var fatal = ex.InnerExceptions.FirstOrDefault(static e =>
+                e is OutOfMemoryException or StackOverflowException or AccessViolationException);
+            if (fatal != null)
+            {
+                ExceptionDispatchInfo.Capture(fatal).Throw();
+            }
         }
 
         _receiveLoopCts?.Dispose();

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -137,7 +137,7 @@ public sealed class IpcConnection : IDisposable
                     }
                 }
             }
-        }, loopCt);
+        }, CancellationToken.None);
     }
 
     public async ValueTask SendAsync(IpcMessage message, CancellationToken ct = default)

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -20,7 +20,7 @@ public sealed class IpcConnection : IDisposable
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private readonly SemaphoreSlim _readLock = new(1, 1);
     private int _nextId;
-    private bool _disposed;
+    private volatile bool _disposed;
 
     // 多重化モード用
     private readonly ConcurrentDictionary<int, TaskCompletionSource<IpcMessage>> _pendingRequests = new();
@@ -314,6 +314,20 @@ public sealed class IpcConnection : IDisposable
         _disposed = true;
 
         _receiveLoopCts?.Cancel();
+
+        // 受信ループを待ってからパイプ/セマフォを破棄する。先にパイプを破棄すると
+        // 進行中の ReadMessageAsync が ObjectDisposedException で死に、自己 Dispose が
+        // 誤って "broken pipe" として pending リクエストに伝播してしまう。上限を切って
+        // 待つことで、ループ内ハング (理論上ありえない) でも Dispose は必ず進む。
+        try
+        {
+            _receiveLoopTask?.Wait(TimeSpan.FromSeconds(5));
+        }
+        catch (AggregateException)
+        {
+            // 受信ループ内例外は finally で pending TCS へ伝播済み。
+        }
+
         _receiveLoopCts?.Dispose();
 
         _requestLock.Dispose();

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -9,7 +9,9 @@ namespace Beutl.FFmpegIpc.Transport;
 /// 名前付きパイプ上のIPC接続。リクエスト/レスポンスの送受信を行う。
 /// 通常モード: SendAndReceiveAsync で逐次リクエスト/レスポンス。
 /// 多重化モード: StartMultiplexedReceive でバックグラウンド受信ループを開始し、
-///              IDベースで並行リクエスト/レスポンスを実現する。
+///              IDベースで並行リクエスト/レスポンスを実現する。送信元のキャンセルと
+///              レスポンス到着がレースしうるため、待機者を失ったレスポンスは
+///              <see cref="DroppedResponseHandler"/> 経由でドレインされる。
 /// </summary>
 public sealed class IpcConnection : IDisposable
 {
@@ -35,9 +37,15 @@ public sealed class IpcConnection : IDisposable
     public bool IsMultiplexed => _receiveLoopTask != null;
 
     /// <summary>
-    /// 多重化モードで、対応する待機者が居ない/既にキャンセル済みの待機者にメッセージが
-    /// 届いた場合に呼ばれるフック。共有メモリバッファ (bufferIndex 等) のセマンティクスを
-    /// 持つ上位レイヤーがリソース解放のために設定する。例外を投げないこと。
+    /// 多重化モードでルーティング先を失ったレスポンスを受け取るフック。
+    /// 次のいずれかで呼ばれる:
+    ///   - <c>_pendingRequests</c> から TCS を取り出せたがキャンセル済みで TrySetResult が失敗した。
+    ///   - 対応する <c>request.Id</c> の TCS が <c>_pendingRequests</c> に居なかった (キャンセル後到着の stray)。
+    /// 主用途は共有メモリバッファ (bufferIndex 等) を握っているレスポンスを上位レイヤー
+    /// (例: <c>IpcFrameProvider</c>) で解放するセマフォとなること。
+    /// 呼び出しは受信ループスレッドで同期的に行われるため、ブロックすると後続メッセージの
+    /// 処理が遅延する。例外は投げないことを契約とするが、万一スローした場合でも受信ループは
+    /// 継続し、内容は <see cref="Trace"/> に記録される。
     /// </summary>
     public Action<IpcMessage>? DroppedResponseHandler { get; set; }
 
@@ -236,6 +244,9 @@ public sealed class IpcConnection : IDisposable
 
         // SendAsync の前にキャンセルを購読し、送信中・受信待機中いずれの局面でも
         // ct 発火が確実に tcs へ伝播するようにする。
+        // 旧実装は SendAsync 完了後に Register していたため、送信成功とキャンセル発火と
+        // レスポンス到着が同時に走ると、TCS が中途半端に解決されず競合の隙間で
+        // バッファインデックスを未消費のまま落とすケースがあった。
         using var registration = ct.Register(static state =>
         {
             var (innerTcs, token) = ((TaskCompletionSource<IpcMessage> Tcs, CancellationToken Token))state!;
@@ -254,8 +265,11 @@ public sealed class IpcConnection : IDisposable
         }
         finally
         {
-            // 自身が登録した TCS のみを撤去する。受信ループが先に取り出していれば
-            // TryRemove は失敗し、別 ID で再利用された TCS は誤って消さない。
+            // 自身が登録した TCS のみを撤去する (KeyValuePair オーバーロード)。
+            // 受信ループが先に取り出していれば TryRemove は失敗する。
+            // 通常 _nextId は単調増加するが int を一巡 (2^31 件) すると同じ Id が
+            // 再利用されうるため、value 一致を要求して別リクエストの TCS を
+            // 誤って消さないようにする防御的措置。
             _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
         }
     }

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -284,7 +284,14 @@ public sealed class IpcConnection : IDisposable
             throw fault;
 
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _pendingRequests[request.Id] = tcs;
+        // 同じ Id が既に in-flight なら、indexer 代入だと前 TCS を黙って捨てて永久 await が
+        // 生まれる。TryAdd で衝突を表面化する。_nextId が int を一巡して再利用された場合や、
+        // 呼び出し元が手動 Id を渡すバグでも、症状が確実に上に伝わる。
+        if (!_pendingRequests.TryAdd(request.Id, tcs))
+        {
+            throw new InvalidOperationException(
+                $"Request id {request.Id} is already in flight on this multiplexed connection.");
+        }
 
         // 登録→fault チェックの順を逆にできない: 逆だと「fault 読み (null)」→「ループが
         // finally で fault 書き&foreach (空)」→「登録」のレースで永久 await になる。

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -71,10 +71,12 @@ public sealed class IpcConnection : IDisposable
 
         _receiveLoopTask = Task.Run(async () =>
         {
-            // 受信ループが I/O 障害で終了した場合、待機中の TCS にはキャンセルではなく
-            // この例外を伝播させることで「ユーザーがキャンセルした」と「ワーカーが落ちた」を
-            // 呼び出し元から区別可能にする。OperationCanceledException / ObjectDisposedException
-            // (= 正常終了) のときは null のまま finally で TrySetCanceled される。
+            // 受信ループが終了する理由を以下のように区別する:
+            //   - loopCt キャンセル/ObjectDisposedException: 自プロセス由来の停止。
+            //     finally で待機中 TCS を TrySetCanceled(loopCt) してキャンセル扱い。
+            //   - EOF (msg == null) / IOException: 相手側起因の切断。
+            //     terminationError に詰めて TrySetException で伝播し、
+            //     「ユーザーがキャンセル」と「接続が死んだ」を呼び出し元から区別可能にする。
             Exception? terminationError = null;
             try
             {
@@ -82,7 +84,11 @@ public sealed class IpcConnection : IDisposable
                 {
                     var msg = await MessageSerializer.ReadMessageAsync(_pipe, loopCt).ConfigureAwait(false);
                     if (msg == null)
+                    {
+                        terminationError = new IOException(
+                            "IPC receive loop terminated: remote endpoint closed the pipe.");
                         break;
+                    }
 
                     if (_pendingRequests.TryRemove(msg.Id, out var tcs))
                     {

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -45,11 +45,12 @@ public sealed class IpcConnection : IDisposable
     /// 次のいずれかで呼ばれる:
     ///   - <c>_pendingRequests</c> から TCS を取り出せたがキャンセル済みで TrySetResult が失敗した。
     ///   - 対応する <c>request.Id</c> の TCS が <c>_pendingRequests</c> に居なかった (キャンセル後到着の stray)。
-    /// 主用途は共有メモリバッファ (bufferIndex 等) を握っているレスポンスを上位レイヤー
-    /// (例: <c>IpcFrameProvider</c>) で解放するセマフォとなること。
+    /// 想定する使い方は、共有メモリバッファ (bufferIndex 等) を握ったまま捨てられるレスポンスを
+    /// 上位レイヤーで解放するためのコールバック。現状は配線されておらず、配線するのは消費側 (例:
+    /// IpcFrameProvider) の責務とする。
     /// 呼び出しは受信ループスレッドで同期的に行われるため、ブロックすると後続メッセージの
     /// 処理が遅延する。例外は投げないことを契約とするが、万一スローした場合でも受信ループは
-    /// 継続し、内容は <see cref="Trace"/> に記録される。
+    /// 継続し、内容は <see cref="System.Diagnostics.Trace.TraceError(string)"/> に記録される。
     /// </summary>
     public Action<IpcMessage>? DroppedResponseHandler { get; set; }
 
@@ -81,6 +82,8 @@ public sealed class IpcConnection : IDisposable
             //   - EOF (msg == null) / IOException: 相手側起因の切断。
             //     terminationError に詰めて TrySetException で伝播し、
             //     「ユーザーがキャンセル」と「接続が死んだ」を呼び出し元から区別可能にする。
+            //   - 想定外例外 (プロトコル破損/JSON 失敗 など): 同じ termination 経路に集約し、
+            //     IOException として待機中 TCS と _receiveLoopFault に伝播する。
             Exception? terminationError = null;
             try
             {
@@ -136,7 +139,8 @@ public sealed class IpcConnection : IDisposable
                     Volatile.Write(ref _receiveLoopFault, terminationError);
 
                 // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、
-                // それ以外 (正常クローズ / loopCt キャンセル) は loopCt 付きでキャンセル。
+                // それ以外 (ObjectDisposed / loopCt キャンセル) は loopCt 付きでキャンセル。
+                // EOF は terminationError 経路を通るのでここでは TrySetException 側に入る点に注意。
                 foreach (var kvp in _pendingRequests)
                 {
                     if (_pendingRequests.TryRemove(kvp.Key, out var tcs))
@@ -308,10 +312,10 @@ public sealed class IpcConnection : IDisposable
         finally
         {
             // 自身が登録した TCS のみを撤去する (KeyValuePair オーバーロード)。
-            // 受信ループが先に取り出していれば TryRemove は失敗する。
-            // 通常 _nextId は単調増加するが int を一巡 (2^31 件) すると同じ Id が
-            // 再利用されうるため、value 一致を要求して別リクエストの TCS を
-            // 誤って消さないようにする防御的措置。
+            // 主目的は受信ループとのレース対策: ループが先にこのスロットを取り出して
+            // 別レスポンスを刺し直していた場合、参照不一致になり TryRemove は失敗 — 別リクエストの
+            // TCS を取り違えて消すのを防ぐ。副次的に、_nextId が int を一巡 (2^31 件) して Id が
+            // 再利用された場合の保険も兼ねる。
             _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
         }
     }

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -52,11 +52,33 @@ public sealed class IpcConnection : IDisposable
     /// IpcFrameProvider) の責務とする。
     /// 呼び出しは受信ループスレッドで同期的に行われるため、ブロックすると後続メッセージの
     /// 処理が遅延する。例外は投げないことを契約とするが、非致命例外をスローしても
-    /// 受信ループは継続し、内容は <see cref="System.Diagnostics.Trace.TraceError(string)"/>
-    /// に記録される。OOM/SOE/AVE 等の致命例外は呼び出し元 (受信ループ) に伝播し、
+    /// 受信ループは継続し、内容は <see cref="DiagnosticLogger"/> (未設定時は
+    /// <see cref="System.Diagnostics.Trace.TraceError(string)"/>) に記録される。
+    /// OOM/SOE/AVE 等の致命例外は呼び出し元 (受信ループ) に伝播し、
     /// ループを終了させてプロセス状態を上位に晒す。
     /// </summary>
     public Action<IpcMessage>? DroppedResponseHandler { get; set; }
+
+    /// <summary>
+    /// 異常系の診断メッセージを上位レイヤーのロガーに流すためのフック
+    /// (例: ハンドラ例外 / Dispose タイムアウト / 受信ループ終了時の根因)。
+    /// <para>
+    /// 第 1 引数はメッセージ、第 2 引数は関連例外 (無い場合は null)。
+    /// </para>
+    /// <para>
+    /// 本ライブラリは依存ゼロを保つため <see cref="System.Diagnostics.Trace"/> を
+    /// デフォルトの出力先とするが、ホスト側 (例: Beutl.Extensions.FFmpeg の
+    /// <c>Microsoft.Extensions.Logging.ILogger</c>) やワーカー側 (例: Beutl.FFmpegWorker
+    /// の <c>WorkerLog</c>) はこのフックを設定して各レイヤーの慣習に合わせたロガーへ
+    /// 転送できる。フックが <c>null</c> の場合、メッセージは <see cref="System.Diagnostics.Trace.TraceError(string)"/>
+    /// に出力される。
+    /// </para>
+    /// <para>
+    /// フック内例外は飲み込まれ、診断は <see cref="System.Diagnostics.Trace"/> に
+    /// フォールバックする。受信ループや Dispose を巻き込まないことを優先する。
+    /// </para>
+    /// </summary>
+    public Action<string, Exception?>? DiagnosticLogger { get; set; }
 
     public int NextId() => Interlocked.Increment(ref _nextId);
 
@@ -345,9 +367,51 @@ public sealed class IpcConnection : IDisposable
                                        and not StackOverflowException
                                        and not AccessViolationException)
         {
-            // ハンドラ例外は受信ループを止めない。診断のため Trace へ送る。
-            Trace.TraceError(
-                $"IpcConnection.DroppedResponseHandler threw {ex.GetType().Name} for message Id={message.Id} Type={message.Type}: {ex}");
+            // ハンドラ例外は受信ループを止めない。診断のため上位ロガーへ送る。
+            WriteDiagnostic(
+                $"IpcConnection.DroppedResponseHandler threw {ex.GetType().Name} for message Id={message.Id} Type={message.Type}.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// 異常系の診断メッセージを出力する。<see cref="DiagnosticLogger"/> が設定されていれば
+    /// そちらへ、無ければ <see cref="Trace.TraceError(string)"/> へフォールバックする。
+    /// フック自身が例外を投げても受信ループ / Dispose を巻き込まないよう、二重に try-catch する。
+    /// </summary>
+    private void WriteDiagnostic(string message, Exception? exception = null)
+    {
+        var logger = DiagnosticLogger;
+        if (logger != null)
+        {
+            try
+            {
+                logger(message, exception);
+                return;
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException
+                                           and not StackOverflowException
+                                           and not AccessViolationException)
+            {
+                // フック自身の例外。フォールバックの Trace 出力に切り替える。
+                try
+                {
+                    Trace.TraceError(
+                        $"IpcConnection.DiagnosticLogger threw {ex.GetType().Name}: {ex}. Original message: {message}{(exception != null ? " | " + exception : string.Empty)}");
+                }
+                catch
+                {
+                }
+                return;
+            }
+        }
+
+        try
+        {
+            Trace.TraceError(exception != null ? $"{message} {exception}" : message);
+        }
+        catch
+        {
         }
     }
 
@@ -370,15 +434,15 @@ public sealed class IpcConnection : IDisposable
                 {
                     // タイムアウト = ループが停止しなかった。続行するとパイプ破棄で
                     // ObjectDisposedException を引き起こし、その先で診断が消える。
-                    // 続行はするが、痕跡が残るよう Trace に出す。
-                    Trace.TraceError("IpcConnection.Dispose: receive loop did not exit within 5s; proceeding with disposal.");
+                    // 続行はするが、痕跡が残るよう上位ロガーへ出す。
+                    WriteDiagnostic("IpcConnection.Dispose: receive loop did not exit within 5s; proceeding with disposal.");
                 }
             }
             catch (AggregateException ex)
             {
                 // 受信ループ内例外は finally で pending TCS / _receiveLoopFault へ伝播済みだが、
                 // Dispose 時の根因をたどれるよう原例外を残す。
-                Trace.TraceError($"IpcConnection.Dispose: receive loop ended with exception: {ex}");
+                WriteDiagnostic("IpcConnection.Dispose: receive loop ended with exception.", ex);
 
                 // 受信ループの generic catch が除外している致命系 (OOM/SOE/AVE) は
                 // Dispose 経路でも握りつぶさず再 throw する。リソース解放後に投げ直すため

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -357,11 +357,19 @@ public sealed class IpcConnection : IDisposable
         // 待つことで、ループ内ハング (理論上ありえない) でも Dispose は必ず進む。
         try
         {
-            _receiveLoopTask?.Wait(TimeSpan.FromSeconds(5));
+            if (_receiveLoopTask is { } task && !task.Wait(TimeSpan.FromSeconds(5)))
+            {
+                // タイムアウト = ループが停止しなかった。続行するとパイプ破棄で
+                // ObjectDisposedException を引き起こし、その先で診断が消える。
+                // 続行はするが、痕跡が残るよう Trace に出す。
+                Trace.TraceError("IpcConnection.Dispose: receive loop did not exit within 5s; proceeding with disposal.");
+            }
         }
-        catch (AggregateException)
+        catch (AggregateException ex)
         {
-            // 受信ループ内例外は finally で pending TCS へ伝播済み。
+            // 受信ループ内例外は finally で pending TCS / _receiveLoopFault へ伝播済みだが、
+            // Dispose 時の根因をたどれるよう原例外を残す。
+            Trace.TraceError($"IpcConnection.Dispose: receive loop ended with exception: {ex}");
         }
 
         _receiveLoopCts?.Dispose();

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -256,19 +256,21 @@ public sealed class IpcConnection : IDisposable
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pendingRequests[request.Id] = tcs;
 
-        // SendAsync の前にキャンセルを購読し、送信中・受信待機中いずれの局面でも
-        // ct 発火が確実に tcs へ伝播するようにする。
-        // 旧実装は SendAsync 完了後に Register していたため、送信成功とキャンセル発火と
-        // レスポンス到着が同時に走ると、TCS が中途半端に解決されず競合の隙間で
-        // バッファインデックスを未消費のまま落とすケースがあった。
-        using var registration = ct.Register(static state =>
-        {
-            var (innerTcs, token) = ((TaskCompletionSource<IpcMessage> Tcs, CancellationToken Token))state!;
-            innerTcs.TrySetCanceled(token);
-        }, (tcs, ct));
-
         try
         {
+            // SendAsync の前にキャンセルを購読し、送信中・受信待機中いずれの局面でも
+            // ct 発火が確実に tcs へ伝播するようにする。
+            // 旧実装は SendAsync 完了後に Register していたため、送信成功とキャンセル発火と
+            // レスポンス到着が同時に走ると、TCS が中途半端に解決されず競合の隙間で
+            // バッファインデックスを未消費のまま落とすケースがあった。
+            // Register 自体は ObjectDisposedException 等で失敗しうるため try の内側
+            // に置き、失敗時にも finally で pending を確実に撤去する。
+            using var registration = ct.Register(static state =>
+            {
+                var (innerTcs, token) = ((TaskCompletionSource<IpcMessage> Tcs, CancellationToken Token))state!;
+                innerTcs.TrySetCanceled(token);
+            }, (tcs, ct));
+
             await SendAsync(request, ct).ConfigureAwait(false);
             var response = await tcs.Task.ConfigureAwait(false);
 

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -33,6 +33,13 @@ public sealed class IpcConnection : IDisposable
 
     public bool IsMultiplexed => _receiveLoopTask != null;
 
+    /// <summary>
+    /// 多重化モードで、対応する待機者が居ない/既にキャンセル済みの待機者にメッセージが
+    /// 届いた場合に呼ばれるフック。共有メモリバッファ (bufferIndex 等) のセマンティクスを
+    /// 持つ上位レイヤーがリソース解放のために設定する。例外を投げないこと。
+    /// </summary>
+    public Action<IpcMessage>? DroppedResponseHandler { get; set; }
+
     public int NextId() => Interlocked.Increment(ref _nextId);
 
     /// <summary>
@@ -60,7 +67,18 @@ public sealed class IpcConnection : IDisposable
 
                     if (_pendingRequests.TryRemove(msg.Id, out var tcs))
                     {
-                        tcs.TrySetResult(msg);
+                        // tcs が既にキャンセル済みなら TrySetResult は false を返す。
+                        // その場合、呼び出し元はレスポンスを受け取らないので
+                        // 上位レイヤーに通知してリソース解放のチャンスを与える。
+                        if (!tcs.TrySetResult(msg))
+                        {
+                            InvokeDroppedResponseHandler(msg);
+                        }
+                    }
+                    else
+                    {
+                        // 待機中の TCS が居ない (キャンセル後に到着した stray message)。
+                        InvokeDroppedResponseHandler(msg);
                     }
                 }
             }
@@ -73,7 +91,7 @@ public sealed class IpcConnection : IDisposable
                 foreach (var kvp in _pendingRequests)
                 {
                     if (_pendingRequests.TryRemove(kvp.Key, out var tcs))
-                        tcs.TrySetCanceled();
+                        tcs.TrySetCanceled(loopCt);
                 }
             }
         }, loopCt);
@@ -190,13 +208,22 @@ public sealed class IpcConnection : IDisposable
 
     private async ValueTask<IpcMessage> SendAndReceiveMultiplexedAsync(IpcMessage request, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pendingRequests[request.Id] = tcs;
+
+        // SendAsync の前にキャンセルを購読し、送信中・受信待機中いずれの局面でも
+        // ct 発火が確実に tcs へ伝播するようにする。
+        using var registration = ct.Register(static state =>
+        {
+            var (innerTcs, token) = ((TaskCompletionSource<IpcMessage> Tcs, CancellationToken Token))state!;
+            innerTcs.TrySetCanceled(token);
+        }, (tcs, ct));
 
         try
         {
             await SendAsync(request, ct).ConfigureAwait(false);
-            using var registration = ct.Register(() => tcs.TrySetCanceled(ct));
             var response = await tcs.Task.ConfigureAwait(false);
 
             if (response.Error != null)
@@ -204,10 +231,25 @@ public sealed class IpcConnection : IDisposable
 
             return response;
         }
+        finally
+        {
+            // 自身が登録した TCS のみを撤去する。受信ループが先に取り出していれば
+            // TryRemove は失敗し、別 ID で再利用された TCS は誤って消さない。
+            _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
+        }
+    }
+
+    private void InvokeDroppedResponseHandler(IpcMessage message)
+    {
+        var handler = DroppedResponseHandler;
+        if (handler == null) return;
+        try
+        {
+            handler(message);
+        }
         catch
         {
-            _pendingRequests.TryRemove(request.Id, out _);
-            throw;
+            // ハンドラ例外は受信ループを止めない。
         }
     }
 

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -114,6 +114,14 @@ public sealed class IpcConnection : IDisposable
                 terminationError = new IOException(
                     "IPC receive loop terminated due to a broken pipe. The remote endpoint may have crashed.", ex);
             }
+            catch (Exception ex)
+            {
+                // プロトコル破損 (length out of range, JSON deserialize 失敗, 想定外の状態) など
+                // I/O 以外の例外も同じ termination 経路に集約し、呼び出し元から
+                // 「キャンセル」と「ループが死んだ」を区別可能にする。
+                terminationError = new IOException(
+                    "IPC receive loop terminated due to an unexpected protocol or deserialization error.", ex);
+            }
             finally
             {
                 // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -273,9 +273,11 @@ public sealed class IpcConnection : IDisposable
         ct.ThrowIfCancellationRequested();
 
         // 受信ループが既に死んでいたら、TCS をハングさせずに即時失敗する。
+        // 同じ fault インスタンスが複数 caller に rethrow されるため、各 caller の
+        // スタックトレースが残るよう ExceptionDispatchInfo 経由で投げる。
         var fault = Volatile.Read(ref _receiveLoopFault);
         if (fault != null)
-            throw fault;
+            ExceptionDispatchInfo.Capture(fault).Throw();
 
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         // Id 衝突は indexer 代入だと前 TCS を黙って捨てて永久 await になる。
@@ -292,7 +294,7 @@ public sealed class IpcConnection : IDisposable
         if (fault != null)
         {
             _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
-            throw fault;
+            ExceptionDispatchInfo.Capture(fault).Throw();
         }
 
         try

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -27,9 +27,8 @@ public sealed class IpcConnection : IDisposable
     private readonly ConcurrentDictionary<int, TaskCompletionSource<IpcMessage>> _pendingRequests = new();
     private Task? _receiveLoopTask;
     private CancellationTokenSource? _receiveLoopCts;
-    // 受信ループが I/O 障害/プロトコル破損で終了した際の例外。
-    // 死後に届いたリクエストを永久 await させないため、SendAndReceiveMultiplexedAsync で
-    // fail-fast に使う。Volatile.Write/Read で公開する。
+    // 受信ループ終了後の新規リクエストを fail-fast させるための終端例外。
+    // Volatile アクセスでループ→送信側に公開する。
     private Exception? _receiveLoopFault;
 
     public IpcConnection(PipeStream pipe)
@@ -136,22 +135,16 @@ public sealed class IpcConnection : IDisposable
             }
             finally
             {
-                // 死後の新規呼び出しが fail-fast できるよう、終了状態を先に公開してから
-                // 待機中リクエストを解放する。逆順だと finally の foreach 後に追加された
-                // TCS をループが拾えず永久ハングしうる。SendAndReceiveMultiplexedAsync 側で
-                // _pendingRequests への登録後にもう一度 fault を読むことで競合を閉じる。
-                // I/O / プロトコル系の終端は terminationError、loopCt キャンセルや
-                // 自プロセス Dispose は ObjectDisposedException として記録する。後者を
-                // 「fault は無し」と表現すると、ループ死亡後の caller が永久 await しうる。
+                // fault を先に公開し、その後で待機中 TCS を解放する。
+                // 送信側は登録後にもう一度 fault を読むことで、foreach に拾われなかった
+                // 新規 TCS の永久 await を防ぐ。clean-cancel の場合も「fault 無し」では
+                // なく ObjectDisposedException を載せて fail-fast を保証する。
                 Volatile.Write(
                     ref _receiveLoopFault,
                     terminationError ?? (Exception)new ObjectDisposedException(
                         nameof(IpcConnection),
                         "IPC receive loop has stopped; the connection no longer accepts multiplexed requests."));
 
-                // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、
-                // それ以外 (ObjectDisposed / loopCt キャンセル) は loopCt 付きでキャンセル。
-                // EOF は terminationError 経路を通るのでここでは TrySetException 側に入る点に注意。
                 foreach (var kvp in _pendingRequests)
                 {
                     if (_pendingRequests.TryRemove(kvp.Key, out var tcs))
@@ -285,18 +278,16 @@ public sealed class IpcConnection : IDisposable
             throw fault;
 
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
-        // 同じ Id が既に in-flight なら、indexer 代入だと前 TCS を黙って捨てて永久 await が
-        // 生まれる。TryAdd で衝突を表面化する。_nextId が int を一巡して再利用された場合や、
-        // 呼び出し元が手動 Id を渡すバグでも、症状が確実に上に伝わる。
+        // Id 衝突は indexer 代入だと前 TCS を黙って捨てて永久 await になる。
+        // TryAdd で表面化させる。
         if (!_pendingRequests.TryAdd(request.Id, tcs))
         {
             throw new InvalidOperationException(
                 $"Request id {request.Id} is already in flight on this multiplexed connection.");
         }
 
-        // 登録→fault チェックの順を逆にできない: 逆だと「fault 読み (null)」→「ループが
-        // finally で fault 書き&foreach (空)」→「登録」のレースで永久 await になる。
-        // 登録後にもう一度読み直すことで、foreach に拾われなかった TCS も検出する。
+        // 登録後にもう一度 fault を読む。「fault 読み (null)」→「ループ finally で
+        // fault 書き&foreach (空)」→「登録」のレースで永久 await になるのを防ぐ。
         fault = Volatile.Read(ref _receiveLoopFault);
         if (fault != null)
         {
@@ -306,13 +297,9 @@ public sealed class IpcConnection : IDisposable
 
         try
         {
-            // SendAsync の前にキャンセルを購読し、送信中・受信待機中いずれの局面でも
-            // ct 発火が確実に tcs へ伝播するようにする。
-            // 旧実装は SendAsync 完了後に Register していたため、送信成功とキャンセル発火と
-            // レスポンス到着が同時に走ると、TCS が中途半端に解決されず競合の隙間で
-            // バッファインデックスを未消費のまま落とすケースがあった。
-            // Register 自体は ObjectDisposedException 等で失敗しうるため try の内側
-            // に置き、失敗時にも finally で pending を確実に撤去する。
+            // SendAsync 前にキャンセルを購読する。送信中・受信待機中いずれの局面でも
+            // ct 発火を tcs に伝播させる必要がある。Register は ObjectDisposedException
+            // を投げうるため try 内に置き、失敗時も finally で pending を撤去する。
             using var registration = ct.Register(static state =>
             {
                 var (innerTcs, token) = ((TaskCompletionSource<IpcMessage> Tcs, CancellationToken Token))state!;
@@ -329,11 +316,9 @@ public sealed class IpcConnection : IDisposable
         }
         finally
         {
-            // 自身が登録した TCS のみを撤去する (KeyValuePair オーバーロード)。
-            // 主目的は受信ループとのレース対策: ループが先にこのスロットを取り出して
-            // 別レスポンスを刺し直していた場合、参照不一致になり TryRemove は失敗 — 別リクエストの
-            // TCS を取り違えて消すのを防ぐ。副次的に、_nextId が int を一巡 (2^31 件) して Id が
-            // 再利用された場合の保険も兼ねる。
+            // 自身が登録した TCS のみを撤去する。受信ループが先にスロットを取り出して
+            // 別の登録に差し替わっていた場合、KeyValuePair オーバーロードの参照不一致で
+            // TryRemove は失敗し、他リクエストの TCS を取り違えて消すのを防ぐ。
             _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
         }
     }

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -107,8 +107,8 @@ public sealed class IpcConnection : IDisposable
                     }
                 }
             }
-            catch (OperationCanceledException) { }
-            catch (ObjectDisposedException) { }
+            catch (OperationCanceledException) when (loopCt.IsCancellationRequested) { }
+            catch (ObjectDisposedException) when (loopCt.IsCancellationRequested) { }
             catch (IOException ex)
             {
                 terminationError = new IOException(

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -139,10 +139,12 @@ public sealed class IpcConnection : IDisposable
             }
             finally
             {
-                // fault を先に公開し、その後で待機中 TCS を解放する。
-                // 送信側は登録後にもう一度 fault を読むことで、foreach に拾われなかった
-                // 新規 TCS の永久 await を防ぐ。clean-cancel の場合も「fault 無し」では
-                // なく ObjectDisposedException を載せて fail-fast を保証する。
+                // ストア順序: Volatile.Write (release) → foreach の順を厳守する。
+                // 送信側は TryAdd 後に Volatile.Read (acquire) で fault を読み直すので、
+                // この release/acquire ペアが ARM などの弱メモリモデルでも保証される。
+                // 逆順だと foreach で拾われなかった TCS が永久 await になる。
+                // clean-cancel の場合も「fault 無し」ではなく ObjectDisposedException を
+                // 載せて fail-fast を保証する。
                 Volatile.Write(
                     ref _receiveLoopFault,
                     terminationError ?? (Exception)new ObjectDisposedException(
@@ -292,8 +294,10 @@ public sealed class IpcConnection : IDisposable
                 $"Request id {request.Id} is already in flight on this multiplexed connection.");
         }
 
-        // 登録後にもう一度 fault を読む。「fault 読み (null)」→「ループ finally で
-        // fault 書き&foreach (空)」→「登録」のレースで永久 await になるのを防ぐ。
+        // TryAdd の後に acquire-read で fault を再読する。受信ループ finally の
+        // Volatile.Write (release) と対になり、ループが foreach を抜けた後の状態
+        // (fault 公開済み) を必ず観測できる。「fault 読み (null)」→「ループ finally で
+        // fault 書き & foreach (空)」→「登録」のレースで永久 await になるのを防ぐ。
         fault = Volatile.Read(ref _receiveLoopFault);
         if (fault != null)
         {

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -121,11 +121,15 @@ public sealed class IpcConnection : IDisposable
                 terminationError = new IOException(
                     "IPC receive loop terminated due to a broken pipe. The remote endpoint may have crashed.", ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OutOfMemoryException
+                                           and not StackOverflowException
+                                           and not AccessViolationException)
             {
                 // プロトコル破損 (length out of range, JSON deserialize 失敗, 想定外の状態) など
                 // I/O 以外の例外も同じ termination 経路に集約し、呼び出し元から
                 // 「キャンセル」と「ループが死んだ」を区別可能にする。
+                // 致命系 (OOM/SOE/AVE) は IOException に包んで誤魔化さず、プロセス側に
+                // 元のクラッシュ意図を伝播させる (InvokeDroppedResponseHandler と同じ規約)。
                 terminationError = new IOException(
                     "IPC receive loop terminated due to an unexpected protocol or deserialization error.", ex);
             }

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO.Pipes;
 using Beutl.FFmpegIpc.Protocol;
 
@@ -267,9 +268,13 @@ public sealed class IpcConnection : IDisposable
         {
             handler(message);
         }
-        catch
+        catch (Exception ex) when (ex is not OutOfMemoryException
+                                       and not StackOverflowException
+                                       and not AccessViolationException)
         {
-            // ハンドラ例外は受信ループを止めない。
+            // ハンドラ例外は受信ループを止めない。診断のため Trace へ送る。
+            Trace.TraceError(
+                $"IpcConnection.DroppedResponseHandler threw {ex.GetType().Name} for message Id={message.Id} Type={message.Type}: {ex}");
         }
     }
 

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -51,8 +51,10 @@ public sealed class IpcConnection : IDisposable
     /// 上位レイヤーで解放するためのコールバック。現状は配線されておらず、配線するのは消費側 (例:
     /// IpcFrameProvider) の責務とする。
     /// 呼び出しは受信ループスレッドで同期的に行われるため、ブロックすると後続メッセージの
-    /// 処理が遅延する。例外は投げないことを契約とするが、万一スローした場合でも受信ループは
-    /// 継続し、内容は <see cref="System.Diagnostics.Trace.TraceError(string)"/> に記録される。
+    /// 処理が遅延する。例外は投げないことを契約とするが、非致命例外をスローしても
+    /// 受信ループは継続し、内容は <see cref="System.Diagnostics.Trace.TraceError(string)"/>
+    /// に記録される。OOM/SOE/AVE 等の致命例外は呼び出し元 (受信ループ) に伝播し、
+    /// ループを終了させてプロセス状態を上位に晒す。
     /// </summary>
     public Action<IpcMessage>? DroppedResponseHandler { get; set; }
 
@@ -356,8 +358,8 @@ public sealed class IpcConnection : IDisposable
 
             // 受信ループを待ってからパイプ/セマフォを破棄する。先にパイプを破棄すると
             // 進行中の ReadMessageAsync が ObjectDisposedException で死に、自己 Dispose が
-            // 誤って "broken pipe" として pending リクエストに伝播してしまう。上限を切って
-            // 待つことで、ループ内ハング (理論上ありえない) でも Dispose は必ず進む。
+            // 誤って "broken pipe" として pending リクエストに伝播してしまう。
+            // 上限を切って待つので、ループが loopCt を尊重しない異常状態でも Dispose は完走する。
             try
             {
                 if (_receiveLoopTask is { } task && !task.Wait(TimeSpan.FromSeconds(5)))

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -62,6 +62,11 @@ public sealed class IpcConnection : IDisposable
 
         _receiveLoopTask = Task.Run(async () =>
         {
+            // 受信ループが I/O 障害で終了した場合、待機中の TCS にはキャンセルではなく
+            // この例外を伝播させることで「ユーザーがキャンセルした」と「ワーカーが落ちた」を
+            // 呼び出し元から区別可能にする。OperationCanceledException / ObjectDisposedException
+            // (= 正常終了) のときは null のまま finally で TrySetCanceled される。
+            Exception? terminationError = null;
             try
             {
                 while (!loopCt.IsCancellationRequested)
@@ -89,14 +94,24 @@ public sealed class IpcConnection : IDisposable
             }
             catch (OperationCanceledException) { }
             catch (ObjectDisposedException) { }
-            catch (IOException) { }
+            catch (IOException ex)
+            {
+                terminationError = new IOException(
+                    "IPC receive loop terminated due to a broken pipe. The remote endpoint may have crashed.", ex);
+            }
             finally
             {
-                // 残っている全ての待機中リクエストをキャンセル
+                // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、
+                // それ以外 (正常クローズ / loopCt キャンセル) は loopCt 付きでキャンセル。
                 foreach (var kvp in _pendingRequests)
                 {
                     if (_pendingRequests.TryRemove(kvp.Key, out var tcs))
-                        tcs.TrySetCanceled(loopCt);
+                    {
+                        if (terminationError != null)
+                            tcs.TrySetException(terminationError);
+                        else
+                            tcs.TrySetCanceled(loopCt);
+                    }
                 }
             }
         }, loopCt);

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -135,8 +135,14 @@ public sealed class IpcConnection : IDisposable
                 // 待機中リクエストを解放する。逆順だと finally の foreach 後に追加された
                 // TCS をループが拾えず永久ハングしうる。SendAndReceiveMultiplexedAsync 側で
                 // _pendingRequests への登録後にもう一度 fault を読むことで競合を閉じる。
-                if (terminationError != null)
-                    Volatile.Write(ref _receiveLoopFault, terminationError);
+                // I/O / プロトコル系の終端は terminationError、loopCt キャンセルや
+                // 自プロセス Dispose は ObjectDisposedException として記録する。後者を
+                // 「fault は無し」と表現すると、ループ死亡後の caller が永久 await しうる。
+                Volatile.Write(
+                    ref _receiveLoopFault,
+                    terminationError ?? (Exception)new ObjectDisposedException(
+                        nameof(IpcConnection),
+                        "IPC receive loop has stopped; the connection no longer accepts multiplexed requests."));
 
                 // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、
                 // それ以外 (ObjectDisposed / loopCt キャンセル) は loopCt 付きでキャンセル。

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -80,6 +80,11 @@ public sealed class IpcConnection : IDisposable
     /// </summary>
     public Action<string, Exception?>? DiagnosticLogger { get; set; }
 
+    // corrupted-process 例外 (OOM/SOE/AVE) は generic catch / when filter / Dispose の
+    // inner-exception スキャンで一貫して "捕まえない・潰さない" として扱う。
+    private static bool IsFatal(Exception ex) =>
+        ex is OutOfMemoryException or StackOverflowException or AccessViolationException;
+
     public int NextId() => Interlocked.Increment(ref _nextId);
 
     /// <summary>
@@ -147,9 +152,7 @@ public sealed class IpcConnection : IDisposable
                 terminationError = new IOException(
                     "IPC receive loop terminated due to a broken pipe. The remote endpoint may have crashed.", ex);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException
-                                           and not StackOverflowException
-                                           and not AccessViolationException)
+            catch (Exception ex) when (!IsFatal(ex))
             {
                 // プロトコル破損 (length out of range, JSON deserialize 失敗, 想定外の状態) など
                 // I/O 以外の例外も同じ termination 経路に集約し、呼び出し元から
@@ -363,9 +366,7 @@ public sealed class IpcConnection : IDisposable
         {
             handler(message);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException
-                                       and not StackOverflowException
-                                       and not AccessViolationException)
+        catch (Exception ex) when (!IsFatal(ex))
         {
             // ハンドラ例外は受信ループを止めない。診断のため上位ロガーへ送る。
             WriteDiagnostic(
@@ -377,7 +378,7 @@ public sealed class IpcConnection : IDisposable
     /// <summary>
     /// 異常系の診断メッセージを出力する。<see cref="DiagnosticLogger"/> が設定されていれば
     /// そちらへ、無ければ <see cref="Trace.TraceError(string)"/> へフォールバックする。
-    /// フック自身が例外を投げても受信ループ / Dispose を巻き込まないよう、二重に try-catch する。
+    /// フック自身が例外を投げても受信ループ / Dispose を巻き込まないよう Trace に切り替える。
     /// </summary>
     private void WriteDiagnostic(string message, Exception? exception = null)
     {
@@ -389,30 +390,15 @@ public sealed class IpcConnection : IDisposable
                 logger(message, exception);
                 return;
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException
-                                           and not StackOverflowException
-                                           and not AccessViolationException)
+            catch (Exception ex) when (!IsFatal(ex))
             {
-                // フック自身の例外。フォールバックの Trace 出力に切り替える。
-                try
-                {
-                    Trace.TraceError(
-                        $"IpcConnection.DiagnosticLogger threw {ex.GetType().Name}: {ex}. Original message: {message}{(exception != null ? " | " + exception : string.Empty)}");
-                }
-                catch
-                {
-                }
+                Trace.TraceError(
+                    $"IpcConnection.DiagnosticLogger threw {ex.GetType().Name}: {ex}. Original message: {message}{(exception != null ? " | " + exception : string.Empty)}");
                 return;
             }
         }
 
-        try
-        {
-            Trace.TraceError(exception != null ? $"{message} {exception}" : message);
-        }
-        catch
-        {
-        }
+        Trace.TraceError(exception != null ? $"{message} {exception}" : message);
     }
 
     public void Dispose()
@@ -447,8 +433,7 @@ public sealed class IpcConnection : IDisposable
                 // 受信ループの generic catch が除外している致命系 (OOM/SOE/AVE) は
                 // Dispose 経路でも握りつぶさず再 throw する。リソース解放後に投げ直すため
                 // ExceptionDispatchInfo として捕捉だけしておく。
-                var fatal = ex.InnerExceptions.FirstOrDefault(static e =>
-                    e is OutOfMemoryException or StackOverflowException or AccessViolationException);
+                var fatal = ex.InnerExceptions.FirstOrDefault(IsFatal);
                 if (fatal != null)
                 {
                     fatalToRethrow = ExceptionDispatchInfo.Capture(fatal);

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -43,6 +43,11 @@ public sealed class IpcConnection : IDisposable
     public int NextId() => Interlocked.Increment(ref _nextId);
 
     /// <summary>
+    /// 多重化モード用 pending request 辞書のエントリ数。テスト/診断専用。
+    /// </summary>
+    internal int PendingRequestCount => _pendingRequests.Count;
+
+    /// <summary>
     /// 多重化受信モードを開始する。バックグラウンドでメッセージを受信し、
     /// IDベースで待機中のリクエストにルーティングする。
     /// クライアント側で複数リーダーからの並行リクエストを可能にする。

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -21,7 +21,9 @@ public sealed class IpcConnection : IDisposable
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private readonly SemaphoreSlim _readLock = new(1, 1);
     private int _nextId;
-    private volatile bool _disposed;
+    // 0 = 未 Dispose、1 = Dispose 開始済み。Interlocked で check-and-set し、
+    // 並行 Dispose 呼び出しでも本体は厳密に 1 度しか走らないようにする。
+    private int _disposed;
 
     // 多重化モード用
     private readonly ConcurrentDictionary<int, TaskCompletionSource<IpcMessage>> _pendingRequests = new();
@@ -345,8 +347,7 @@ public sealed class IpcConnection : IDisposable
 
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
         ExceptionDispatchInfo? fatalToRethrow = null;
         try

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -116,7 +116,7 @@ public sealed class IpcConnection : IDisposable
                     }
                 }
             }
-            catch (OperationCanceledException) when (loopCt.IsCancellationRequested) { }
+            catch (OperationCanceledException oce) when (oce.CancellationToken == loopCt && loopCt.IsCancellationRequested) { }
             catch (ObjectDisposedException) when (loopCt.IsCancellationRequested) { }
             catch (IOException ex)
             {

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -26,6 +26,10 @@ public sealed class IpcConnection : IDisposable
     private readonly ConcurrentDictionary<int, TaskCompletionSource<IpcMessage>> _pendingRequests = new();
     private Task? _receiveLoopTask;
     private CancellationTokenSource? _receiveLoopCts;
+    // 受信ループが I/O 障害/プロトコル破損で終了した際の例外。
+    // 死後に届いたリクエストを永久 await させないため、SendAndReceiveMultiplexedAsync で
+    // fail-fast に使う。Volatile.Write/Read で公開する。
+    private Exception? _receiveLoopFault;
 
     public IpcConnection(PipeStream pipe)
     {
@@ -124,6 +128,13 @@ public sealed class IpcConnection : IDisposable
             }
             finally
             {
+                // 死後の新規呼び出しが fail-fast できるよう、終了状態を先に公開してから
+                // 待機中リクエストを解放する。逆順だと finally の foreach 後に追加された
+                // TCS をループが拾えず永久ハングしうる。SendAndReceiveMultiplexedAsync 側で
+                // _pendingRequests への登録後にもう一度 fault を読むことで競合を閉じる。
+                if (terminationError != null)
+                    Volatile.Write(ref _receiveLoopFault, terminationError);
+
                 // 残っている全ての待機中リクエストを解放。I/O 障害があれば例外として、
                 // それ以外 (正常クローズ / loopCt キャンセル) は loopCt 付きでキャンセル。
                 foreach (var kvp in _pendingRequests)
@@ -253,8 +264,23 @@ public sealed class IpcConnection : IDisposable
     {
         ct.ThrowIfCancellationRequested();
 
+        // 受信ループが既に死んでいたら、TCS をハングさせずに即時失敗する。
+        var fault = Volatile.Read(ref _receiveLoopFault);
+        if (fault != null)
+            throw fault;
+
         var tcs = new TaskCompletionSource<IpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pendingRequests[request.Id] = tcs;
+
+        // 登録→fault チェックの順を逆にできない: 逆だと「fault 読み (null)」→「ループが
+        // finally で fault 書き&foreach (空)」→「登録」のレースで永久 await になる。
+        // 登録後にもう一度読み直すことで、foreach に拾われなかった TCS も検出する。
+        fault = Volatile.Read(ref _receiveLoopFault);
+        if (fault != null)
+        {
+            _pendingRequests.TryRemove(new KeyValuePair<int, TaskCompletionSource<IpcMessage>>(request.Id, tcs));
+            throw fault;
+        }
 
         try
         {

--- a/src/Beutl.FFmpegWorker/Program.cs
+++ b/src/Beutl.FFmpegWorker/Program.cs
@@ -84,7 +84,12 @@ internal static class Program
             return 3;
         }
 
-        using var connection = new IpcConnection(pipeClient);
+        using var connection = new IpcConnection(pipeClient)
+        {
+            // 受信ループ / Dispose 異常系の診断は WorkerLog 経由でホストに送る。
+            // DroppedResponseHandler はワーカー側が多重化モードを使わないため未設定。
+            DiagnosticLogger = (msg, ex) => WorkerLog.Error(msg, ex)
+        };
 
         // ハンドシェイク送信（プロトコルバージョン含む）
         await connection.SendAsync(

--- a/src/Beutl.FFmpegWorker/Program.cs
+++ b/src/Beutl.FFmpegWorker/Program.cs
@@ -88,7 +88,7 @@ internal static class Program
         {
             // 受信ループ / Dispose 異常系の診断は WorkerLog 経由でホストに送る。
             // DroppedResponseHandler はワーカー側が多重化モードを使わないため未設定。
-            DiagnosticLogger = (msg, ex) => WorkerLog.Error(msg, ex)
+            DiagnosticLogger = WorkerLog.Error
         };
 
         // ハンドシェイク送信（プロトコルバージョン含む）

--- a/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
+++ b/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
+++ b/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Beutl.FFmpegIpc\Beutl.FFmpegIpc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.IO.Pipes;
-using System.Reflection;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Transport;
 
@@ -32,13 +31,7 @@ public class IpcConnectionMultiplexedTests
         return (server, client);
     }
 
-    private static int PendingCount(IpcConnection conn)
-    {
-        var field = typeof(IpcConnection).GetField(
-            "_pendingRequests", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var dict = (System.Collections.IDictionary)field.GetValue(conn)!;
-        return dict.Count;
-    }
+    private static int PendingCount(IpcConnection conn) => conn.PendingRequestCount;
 
     [Test]
     public async Task ConcurrentRequests_AllReceiveCorrectResponses()

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -498,6 +498,22 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public void Dispose_CalledTwice_SecondCallIsNoOp()
+    {
+        // Interlocked.Exchange ガードが効いていれば 2 回目以降の Dispose は本体を
+        // 通らない。ガードが緩むと SemaphoreSlim が再 Dispose されて
+        // ObjectDisposedException が漏れ出すため、no-throw でガードをピン留めできる。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        Assert.DoesNotThrow(() => conn.Dispose());
+        Assert.DoesNotThrow(() => conn.Dispose(), "second Dispose must be a no-op");
+        Assert.DoesNotThrow(() => conn.Dispose(), "third Dispose must be a no-op");
+    }
+
+    [Test]
     public async Task Dispose_ProceedsWhenReceiveLoopDoesNotExitWithinTimeout()
     {
         // 受信ループが loopCt を無視してハングした場合、Dispose は 5 秒で

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -189,6 +189,58 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task DroppedResponseHandler_Throws_ReceiveLoopSurvives()
+    {
+        // IpcConnection.cs の DroppedResponseHandler XML doc が
+        // 「万一スローしても受信ループは継続」と契約している。
+        // ハンドラ catch を狭めた変更が壊れたら、次のリクエストが永久ハングする。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        using var conn = new IpcConnection(client);
+
+        int handlerCalls = 0;
+        conn.DroppedResponseHandler = _ =>
+        {
+            Interlocked.Increment(ref handlerCalls);
+            throw new InvalidOperationException("intentional from test");
+        };
+        conn.StartMultiplexedReceive();
+
+        // 1) キャンセル後の遅延応答でハンドラを発火させる。
+        using (var cts = new CancellationTokenSource())
+        {
+            int firstId = conn.NextId();
+            var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
+            var firstTask = conn.SendAndReceiveAsync(firstReq, cts.Token).AsTask();
+
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request enters pending dict");
+            cts.Cancel();
+            Assert.CatchAsync<OperationCanceledException>(async () => await firstTask);
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
+
+            var lateResp = IpcMessage.CreateSimple(firstId, ResponseType);
+            await MessageSerializer.WriteMessageAsync(server, lateResp);
+            await WaitUntil(() => Volatile.Read(ref handlerCalls) >= 1, TimeSpan.FromSeconds(5), "dropped handler is invoked");
+        }
+
+        // 2) 二本目のリクエストが正常応答を受け取る = 受信ループ生存中。
+        int secondId = conn.NextId();
+        var secondReq = IpcMessage.CreateSimple(secondId, RequestType);
+        var secondTask = conn.SendAndReceiveAsync(secondReq).AsTask();
+
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "second request enters pending dict");
+
+        // ハンドラを差し替えてから応答を返す (二本目で再度発火させない)。
+        conn.DroppedResponseHandler = null;
+        var secondResp = IpcMessage.CreateSimple(secondId, ResponseType);
+        await MessageSerializer.WriteMessageAsync(server, secondResp);
+
+        var got = await AwaitWithResult(secondTask, TimeSpan.FromSeconds(5));
+        Assert.That(got.Id, Is.EqualTo(secondId));
+        Assert.That(got.Type, Is.EqualTo(ResponseType));
+    }
+
+    [Test]
     public async Task RaceCancelAndResponse_NoLeak_StressLoop()
     {
         // レスポンス勝ち / キャンセル勝ち どちらでもリークしない不変を確認。
@@ -392,5 +444,18 @@ public class IpcConnectionMultiplexedTests
             Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for: {description}");
         }
         await task;
+    }
+
+    /// <summary>
+    /// 結果付き Task の完了を上限時間で待つ。タイムアウト時は Assert.Fail でテストを落とす。
+    /// </summary>
+    private static async Task<T> AwaitWithResult<T>(Task<T> task, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout));
+        if (completed != task)
+        {
+            Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for task result.");
+        }
+        return await task;
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -223,13 +223,12 @@ public class IpcConnectionMultiplexedTests
                 // 受信ループとキャンセルがほぼ同時に走るよう仕向ける。
                 cts.Cancel();
 
-                try
-                {
-                    await requestTask;
-                }
-                catch (OperationCanceledException) { }
-                catch (IOException) { }
+                // PR で修正したキャンセル経路がリグレッションすると await が永久に
+                // 返らなくなるため、フェイルファストで上限を切る。
+                await AwaitWithTimeout(requestTask, TimeSpan.FromSeconds(5), $"iter={iter}: requestTask");
             }
+            catch (OperationCanceledException) { }
+            catch (IOException) { }
             finally
             {
                 workerCts.Cancel();
@@ -237,7 +236,7 @@ public class IpcConnectionMultiplexedTests
                 // worker は書き込み中に server.Dispose() を踏むと
                 // ObjectDisposedException を投げうる。stress テストでは
                 // この競合は不可避なので想定例外として許容する。
-                try { await workerTask; }
+                try { await AwaitWithTimeout(workerTask, TimeSpan.FromSeconds(5), $"iter={iter}: workerTask"); }
                 catch (OperationCanceledException) { }
                 catch (IOException) { }
                 catch (ObjectDisposedException) { }
@@ -348,5 +347,19 @@ public class IpcConnectionMultiplexedTests
         {
             Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for: {description}");
         }
+    }
+
+    /// <summary>
+    /// Task の完了を上限時間で待つ。タイムアウト時は Assert.Fail でテストを落とす。
+    /// 既に Task が faulted であれば内側の例外が再 throw される (呼び出し元で catch する想定)。
+    /// </summary>
+    private static async Task AwaitWithTimeout(Task task, TimeSpan timeout, string description)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout));
+        if (completed != task)
+        {
+            Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for: {description}");
+        }
+        await task;
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -426,6 +426,37 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task DisposeWhileRequestPending_ObservesCancellationNotIOException()
+    {
+        // commit 1d3304e5c で修正した Dispose 順序の回帰テスト。
+        // 自己 Dispose 中は受信ループの完了を待ってからパイプを破棄する契約。
+        // パイプ破棄を先にすると pending TCS に IOException("broken pipe") が
+        // 伝播してしまい、自プロセス由来か peer 由来かが区別不能になる。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        var conn = new IpcConnection(client);
+        try
+        {
+            conn.StartMultiplexedReceive();
+
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            var requestTask = conn.SendAndReceiveAsync(req).AsTask();
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
+
+            conn.Dispose();
+
+            var ex = Assert.CatchAsync(async () => await requestTask);
+            Assert.That(ex, Is.InstanceOf<OperationCanceledException>(),
+                $"expected OperationCanceledException (self-dispose), got {ex?.GetType().Name}: {ex?.Message}");
+        }
+        finally
+        {
+            conn.Dispose();
+        }
+    }
+
+    [Test]
     public async Task BrokenPipe_PendingRequestsObserveIOException()
     {
         var (server, client) = ConnectPair();

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -133,13 +133,13 @@ public class IpcConnectionMultiplexedTests
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
             // 送信完了 (= pending に積まれた) を観測してからキャンセル。Task.Delay よりも安定。
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2), "request enters pending dict");
             cts.Cancel();
 
             var oce = Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
             Assert.That(oce!.CancellationToken, Is.EqualTo(cts.Token));
 
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after cancel");
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
         finally
@@ -167,16 +167,16 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2), "request enters pending dict");
             cts.Cancel();
             Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after cancel");
 
             // 遅延レスポンスを送り込む → dropped ハンドラに来るはず。
             var resp = IpcMessage.CreateSimple(id, ResponseType);
             await MessageSerializer.WriteMessageAsync(server, resp);
 
-            await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(2), "DroppedResponseHandler is invoked for late response");
             Assert.That(dropped.Count, Is.EqualTo(1));
             Assert.That(dropped.TryDequeue(out var dropMsg), Is.True);
             Assert.That(dropMsg!.Id, Is.EqualTo(id));
@@ -243,7 +243,7 @@ public class IpcConnectionMultiplexedTests
                 catch (ObjectDisposedException) { }
             }
 
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), $"iter={iter}: pending dict drains");
             Assert.That(PendingCount(conn), Is.EqualTo(0), $"iter={iter}");
 
             // dropped に乗ったメッセージはすべて送信した id と一致するはず。
@@ -289,7 +289,7 @@ public class IpcConnectionMultiplexedTests
                 async () => await conn.SendAndReceiveAsync(req));
             Assert.That(ex!.Message, Is.EqualTo("boom"));
 
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after error response");
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
         finally
@@ -320,7 +320,7 @@ public class IpcConnectionMultiplexedTests
             tasks.Add(conn.SendAndReceiveAsync(req).AsTask());
         }
 
-        await WaitUntil(() => PendingCount(conn) == 3, TimeSpan.FromSeconds(2));
+        await WaitUntil(() => PendingCount(conn) == 3, TimeSpan.FromSeconds(2), "all 3 requests enter pending dict");
 
         server.Dispose();
 
@@ -333,16 +333,20 @@ public class IpcConnectionMultiplexedTests
         Assert.That(exceptions, Has.All.Not.Null);
         // 全タスクが broken-pipe 例外として観測される (OperationCanceledException ではない)。
         Assert.That(exceptions, Has.All.InstanceOf<IOException>());
-        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after broken pipe");
         Assert.That(PendingCount(conn), Is.EqualTo(0));
     }
 
-    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
+    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout, string description)
     {
         var deadline = DateTime.UtcNow + timeout;
         while (!predicate() && DateTime.UtcNow < deadline)
         {
             await Task.Delay(10);
+        }
+        if (!predicate())
+        {
+            Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for: {description}");
         }
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -303,6 +303,37 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause()
+    {
+        // commit 9325ed5 で追加した catch (Exception) アームの回帰テスト。
+        // 不正な length prefix を流し込み、MessageSerializer が
+        // InvalidOperationException を投げて受信ループが死ぬケースを再現する。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        var requestTask = conn.SendAndReceiveAsync(req).AsTask();
+
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
+
+        // 長さ -1 は MessageSerializer.ReadMessageAsync で
+        // "Invalid message length" の InvalidOperationException を引き起こす。
+        byte[] badLength = [0xFF, 0xFF, 0xFF, 0xFF];
+        await server.WriteAsync(badLength);
+        await server.FlushAsync();
+
+        var ex = Assert.CatchAsync<IOException>(async () => await requestTask);
+        Assert.That(ex!.Message, Does.Contain("unexpected protocol or deserialization error"));
+        Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
+
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after protocol error");
+        Assert.That(PendingCount(conn), Is.EqualTo(0));
+    }
+
+    [Test]
     public async Task BrokenPipe_PendingRequestsObserveIOException()
     {
         var (server, client) = ConnectPair();

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -559,8 +559,9 @@ public class IpcConnectionMultiplexedTests
         int id = conn.NextId();
         var req = IpcMessage.CreateSimple(id, RequestType);
         var ex = Assert.CatchAsync<IOException>(async () => await conn.SendAndReceiveAsync(req));
-        Assert.That(ex!.Message, Does.Contain("unexpected protocol or deserialization error"));
-        Assert.That(ex.InnerException, Is.InstanceOf<OperationCanceledException>());
+        // メッセージ文字列ではなく InnerException 型でルートを判定する。
+        // 「OCE を clean-cancel として握り潰すかどうか」だけが本テストの本質。
+        Assert.That(ex!.InnerException, Is.InstanceOf<OperationCanceledException>());
 
         await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after foreign-token OCE");
     }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.IO.Pipes;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Transport;

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -6,9 +6,14 @@ using Beutl.FFmpegIpc.Transport;
 namespace Beutl.FFmpegIpc.Tests;
 
 /// <summary>
-/// IpcConnection.SendAndReceiveMultiplexedAsync のキャンセル順序と
-/// 競合パスを検証する。NamedPipe を使ったクロスプラットフォーム動作。
+/// IpcConnection.SendAndReceiveMultiplexedAsync のキャンセル順序・競合パス・
+/// ドロップ応答フック・受信ループ終端処理を検証する。
+/// NamedPipe を使ったクロスプラットフォーム動作。
 /// </summary>
+/// <remarks>
+/// NamedPipe をテストごとに多数生成しタイミングに依存するため、
+/// 他フィクスチャと並列に動作させない。
+/// </remarks>
 [TestFixture, NonParallelizable]
 public class IpcConnectionMultiplexedTests
 {
@@ -129,9 +134,9 @@ public class IpcConnectionMultiplexedTests
             await Task.Delay(50);
             cts.Cancel();
 
-            Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
+            var oce = Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
+            Assert.That(oce!.CancellationToken, Is.EqualTo(cts.Token));
 
-            // dict は撤去済み。
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
@@ -170,8 +175,10 @@ public class IpcConnectionMultiplexedTests
             await MessageSerializer.WriteMessageAsync(server, resp);
 
             await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(2));
-            Assert.That(dropped.Count, Is.GreaterThanOrEqualTo(1));
-            Assert.That(dropped.Any(m => m.Id == id), Is.True);
+            Assert.That(dropped.Count, Is.EqualTo(1));
+            Assert.That(dropped.TryDequeue(out var dropMsg), Is.True);
+            Assert.That(dropMsg!.Id, Is.EqualTo(id));
+            Assert.That(dropMsg.Type, Is.EqualTo(ResponseType));
         }
         finally
         {
@@ -237,6 +244,86 @@ public class IpcConnectionMultiplexedTests
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
             Assert.That(PendingCount(conn), Is.EqualTo(0), $"iter={iter}");
         }
+    }
+
+    [Test]
+    public void StartMultiplexedReceive_CalledTwice_Throws()
+    {
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        Assert.Throws<InvalidOperationException>(() => conn.StartMultiplexedReceive());
+    }
+
+    [Test]
+    public async Task ErrorResponse_ThrowsWorkerException_AndDictIsClean()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        var workerCts = new CancellationTokenSource();
+        var workerTask = Task.Run(async () =>
+        {
+            var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
+            if (req == null) return;
+            var resp = IpcMessage.CreateError(req.Id, "boom", "stack-here");
+            await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
+        });
+
+        try
+        {
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            var ex = Assert.ThrowsAsync<FFmpegWorkerException>(
+                async () => await conn.SendAndReceiveAsync(req));
+            Assert.That(ex!.Message, Is.EqualTo("boom"));
+
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            Assert.That(PendingCount(conn), Is.EqualTo(0));
+        }
+        finally
+        {
+            workerCts.Cancel();
+            server.Dispose();
+            await workerTask;
+        }
+    }
+
+    [Test]
+    public async Task BrokenPipe_PendingRequestsObserveIOException()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        // worker は何も返さない。リクエストを 3 本立てて in-flight にしてから
+        // server 側を強制クローズし、受信ループを IOException で終わらせる。
+        var tasks = new List<Task<IpcMessage>>();
+        for (int i = 0; i < 3; i++)
+        {
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            tasks.Add(conn.SendAndReceiveAsync(req).AsTask());
+        }
+
+        await WaitUntil(() => PendingCount(conn) == 3, TimeSpan.FromSeconds(2));
+
+        server.Dispose();
+
+        var exceptions = await Task.WhenAll(tasks.Select(async t =>
+        {
+            try { await t; return (Exception?)null; }
+            catch (Exception ex) { return ex; }
+        }));
+
+        Assert.That(exceptions, Has.All.Not.Null);
+        // 全タスクが broken-pipe 例外として観測される (OperationCanceledException ではない)。
+        Assert.That(exceptions, Has.All.InstanceOf<IOException>());
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+        Assert.That(PendingCount(conn), Is.EqualTo(0));
     }
 
     private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -513,7 +513,7 @@ public class IpcConnectionMultiplexedTests
         Assert.DoesNotThrow(() => conn.Dispose(), "third Dispose must be a no-op");
     }
 
-    [Test]
+    [Test, Category("Slow")]
     public async Task Dispose_ProceedsWhenReceiveLoopDoesNotExitWithinTimeout()
     {
         // 受信ループが loopCt を無視してハングした場合、Dispose は 5 秒で

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -497,6 +497,27 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task Dispose_RethrowsFatalExceptionFromReceiveLoop()
+    {
+        // 受信ループが OOM/SOE/AVE を投げた場合、IPC のフレーム化エラーとして
+        // 握りつぶしてはならない。Dispose は AggregateException から取り出した
+        // 致命例外を ExceptionDispatchInfo で原型のまま再 throw する。
+        var pipe = new FailingPipeStream(() => new OutOfMemoryException("synthetic fatal"));
+        var conn = new IpcConnection(pipe);
+        conn.StartMultiplexedReceive();
+
+        // ループが OOM を投げて Faulted で終わるまで観測してから Dispose を呼ぶ。
+        // StartMultiplexedReceive 直後に Dispose だと、まだ loop body が走らないうちに
+        // _receiveLoopCts.Cancel() が先に走り、OOM ではなく cancel 経路で終わる可能性がある。
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        Assert.CatchAsync(async () => await conn.SendAndReceiveAsync(req));
+
+        var oom = Assert.Throws<OutOfMemoryException>(() => conn.Dispose());
+        Assert.That(oom!.Message, Is.EqualTo("synthetic fatal"));
+    }
+
+    [Test]
     public async Task BrokenPipe_PendingRequestsObserveIOException()
     {
         var (server, client) = ConnectPair();
@@ -568,5 +589,35 @@ public class IpcConnectionMultiplexedTests
             Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for task result.");
         }
         return await task;
+    }
+
+    /// <summary>
+    /// ReadAsync/Read で任意の例外を投げる PipeStream。Dispose 内 receive-loop の
+    /// fail-fast 経路や fatal 再 throw 経路をテストするために使う。
+    /// </summary>
+    private sealed class FailingPipeStream : PipeStream
+    {
+        private readonly Func<Exception> _factory;
+
+        public FailingPipeStream(Func<Exception> factory)
+            : base(PipeDirection.InOut, 4096)
+        {
+            _factory = factory;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw _factory();
+
+        public override int Read(Span<byte> buffer) => throw _factory();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => throw _factory();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => throw _factory();
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -311,6 +311,56 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task SamePendingRequestId_ThrowsAndFirstSurvives()
+    {
+        // _pendingRequests に同じ Id を二重登録しようとすると、TryAdd 化により
+        // 2 つ目が InvalidOperationException で失敗し、1 つ目の TCS には影響しない。
+        // 旧 indexer 代入では 1 つ目を黙って捨てて 1 つ目の awaiter が永久 await になっていた。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        using var cts = new CancellationTokenSource();
+        const int fixedId = 12345;
+        var first = IpcMessage.CreateSimple(fixedId, RequestType);
+        var second = IpcMessage.CreateSimple(fixedId, RequestType);
+
+        var firstTask = conn.SendAndReceiveAsync(first, cts.Token).AsTask();
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request enters pending dict");
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await conn.SendAndReceiveAsync(second));
+        Assert.That(ex!.Message, Does.Contain("already in flight"));
+        Assert.That(PendingCount(conn), Is.EqualTo(1));
+
+        cts.Cancel();
+        Assert.CatchAsync<OperationCanceledException>(async () => await firstTask);
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
+    }
+
+    [Test]
+    public async Task PostDispose_SendAndReceive_FailsFastWithObjectDisposed()
+    {
+        // clean-cancel パスでも _receiveLoopFault が公開されることのテスト。
+        // 旧コードでは terminationError 無しのとき fault を書かず、Dispose 後の
+        // 新規呼び出しが永久 await した。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+        conn.Dispose();
+
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        var task = conn.SendAndReceiveAsync(req).AsTask();
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.That(completed, Is.SameAs(task), "post-Dispose call must fail fast, not hang");
+        Assert.CatchAsync<ObjectDisposedException>(async () => await task);
+        Assert.That(PendingCount(conn), Is.EqualTo(0));
+    }
+
+    [Test]
     public void StartMultiplexedReceive_CalledTwice_Throws()
     {
         var (server, client) = ConnectPair();

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -543,6 +543,29 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task ForeignTokenCancellation_ObservedAsIOExceptionNotCleanCancel()
+    {
+        // 受信ループの clean-cancel フィルタは loopCt 自身のトークンを持つ OCE だけを
+        // 黙って吸収する契約。別トークンの OCE は protocol-corruption と同じ経路で
+        // IOException (InnerException = OCE) として pending リクエストに伝播する。
+        // フィルタが loopCt 同一性チェックを失うと、外部由来の OCE が clean-cancel として
+        // 握り潰されてしまい、呼び出し元はループ死亡を観測できなくなる。
+        var foreignCts = new CancellationTokenSource();
+        foreignCts.Cancel();
+        var pipe = new FailingPipeStream(() => new OperationCanceledException(foreignCts.Token));
+        using var conn = new IpcConnection(pipe);
+        conn.StartMultiplexedReceive();
+
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        var ex = Assert.CatchAsync<IOException>(async () => await conn.SendAndReceiveAsync(req));
+        Assert.That(ex!.Message, Does.Contain("unexpected protocol or deserialization error"));
+        Assert.That(ex.InnerException, Is.InstanceOf<OperationCanceledException>());
+
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after foreign-token OCE");
+    }
+
+    [Test]
     public async Task Dispose_RethrowsFatalExceptionFromReceiveLoop()
     {
         // 受信ループが OOM/SOE/AVE を投げた場合、IPC のフレーム化エラーとして

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -571,19 +571,27 @@ public class IpcConnectionMultiplexedTests
         // 受信ループが OOM/SOE/AVE を投げた場合、IPC のフレーム化エラーとして
         // 握りつぶしてはならない。Dispose は AggregateException から取り出した
         // 致命例外を ExceptionDispatchInfo で原型のまま再 throw する。
-        var pipe = new FailingPipeStream(() => new OutOfMemoryException("synthetic fatal"));
+        using var pipe = new FailingPipeStream(() => new OutOfMemoryException("synthetic fatal"));
         var conn = new IpcConnection(pipe);
-        conn.StartMultiplexedReceive();
+        try
+        {
+            conn.StartMultiplexedReceive();
 
-        // ループが OOM を投げて Faulted で終わるまで観測してから Dispose を呼ぶ。
-        // StartMultiplexedReceive 直後に Dispose だと、まだ loop body が走らないうちに
-        // _receiveLoopCts.Cancel() が先に走り、OOM ではなく cancel 経路で終わる可能性がある。
-        int id = conn.NextId();
-        var req = IpcMessage.CreateSimple(id, RequestType);
-        Assert.CatchAsync(async () => await conn.SendAndReceiveAsync(req));
+            // ループが OOM を投げて Faulted で終わるまで観測してから Dispose を呼ぶ。
+            // StartMultiplexedReceive 直後に Dispose だと、まだ loop body が走らないうちに
+            // _receiveLoopCts.Cancel() が先に走り、OOM ではなく cancel 経路で終わる可能性がある。
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            Assert.CatchAsync(async () => await conn.SendAndReceiveAsync(req));
 
-        var oom = Assert.Throws<OutOfMemoryException>(() => conn.Dispose());
-        Assert.That(oom!.Message, Is.EqualTo("synthetic fatal"));
+            var oom = Assert.Throws<OutOfMemoryException>(() => conn.Dispose());
+            Assert.That(oom!.Message, Is.EqualTo("synthetic fatal"));
+        }
+        finally
+        {
+            // OOM で Dispose が抜けた後の保険。Interlocked ガードのおかげで再呼び出しは no-op。
+            conn.Dispose();
+        }
     }
 
     [Test]

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -391,6 +391,41 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task AfterReceiveLoopDies_NewRequestsFailFast()
+    {
+        // _receiveLoopFault のキャッシュが効いていないと、ループ死亡後に登録された
+        // TCS は誰にも完了されず永久 await になる。
+        // 1) 壊れたフレームでループを殺し、2) 最初のリクエストが IOException で
+        // 返ったのを確認、3) 次のリクエストがキャッシュ済み fault で即時失敗する
+        // ことを検証する。
+        var (server, client) = ConnectPair();
+        using var _ = server;
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        int firstId = conn.NextId();
+        var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
+        var firstTask = conn.SendAndReceiveAsync(firstReq).AsTask();
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request enters pending dict");
+
+        byte[] badLength = [0xFF, 0xFF, 0xFF, 0xFF];
+        await server.WriteAsync(badLength);
+        await server.FlushAsync();
+
+        Assert.CatchAsync<IOException>(async () => await firstTask);
+
+        // ここでループは死んで _receiveLoopFault が公開されている。次のリクエストは
+        // 待たずに即時 IOException を投げるはず (cached fault による fail-fast)。
+        int secondId = conn.NextId();
+        var secondReq = IpcMessage.CreateSimple(secondId, RequestType);
+        var secondTask = conn.SendAndReceiveAsync(secondReq).AsTask();
+        var completed = await Task.WhenAny(secondTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.That(completed, Is.SameAs(secondTask), "second request must fail fast, not hang");
+        Assert.CatchAsync<IOException>(async () => await secondTask);
+        Assert.That(PendingCount(conn), Is.EqualTo(0));
+    }
+
+    [Test]
     public async Task BrokenPipe_PendingRequestsObserveIOException()
     {
         var (server, client) = ConnectPair();

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -111,9 +111,7 @@ public class IpcConnectionMultiplexedTests
 
         int id = conn.NextId();
         var req = IpcMessage.CreateSimple(id, RequestType);
-        // ct.ThrowIfCancellationRequested が _pendingRequests への登録より先に走ること
-        // を確認する。登録が先だと finally 経由で消えるため、登録が起きないことの
-        // 直接の証跡として、PendingCount が増えないかどうかは別経路の補強でしかない点に注意。
+        // ct.ThrowIfCancellationRequested が _pendingRequests への登録より先に走る。
         Assert.CatchAsync<OperationCanceledException>(
             async () => await conn.SendAndReceiveAsync(req, cts.Token));
 
@@ -196,9 +194,8 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task DroppedResponseHandler_Throws_ReceiveLoopSurvives()
     {
-        // IpcConnection.cs の DroppedResponseHandler XML doc が
-        // 「万一スローしても受信ループは継続」と契約している。
-        // ハンドラ catch を狭めた変更が壊れたら、次のリクエストが永久ハングする。
+        // DroppedResponseHandler が例外を投げても受信ループは生存し、
+        // 後続リクエストが正常応答を受け取れる契約。
         var (server, client) = ConnectPair();
         using var _ = server;
         using var conn = new IpcConnection(client);
@@ -280,8 +277,7 @@ public class IpcConnectionMultiplexedTests
                 // 受信ループとキャンセルがほぼ同時に走るよう仕向ける。
                 cts.Cancel();
 
-                // PR で修正したキャンセル経路がリグレッションすると await が永久に
-                // 返らなくなるため、フェイルファストで上限を切る。
+                // キャンセル経路がリークすると await が返らなくなるため上限を切る。
                 await AwaitWithTimeout(requestTask, TimeSpan.FromSeconds(5), $"iter={iter}: requestTask");
             }
             catch (OperationCanceledException) { }
@@ -313,9 +309,8 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task SamePendingRequestId_ThrowsAndFirstSurvives()
     {
-        // _pendingRequests に同じ Id を二重登録しようとすると、TryAdd 化により
-        // 2 つ目が InvalidOperationException で失敗し、1 つ目の TCS には影響しない。
-        // 旧 indexer 代入では 1 つ目を黙って捨てて 1 つ目の awaiter が永久 await になっていた。
+        // 同じ Id の二重登録は 2 つ目だけが InvalidOperationException で失敗し、
+        // 1 つ目の TCS には影響しない。
         var (server, client) = ConnectPair();
         using var _ = server;
         using var conn = new IpcConnection(client);
@@ -342,9 +337,8 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task PostDispose_SendAndReceive_FailsFastWithObjectDisposed()
     {
-        // clean-cancel パスでも _receiveLoopFault が公開されることのテスト。
-        // 旧コードでは terminationError 無しのとき fault を書かず、Dispose 後の
-        // 新規呼び出しが永久 await した。
+        // clean-cancel パスでも _receiveLoopFault が公開され、Dispose 後の
+        // 新規呼び出しが永久 await せずに ObjectDisposedException で即時失敗する。
         var (server, client) = ConnectPair();
         using var _ = server;
         var conn = new IpcConnection(client);
@@ -412,9 +406,9 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause()
     {
-        // commit 9325ed5 で追加した catch (Exception) アームの回帰テスト。
-        // 不正な length prefix を流し込み、MessageSerializer が
-        // InvalidOperationException を投げて受信ループが死ぬケースを再現する。
+        // 不正な length prefix で MessageSerializer が InvalidOperationException を
+        // 投げて受信ループが死ぬケース。pending TCS は IOException (InnerException が
+        // 元の InvalidOperationException) として観測されること。
         var (server, client) = ConnectPair();
         using var _ = server;
         using var conn = new IpcConnection(client);
@@ -443,11 +437,8 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task AfterReceiveLoopDies_NewRequestsFailFast()
     {
-        // _receiveLoopFault のキャッシュが効いていないと、ループ死亡後に登録された
-        // TCS は誰にも完了されず永久 await になる。
-        // 1) 壊れたフレームでループを殺し、2) 最初のリクエストが IOException で
-        // 返ったのを確認、3) 次のリクエストがキャッシュ済み fault で即時失敗する
-        // ことを検証する。
+        // 受信ループ死亡後の新規リクエストはキャッシュされた _receiveLoopFault で
+        // 即時失敗する。fault が公開されていないと TCS が誰にも完了されず永久 await になる。
         var (server, client) = ConnectPair();
         using var _ = server;
         using var conn = new IpcConnection(client);
@@ -478,10 +469,9 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task DisposeWhileRequestPending_ObservesCancellationNotIOException()
     {
-        // commit 1d3304e5c で修正した Dispose 順序の回帰テスト。
-        // 自己 Dispose 中は受信ループの完了を待ってからパイプを破棄する契約。
-        // パイプ破棄を先にすると pending TCS に IOException("broken pipe") が
-        // 伝播してしまい、自プロセス由来か peer 由来かが区別不能になる。
+        // 自己 Dispose 中は受信ループ完了を待ってからパイプを破棄する。
+        // 逆順だと pending TCS に IOException("broken pipe") が伝播し、
+        // 自プロセス由来と peer 由来の区別がつかなくなる。
         var (server, client) = ConnectPair();
         using var _ = server;
         var conn = new IpcConnection(client);

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -45,7 +45,7 @@ public class IpcConnectionMultiplexedTests
         using var conn = new IpcConnection(client);
         conn.StartMultiplexedReceive();
 
-        // Worker 役: 受信した順にレスポンスを返す。
+        // Worker 役: 5 本溜まったら受信と逆順でレスポンスを返す。
         // 受信順とは異なる順序で返すことで ID ルーティングを実際にストレスする。
         var workerCts = new CancellationTokenSource();
         var workerTask = Task.Run(async () =>
@@ -177,6 +177,7 @@ public class IpcConnectionMultiplexedTests
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
 
             // 遅延レスポンスを送り込む → dropped ハンドラに来るはず。
+            // cts は既に発火済みなので渡せるトークンが無く、無トークン書き込みでよい。
             var resp = IpcMessage.CreateSimple(id, ResponseType);
             await MessageSerializer.WriteMessageAsync(server, resp);
 

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO.Pipes;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Transport;
@@ -497,6 +498,35 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
+    public async Task Dispose_ProceedsWhenReceiveLoopDoesNotExitWithinTimeout()
+    {
+        // 受信ループが loopCt を無視してハングした場合、Dispose は 5 秒で
+        // 待機を諦め、残りのリソース解放 (pipe / セマフォ / CTS) は完走させる契約。
+        // タイムアウト境界が 5s から例えば 50ms に縮められたらこのテストが先に落ちる。
+        // NOTE: 5 秒の実時間待機が発生する。短縮するなら受信ループ Wait 上限を可変にする
+        //       internal API が必要。
+        var pipe = new HangingPipeStream();
+        var conn = new IpcConnection(pipe);
+        conn.StartMultiplexedReceive();
+
+        // 受信ループが確実に ReadAsync の hang に入った状態にしてから Dispose を呼ぶ。
+        // pending dict に 1 件入った = SendAsync が完走 = ループは ReadAsync 待機中。
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        _ = Task.Run(() => conn.SendAndReceiveAsync(req).AsTask());
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2), "request enters pending dict");
+
+        var sw = Stopwatch.StartNew();
+        Assert.DoesNotThrow(() => conn.Dispose());
+        sw.Stop();
+
+        Assert.That(sw.Elapsed, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(4)),
+            "Dispose must wait for the receive loop until the timeout fires");
+        Assert.That(sw.Elapsed, Is.LessThan(TimeSpan.FromSeconds(8)),
+            "Dispose must give up after the timeout instead of hanging indefinitely");
+    }
+
+    [Test]
     public async Task Dispose_RethrowsFatalExceptionFromReceiveLoop()
     {
         // 受信ループが OOM/SOE/AVE を投げた場合、IPC のフレーム化エラーとして
@@ -589,6 +619,35 @@ public class IpcConnectionMultiplexedTests
             Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for task result.");
         }
         return await task;
+    }
+
+    /// <summary>
+    /// ReadAsync が永久に完了しない PipeStream。Dispose の Wait タイムアウト経路を
+    /// 検証する目的でだけ使う。
+    /// </summary>
+    private sealed class HangingPipeStream : PipeStream
+    {
+        public HangingPipeStream() : base(PipeDirection.InOut, 4096) { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // 同期 Read は使わない想定だが、最低限ハングさせる。
+            new TaskCompletionSource<int>().Task.GetAwaiter().GetResult();
+            return 0;
+        }
+
+        public override int Read(Span<byte> buffer) => Read(Array.Empty<byte>(), 0, 0);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => new ValueTask<int>(new TaskCompletionSource<int>().Task);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => new TaskCompletionSource<int>().Task;
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
     }
 
     /// <summary>

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -78,7 +78,7 @@ public class IpcConnectionMultiplexedTests
                 tasks.Add((id, conn.SendAndReceiveAsync(req).AsTask()));
             }
 
-            await Task.WhenAll(tasks.Select(t => t.Task));
+            await AwaitWithTimeout(Task.WhenAll(tasks.Select(t => t.Task)), TimeSpan.FromSeconds(10), "all 5 concurrent requests complete");
             foreach (var (id, t) in tasks)
             {
                 Assert.That(t.Result.Id, Is.EqualTo(id));
@@ -99,7 +99,7 @@ public class IpcConnectionMultiplexedTests
     }
 
     [Test]
-    public async Task AlreadyCanceledToken_ThrowsBeforeRegistering()
+    public void AlreadyCanceledToken_ThrowsBeforeRegistering()
     {
         var (server, client) = ConnectPair();
         using var _ = server;
@@ -111,6 +111,9 @@ public class IpcConnectionMultiplexedTests
 
         int id = conn.NextId();
         var req = IpcMessage.CreateSimple(id, RequestType);
+        // ct.ThrowIfCancellationRequested が _pendingRequests への登録より先に走ること
+        // を確認する。登録が先だと finally 経由で消えるため、登録が起きないことの
+        // 直接の証跡として、PendingCount が増えないかどうかは別経路の補強でしかない点に注意。
         Assert.CatchAsync<OperationCanceledException>(
             async () => await conn.SendAndReceiveAsync(req, cts.Token));
 
@@ -132,14 +135,15 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
-            // 送信完了 (= pending に積まれた) を観測してからキャンセル。Task.Delay よりも安定。
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2), "request enters pending dict");
+            // 送信完了 (= pending に積まれた) を観測してからキャンセル。
+            // 固定 Task.Delay だと CI 環境差でフレーキーになるため、PendingRequestCount を直接ポーリング。
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
             cts.Cancel();
 
             var oce = Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
             Assert.That(oce!.CancellationToken, Is.EqualTo(cts.Token));
 
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after cancel");
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
         finally
@@ -167,16 +171,16 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2), "request enters pending dict");
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
             cts.Cancel();
             Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after cancel");
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
 
             // 遅延レスポンスを送り込む → dropped ハンドラに来るはず。
             var resp = IpcMessage.CreateSimple(id, ResponseType);
             await MessageSerializer.WriteMessageAsync(server, resp);
 
-            await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(2), "DroppedResponseHandler is invoked for late response");
+            await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(5), "DroppedResponseHandler is invoked for late response");
             Assert.That(dropped.Count, Is.EqualTo(1));
             Assert.That(dropped.TryDequeue(out var dropMsg), Is.True);
             Assert.That(dropMsg!.Id, Is.EqualTo(id));
@@ -340,7 +344,7 @@ public class IpcConnectionMultiplexedTests
                 async () => await conn.SendAndReceiveAsync(req));
             Assert.That(ex!.Message, Is.EqualTo("boom"));
 
-            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after error response");
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after error response");
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
         finally
@@ -402,7 +406,7 @@ public class IpcConnectionMultiplexedTests
             tasks.Add(conn.SendAndReceiveAsync(req).AsTask());
         }
 
-        await WaitUntil(() => PendingCount(conn) == 3, TimeSpan.FromSeconds(2), "all 3 requests enter pending dict");
+        await WaitUntil(() => PendingCount(conn) == 3, TimeSpan.FromSeconds(5), "all 3 requests enter pending dict");
 
         server.Dispose();
 
@@ -415,7 +419,7 @@ public class IpcConnectionMultiplexedTests
         Assert.That(exceptions, Has.All.Not.Null);
         // 全タスクが broken-pipe 例外として観測される (OperationCanceledException ではない)。
         Assert.That(exceptions, Has.All.InstanceOf<IOException>());
-        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2), "pending dict drains after broken pipe");
+        await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after broken pipe");
         Assert.That(PendingCount(conn), Is.EqualTo(0));
     }
 

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -1,0 +1,257 @@
+using System.Collections.Concurrent;
+using System.IO.Pipes;
+using System.Reflection;
+using Beutl.FFmpegIpc.Protocol;
+using Beutl.FFmpegIpc.Transport;
+
+namespace Beutl.FFmpegIpc.Tests;
+
+/// <summary>
+/// IpcConnection.SendAndReceiveMultiplexedAsync のキャンセル順序と
+/// 競合パスを検証する。NamedPipe を使ったクロスプラットフォーム動作。
+/// </summary>
+[TestFixture, NonParallelizable]
+public class IpcConnectionMultiplexedTests
+{
+    private static readonly MessageType RequestType = MessageType.CloseReader;
+    private static readonly MessageType ResponseType = MessageType.CloseReaderResult;
+
+    private static string NewPipeName() => "beutl-ipc-" + Guid.NewGuid().ToString("N")[..8];
+
+    private static (NamedPipeServerStream Server, NamedPipeClientStream Client) ConnectPair()
+    {
+        string name = NewPipeName();
+        var server = new NamedPipeServerStream(
+            name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+        var serverConnectTask = server.WaitForConnectionAsync();
+        client.Connect(TimeSpan.FromSeconds(5));
+        serverConnectTask.GetAwaiter().GetResult();
+        return (server, client);
+    }
+
+    private static int PendingCount(IpcConnection conn)
+    {
+        var field = typeof(IpcConnection).GetField(
+            "_pendingRequests", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var dict = (System.Collections.IDictionary)field.GetValue(conn)!;
+        return dict.Count;
+    }
+
+    [Test]
+    public async Task ConcurrentRequests_AllReceiveCorrectResponses()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        // 「Worker」役: 受信したリクエストをそのまま Pong として返す。
+        var workerCts = new CancellationTokenSource();
+        var workerTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!workerCts.IsCancellationRequested)
+                {
+                    var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
+                    if (req == null) return;
+                    var resp = IpcMessage.CreateSimple(req.Id, ResponseType);
+                    await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (IOException) { }
+        });
+
+        try
+        {
+            var tasks = new List<Task<IpcMessage>>();
+            for (int i = 0; i < 5; i++)
+            {
+                int id = conn.NextId();
+                var req = IpcMessage.CreateSimple(id, RequestType);
+                tasks.Add(conn.SendAndReceiveAsync(req).AsTask());
+            }
+
+            var responses = await Task.WhenAll(tasks);
+            Assert.That(responses.Length, Is.EqualTo(5));
+            Assert.That(responses.Select(r => r.Type), Is.All.EqualTo(ResponseType));
+
+            // Pending dictionary は空に戻っているはず。
+            Assert.That(PendingCount(conn), Is.EqualTo(0));
+        }
+        finally
+        {
+            workerCts.Cancel();
+            server.Dispose();
+            try { await workerTask; } catch { }
+        }
+    }
+
+    [Test]
+    public async Task AlreadyCanceledToken_ThrowsBeforeRegistering()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            Assert.CatchAsync<OperationCanceledException>(
+                async () => await conn.SendAndReceiveAsync(req, cts.Token));
+
+            // dict には何も登録されていない。
+            Assert.That(PendingCount(conn), Is.EqualTo(0));
+        }
+        finally
+        {
+            server.Dispose();
+            await Task.Yield();
+        }
+    }
+
+    [Test]
+    public async Task CancelWhileAwaitingResponse_ThrowsAndDictIsClean()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+        conn.StartMultiplexedReceive();
+
+        // worker は意図的に返事しない。
+        using var cts = new CancellationTokenSource();
+        try
+        {
+            int id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
+
+            // 送信完了を待ってからキャンセル。
+            await Task.Delay(50);
+            cts.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
+
+            // dict は撤去済み。
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            Assert.That(PendingCount(conn), Is.EqualTo(0));
+        }
+        finally
+        {
+            server.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task LateResponseAfterCancel_InvokesDroppedHandler_NoDeadlock()
+    {
+        var (server, client) = ConnectPair();
+        using var conn = new IpcConnection(client);
+
+        var dropped = new ConcurrentQueue<IpcMessage>();
+        conn.DroppedResponseHandler = msg => dropped.Enqueue(msg);
+
+        conn.StartMultiplexedReceive();
+
+        using var cts = new CancellationTokenSource();
+        int id;
+        try
+        {
+            id = conn.NextId();
+            var req = IpcMessage.CreateSimple(id, RequestType);
+            var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
+
+            await Task.Delay(50);
+            cts.Cancel();
+            Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+
+            // 遅延レスポンスを送り込む → dropped ハンドラに来るはず。
+            var resp = IpcMessage.CreateSimple(id, ResponseType);
+            await MessageSerializer.WriteMessageAsync(server, resp);
+
+            await WaitUntil(() => dropped.Count >= 1, TimeSpan.FromSeconds(2));
+            Assert.That(dropped.Count, Is.GreaterThanOrEqualTo(1));
+            Assert.That(dropped.Any(m => m.Id == id), Is.True);
+        }
+        finally
+        {
+            server.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task RaceCancelAndResponse_NoLeak_StressLoop()
+    {
+        for (int iter = 0; iter < 50; iter++)
+        {
+            var (server, client) = ConnectPair();
+            using var conn = new IpcConnection(client);
+
+            var dropped = new ConcurrentQueue<IpcMessage>();
+            conn.DroppedResponseHandler = msg => dropped.Enqueue(msg);
+            conn.StartMultiplexedReceive();
+
+            var workerCts = new CancellationTokenSource();
+            var workerTask = Task.Run(async () =>
+            {
+                try
+                {
+                    var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
+                    if (req == null) return;
+                    // worker からは即時にレスポンス。
+                    var resp = IpcMessage.CreateSimple(req.Id, ResponseType);
+                    await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
+                }
+                catch (OperationCanceledException) { }
+                catch (IOException) { }
+            });
+
+            using var cts = new CancellationTokenSource();
+            try
+            {
+                int id = conn.NextId();
+                var req = IpcMessage.CreateSimple(id, RequestType);
+                var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
+
+                // 受信ループとキャンセルがほぼ同時に走るよう仕向ける。
+                cts.Cancel();
+
+                try
+                {
+                    await requestTask;
+                    // 正常完了でも問題なし。
+                }
+                catch (OperationCanceledException)
+                {
+                    // キャンセル勝ち。
+                }
+            }
+            finally
+            {
+                workerCts.Cancel();
+                server.Dispose();
+                try { await workerTask; } catch { }
+            }
+
+            // 反復毎に dict は空に戻っているべき。
+            await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
+            Assert.That(PendingCount(conn), Is.EqualTo(0), $"iter={iter}");
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!predicate() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+    }
+}

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -45,46 +45,56 @@ public class IpcConnectionMultiplexedTests
         using var conn = new IpcConnection(client);
         conn.StartMultiplexedReceive();
 
-        // 「Worker」役: 受信したリクエストをそのまま Pong として返す。
+        // Worker 役: 受信した順にレスポンスを返す。
+        // 受信順とは異なる順序で返すことで ID ルーティングを実際にストレスする。
         var workerCts = new CancellationTokenSource();
         var workerTask = Task.Run(async () =>
         {
-            try
+            var received = new List<IpcMessage>();
+            while (!workerCts.IsCancellationRequested)
             {
-                while (!workerCts.IsCancellationRequested)
+                var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
+                if (req == null) return;
+                received.Add(req);
+                if (received.Count == 5)
                 {
-                    var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
-                    if (req == null) return;
-                    var resp = IpcMessage.CreateSimple(req.Id, ResponseType);
-                    await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
+                    foreach (var msg in received.AsEnumerable().Reverse())
+                    {
+                        var resp = IpcMessage.CreateSimple(msg.Id, ResponseType);
+                        await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
+                    }
+                    return;
                 }
             }
-            catch (OperationCanceledException) { }
-            catch (IOException) { }
         });
 
         try
         {
-            var tasks = new List<Task<IpcMessage>>();
+            var tasks = new List<(int Id, Task<IpcMessage> Task)>();
             for (int i = 0; i < 5; i++)
             {
                 int id = conn.NextId();
                 var req = IpcMessage.CreateSimple(id, RequestType);
-                tasks.Add(conn.SendAndReceiveAsync(req).AsTask());
+                tasks.Add((id, conn.SendAndReceiveAsync(req).AsTask()));
             }
 
-            var responses = await Task.WhenAll(tasks);
-            Assert.That(responses.Length, Is.EqualTo(5));
-            Assert.That(responses.Select(r => r.Type), Is.All.EqualTo(ResponseType));
+            await Task.WhenAll(tasks.Select(t => t.Task));
+            foreach (var (id, t) in tasks)
+            {
+                Assert.That(t.Result.Id, Is.EqualTo(id));
+                Assert.That(t.Result.Type, Is.EqualTo(ResponseType));
+            }
 
-            // Pending dictionary は空に戻っているはず。
             Assert.That(PendingCount(conn), Is.EqualTo(0));
         }
         finally
         {
             workerCts.Cancel();
             server.Dispose();
-            try { await workerTask; } catch { }
+            try { await workerTask; }
+            catch (OperationCanceledException) { }
+            catch (IOException) { }
+            catch (ObjectDisposedException) { }
         }
     }
 
@@ -92,27 +102,19 @@ public class IpcConnectionMultiplexedTests
     public async Task AlreadyCanceledToken_ThrowsBeforeRegistering()
     {
         var (server, client) = ConnectPair();
+        using var _ = server;
         using var conn = new IpcConnection(client);
         conn.StartMultiplexedReceive();
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        try
-        {
-            int id = conn.NextId();
-            var req = IpcMessage.CreateSimple(id, RequestType);
-            Assert.CatchAsync<OperationCanceledException>(
-                async () => await conn.SendAndReceiveAsync(req, cts.Token));
+        int id = conn.NextId();
+        var req = IpcMessage.CreateSimple(id, RequestType);
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await conn.SendAndReceiveAsync(req, cts.Token));
 
-            // dict には何も登録されていない。
-            Assert.That(PendingCount(conn), Is.EqualTo(0));
-        }
-        finally
-        {
-            server.Dispose();
-            await Task.Yield();
-        }
+        Assert.That(PendingCount(conn), Is.EqualTo(0));
     }
 
     [Test]
@@ -130,8 +132,8 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
-            // 送信完了を待ってからキャンセル。
-            await Task.Delay(50);
+            // 送信完了 (= pending に積まれた) を観測してからキャンセル。Task.Delay よりも安定。
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2));
             cts.Cancel();
 
             var oce = Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
@@ -165,7 +167,7 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
-            await Task.Delay(50);
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(2));
             cts.Cancel();
             Assert.CatchAsync<OperationCanceledException>(async () => await requestTask);
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
@@ -189,7 +191,11 @@ public class IpcConnectionMultiplexedTests
     [Test]
     public async Task RaceCancelAndResponse_NoLeak_StressLoop()
     {
-        for (int iter = 0; iter < 50; iter++)
+        // レスポンス勝ち / キャンセル勝ち どちらでもリークしない不変を確認。
+        // 結果は気にしないが、dropped に乗ったメッセージは必ず送信した id と一致するはず。
+        const int iterations = 500;
+
+        for (int iter = 0; iter < iterations; iter++)
         {
             var (server, client) = ConnectPair();
             using var conn = new IpcConnection(client);
@@ -201,22 +207,16 @@ public class IpcConnectionMultiplexedTests
             var workerCts = new CancellationTokenSource();
             var workerTask = Task.Run(async () =>
             {
-                try
-                {
-                    var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
-                    if (req == null) return;
-                    // worker からは即時にレスポンス。
-                    var resp = IpcMessage.CreateSimple(req.Id, ResponseType);
-                    await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
-                }
-                catch (OperationCanceledException) { }
-                catch (IOException) { }
+                var req = await MessageSerializer.ReadMessageAsync(server, workerCts.Token);
+                if (req == null) return;
+                var resp = IpcMessage.CreateSimple(req.Id, ResponseType);
+                await MessageSerializer.WriteMessageAsync(server, resp, workerCts.Token);
             });
 
             using var cts = new CancellationTokenSource();
+            int id = conn.NextId();
             try
             {
-                int id = conn.NextId();
                 var req = IpcMessage.CreateSimple(id, RequestType);
                 var requestTask = conn.SendAndReceiveAsync(req, cts.Token).AsTask();
 
@@ -226,23 +226,31 @@ public class IpcConnectionMultiplexedTests
                 try
                 {
                     await requestTask;
-                    // 正常完了でも問題なし。
                 }
-                catch (OperationCanceledException)
-                {
-                    // キャンセル勝ち。
-                }
+                catch (OperationCanceledException) { }
+                catch (IOException) { }
             }
             finally
             {
                 workerCts.Cancel();
                 server.Dispose();
-                try { await workerTask; } catch { }
+                // worker は書き込み中に server.Dispose() を踏むと
+                // ObjectDisposedException を投げうる。stress テストでは
+                // この競合は不可避なので想定例外として許容する。
+                try { await workerTask; }
+                catch (OperationCanceledException) { }
+                catch (IOException) { }
+                catch (ObjectDisposedException) { }
             }
 
-            // 反復毎に dict は空に戻っているべき。
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(2));
             Assert.That(PendingCount(conn), Is.EqualTo(0), $"iter={iter}");
+
+            // dropped に乗ったメッセージはすべて送信した id と一致するはず。
+            foreach (var d in dropped)
+            {
+                Assert.That(d.Id, Is.EqualTo(id), $"iter={iter}: dropped foreign id");
+            }
         }
     }
 
@@ -288,7 +296,10 @@ public class IpcConnectionMultiplexedTests
         {
             workerCts.Cancel();
             server.Dispose();
-            await workerTask;
+            try { await workerTask; }
+            catch (OperationCanceledException) { }
+            catch (IOException) { }
+            catch (ObjectDisposedException) { }
         }
     }
 


### PR DESCRIPTION
## Description

- Reorder `IpcConnection.SendAndReceiveMultiplexedAsync` so cancellation
  is registered before `SendAsync`, with an entry-time `ThrowIfCancellationRequested`
  and a unified `finally` cleanup. Previously the registration was set up
  only after `SendAsync` returned, leaving an unnatural ordering and
  contributing to a race where a cancelled request could silently drop
  the worker's reply -- and with it any shared-memory `bufferIndex`.
- Add `DroppedResponseHandler` so upper layers (e.g. `IpcFrameProvider`,
  `IpcSampleProvider`) can release shared-memory buffers when a response
  arrives after its waiter was cancelled or no waiter exists.
  Default is null (no-op), so existing callers are unaffected.
- Harden the receive loop and dispose path:
  - Distinguish self-cancel (loopCt) from peer-side termination
    (`IOException`, EOF) and unexpected protocol errors so each is
    reported with the right exception type to pending TCSes.
  - Publish a `_receiveLoopFault` via a release/acquire pair so new
    requests after the loop dies fail-fast instead of awaiting forever.
  - Wait for the receive loop in `Dispose` (with a 5s upper bound)
    before releasing pipe / semaphores; surface fatal exceptions
    (OOM/SOE/AVE) via `ExceptionDispatchInfo` instead of swallowing them.
  - Detect duplicate request ids with `TryAdd` and remove only the
    caller's own TCS via the keyed-value `TryRemove` overload.
- Introduce `DiagnosticLogger` so the host and worker can each plug
  their own logger for receive-loop / dispose diagnostics. Defaults to
  `Trace.TraceError` so the dependency-free `Beutl.FFmpegIpc` library
  stays self-contained.
- Wire the new hooks at both construction sites:
  - Host (`FFmpegWorkerProcess`): `DiagnosticLogger` forwards to the
    extension's `ILogger`; `DroppedResponseHandler` logs at Warning as
    a defensive observer (today's reader requests are not cancellable
    and shared memory is ref-counted, so this should not fire -- it
    exists to surface regressions if cancellable reads are added).
  - Worker (`Program.cs`): `DiagnosticLogger` forwards to `WorkerLog`.
    `DroppedResponseHandler` is intentionally left unset because the
    worker does not run multiplexed receive.
- Add `tests/Beutl.FFmpegIpc.Tests` (17 tests) covering: concurrent
  requests, already-cancelled token at entry, cancel while awaiting
  response, late-response delivery after cancel (verifying the new
  hook), duplicate-id rejection, post-dispose fail-fast, foreign-token
  OCE not being swallowed, protocol corruption surfaced as `IOException`,
  fatal exception rethrow on dispose, broken-pipe propagation, dispose
  timeout when the loop ignores cancellation, and a 500-iteration
  cancel/response race stress loop. All tests pass repeatedly with no
  flakiness observed.

## Breaking changes

None. `IpcConnection` gains two opt-in hooks (`DroppedResponseHandler`
and `DiagnosticLogger`); behavior on the success path and on plain
cancellation paths is unchanged for existing callers.

## Fixed issues

Tracked on the `b-editor/projects/9` AI Review board as the draft issue
"[Bug] IpcConnection.SendAndReceiveMultiplexedAsync
のキャンセル登録順序で永久ブロック". No GitHub issue number exists.