### PR TITLE
fix: surface partial relocation failures during project export

### DIFF
--- a/src/Beutl.Editor/ProjectPackageService.cs
+++ b/src/Beutl.Editor/ProjectPackageService.cs
@@ -86,9 +86,9 @@ public sealed class ProjectPackageService
                 tempProjectDir,
                 cancellationToken);
             _logger.LogInformation("Relocated {Count} external files", fileResult.SuccessCount);
-            if (fileResult.FailedItems.Count > 0)
+            if (fileResult.FailedResources.Count > 0)
             {
-                _logger.LogWarning("Failed to relocate {Count} external files", fileResult.FailedItems.Count);
+                _logger.LogWarning("Failed to relocate {Count} external files", fileResult.FailedResources.Count);
             }
 
             // Step 6: Copy fonts
@@ -98,9 +98,9 @@ public sealed class ProjectPackageService
                 tempProjectDir,
                 cancellationToken);
             _logger.LogInformation("Relocated {Count} font files", fontResult.SuccessCount);
-            if (fontResult.FailedItems.Count > 0)
+            if (fontResult.FailedResources.Count > 0)
             {
-                _logger.LogWarning("Failed to relocate {Count} font families", fontResult.FailedItems.Count);
+                _logger.LogWarning("Failed to relocate {Count} font families", fontResult.FailedResources.Count);
             }
 
             // Step 7: Save the project
@@ -122,7 +122,7 @@ public sealed class ProjectPackageService
             progress?.Report((Strings.ExportingProject, 1.0));
             _logger.LogInformation("Project exported successfully to {OutputPath}", outputPath);
 
-            List<string> failedResources = [.. fileResult.FailedItems, .. fontResult.FailedItems];
+            List<string> failedResources = [.. fileResult.FailedResources, .. fontResult.FailedResources];
             return new ExportResult(true, failedResources);
         }
         catch (OperationCanceledException)

--- a/src/Beutl.Editor/ProjectPackageService.cs
+++ b/src/Beutl.Editor/ProjectPackageService.cs
@@ -11,7 +11,7 @@ namespace Beutl.Editor;
 /// Result of a project export operation.
 /// </summary>
 /// <param name="Success">Whether the ZIP was written. Cancellation does not set this to <c>false</c> — it propagates as <see cref="OperationCanceledException"/>.</param>
-/// <param name="FailedResources">Identifiers of resources that could not be fully relocated. Non-empty while <see cref="Success"/> is <c>true</c> means partial failure: the ZIP exists, but some referenced files/fonts are either missing from it or still pointing at the original path inside the saved project.</param>
+/// <param name="FailedResources">Identifiers of resources that could not be fully relocated. Non-empty while <see cref="Success"/> is <c>true</c> means partial failure: the ZIP exists, but some referenced files/fonts are either missing from it or still pointing at the original path inside the saved project. When <see cref="Success"/> is <c>false</c>, this preserves any failures that were already collected before the export was aborted.</param>
 public sealed record ExportResult(bool Success, IReadOnlyList<string> FailedResources);
 
 /// <summary>
@@ -22,10 +22,16 @@ public sealed class ProjectPackageService
     public static ProjectPackageService Current { get; } = new();
 
     private readonly ILogger _logger = Log.CreateLogger<ProjectPackageService>();
-    private readonly ResourceRelocationService _relocationService = new();
+    private readonly ResourceRelocationService _relocationService;
 
     private ProjectPackageService()
     {
+        _relocationService = new ResourceRelocationService();
+    }
+
+    internal ProjectPackageService(ResourceRelocationService relocationService)
+    {
+        _relocationService = relocationService;
     }
 
     /// <summary>
@@ -51,6 +57,8 @@ public sealed class ProjectPackageService
         }
 
         string? tempDir = null;
+        RelocationResult fileResult = new(0, []);
+        RelocationResult fontResult = new(0, []);
 
         try
         {
@@ -80,7 +88,7 @@ public sealed class ProjectPackageService
             progress?.Report((Strings.ExportingProject, 0.4));
             ExternalResourceCollector collector = ExternalResourceCollector.Collect(project, projectDir);
 
-            RelocationResult fileResult = await _relocationService.RelocateFileSourcesAsync(
+            fileResult = await _relocationService.RelocateFileSourcesAsync(
                 collector.FileSources,
                 tempProject,
                 tempProjectDir,
@@ -88,19 +96,25 @@ public sealed class ProjectPackageService
             _logger.LogInformation("Relocated {Count} external files", fileResult.SuccessCount);
             if (fileResult.FailedResources.Count > 0)
             {
-                _logger.LogWarning("Failed to relocate {Count} external files", fileResult.FailedResources.Count);
+                _logger.LogWarning(
+                    "Failed to relocate {Count} external files: {Resources}",
+                    fileResult.FailedResources.Count,
+                    string.Join(", ", fileResult.FailedResources));
             }
 
             // Step 6: Copy fonts
             progress?.Report((Strings.ExportingProject, 0.6));
-            RelocationResult fontResult = await _relocationService.RelocateFontsAsync(
+            fontResult = await _relocationService.RelocateFontsAsync(
                 collector.FontFamilies,
                 tempProjectDir,
                 cancellationToken);
             _logger.LogInformation("Relocated {Count} font files", fontResult.SuccessCount);
             if (fontResult.FailedResources.Count > 0)
             {
-                _logger.LogWarning("Failed to relocate {Count} font families", fontResult.FailedResources.Count);
+                _logger.LogWarning(
+                    "Failed to relocate {Count} font families: {Resources}",
+                    fontResult.FailedResources.Count,
+                    string.Join(", ", fontResult.FailedResources));
             }
 
             // Step 7: Save the project
@@ -132,7 +146,7 @@ public sealed class ProjectPackageService
         }
         catch (Exception ex)
         {
-            return LogExportError(ex);
+            return LogExportError(ex, fileResult, fontResult);
         }
         finally
         {
@@ -146,11 +160,11 @@ public sealed class ProjectPackageService
         _logger.LogInformation("Export operation was cancelled");
     }
 
-    [ExcludeFromCodeCoverage]
-    private ExportResult LogExportError(Exception ex)
+    private ExportResult LogExportError(Exception ex, RelocationResult fileResult, RelocationResult fontResult)
     {
         _logger.LogError(ex, "Failed to export project");
-        return new ExportResult(false, []);
+        List<string> failedResources = [.. fileResult.FailedResources, .. fontResult.FailedResources];
+        return new ExportResult(false, failedResources);
     }
 
     [ExcludeFromCodeCoverage]

--- a/src/Beutl.Editor/ProjectPackageService.cs
+++ b/src/Beutl.Editor/ProjectPackageService.cs
@@ -8,6 +8,13 @@ using Microsoft.Extensions.Logging;
 namespace Beutl.Editor;
 
 /// <summary>
+/// Result of a project export operation.
+/// </summary>
+/// <param name="Success">Whether the export completed without a fatal error. The ZIP file is created when this is <c>true</c>.</param>
+/// <param name="FailedResources">Identifiers of resources that could not be copied. Non-empty even when <see cref="Success"/> is <c>true</c> indicates a partial failure: the ZIP exists but some referenced files or fonts are missing.</param>
+public sealed record ExportResult(bool Success, IReadOnlyList<string> FailedResources);
+
+/// <summary>
 /// Service for exporting and importing projects.
 /// </summary>
 public sealed class ProjectPackageService
@@ -28,8 +35,8 @@ public sealed class ProjectPackageService
     /// <param name="outputPath">The output ZIP file path.</param>
     /// <param name="progress">Progress reporter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns><c>true</c> if the export was successful.</returns>
-    public async Task<bool> ExportAsync(
+    /// <returns>An <see cref="ExportResult"/> describing whether the export completed and any resources that failed to copy.</returns>
+    public async Task<ExportResult> ExportAsync(
         Project project,
         string outputPath,
         IProgress<(string Message, double Progress)>? progress = null,
@@ -73,20 +80,28 @@ public sealed class ProjectPackageService
             progress?.Report((Strings.ExportingProject, 0.4));
             ExternalResourceCollector collector = ExternalResourceCollector.Collect(project, projectDir);
 
-            int fileCount = await _relocationService.RelocateFileSourcesAsync(
+            RelocationResult fileResult = await _relocationService.RelocateFileSourcesAsync(
                 collector.FileSources,
                 tempProject,
                 tempProjectDir,
                 cancellationToken);
-            _logger.LogInformation("Relocated {Count} external files", fileCount);
+            _logger.LogInformation("Relocated {Count} external files", fileResult.SuccessCount);
+            if (fileResult.FailedItems.Count > 0)
+            {
+                _logger.LogWarning("Failed to relocate {Count} external files", fileResult.FailedItems.Count);
+            }
 
             // Step 6: Copy fonts
             progress?.Report((Strings.ExportingProject, 0.6));
-            int fontCount = await _relocationService.RelocateFontsAsync(
+            RelocationResult fontResult = await _relocationService.RelocateFontsAsync(
                 collector.FontFamilies,
                 tempProjectDir,
                 cancellationToken);
-            _logger.LogInformation("Relocated {Count} font files", fontCount);
+            _logger.LogInformation("Relocated {Count} font files", fontResult.SuccessCount);
+            if (fontResult.FailedItems.Count > 0)
+            {
+                _logger.LogWarning("Failed to relocate {Count} font families", fontResult.FailedItems.Count);
+            }
 
             // Step 7: Save the project
             progress?.Report((Strings.ExportingProject, 0.8));
@@ -107,7 +122,8 @@ public sealed class ProjectPackageService
             progress?.Report((Strings.ExportingProject, 1.0));
             _logger.LogInformation("Project exported successfully to {OutputPath}", outputPath);
 
-            return true;
+            List<string> failedResources = [.. fileResult.FailedItems, .. fontResult.FailedItems];
+            return new ExportResult(true, failedResources);
         }
         catch (OperationCanceledException)
         {
@@ -131,10 +147,10 @@ public sealed class ProjectPackageService
     }
 
     [ExcludeFromCodeCoverage]
-    private bool LogExportError(Exception ex)
+    private ExportResult LogExportError(Exception ex)
     {
         _logger.LogError(ex, "Failed to export project");
-        return false;
+        return new ExportResult(false, []);
     }
 
     [ExcludeFromCodeCoverage]

--- a/src/Beutl.Editor/ProjectPackageService.cs
+++ b/src/Beutl.Editor/ProjectPackageService.cs
@@ -10,8 +10,8 @@ namespace Beutl.Editor;
 /// <summary>
 /// Result of a project export operation.
 /// </summary>
-/// <param name="Success">Whether the export completed without a fatal error. The ZIP file is created when this is <c>true</c>.</param>
-/// <param name="FailedResources">Identifiers of resources that could not be copied. Non-empty even when <see cref="Success"/> is <c>true</c> indicates a partial failure: the ZIP exists but some referenced files or fonts are missing.</param>
+/// <param name="Success">Whether the ZIP was written. Cancellation does not set this to <c>false</c> — it propagates as <see cref="OperationCanceledException"/>.</param>
+/// <param name="FailedResources">Identifiers of resources that could not be fully relocated. Non-empty while <see cref="Success"/> is <c>true</c> means partial failure: the ZIP exists, but some referenced files/fonts are either missing from it or still pointing at the original path inside the saved project.</param>
 public sealed record ExportResult(bool Success, IReadOnlyList<string> FailedResources);
 
 /// <summary>

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -64,35 +64,42 @@ public sealed class ResourceRelocationService
         {
             cancellationToken.ThrowIfCancellationRequested();
             var originalUri = group.Key;
+            string sourceFilePath = originalUri.LocalPath;
+            if (!File.Exists(sourceFilePath))
+            {
+                _logger.LogWarning("Source file not found: {FilePath}", sourceFilePath);
+                failedItems.Add(sourceFilePath);
+                continue;
+            }
+
+            string destFilePath;
             try
             {
-                string sourceFilePath = originalUri.LocalPath;
-                if (!File.Exists(sourceFilePath))
-                {
-                    _logger.LogWarning("Source file not found: {FilePath}", sourceFilePath);
-                    failedItems.Add(sourceFilePath);
-                    continue;
-                }
-
                 string fileName = Path.GetFileName(sourceFilePath);
-                string destFilePath = GetUniqueFilePath(resourcesDir, fileName);
-
+                destFilePath = GetUniqueFilePath(resourcesDir, fileName);
                 await CopyFileAsync(sourceFilePath, destFilePath, cancellationToken);
-
-                foreach ((Guid id, string prop, _) in group)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    // Update the URI to the new path
-                    UpdateUri(stagingProject, id, prop, new Uri(destFilePath));
-
-                    count++;
-                    _logger.LogDebug("Relocated file: {OriginalPath} -> {NewPath}", sourceFilePath, destFilePath);
-                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to relocate file: {Uri}", originalUri);
+                _logger.LogError(ex, "Failed to copy file: {Uri}", originalUri);
                 failedItems.Add(originalUri.ToString());
+                continue;
+            }
+
+            foreach ((Guid id, string prop, _) in group)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    UpdateUri(stagingProject, id, prop, new Uri(destFilePath));
+                    count++;
+                    _logger.LogDebug("Relocated file: {OriginalPath} -> {NewPath}", sourceFilePath, destFilePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to update URI for {Id}.{Property}: {Uri}", id, prop, originalUri);
+                    failedItems.Add($"{originalUri} ({id}.{prop})");
+                }
             }
         }
 

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -79,6 +79,10 @@ public sealed class ResourceRelocationService
                 destFilePath = GetUniqueFilePath(resourcesDir, fileName);
                 await CopyFileAsync(sourceFilePath, destFilePath, cancellationToken);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to copy file: {Uri}", originalUri);
@@ -190,6 +194,10 @@ public sealed class ResourceRelocationService
                     _logger.LogWarning("No font files found for family: {FontFamily}", fontFamily.Name);
                     failedResources.Add(fontFamily.Name);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -162,8 +162,10 @@ public sealed class ResourceRelocationService
                 IEnumerable<string> fontFiles = _fontFileFinder != null
                     ? _fontFileFinder(fontFamily.Name)
                     : FindFontFiles(fontFamily.Name);
+                bool foundAnyFile = false;
                 foreach (string sourceFilePath in fontFiles)
                 {
+                    foundAnyFile = true;
                     if (!copiedFiles.Add(sourceFilePath))
                         continue;
 
@@ -174,6 +176,12 @@ public sealed class ResourceRelocationService
 
                     count++;
                     _logger.LogDebug("Relocated font: {OriginalPath} -> {NewPath}", sourceFilePath, destFilePath);
+                }
+
+                if (!foundAnyFile)
+                {
+                    _logger.LogWarning("No font files found for family: {FontFamily}", fontFamily.Name);
+                    failedItems.Add(fontFamily.Name);
                 }
             }
             catch (Exception ex)

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -20,7 +20,7 @@ public sealed record RelocationResult(int SuccessCount, IReadOnlyList<string> Fa
 /// <summary>
 /// Service for copying resource files and rewriting their URIs.
 /// </summary>
-public sealed class ResourceRelocationService
+public class ResourceRelocationService
 {
     private readonly ILogger _logger = Log.CreateLogger<ResourceRelocationService>();
     private readonly Func<string, IEnumerable<string>>? _fontFileFinder;
@@ -49,7 +49,7 @@ public sealed class ResourceRelocationService
     /// <param name="projectDirectory">The path of the project directory.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="RelocationResult"/> with success count and failed source identifiers.</returns>
-    public async Task<RelocationResult> RelocateFileSourcesAsync(
+    public virtual async Task<RelocationResult> RelocateFileSourcesAsync(
         IEnumerable<(Guid Object, string PropertyName, Uri OriginalUri)> sources,
         Project stagingProject,
         string projectDirectory,
@@ -152,7 +152,7 @@ public sealed class ResourceRelocationService
     /// <param name="projectDirectory">The path of the project directory.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="RelocationResult"/> with success count and failed font family names.</returns>
-    public async Task<RelocationResult> RelocateFontsAsync(
+    public virtual async Task<RelocationResult> RelocateFontsAsync(
         IEnumerable<FontFamily> fontFamilies,
         string projectDirectory,
         CancellationToken cancellationToken = default)

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -13,8 +13,8 @@ namespace Beutl.Editor;
 /// <summary>
 /// Result of a resource relocation operation.
 /// </summary>
-/// <param name="SuccessCount">Number of resources successfully relocated.</param>
-/// <param name="FailedItems">Identifiers (URI strings, paths, or font family names) of resources that failed to relocate.</param>
+/// <param name="SuccessCount">Number of property updates (file sources) or font files (fonts) that were successfully relocated. Granularity differs from <paramref name="FailedItems"/>.Count.</param>
+/// <param name="FailedItems">Identifiers of resources that could not be relocated. The string format depends on the failure path: local file paths for missing sources, "<c>uri (guid.property)</c>" for per-property URI rewrites that threw, full URI strings for file-copy failures, and font family names for font failures.</param>
 public sealed record RelocationResult(int SuccessCount, IReadOnlyList<string> FailedItems);
 
 /// <summary>

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -11,6 +11,13 @@ using SkiaSharp;
 namespace Beutl.Editor;
 
 /// <summary>
+/// Result of a resource relocation operation.
+/// </summary>
+/// <param name="SuccessCount">Number of resources successfully relocated.</param>
+/// <param name="FailedItems">Identifiers (URI strings, paths, or font family names) of resources that failed to relocate.</param>
+public sealed record RelocationResult(int SuccessCount, IReadOnlyList<string> FailedItems);
+
+/// <summary>
 /// Service for copying resource files and rewriting their URIs.
 /// </summary>
 public sealed class ResourceRelocationService
@@ -41,8 +48,8 @@ public sealed class ResourceRelocationService
     /// <param name="stagingProject">The project to apply URI updates to.</param>
     /// <param name="projectDirectory">The path of the project directory.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The number of files copied.</returns>
-    public async Task<int> RelocateFileSourcesAsync(
+    /// <returns>A <see cref="RelocationResult"/> with success count and failed source identifiers.</returns>
+    public async Task<RelocationResult> RelocateFileSourcesAsync(
         IEnumerable<(Guid Object, string PropertyName, Uri OriginalUri)> sources,
         Project stagingProject,
         string projectDirectory,
@@ -52,6 +59,7 @@ public sealed class ResourceRelocationService
         Directory.CreateDirectory(resourcesDir);
 
         int count = 0;
+        List<string> failedItems = [];
         foreach (var group in sources.GroupBy(i => i.OriginalUri))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -62,6 +70,7 @@ public sealed class ResourceRelocationService
                 if (!File.Exists(sourceFilePath))
                 {
                     _logger.LogWarning("Source file not found: {FilePath}", sourceFilePath);
+                    failedItems.Add(sourceFilePath);
                     continue;
                 }
 
@@ -83,10 +92,11 @@ public sealed class ResourceRelocationService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to relocate file: {Uri}", originalUri);
+                failedItems.Add(originalUri.ToString());
             }
         }
 
-        return count;
+        return new RelocationResult(count, failedItems);
     }
 
     private void UpdateUri(Project stagingProject, Guid id, string propertyName, Uri newUri)
@@ -130,8 +140,8 @@ public sealed class ResourceRelocationService
     /// <param name="fontFamilies">The list of font families to copy.</param>
     /// <param name="projectDirectory">The path of the project directory.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The number of font files copied.</returns>
-    public async Task<int> RelocateFontsAsync(
+    /// <returns>A <see cref="RelocationResult"/> with success count and failed font family names.</returns>
+    public async Task<RelocationResult> RelocateFontsAsync(
         IEnumerable<FontFamily> fontFamilies,
         string projectDirectory,
         CancellationToken cancellationToken = default)
@@ -141,6 +151,7 @@ public sealed class ResourceRelocationService
 
         HashSet<string> copiedFiles = [];
         int count = 0;
+        List<string> failedItems = [];
 
         foreach (FontFamily fontFamily in fontFamilies)
         {
@@ -168,10 +179,11 @@ public sealed class ResourceRelocationService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to relocate font: {FontFamily}", fontFamily.Name);
+                failedItems.Add(fontFamily.Name);
             }
         }
 
-        return count;
+        return new RelocationResult(count, failedItems);
     }
 
     /// <summary>

--- a/src/Beutl.Editor/ResourceRelocationService.cs
+++ b/src/Beutl.Editor/ResourceRelocationService.cs
@@ -13,9 +13,9 @@ namespace Beutl.Editor;
 /// <summary>
 /// Result of a resource relocation operation.
 /// </summary>
-/// <param name="SuccessCount">Number of property updates (file sources) or font files (fonts) that were successfully relocated. Granularity differs from <paramref name="FailedItems"/>.Count.</param>
-/// <param name="FailedItems">Identifiers of resources that could not be relocated. The string format depends on the failure path: local file paths for missing sources, "<c>uri (guid.property)</c>" for per-property URI rewrites that threw, full URI strings for file-copy failures, and font family names for font failures.</param>
-public sealed record RelocationResult(int SuccessCount, IReadOnlyList<string> FailedItems);
+/// <param name="SuccessCount">Number of property updates (file sources) or font files (fonts) that were successfully relocated. Granularity differs from <paramref name="FailedResources"/>.Count.</param>
+/// <param name="FailedResources">Identifiers of resources that could not be relocated. The string format depends on the failure path: local file paths for missing sources, "<c>uri (guid.property)</c>" for per-property URI rewrites that threw, full URI strings for file-copy failures, and font family names for font failures.</param>
+public sealed record RelocationResult(int SuccessCount, IReadOnlyList<string> FailedResources);
 
 /// <summary>
 /// Service for copying resource files and rewriting their URIs.
@@ -59,7 +59,7 @@ public sealed class ResourceRelocationService
         Directory.CreateDirectory(resourcesDir);
 
         int count = 0;
-        List<string> failedItems = [];
+        List<string> failedResources = [];
         foreach (var group in sources.GroupBy(i => i.OriginalUri))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -68,7 +68,7 @@ public sealed class ResourceRelocationService
             if (!File.Exists(sourceFilePath))
             {
                 _logger.LogWarning("Source file not found: {FilePath}", sourceFilePath);
-                failedItems.Add(sourceFilePath);
+                failedResources.Add(sourceFilePath);
                 continue;
             }
 
@@ -82,7 +82,7 @@ public sealed class ResourceRelocationService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to copy file: {Uri}", originalUri);
-                failedItems.Add(originalUri.ToString());
+                failedResources.Add(originalUri.ToString());
                 continue;
             }
 
@@ -98,12 +98,12 @@ public sealed class ResourceRelocationService
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to update URI for {Id}.{Property}: {Uri}", id, prop, originalUri);
-                    failedItems.Add($"{originalUri} ({id}.{prop})");
+                    failedResources.Add($"{originalUri} ({id}.{prop})");
                 }
             }
         }
 
-        return new RelocationResult(count, failedItems);
+        return new RelocationResult(count, failedResources);
     }
 
     private void UpdateUri(Project stagingProject, Guid id, string propertyName, Uri newUri)
@@ -158,7 +158,7 @@ public sealed class ResourceRelocationService
 
         HashSet<string> copiedFiles = [];
         int count = 0;
-        List<string> failedItems = [];
+        List<string> failedResources = [];
 
         foreach (FontFamily fontFamily in fontFamilies)
         {
@@ -188,17 +188,17 @@ public sealed class ResourceRelocationService
                 if (!foundAnyFile)
                 {
                     _logger.LogWarning("No font files found for family: {FontFamily}", fontFamily.Name);
-                    failedItems.Add(fontFamily.Name);
+                    failedResources.Add(fontFamily.Name);
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to relocate font: {FontFamily}", fontFamily.Name);
-                failedItems.Add(fontFamily.Name);
+                failedResources.Add(fontFamily.Name);
             }
         }
 
-        return new RelocationResult(count, failedItems);
+        return new RelocationResult(count, failedResources);
     }
 
     /// <summary>

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -24,6 +24,9 @@
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
     <value>操作が正常に完了しました。</value>
   </data>
+  <data name="ExportProjectPartialFailure" xml:space="preserve">
+    <value>エクスポートは完了しましたが、{0}件のリソースのコピーに失敗しました。書き出されたパッケージが不完全な可能性があります。</value>
+  </data>
   <data name="ConfirmDeleteDirectory" xml:space="preserve">
     <value>このディレクトリを削除しますか？</value>
   </data>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -29,6 +29,9 @@
   <data name="OperationCompletedSuccessfully" xml:space="preserve">
     <value>The operation completed successfully.</value>
   </data>
+  <data name="ExportProjectPartialFailure" xml:space="preserve">
+    <value>Export completed, but {0} resources failed to copy. The exported package may be incomplete.</value>
+  </data>
   <data name="ConfirmDeleteDirectory" xml:space="preserve">
     <value>Do you want to delete this directory?</value>
   </data>

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -267,6 +267,10 @@ public partial class MainView
                     NotificationService.ShowSuccess(Strings.ExportProject, MessageStrings.OperationCompletedSuccessfully);
                 }
             }
+            catch (OperationCanceledException)
+            {
+                // User-initiated cancellation is not a failure.
+            }
             catch (Exception ex)
             {
                 _ = ex.Handle();
@@ -331,6 +335,10 @@ public partial class MainView
             {
                 NotificationService.ShowError(Strings.ImportProject, MessageStrings.OperationFailed);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            // User-initiated cancellation is not a failure.
         }
         catch (Exception ex)
         {

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -15,6 +15,7 @@ using Beutl.ViewModels;
 using Beutl.Views.Dialogs;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings.Extensions;
 
 namespace Beutl.Views;
@@ -254,10 +255,16 @@ public partial class MainView
 
                 if (!result.Success)
                 {
+                    _logger.LogWarning(
+                        "Project export failed; partial failures collected before abort: [{Resources}]",
+                        string.Join(", ", result.FailedResources));
                     NotificationService.ShowError(Strings.ExportProject, MessageStrings.OperationFailed);
                 }
                 else if (result.FailedResources.Count > 0)
                 {
+                    _logger.LogWarning(
+                        "Project exported with partial failures: [{Resources}]",
+                        string.Join(", ", result.FailedResources));
                     NotificationService.ShowWarning(
                         Strings.ExportProject,
                         string.Format(MessageStrings.ExportProjectPartialFailure, result.FailedResources.Count));
@@ -273,6 +280,7 @@ public partial class MainView
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Unhandled exception while exporting project to {OutputPath}", outputPath);
                 _ = ex.Handle();
                 NotificationService.ShowError(Strings.ExportProject, MessageStrings.OperationFailed);
             }
@@ -342,6 +350,7 @@ public partial class MainView
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Unhandled exception while importing project from {PackagePath}", packagePath);
             _ = ex.Handle();
             NotificationService.ShowError(Strings.ImportProject, MessageStrings.OperationFailed);
         }

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -244,7 +244,7 @@ public partial class MainView
         {
             try
             {
-                bool result = await ProjectPackageService.Current.ExportAsync(
+                ExportResult result = await ProjectPackageService.Current.ExportAsync(
                     project,
                     outputPath,
                     new Progress<(string Message, double Progress)>(p =>
@@ -252,13 +252,19 @@ public partial class MainView
                         // 進捗表示（将来的にはプログレスダイアログを表示）
                     }));
 
-                if (result)
+                if (!result.Success)
                 {
-                    NotificationService.ShowSuccess(Strings.ExportProject, MessageStrings.OperationCompletedSuccessfully);
+                    NotificationService.ShowError(Strings.ExportProject, MessageStrings.OperationFailed);
+                }
+                else if (result.FailedResources.Count > 0)
+                {
+                    NotificationService.ShowWarning(
+                        Strings.ExportProject,
+                        string.Format(MessageStrings.ExportProjectPartialFailure, result.FailedResources.Count));
                 }
                 else
                 {
-                    NotificationService.ShowError(Strings.ExportProject, MessageStrings.OperationFailed);
+                    NotificationService.ShowSuccess(Strings.ExportProject, MessageStrings.OperationCompletedSuccessfully);
                 }
             }
             catch (Exception ex)

--- a/tests/Beutl.UnitTests/Editor/ProjectPackageServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ProjectPackageServiceTests.cs
@@ -118,12 +118,13 @@ public class ProjectPackageServiceTests
         string outputPath = Path.Combine(_exportDir, "test.zip");
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(result, Is.True);
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.FailedResources, Is.Empty);
             Assert.That(File.Exists(outputPath), Is.True);
         });
     }
@@ -140,10 +141,10 @@ public class ProjectPackageServiceTests
         var progress = new Progress<(string Message, double Progress)>(p => progressValues.Add(p.Progress));
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath, progress);
+        ExportResult result = await service.ExportAsync(project, outputPath, progress);
 
         // Assert
-        Assert.That(result, Is.True);
+        Assert.That(result.Success, Is.True);
         // Progress may or may not be reported depending on timing
     }
 
@@ -175,12 +176,12 @@ public class ProjectPackageServiceTests
         File.WriteAllText(outputPath, "dummy content");
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(result, Is.True);
+            Assert.That(result.Success, Is.True);
             // File should be a valid ZIP now, not "dummy content"
             Assert.That(new FileInfo(outputPath).Length, Is.GreaterThan(13)); // "dummy content" length
         });
@@ -200,10 +201,10 @@ public class ProjectPackageServiceTests
         File.WriteAllText(Path.Combine(beutlDir, "state.json"), "{}");
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
-        Assert.That(result, Is.True);
+        Assert.That(result.Success, Is.True);
         // Extract and verify .beutl is not included
         string extractDir = Path.Combine(_testDir, "verify");
         System.IO.Compression.ZipFile.ExtractToDirectory(outputPath, extractDir);
@@ -220,12 +221,13 @@ public class ProjectPackageServiceTests
         string outputPath = Path.Combine(_exportDir, "test_with_items.zip");
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(result, Is.True);
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.FailedResources, Is.Empty);
             Assert.That(File.Exists(outputPath), Is.True);
         });
     }
@@ -406,10 +408,10 @@ public class ProjectPackageServiceTests
         File.WriteAllText(Path.Combine(nestedDir, "image.txt"), "image data");
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
-        Assert.That(result, Is.True);
+        Assert.That(result.Success, Is.True);
     }
 
     [Test]
@@ -424,10 +426,10 @@ public class ProjectPackageServiceTests
         Directory.CreateDirectory(Path.Combine(_projectDir, "empty_dir"));
 
         // Act
-        bool result = await service.ExportAsync(project, outputPath);
+        ExportResult result = await service.ExportAsync(project, outputPath);
 
         // Assert
-        Assert.That(result, Is.True);
+        Assert.That(result.Success, Is.True);
     }
 
     [Test]
@@ -492,10 +494,10 @@ public class ProjectPackageServiceTests
         Directory.CreateDirectory(invalidOutputPath);
 
         // Act
-        bool result = await service.ExportAsync(project, invalidOutputPath);
+        ExportResult result = await service.ExportAsync(project, invalidOutputPath);
 
         // Assert - should return false because the export failed
-        Assert.That(result, Is.False);
+        Assert.That(result.Success, Is.False);
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/ProjectPackageServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ProjectPackageServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using Beutl.Editor;
 using Beutl.Logging;
+using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
@@ -229,6 +230,107 @@ public class ProjectPackageServiceTests
             Assert.That(result.Success, Is.True);
             Assert.That(result.FailedResources, Is.Empty);
             Assert.That(File.Exists(outputPath), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ExportAsync_WithFileAndFontFailures_SurfacesBothInResult()
+    {
+        // Arrange: the stub returns canned failures from both file and font relocation
+        // so we can verify ExportAsync concatenates them into ExportResult.FailedResources.
+        var stub = new StubRelocationService(
+            new RelocationResult(2, ["missing/file_a.png", "missing/file_b.png"]),
+            new RelocationResult(1, ["MissingFamily1", "MissingFamily2"]));
+        var service = new ProjectPackageService(stub);
+        Project project = CreateAndSaveTestProject();
+        string outputPath = Path.Combine(_exportDir, "partial_failure.zip");
+
+        // Act
+        ExportResult result = await service.ExportAsync(project, outputPath);
+
+        // Assert: the ZIP was still written (partial success), and FailedResources
+        // contains file failures first, then font failures, preserving order.
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(File.Exists(outputPath), Is.True);
+            Assert.That(result.FailedResources, Is.EqualTo(new[]
+            {
+                "missing/file_a.png",
+                "missing/file_b.png",
+                "MissingFamily1",
+                "MissingFamily2",
+            }));
+        });
+    }
+
+    [Test]
+    public async Task ExportAsync_WithOnlyFileFailures_SurfacesFileFailures()
+    {
+        // Arrange
+        var stub = new StubRelocationService(
+            new RelocationResult(0, ["missing/only_file.png"]),
+            new RelocationResult(0, []));
+        var service = new ProjectPackageService(stub);
+        Project project = CreateAndSaveTestProject();
+        string outputPath = Path.Combine(_exportDir, "file_only.zip");
+
+        // Act
+        ExportResult result = await service.ExportAsync(project, outputPath);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.FailedResources, Is.EqualTo(new[] { "missing/only_file.png" }));
+        });
+    }
+
+    [Test]
+    public async Task ExportAsync_WithOnlyFontFailures_SurfacesFontFailures()
+    {
+        // Arrange
+        var stub = new StubRelocationService(
+            new RelocationResult(0, []),
+            new RelocationResult(0, ["MissingFontFamily"]));
+        var service = new ProjectPackageService(stub);
+        Project project = CreateAndSaveTestProject();
+        string outputPath = Path.Combine(_exportDir, "font_only.zip");
+
+        // Act
+        ExportResult result = await service.ExportAsync(project, outputPath);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.FailedResources, Is.EqualTo(new[] { "MissingFontFamily" }));
+        });
+    }
+
+    [Test]
+    public async Task ExportAsync_WhenZipCreationFails_PreservesAlreadyCollectedFailures()
+    {
+        // Arrange: file relocation accumulates failures, then the outer ZIP creation
+        // step throws because the output path is a directory. The failures collected
+        // before the abort must still be surfaced — otherwise we lose information
+        // that's already in memory.
+        var stub = new StubRelocationService(
+            new RelocationResult(0, ["pre_abort_file.png"]),
+            new RelocationResult(0, ["pre_abort_font"]));
+        var service = new ProjectPackageService(stub);
+        Project project = CreateAndSaveTestProject();
+        string invalidOutputPath = Path.Combine(_exportDir, "invalid_output_dir");
+        Directory.CreateDirectory(invalidOutputPath);
+
+        // Act
+        ExportResult result = await service.ExportAsync(project, invalidOutputPath);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.FailedResources, Is.EqualTo(new[] { "pre_abort_file.png", "pre_abort_font" }));
         });
     }
 
@@ -533,6 +635,24 @@ public class ProjectPackageServiceTests
 
         // Restore the project to get a proper Uri set
         return CoreSerializer.RestoreFromUri<Project>(projectUri);
+    }
+
+    private sealed class StubRelocationService(
+        RelocationResult fileResult,
+        RelocationResult fontResult) : ResourceRelocationService
+    {
+        public override Task<RelocationResult> RelocateFileSourcesAsync(
+            IEnumerable<(Guid Object, string PropertyName, Uri OriginalUri)> sources,
+            Project stagingProject,
+            string projectDirectory,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(fileResult);
+
+        public override Task<RelocationResult> RelocateFontsAsync(
+            IEnumerable<FontFamily> fontFamilies,
+            string projectDirectory,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(fontResult);
     }
 
     private Project CreateAndSaveTestProjectWithItems()

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -68,17 +68,20 @@ public class ResourceRelocationServiceTests
         string sourceFilePath = Path.Combine(_testDir, "asset.bin");
         await File.WriteAllBytesAsync(sourceFilePath, new byte[] { 1, 2, 3 });
         Uri sourceUri = new(sourceFilePath);
-        var sources = new[] { (Guid.NewGuid(), "NonExistentProperty", sourceUri) };
+        Guid id = Guid.NewGuid();
+        var sources = new[] { (id, "NonExistentProperty", sourceUri) };
 
         // Act
         RelocationResult result = await service.RelocateFileSourcesAsync(sources, project, _projectDir);
 
-        // Assert
+        // Assert: the per-property failure path tags the entry with the GUID and property,
+        // which lets us tell it apart from the source-not-found branch.
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
             Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Does.Contain("asset.bin"));
+            Assert.That(result.FailedItems[0], Does.Contain(id.ToString()));
+            Assert.That(result.FailedItems[0], Does.Contain("NonExistentProperty"));
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -54,8 +54,8 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Does.Contain("does_not_exist.png"));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Does.Contain("does_not_exist.png"));
         });
     }
 
@@ -79,9 +79,9 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Does.Contain(id.ToString()));
-            Assert.That(result.FailedItems[0], Does.Contain("NonExistentProperty"));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Does.Contain(id.ToString()));
+            Assert.That(result.FailedResources[0], Does.Contain("NonExistentProperty"));
         });
     }
 
@@ -104,8 +104,8 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Is.EqualTo("BrokenFont"));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Is.EqualTo("BrokenFont"));
         });
     }
 
@@ -123,8 +123,8 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Is.EqualTo("UnknownFamily"));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Is.EqualTo("UnknownFamily"));
         });
     }
 
@@ -144,8 +144,8 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
-            Assert.That(result.FailedItems[0], Is.EqualTo("FamilyWithMissingFile"));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Is.EqualTo("FamilyWithMissingFile"));
         });
     }
 
@@ -163,7 +163,7 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Is.Empty);
+            Assert.That(result.FailedResources, Is.Empty);
         });
     }
 
@@ -180,7 +180,7 @@ public class ResourceRelocationServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.SuccessCount, Is.EqualTo(0));
-            Assert.That(result.FailedItems, Is.Empty);
+            Assert.That(result.FailedResources, Is.Empty);
         });
     }
 }

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor;
+﻿using Beutl.Editor;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.ProjectSystem;

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -107,6 +107,25 @@ public class ResourceRelocationServiceTests
     }
 
     [Test]
+    public async Task RelocateFontsAsync_WithNoMatchingFontFiles_ReportsFailedItem()
+    {
+        // Arrange: font finder returns an empty enumerable for the family (font not installed).
+        var service = new ResourceRelocationService(_ => []);
+        var fonts = new[] { new FontFamily("UnknownFamily") };
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync(fonts, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
+            Assert.That(result.FailedItems[0], Is.EqualTo("UnknownFamily"));
+        });
+    }
+
+    [Test]
     public async Task RelocateFontsAsync_WithMissingFontFile_ReportsFailedItem()
     {
         // Arrange: font finder returns a path that does not exist; CopyFileAsync throws.

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -242,6 +242,40 @@ public class ResourceRelocationServiceTests
     }
 
     [Test]
+    public void RelocateFileSourcesAsync_WithCancelledCopy_PropagatesCancellation()
+    {
+        // Arrange: a token already cancelled. CopyFileAsync should throw OCE
+        // before we touch failedResources.
+        var service = new ResourceRelocationService();
+        var project = new Project();
+        string sourceFilePath = Path.Combine(_testDir, "src.bin");
+        File.WriteAllBytes(sourceFilePath, [1, 2, 3]);
+        var sources = new[] { (Guid.NewGuid(), "Prop", new Uri(sourceFilePath)) };
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        // Act & Assert
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await service.RelocateFileSourcesAsync(sources, project, _projectDir, cts.Token));
+    }
+
+    [Test]
+    public void RelocateFontsAsync_WithCancelledCopy_PropagatesCancellation()
+    {
+        // Arrange
+        string fontPath = Path.Combine(_testDir, "font.ttf");
+        File.WriteAllBytes(fontPath, [1, 2, 3]);
+        var service = new ResourceRelocationService(_ => new[] { fontPath });
+        var fonts = new[] { new FontFamily("AnyFamily") };
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        // Act & Assert
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await service.RelocateFontsAsync(fonts, _projectDir, cts.Token));
+    }
+
+    [Test]
     public async Task RelocateFontsAsync_WithNoFamilies_ReturnsEmptyResult()
     {
         // Arrange

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -150,6 +150,80 @@ public class ResourceRelocationServiceTests
     }
 
     [Test]
+    public async Task RelocateFontsAsync_WithMixedFailingAndWorkingFamilies_ReportsBothCountAndFailures()
+    {
+        // Arrange: one family resolves to a real file, the other throws from the finder.
+        string goodFontPath = Path.Combine(_testDir, "good.ttf");
+        await File.WriteAllBytesAsync(goodFontPath, [1, 2, 3]);
+        var service = new ResourceRelocationService(name => name switch
+        {
+            "GoodFamily" => [goodFontPath],
+            "BadFamily" => throw new InvalidOperationException("simulated"),
+            _ => Array.Empty<string>(),
+        });
+        var fonts = new[] { new FontFamily("GoodFamily"), new FontFamily("BadFamily") };
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync(fonts, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(1));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+            Assert.That(result.FailedResources[0], Is.EqualTo("BadFamily"));
+            Assert.That(File.Exists(Path.Combine(_projectDir, "resources", "fonts", "good.ttf")), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task RelocateFontsAsync_WithDuplicateFontFilesAcrossFamilies_CopiesOnce()
+    {
+        // Arrange: two families share the same physical font file.
+        string sharedPath = Path.Combine(_testDir, "shared.ttf");
+        await File.WriteAllBytesAsync(sharedPath, [1, 2, 3]);
+        var service = new ResourceRelocationService(_ => new[] { sharedPath });
+        var fonts = new[] { new FontFamily("Family1"), new FontFamily("Family2") };
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync(fonts, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(1));
+            Assert.That(result.FailedResources, Is.Empty);
+            string[] copied = Directory.GetFiles(Path.Combine(_projectDir, "resources", "fonts"));
+            Assert.That(copied, Has.Length.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task RelocateFileSourcesAsync_WithSameMissingUriReferencedTwice_ReportsSingleFailure()
+    {
+        // Arrange: two properties point at the same missing file. GroupBy on OriginalUri
+        // means the failure is reported once, not twice.
+        var service = new ResourceRelocationService();
+        var project = new Project();
+        Uri missingUri = new(Path.Combine(_testDir, "missing.png"));
+        var sources = new[]
+        {
+            (Guid.NewGuid(), "Prop1", missingUri),
+            (Guid.NewGuid(), "Prop2", missingUri),
+        };
+
+        // Act
+        RelocationResult result = await service.RelocateFileSourcesAsync(sources, project, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedResources, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
     public async Task RelocateFileSourcesAsync_WithNoSources_ReturnsEmptyResult()
     {
         // Arrange

--- a/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ResourceRelocationServiceTests.cs
@@ -1,0 +1,164 @@
+using Beutl.Editor;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.UnitTests.Editor;
+
+public class ResourceRelocationServiceTests
+{
+    private string _testDir = null!;
+    private string _projectDir = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
+
+        _testDir = Path.Combine(Path.GetTempPath(), $"beutl_reloc_test_{Guid.NewGuid():N}");
+        _projectDir = Path.Combine(_testDir, "project");
+        Directory.CreateDirectory(_projectDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            try
+            {
+                Directory.Delete(_testDir, recursive: true);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    [Test]
+    public async Task RelocateFileSourcesAsync_WithMissingSourceFile_ReportsFailedItem()
+    {
+        // Arrange
+        var service = new ResourceRelocationService();
+        var project = new Project();
+        string missingPath = Path.Combine(_testDir, "does_not_exist.png");
+        Uri missingUri = new(missingPath);
+        var sources = new[] { (Guid.NewGuid(), "Source", missingUri) };
+
+        // Act
+        RelocationResult result = await service.RelocateFileSourcesAsync(sources, project, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
+            Assert.That(result.FailedItems[0], Does.Contain("does_not_exist.png"));
+        });
+    }
+
+    [Test]
+    public async Task RelocateFileSourcesAsync_WithExistingFileButUnknownObject_ReportsFailedItem()
+    {
+        // Arrange: file exists, but the GUID does not resolve in the project, so UpdateUri throws.
+        var service = new ResourceRelocationService();
+        var project = new Project();
+        string sourceFilePath = Path.Combine(_testDir, "asset.bin");
+        await File.WriteAllBytesAsync(sourceFilePath, new byte[] { 1, 2, 3 });
+        Uri sourceUri = new(sourceFilePath);
+        var sources = new[] { (Guid.NewGuid(), "NonExistentProperty", sourceUri) };
+
+        // Act
+        RelocationResult result = await service.RelocateFileSourcesAsync(sources, project, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
+            Assert.That(result.FailedItems[0], Does.Contain("asset.bin"));
+        });
+    }
+
+    [Test]
+    public async Task RelocateFontsAsync_WithFailingFontFinder_ReportsFailedItem()
+    {
+        // Arrange: font finder throws for a specific family name.
+        var service = new ResourceRelocationService(name =>
+        {
+            if (name == "BrokenFont")
+                throw new InvalidOperationException("simulated finder failure");
+            return [];
+        });
+        var fonts = new[] { new FontFamily("BrokenFont") };
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync(fonts, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
+            Assert.That(result.FailedItems[0], Is.EqualTo("BrokenFont"));
+        });
+    }
+
+    [Test]
+    public async Task RelocateFontsAsync_WithMissingFontFile_ReportsFailedItem()
+    {
+        // Arrange: font finder returns a path that does not exist; CopyFileAsync throws.
+        string missingFontPath = Path.Combine(_testDir, "missing.ttf");
+        var service = new ResourceRelocationService(name =>
+            name == "FamilyWithMissingFile" ? new[] { missingFontPath } : []);
+        var fonts = new[] { new FontFamily("FamilyWithMissingFile") };
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync(fonts, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Has.Count.EqualTo(1));
+            Assert.That(result.FailedItems[0], Is.EqualTo("FamilyWithMissingFile"));
+        });
+    }
+
+    [Test]
+    public async Task RelocateFileSourcesAsync_WithNoSources_ReturnsEmptyResult()
+    {
+        // Arrange
+        var service = new ResourceRelocationService();
+        var project = new Project();
+
+        // Act
+        RelocationResult result = await service.RelocateFileSourcesAsync([], project, _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task RelocateFontsAsync_WithNoFamilies_ReturnsEmptyResult()
+    {
+        // Arrange
+        var service = new ResourceRelocationService(_ => []);
+
+        // Act
+        RelocationResult result = await service.RelocateFontsAsync([], _projectDir);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SuccessCount, Is.EqualTo(0));
+            Assert.That(result.FailedItems, Is.Empty);
+        });
+    }
+}


### PR DESCRIPTION
## Description

- Project export silently produced incomplete ZIPs when individual
  relocation steps failed: ResourceRelocationService caught file-copy
  and UpdateUri errors, logged them, and returned only a success
  count, so ExportAsync reported success even when referenced files
  or fonts were missing from the package.
- Surface partial failures through new RelocationResult / ExportResult
  records, aggregate them in ExportAsync, and add a warning toast in
  MainView so users learn about truncated exports immediately instead
  of when opening the package elsewhere.
- Also fixes silent-failure regressions found during review: font
  families whose finder returns no files are now reported, UpdateUri
  failures are tracked per-property, and user-initiated cancellation
  no longer triggers an error toast.

## Breaking changes

- `ProjectPackageService.ExportAsync` now returns `Task<ExportResult>`
  instead of `Task<bool>`. Callers should check `result.Success` and
  `result.FailedResources`.
- `ResourceRelocationService.RelocateFileSourcesAsync` and
  `RelocateFontsAsync` now return `Task<RelocationResult>` instead of
  `Task<int>`. The previous success count is available as
  `result.SuccessCount`.

## Fixed issues

None