### PR TITLE
feat: add clip duplication via Ctrl+D and Alt+drag

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -62,6 +62,11 @@ public sealed class TimelineTabExtension : ToolTabExtension
             new ContextCommandKeyGesture("Ctrl+K"),
             new ContextCommandKeyGesture("Cmd+K", OSPlatform.OSX),
         ]),
+        new ContextCommandDefinition("Duplicate", Strings.Duplicate, Strings.Duplicate_Description,
+        [
+            new ContextCommandKeyGesture("Ctrl+D"),
+            new ContextCommandKeyGesture("Cmd+D", OSPlatform.OSX),
+        ]),
         new ContextCommandDefinition("SetStartTime", Strings.SetStartTime, "",
         [
             new ContextCommandKeyGesture("OemOpenBrackets")

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia;
@@ -559,51 +558,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             minZIndex,
             maxZIndex);
 
-        PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
+        DuplicateHelper.PlaceDuplicates(
+            Scene, newElements, oldElements, newStart, newZIndex, Constants.ElementFileExtension);
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.PasteElement);
 
         ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
-    }
-
-    private void PlaceAndAddDuplicates(
-        Element[] newElements,
-        Element[] sourceElements,
-        TimeSpan newStartAnchor,
-        int newZIndexAnchor)
-    {
-        TimeSpan minStart = newElements.Min(e => e.Start);
-        int minZIndex = newElements.Min(e => e.ZIndex);
-
-        foreach (Element newElement in newElements)
-        {
-            newElement.Start = newElement.Start - minStart + newStartAnchor;
-            newElement.ZIndex = newElement.ZIndex - minZIndex + newZIndexAnchor;
-
-            CoreSerializer.StoreToUri(newElement,
-                RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension));
-        }
-
-        var idMapping = new Dictionary<Guid, Guid>();
-        for (int i = 0; i < sourceElements.Length; i++)
-        {
-            idMapping[sourceElements[i].Id] = newElements[i].Id;
-        }
-
-        List<ImmutableHashSet<Guid>> newGroups = Scene.Groups
-            .Select(g => g.Where(id => idMapping.ContainsKey(id))
-                .Select(id => idMapping[id])
-                .ToImmutableHashSet())
-            .Where(g => g.Count >= 2)
-            .ToList();
-        if (newGroups.Count > 0)
-        {
-            Scene.Groups.AddRange(newGroups);
-        }
-
-        foreach (Element newElement in newElements)
-        {
-            Scene.AddChild(newElement);
-        }
     }
 
     private void DuplicateSelectedElements()
@@ -612,14 +571,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         {
             if (SelectedElements.Count == 0) return;
 
-            var ids = new HashSet<Guid>(SelectedElements.Select(s => s.Model.Id));
-            foreach (ImmutableHashSet<Guid> group in Scene.Groups)
-            {
-                if (group.Overlaps(ids))
-                {
-                    ids.UnionWith(group);
-                }
-            }
+            HashSet<Guid> ids = DuplicateHelper.ExpandWithGroupSiblings(
+                SelectedElements.Select(s => s.Model.Id),
+                Scene.Groups);
 
             var sourceVMs = Elements.Where(x => ids.Contains(x.Model.Id)).ToArray();
             if (sourceVMs.Length == 0) return;
@@ -627,21 +581,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             var oldElements = sourceVMs.Select(x => x.Model).ToArray();
             ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
 
-            TimeSpan minStart = newElements.Min(e => e.Start);
-            int minZIndex = newElements.Min(e => e.ZIndex);
-            TimeSpan maxEnd = newElements.Max(e => e.Range.End);
-            int maxZIndex = newElements.Max(e => e.ZIndex);
-            TimeSpan length = maxEnd - minStart;
+            (TimeRange seedRange, int minZIndex, int maxZIndex) = DuplicateHelper.ComputePlacementRange(newElements);
+            var (newStart, newZIndex) = CorrectPosition(seedRange, minZIndex, maxZIndex);
 
-            var (newStart, newZIndex) = CorrectPosition(
-                new TimeRange(minStart, length),
-                minZIndex,
-                maxZIndex);
-
-            PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
+            DuplicateHelper.PlaceDuplicates(
+                Scene, newElements, oldElements, newStart, newZIndex, Constants.ElementFileExtension);
             EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
 
-            ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+            ScrollTo.Execute((new TimeRange(newStart, seedRange.Duration), newZIndex));
         }
         catch (Exception ex)
         {
@@ -659,7 +606,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             var src = sourceElements.ToArray();
             ObjectRegenerator.Regenerate(src, out Element[] newElements);
 
-            PlaceAndAddDuplicates(newElements, src, anchorStart, Math.Max(anchorZIndex, 0));
+            DuplicateHelper.PlaceDuplicates(
+                Scene, newElements, src, anchorStart, Math.Max(anchorZIndex, 0), Constants.ElementFileExtension);
             EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
         }
         catch (Exception ex)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -608,38 +608,54 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void DuplicateSelectedElements()
     {
-        var sourceVMs = SelectedElements.ToArray();
-        if (sourceVMs.Length == 0) return;
+        try
+        {
+            var sourceVMs = SelectedElements.ToArray();
+            if (sourceVMs.Length == 0) return;
 
-        var oldElements = sourceVMs.Select(x => x.Model).ToArray();
-        ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
+            var oldElements = sourceVMs.Select(x => x.Model).ToArray();
+            ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
 
-        TimeSpan minStart = newElements.Min(e => e.Start);
-        int minZIndex = newElements.Min(e => e.ZIndex);
-        TimeSpan maxStart = newElements.Max(e => e.Start);
-        int maxZIndex = newElements.Max(e => e.ZIndex);
-        TimeSpan length = maxStart - minStart;
+            TimeSpan minStart = newElements.Min(e => e.Start);
+            int minZIndex = newElements.Min(e => e.ZIndex);
+            TimeSpan maxStart = newElements.Max(e => e.Start);
+            int maxZIndex = newElements.Max(e => e.ZIndex);
+            TimeSpan length = maxStart - minStart;
 
-        var (newStart, newZIndex) = CorrectPosition(
-            new TimeRange(minStart, length),
-            minZIndex,
-            maxZIndex);
+            var (newStart, newZIndex) = CorrectPosition(
+                new TimeRange(minStart, length),
+                minZIndex,
+                maxZIndex);
 
-        PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
+            PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
+            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
 
-        ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+            ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while duplicating elements.");
+            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+        }
     }
 
     internal void DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
     {
         if (sourceElements.Count == 0) return;
 
-        var src = sourceElements.ToArray();
-        ObjectRegenerator.Regenerate(src, out Element[] newElements);
+        try
+        {
+            var src = sourceElements.ToArray();
+            ObjectRegenerator.Regenerate(src, out Element[] newElements);
 
-        PlaceAndAddDuplicates(newElements, src, anchorStart, Math.Max(anchorZIndex, 0));
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
+            PlaceAndAddDuplicates(newElements, src, anchorStart, Math.Max(anchorZIndex, 0));
+            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception has occurred while duplicating elements at position.");
+            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+        }
     }
 
     private async Task PasteElement(IClipboard clipboard)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -495,6 +495,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         int stepped = 0; // その方向で進んだ歩数
         int turnCount = 0; // 方向転換回数（2回ごとに stepLen を+1）
 
+        // タイムラインが要素で隙間なく埋め尽くされた病的なケースで UI スレッドが
+        // 永久ループに陥らないよう、探索回数に上限を設ける。100_000 ステップは
+        // 30fps なら ±1500 フレーム ≒ ±50 秒分の渦巻きをカバーするので、
+        // 実運用で到達することは想定していない。到達した場合は最後に検査した
+        // 候補位置をそのまま返す (Overlap している可能性があるが、UI フリーズより
+        // 既存要素と重なる方が回復可能)。
+        const int MaxSearchSteps = 100_000;
+        int searchSteps = 0;
+        bool capped = false;
+
         while (true)
         {
             // 1歩進ませる
@@ -510,6 +520,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             if (!IsOverlapping(new TimeRange(newStart, length), newZIndex, newZIndex + layerCount - 1))
                 break;
 
+            if (++searchSteps >= MaxSearchSteps)
+            {
+                capped = true;
+                break;
+            }
+
             // 歩数管理：指定歩数進んだら時計回りに方向転換
             stepped++;
             if (stepped == stepLen)
@@ -520,6 +536,13 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 if ((turnCount & 1) == 0)
                     stepLen++; // 2回方向転換するごとに 1,1,2,2,3,3,… と広がる
             }
+        }
+
+        if (capped)
+        {
+            _logger.LogWarning(
+                "CorrectPosition gave up after {Steps} steps without finding a non-overlapping slot; using last candidate at start={Start}, zIndex={ZIndex}.",
+                searchSteps, newStart, newZIndex);
         }
 
         return (newStart, newZIndex);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -631,14 +631,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    internal void DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
+    // Returns true if a duplicate was placed and committed. Caller (Alt+drag) uses
+    // this to decide whether to fall back to a plain move.
+    internal bool DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
     {
         if (sourceElements.Count == 0)
         {
             // Caller (ElementView.OnBorderPointerReleased) already guards this — if we
             // get here, the caller has a bug worth surfacing.
             _logger.LogWarning("DuplicateElementsAt called with empty sourceElements; investigate caller.");
-            return;
+            return false;
         }
 
         try
@@ -649,10 +651,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             DuplicateHelper.PlaceDuplicates(
                 Scene, newElements, src, anchorStart, Math.Max(anchorZIndex, 0), Constants.ElementFileExtension);
             EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
+            return true;
         }
         catch (Exception ex)
         {
             HandleDuplicateException(ex, "duplicating elements at position");
+            return false;
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -495,9 +495,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         int stepped = 0; // その方向で進んだ歩数
         int turnCount = 0; // 方向転換回数（2回ごとに stepLen を+1）
 
-        // Cap to prevent UI freeze when the timeline is densely packed. Spiral radius
-        // is ~sqrt(MaxSearchSteps / 4) frames; on cap we return the last candidate
-        // (may overlap) and notify the user — overlap is recoverable, a hang is not.
+        // Cap the spiral so a densely-packed timeline cannot hang the UI thread.
+        // On cap we return the last candidate (may overlap) and notify the user —
+        // overlap is recoverable, a hang is not.
         const int MaxSearchSteps = 100_000;
         int searchSteps = 0;
         bool capped = false;
@@ -557,7 +557,6 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private async Task PasteElementList(IClipboard clipboard)
     {
-        // Format was advertised by PasteCore; a missing/invalid payload here is an anomaly.
         if (await clipboard.TryGetValueAsync(BeutlDataFormats.Elements) is not { } json)
         {
             _logger.LogWarning("Paste skipped: clipboard advertises Elements format but returned null.");
@@ -581,16 +580,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             return;
         }
 
-        ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
-
-        (TimeRange seedRange, int minZIndex, int maxZIndex) = DuplicateHelper.ComputePlacementRange(newElements);
-        var (newStart, newZIndex) = CorrectPosition(seedRange, minZIndex, maxZIndex);
-
-        DuplicateHelper.PlaceDuplicates(
-            Scene, newElements, oldElements, newStart, newZIndex, Constants.ElementFileExtension);
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.PasteElement);
-
-        ScrollTo.Execute((new TimeRange(newStart, seedRange.Duration), newZIndex));
+        RegenerateAndPlaceAtCorrectedPosition(oldElements, CommandNames.PasteElement);
     }
 
     private void DuplicateSelectedElements()
@@ -606,24 +596,15 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             var sourceVMs = Elements.Where(x => ids.Contains(x.Model.Id)).ToArray();
             if (sourceVMs.Length == 0)
             {
-                // Selected IDs do not resolve in Elements — should not happen.
                 _logger.LogWarning(
                     "Duplicate skipped: selected element IDs did not resolve to Elements. Ids={Ids}",
                     string.Join(", ", ids));
                 return;
             }
 
-            var oldElements = sourceVMs.Select(x => x.Model).ToArray();
-            ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
-
-            (TimeRange seedRange, int minZIndex, int maxZIndex) = DuplicateHelper.ComputePlacementRange(newElements);
-            var (newStart, newZIndex) = CorrectPosition(seedRange, minZIndex, maxZIndex);
-
-            DuplicateHelper.PlaceDuplicates(
-                Scene, newElements, oldElements, newStart, newZIndex, Constants.ElementFileExtension);
-            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
-
-            ScrollTo.Execute((new TimeRange(newStart, seedRange.Duration), newZIndex));
+            RegenerateAndPlaceAtCorrectedPosition(
+                sourceVMs.Select(x => x.Model).ToArray(),
+                CommandNames.DuplicateElement);
         }
         catch (Exception ex)
         {
@@ -631,14 +612,27 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    // Returns true if a duplicate was placed and committed. Caller (Alt+drag) uses
-    // this to decide whether to fall back to a plain move.
+    private void RegenerateAndPlaceAtCorrectedPosition(Element[] oldElements, string commandName)
+    {
+        ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
+
+        (TimeRange seedRange, int minZIndex, int maxZIndex) = DuplicateHelper.ComputePlacementRange(newElements);
+        (TimeSpan newStart, int newZIndex) = CorrectPosition(seedRange, minZIndex, maxZIndex);
+
+        DuplicateHelper.PlaceDuplicates(Scene, newElements, oldElements, newStart, newZIndex);
+        EditorContext.GetRequiredService<HistoryManager>().Commit(commandName);
+
+        ScrollTo.Execute((new TimeRange(newStart, seedRange.Duration), newZIndex));
+    }
+
+    /// <summary>
+    /// Returns true when a duplicate was placed and committed. Alt+drag uses the
+    /// return value to decide whether to fall back to a plain move.
+    /// </summary>
     internal bool DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
     {
         if (sourceElements.Count == 0)
         {
-            // Caller (ElementView.OnBorderPointerReleased) already guards this — if we
-            // get here, the caller has a bug worth surfacing.
             _logger.LogWarning("DuplicateElementsAt called with empty sourceElements; investigate caller.");
             return false;
         }
@@ -648,8 +642,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             var src = sourceElements.ToArray();
             ObjectRegenerator.Regenerate(src, out Element[] newElements);
 
-            DuplicateHelper.PlaceDuplicates(
-                Scene, newElements, src, anchorStart, Math.Max(anchorZIndex, 0), Constants.ElementFileExtension);
+            DuplicateHelper.PlaceDuplicates(Scene, newElements, src, anchorStart, Math.Max(anchorZIndex, 0));
             EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
             return true;
         }
@@ -660,8 +653,6 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    // Map expected failures (no project Uri / I/O) to localized messages; otherwise
-    // surface the raw exception as a generic unexpected error.
     private void HandleDuplicateException(Exception ex, string context)
     {
         switch (ex)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -610,7 +610,18 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         try
         {
-            var sourceVMs = SelectedElements.ToArray();
+            if (SelectedElements.Count == 0) return;
+
+            var ids = new HashSet<Guid>(SelectedElements.Select(s => s.Model.Id));
+            foreach (ImmutableHashSet<Guid> group in Scene.Groups)
+            {
+                if (group.Overlaps(ids))
+                {
+                    ids.UnionWith(group);
+                }
+            }
+
+            var sourceVMs = Elements.Where(x => ids.Contains(x.Model.Id)).ToArray();
             if (sourceVMs.Length == 0) return;
 
             var oldElements = sourceVMs.Select(x => x.Model).ToArray();

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -94,6 +94,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         Paste.Subscribe(PasteCore)
             .AddTo(_disposables);
 
+        Duplicate.Subscribe(DuplicateSelectedElements)
+            .AddTo(_disposables);
+
         TimelineOptions options = Options.Value;
         LayerHeaders.AddRange(Enumerable.Range(0, options.MaxLayerCount)
             .Select(num => new LayerHeaderViewModel(num, this)));
@@ -363,6 +366,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public ReactiveCommand Paste { get; } = new();
 
+    public ReactiveCommand Duplicate { get; } = new();
+
     public ReactiveCommand<(TimeRange Range, int ZIndex)> ScrollTo { get; } = new();
 
     public ReactiveCommandSlim SetStartTimeToPointerPosition { get; } = new();
@@ -543,7 +548,6 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
 
-        // 時間の範囲、レイヤーの範囲を計算
         TimeSpan minStart = newElements.Min(e => e.Start);
         int minZIndex = newElements.Min(e => e.ZIndex);
         TimeSpan maxStart = newElements.Max(e => e.Start);
@@ -555,26 +559,36 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             minZIndex,
             maxZIndex);
 
-        // 新しい位置に移動して保存、シーンに追加
+        PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
+        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.PasteElement);
+
+        ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+    }
+
+    private void PlaceAndAddDuplicates(
+        Element[] newElements,
+        Element[] sourceElements,
+        TimeSpan newStartAnchor,
+        int newZIndexAnchor)
+    {
+        TimeSpan minStart = newElements.Min(e => e.Start);
+        int minZIndex = newElements.Min(e => e.ZIndex);
+
         foreach (Element newElement in newElements)
         {
-            newElement.Start = newElement.Start - minStart + newStart;
-            newElement.ZIndex = newElement.ZIndex - minZIndex + newZIndex;
+            newElement.Start = newElement.Start - minStart + newStartAnchor;
+            newElement.ZIndex = newElement.ZIndex - minZIndex + newZIndexAnchor;
 
             CoreSerializer.StoreToUri(newElement,
                 RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension));
         }
 
-        HistoryManager history = EditorContext.GetRequiredService<HistoryManager>();
-
         var idMapping = new Dictionary<Guid, Guid>();
-        for (int i = 0; i < oldElements.Length; i++)
+        for (int i = 0; i < sourceElements.Length; i++)
         {
-            idMapping[oldElements[i].Id] = newElements[i].Id;
+            idMapping[sourceElements[i].Id] = newElements[i].Id;
         }
 
-        // コピーする要素が含まれるグループを取得
-        var scene = Scene;
         List<ImmutableHashSet<Guid>> newGroups = Scene.Groups
             .Select(g => g.Where(id => idMapping.ContainsKey(id))
                 .Select(id => idMapping[id])
@@ -583,17 +597,49 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .ToList();
         if (newGroups.Count > 0)
         {
-            scene.Groups.AddRange(newGroups);
+            Scene.Groups.AddRange(newGroups);
         }
 
         foreach (Element newElement in newElements)
         {
             Scene.AddChild(newElement);
         }
+    }
 
-        history.Commit(CommandNames.PasteElement);
+    private void DuplicateSelectedElements()
+    {
+        var sourceVMs = SelectedElements.ToArray();
+        if (sourceVMs.Length == 0) return;
 
-        ScrollTo.Execute((new TimeRange(newStart, maxStart - minStart), newZIndex));
+        var oldElements = sourceVMs.Select(x => x.Model).ToArray();
+        ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
+
+        TimeSpan minStart = newElements.Min(e => e.Start);
+        int minZIndex = newElements.Min(e => e.ZIndex);
+        TimeSpan maxStart = newElements.Max(e => e.Start);
+        int maxZIndex = newElements.Max(e => e.ZIndex);
+        TimeSpan length = maxStart - minStart;
+
+        var (newStart, newZIndex) = CorrectPosition(
+            new TimeRange(minStart, length),
+            minZIndex,
+            maxZIndex);
+
+        PlaceAndAddDuplicates(newElements, oldElements, newStart, newZIndex);
+        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
+
+        ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+    }
+
+    internal void DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
+    {
+        if (sourceElements.Count == 0) return;
+
+        var src = sourceElements.ToArray();
+        ObjectRegenerator.Regenerate(src, out Element[] newElements);
+
+        PlaceAndAddDuplicates(newElements, src, anchorStart, Math.Max(anchorZIndex, 0));
+        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DuplicateElement);
     }
 
     private async Task PasteElement(IClipboard clipboard)
@@ -1107,7 +1153,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         return execution.CommandName switch
         {
-            "Copy" or "Cut" or "Delete" or "Exclude" => SelectedElements.Count > 0,
+            "Copy" or "Cut" or "Delete" or "Exclude" or "Duplicate" => SelectedElements.Count > 0,
             "NudgeLeftFrame" or "NudgeRightFrame"
                 or "NudgeLeftLarge" or "NudgeRightLarge"
                 or "NudgeLeftSecond" or "NudgeRightSecond" => SelectedElements.Count > 0,
@@ -1141,6 +1187,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 {
                     execution.KeyEventArgs.Handled = true;
                     _logger.LogDebug("Paste command executed and KeyEventArgs handled.");
+                }
+
+                break;
+            case "Duplicate":
+                Duplicate.Execute();
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
                 }
 
                 break;

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -576,7 +576,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 Scene.Groups);
 
             var sourceVMs = Elements.Where(x => ids.Contains(x.Model.Id)).ToArray();
-            if (sourceVMs.Length == 0) return;
+            if (sourceVMs.Length == 0)
+            {
+                // SelectedElements は非空だが Elements の側で ID が解決できない
+                // = 選択モデルと VM コレクションのライフサイクルが desync している。
+                // どちらかの管理にバグがあるので警告として残す (ユーザー操作では起きない想定)。
+                _logger.LogWarning(
+                    "Duplicate skipped: selected element IDs did not resolve to Elements. Ids={Ids}",
+                    string.Join(", ", ids));
+                return;
+            }
 
             var oldElements = sourceVMs.Select(x => x.Model).ToArray();
             ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
@@ -599,7 +608,13 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     internal void DuplicateElementsAt(IReadOnlyList<Element> sourceElements, TimeSpan anchorStart, int anchorZIndex)
     {
-        if (sourceElements.Count == 0) return;
+        if (sourceElements.Count == 0)
+        {
+            // Alt+drag は閾値未満のドラッグでここに来うる。通常経路なので
+            // notification は出さないが、想定外の no-op を後追いできるよう debug ログを残す。
+            _logger.LogDebug("DuplicateElementsAt skipped: sourceElements is empty.");
+            return;
+        }
 
         try
         {

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -629,9 +629,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
             TimeSpan minStart = newElements.Min(e => e.Start);
             int minZIndex = newElements.Min(e => e.ZIndex);
-            TimeSpan maxStart = newElements.Max(e => e.Start);
+            TimeSpan maxEnd = newElements.Max(e => e.Range.End);
             int maxZIndex = newElements.Max(e => e.ZIndex);
-            TimeSpan length = maxStart - minStart;
+            TimeSpan length = maxEnd - minStart;
 
             var (newStart, newZIndex) = CorrectPosition(
                 new TimeRange(minStart, length),

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -495,12 +495,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         int stepped = 0; // その方向で進んだ歩数
         int turnCount = 0; // 方向転換回数（2回ごとに stepLen を+1）
 
-        // タイムラインが要素で隙間なく埋め尽くされた病的なケースで UI スレッドが
-        // 永久ループに陥らないよう、探索回数に上限を設ける。100_000 ステップは
-        // 30fps なら ±1500 フレーム ≒ ±50 秒分の渦巻きをカバーするので、
-        // 実運用で到達することは想定していない。到達した場合は最後に検査した
-        // 候補位置をそのまま返す (Overlap している可能性があるが、UI フリーズより
-        // 既存要素と重なる方が回復可能)。
+        // Cap to prevent UI freeze when the timeline is densely packed. Spiral radius
+        // is ~sqrt(MaxSearchSteps / 4) frames; on cap we return the last candidate
+        // (may overlap) and notify the user — overlap is recoverable, a hang is not.
         const int MaxSearchSteps = 100_000;
         int searchSteps = 0;
         bool capped = false;
@@ -543,6 +540,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             _logger.LogWarning(
                 "CorrectPosition gave up after {Steps} steps without finding a non-overlapping slot; using last candidate at start={Start}, zIndex={ZIndex}.",
                 searchSteps, newStart, newZIndex);
+            NotificationService.ShowWarning(Strings.Duplicate, Strings.Duplicate_NoEmptySlot);
         }
 
         return (newStart, newZIndex);
@@ -559,8 +557,17 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private async Task PasteElementList(IClipboard clipboard)
     {
-        if (await clipboard.TryGetValueAsync(BeutlDataFormats.Elements) is not { } json
-            || JsonNode.Parse(json) is not JsonArray jsonArray) return;
+        // Format was advertised by PasteCore; a missing/invalid payload here is an anomaly.
+        if (await clipboard.TryGetValueAsync(BeutlDataFormats.Elements) is not { } json)
+        {
+            _logger.LogWarning("Paste skipped: clipboard advertises Elements format but returned null.");
+            return;
+        }
+        if (JsonNode.Parse(json) is not JsonArray jsonArray)
+        {
+            _logger.LogWarning("Paste skipped: clipboard Elements payload is not a JsonArray. Length={Length}", json.Length);
+            return;
+        }
 
         var oldElements = jsonArray
             .Select(node => (node, element: new Element()))
@@ -568,24 +575,22 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .Select(t => t.element)
             .ToArray();
 
+        if (oldElements.Length == 0)
+        {
+            _logger.LogWarning("Paste skipped: clipboard Elements payload is an empty array.");
+            return;
+        }
+
         ObjectRegenerator.Regenerate(oldElements, out Element[] newElements);
 
-        TimeSpan minStart = newElements.Min(e => e.Start);
-        int minZIndex = newElements.Min(e => e.ZIndex);
-        TimeSpan maxStart = newElements.Max(e => e.Start);
-        int maxZIndex = newElements.Max(e => e.ZIndex);
-        TimeSpan length = maxStart - minStart;
-
-        var (newStart, newZIndex) = CorrectPosition(
-            new TimeRange(minStart, length),
-            minZIndex,
-            maxZIndex);
+        (TimeRange seedRange, int minZIndex, int maxZIndex) = DuplicateHelper.ComputePlacementRange(newElements);
+        var (newStart, newZIndex) = CorrectPosition(seedRange, minZIndex, maxZIndex);
 
         DuplicateHelper.PlaceDuplicates(
             Scene, newElements, oldElements, newStart, newZIndex, Constants.ElementFileExtension);
         EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.PasteElement);
 
-        ScrollTo.Execute((new TimeRange(newStart, length), newZIndex));
+        ScrollTo.Execute((new TimeRange(newStart, seedRange.Duration), newZIndex));
     }
 
     private void DuplicateSelectedElements()
@@ -601,9 +606,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             var sourceVMs = Elements.Where(x => ids.Contains(x.Model.Id)).ToArray();
             if (sourceVMs.Length == 0)
             {
-                // SelectedElements は非空だが Elements の側で ID が解決できない
-                // = 選択モデルと VM コレクションのライフサイクルが desync している。
-                // どちらかの管理にバグがあるので警告として残す (ユーザー操作では起きない想定)。
+                // Selected IDs do not resolve in Elements — should not happen.
                 _logger.LogWarning(
                     "Duplicate skipped: selected element IDs did not resolve to Elements. Ids={Ids}",
                     string.Join(", ", ids));
@@ -624,8 +627,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception has occurred while duplicating elements.");
-            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+            HandleDuplicateException(ex, "duplicating elements");
         }
     }
 
@@ -633,9 +635,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         if (sourceElements.Count == 0)
         {
-            // Alt+drag は閾値未満のドラッグでここに来うる。通常経路なので
-            // notification は出さないが、想定外の no-op を後追いできるよう debug ログを残す。
-            _logger.LogDebug("DuplicateElementsAt skipped: sourceElements is empty.");
+            // Caller (ElementView.OnBorderPointerReleased) already guards this — if we
+            // get here, the caller has a bug worth surfacing.
+            _logger.LogWarning("DuplicateElementsAt called with empty sourceElements; investigate caller.");
             return;
         }
 
@@ -650,15 +652,44 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception has occurred while duplicating elements at position.");
-            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+            HandleDuplicateException(ex, "duplicating elements at position");
+        }
+    }
+
+    // Map expected failures (no project Uri / I/O) to localized messages; otherwise
+    // surface the raw exception as a generic unexpected error.
+    private void HandleDuplicateException(Exception ex, string context)
+    {
+        switch (ex)
+        {
+            case InvalidOperationException when Scene.Uri is null:
+                _logger.LogWarning(ex, "Duplicate skipped while {Context}: project has no Uri.", context);
+                NotificationService.ShowWarning(Strings.Duplicate_Failed, Strings.Duplicate_ProjectNotSaved);
+                break;
+            case IOException:
+            case UnauthorizedAccessException:
+                _logger.LogError(ex, "Duplicate failed while {Context}: I/O error.", context);
+                NotificationService.ShowError(Strings.Duplicate_Failed, Strings.Duplicate_IOFailed);
+                break;
+            default:
+                _logger.LogError(ex, "An exception has occurred while {Context}.", context);
+                NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+                break;
         }
     }
 
     private async Task PasteElement(IClipboard clipboard)
     {
-        if (await clipboard.TryGetValueAsync(BeutlDataFormats.Element) is not { } json) return;
-        if (JsonNode.Parse(json) is not JsonObject jsonObject) return;
+        if (await clipboard.TryGetValueAsync(BeutlDataFormats.Element) is not { } json)
+        {
+            _logger.LogWarning("Paste skipped: clipboard advertises Element format but returned null.");
+            return;
+        }
+        if (JsonNode.Parse(json) is not JsonObject jsonObject)
+        {
+            _logger.LogWarning("Paste skipped: clipboard Element payload is not a JsonObject. Length={Length}", json.Length);
+            return;
+        }
 
         var oldElement = new Element();
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -4,9 +4,11 @@ using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Media.Immutable;
 using Avalonia.Threading;
 using Avalonia.Xaml.Interactivity;
 using Beutl.Configuration;
@@ -548,6 +550,8 @@ public sealed partial class ElementView : UserControl
 
         private bool _pressed;
         private bool _duplicateMode;
+        private bool _duplicateGhostShown;
+        private readonly List<Control> _ghosts = [];
         private Point _start;
 
         protected override void OnAttached()
@@ -564,6 +568,8 @@ public sealed partial class ElementView : UserControl
         {
             base.OnDetaching();
             if (AssociatedObject == null) return;
+
+            if (AssociatedObject._timeline is { } timeline) RemoveGhosts(timeline);
 
             AssociatedObject.RemoveHandler(PointerMovedEvent, OnPointerMoved);
             AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
@@ -600,6 +606,21 @@ public sealed partial class ElementView : UserControl
                     item.BorderMargin.Value = new(item.BorderMargin.Value.Left + deltaLeft, 0, 0, 0);
                 }
 
+                if (_duplicateMode && !_duplicateGhostShown)
+                {
+                    int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+                    TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
+                    TimeSpan modelStart = viewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
+                    TimeSpan deltaStart = modelStart - viewModel.Model.Start;
+                    int modelIndex = viewModel.Timeline.ToLayerNumber(viewModel.Margin.Value);
+                    int deltaIndex = modelIndex - viewModel.Model.ZIndex;
+                    if (Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0)
+                    {
+                        SpawnGhostsForRelatedElements(relatedElements, timeline);
+                        _duplicateGhostShown = true;
+                    }
+                }
+
                 e.Handled = true;
             }
         }
@@ -619,6 +640,8 @@ public sealed partial class ElementView : UserControl
                 {
                     _pressed = true;
                     _duplicateMode = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+                    _duplicateGhostShown = false;
+                    _ghosts.Clear();
                     _start = point.Position;
                     e.Handled = true;
                 }
@@ -641,85 +664,140 @@ public sealed partial class ElementView : UserControl
 
         private async void OnBorderPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
-            if (_pressed)
+            if (!_pressed) return;
+
+            _pressed = false;
+            bool duplicate = _duplicateMode;
+            bool ghostShown = _duplicateGhostShown;
+            _duplicateMode = false;
+            _duplicateGhostShown = false;
+
+            if (AssociatedObject is not { ViewModel: { } viewModel, _timeline: { } timeline }) return;
+
+            RemoveGhosts(timeline);
+
+            viewModel.Timeline.SnapBarPosition.Value = null;
+            HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+            e.Handled = true;
+            IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
+            var elems = relatedElements.Select(x => x.Model).ToArray();
+
+            float scale = viewModel.Timeline.Options.Value.Scale;
+            int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+            TimeSpan newStart = viewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
+            TimeSpan deltaStart = newStart - viewModel.Model.Start;
+            int newIndex = viewModel.Timeline.ToLayerNumber(viewModel.Margin.Value);
+            int deltaIndex = newIndex - viewModel.Model.ZIndex;
+
+            if (duplicate && ghostShown)
             {
-                _pressed = false;
-                bool duplicate = _duplicateMode;
-                _duplicateMode = false;
+                var animations = relatedElements
+                    .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
+                    .ToArray();
 
-                if (AssociatedObject is { ViewModel: { } viewModel })
+                try
                 {
-                    viewModel.Timeline.SnapBarPosition.Value = null;
-                    HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
-                    e.Handled = true;
-                    IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
-                    var elems = relatedElements.Select(x => x.Model).ToArray();
-
-                    float scale = viewModel.Timeline.Options.Value.Scale;
-                    int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-                    TimeSpan newStart = viewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
-                    TimeSpan deltaStart = newStart - viewModel.Model.Start;
-                    int newIndex = viewModel.Timeline.ToLayerNumber(viewModel.Margin.Value);
-                    int deltaIndex = newIndex - viewModel.Model.ZIndex;
-
-                    if (duplicate)
+                    if (elems.Length > 0)
                     {
-                        // ドラッグした要素はすべて元位置に戻し、ドロップ位置に複製を作成
-                        var animations = relatedElements
-                            .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
-                            .ToArray();
+                        TimeSpan minSourceStart = elems.Min(m => m.Start);
+                        int minSourceZIndex = elems.Min(m => m.ZIndex);
+                        TimeSpan anchorStart = minSourceStart + deltaStart;
+                        if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
+                        int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
 
-                        try
+                        viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                    }
+
+                    // 旧実装は fire-and-forget で AnimationRequest を投げており、
+                    // Task 内の例外が unobserved となって視覚位置がドラッグ中のまま
+                    // 取り残されることがあった。await + 失敗時のフォールバックで防ぐ。
+                    await Task.WhenAll(
+                        animations.Select(a => a.ViewModel.AnimationRequest(a.Context)));
+                }
+                catch (Exception ex)
+                {
+                    // 複製が失敗してもユーザーのドラッグ操作を捨てない: 元要素を
+                    // ドロップ位置で MoveElement として確定させる。視覚は既にドロップ
+                    // 位置にあるためアニメ不要。Move 自体も失敗した場合のみ視覚を
+                    // モデルへ強制リストアする。
+                    s_logger.LogError(ex, "Failed to duplicate; falling back to plain move.");
+                    NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+                    try
+                    {
+                        if (elems.Length > 0 && (deltaStart != TimeSpan.Zero || deltaIndex != 0))
                         {
-                            TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
-                            bool hasDrag = Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0;
-                            if (hasDrag && elems.Length > 0)
-                            {
-                                TimeSpan minSourceStart = elems.Min(m => m.Start);
-                                int minSourceZIndex = elems.Min(m => m.ZIndex);
-                                TimeSpan anchorStart = minSourceStart + deltaStart;
-                                if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
-                                int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
-
-                                viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
-                            }
-
-                            // 旧実装は fire-and-forget で AnimationRequest を投げており、
-                            // Task 内の例外が unobserved となって視覚位置がドラッグ中のまま
-                            // 取り残されることがあった。await + 失敗時の強制リストアで防ぐ。
-                            await Task.WhenAll(
-                                animations.Select(a => a.ViewModel.AnimationRequest(a.Context)));
-                        }
-                        catch (Exception ex)
-                        {
-                            // 例外が起きるとソースクリップが BorderMargin/Margin = ドラッグ後の
-                            // 視覚位置のまま残り、モデルとずれた表示が次の操作まで続いてしまう。
-                            // Model から再計算して強制的に視覚を巻き戻す。
-                            ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
-                            s_logger.LogError(ex, "Failed to complete duplicate drag.");
-                            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+                            viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
+                            history.Commit(CommandNames.MoveElement);
                         }
                     }
-                    else if (elems.Length == 1)
+                    catch (Exception ex2)
                     {
-                        await viewModel.SubmitViewModelChanges();
-                    }
-                    else if (elems.Length > 1)
-                    {
-                        var animations = relatedElements
-                            .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
-                            .ToArray();
-
-                        viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
-                        history.Commit(CommandNames.MoveElement);
-
-                        foreach (var (item, context) in animations)
-                        {
-                            _ = item.AnimationRequest(context);
-                        }
+                        ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
+                        s_logger.LogError(ex2, "Move fallback also failed.");
                     }
                 }
             }
+            else if (duplicate)
+            {
+                // Alt 押下でドラッグ閾値未満のまま離した = 複製なしで no-op。
+                // PointerMoved の段階で視覚を動かしている可能性があるためモデル値へ戻す。
+                ForceRestoreVisualToModel(relatedElements);
+            }
+            else if (elems.Length == 1)
+            {
+                await viewModel.SubmitViewModelChanges();
+            }
+            else if (elems.Length > 1)
+            {
+                var animations = relatedElements
+                    .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
+                    .ToArray();
+
+                viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
+                history.Commit(CommandNames.MoveElement);
+
+                foreach (var (item, context) in animations)
+                {
+                    _ = item.AnimationRequest(context);
+                }
+            }
+        }
+
+        private void SpawnGhostsForRelatedElements(
+            IReadOnlyList<ElementViewModel> related,
+            TimelineTabView timeline)
+        {
+            foreach (ElementViewModel vm in related)
+            {
+                float scale = vm.Timeline.Options.Value.Scale;
+                double left = vm.Model.Start.TimeToPixel(scale);
+                double top = vm.Timeline.CalculateLayerTop(vm.Model.ZIndex);
+                double width = vm.Model.Length.TimeToPixel(scale);
+
+                var ghost = new Border
+                {
+                    Background = new ImmutableSolidColorBrush(vm.Color.Value),
+                    Opacity = 0.4,
+                    Width = width,
+                    Height = FrameNumberHelper.LayerHeight,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Margin = new Thickness(left, top, 0, 0),
+                    IsHitTestVisible = false,
+                };
+                timeline.TimelinePanel.Children.Add(ghost);
+                _ghosts.Add(ghost);
+            }
+        }
+
+        private void RemoveGhosts(TimelineTabView timeline)
+        {
+            if (_ghosts.Count == 0) return;
+            foreach (Control ghost in _ghosts)
+            {
+                timeline.TimelinePanel.Children.Remove(ghost);
+            }
+            _ghosts.Clear();
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -543,13 +543,12 @@ public sealed partial class ElementView : UserControl
 
     private sealed class _MoveBehavior : Behavior<ElementView>
     {
-        // Logger for the async void handler; see OnBorderPointerReleased.
         private static readonly ILogger s_logger = Log.CreateLogger<ElementView>();
 
         private bool _pressed;
         private bool _duplicateMode;
-        private bool _duplicateGhostShown;
         private readonly List<Control> _ghosts = [];
+        private IReadOnlyList<ElementViewModel> _relatedElements = [];
         private Point _start;
 
         protected override void OnAttached()
@@ -568,6 +567,7 @@ public sealed partial class ElementView : UserControl
             if (AssociatedObject == null) return;
 
             if (AssociatedObject._timeline is { } timeline) RemoveGhosts(timeline);
+            _relatedElements = [];
 
             AssociatedObject.RemoveHandler(PointerMovedEvent, OnPointerMoved);
             AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
@@ -596,15 +596,14 @@ public sealed partial class ElementView : UserControl
                 viewModel.Margin.Value = new(0, newTop, 0, 0);
                 viewModel.BorderMargin.Value = new Thickness(newLeft, 0, 0, 0);
 
-                IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
-
-                foreach (ElementViewModel item in relatedElements.Where(i => i != viewModel))
+                foreach (ElementViewModel item in _relatedElements)
                 {
+                    if (item == viewModel) continue;
                     item.Margin.Value = new(0, item.Margin.Value.Top + deltaTop, 0, 0);
                     item.BorderMargin.Value = new(item.BorderMargin.Value.Left + deltaLeft, 0, 0, 0);
                 }
 
-                if (_duplicateMode && !_duplicateGhostShown)
+                if (_duplicateMode && _ghosts.Count == 0)
                 {
                     int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                     TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
@@ -614,8 +613,7 @@ public sealed partial class ElementView : UserControl
                     int deltaIndex = modelIndex - viewModel.Model.ZIndex;
                     if (Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0)
                     {
-                        SpawnGhostsForRelatedElements(relatedElements, timeline);
-                        _duplicateGhostShown = true;
+                        SpawnGhostsForRelatedElements(_relatedElements, timeline);
                     }
                 }
 
@@ -638,8 +636,8 @@ public sealed partial class ElementView : UserControl
                 {
                     _pressed = true;
                     _duplicateMode = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
-                    _duplicateGhostShown = false;
-                    // Drop any orphan ghosts left by a previous Released that took an early return.
+                    _relatedElements = viewModel.GetGroupOrSelectedElements();
+                    // Defensive: clear any ghosts orphaned by a prior Released early-return.
                     RemoveGhosts(timeline);
                     _start = point.Position;
                     e.Handled = true;
@@ -674,9 +672,10 @@ public sealed partial class ElementView : UserControl
 
             _pressed = false;
             bool duplicate = _duplicateMode;
-            bool ghostShown = _duplicateGhostShown;
+            bool ghostShown = _ghosts.Count > 0;
             _duplicateMode = false;
-            _duplicateGhostShown = false;
+            IReadOnlyList<ElementViewModel> relatedElements = _relatedElements;
+            _relatedElements = [];
 
             if (AssociatedObject is not { ViewModel: { } viewModel, _timeline: { } timeline }) return;
 
@@ -685,7 +684,6 @@ public sealed partial class ElementView : UserControl
             viewModel.Timeline.SnapBarPosition.Value = null;
             HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
             e.Handled = true;
-            IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
             var elems = relatedElements.Select(x => x.Model).ToArray();
 
             float scale = viewModel.Timeline.Options.Value.Scale;

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -711,6 +711,16 @@ public sealed partial class ElementView : UserControl
                         if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
                         int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
 
+                        // Skip the duplicate when the copy would land on top of any source clip.
+                        if (DuplicateHelper.WouldOverlapSources(elems, anchorStart, anchorZIndex))
+                        {
+                            s_logger.LogDebug(
+                                "Alt+drag duplicate cancelled: copy would overlap source clip(s) at start={Start}, zIndex={ZIndex}.",
+                                anchorStart, anchorZIndex);
+                            ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
+                            return;
+                        }
+
                         viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
                     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -326,7 +326,7 @@ public sealed partial class ElementView : UserControl
 
                 if (view._timeline is { } timeline && _pressed)
                 {
-                    pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+                    pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
                     point = point.WithX(pointerFrame.TimeToPixel(scale));
                     int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                     double minWidth = TimeSpan.FromSeconds(1d / rate).TimeToPixel(scale);
@@ -387,7 +387,7 @@ public sealed partial class ElementView : UserControl
                 }
 
                 PointerPoint point = e.GetCurrentPoint(view.border);
-                if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
+                if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Shift
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
@@ -495,7 +495,7 @@ public sealed partial class ElementView : UserControl
                     return;
                 }
 
-                if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Alt))
+                if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Shift))
                 {
                     view.Cursor = null;
                     _resizeType = AlignmentX.Center;
@@ -539,6 +539,7 @@ public sealed partial class ElementView : UserControl
     private sealed class _MoveBehavior : Behavior<ElementView>
     {
         private bool _pressed;
+        private bool _duplicateMode;
         private Point _start;
 
         protected override void OnAttached()
@@ -569,7 +570,7 @@ public sealed partial class ElementView : UserControl
                 float scale = viewModel.Timeline.Options.Value.Scale;
                 TimeSpan pointerFrame = point.X.PixelToTimeSpan(scale);
 
-                pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+                pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
 
                 TimeSpan newframe = pointerFrame - _start.X.PixelToTimeSpan(scale);
 
@@ -609,6 +610,7 @@ public sealed partial class ElementView : UserControl
                     && (view.Cursor == Cursors.Arrow || view.Cursor == null))
                 {
                     _pressed = true;
+                    _duplicateMode = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
                     _start = point.Position;
                     e.Handled = true;
                 }
@@ -620,6 +622,8 @@ public sealed partial class ElementView : UserControl
             if (_pressed)
             {
                 _pressed = false;
+                bool duplicate = _duplicateMode;
+                _duplicateMode = false;
 
                 if (AssociatedObject is { ViewModel: { } viewModel })
                 {
@@ -629,7 +633,39 @@ public sealed partial class ElementView : UserControl
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
                     var elems = relatedElements.Select(x => x.Model).ToArray();
 
-                    if (elems.Length == 1)
+                    float scale = viewModel.Timeline.Options.Value.Scale;
+                    int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+                    TimeSpan newStart = viewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
+                    TimeSpan deltaStart = newStart - viewModel.Model.Start;
+                    int newIndex = viewModel.Timeline.ToLayerNumber(viewModel.Margin.Value);
+                    int deltaIndex = newIndex - viewModel.Model.ZIndex;
+
+                    if (duplicate)
+                    {
+                        // ドラッグした要素はすべて元位置に戻し、ドロップ位置に複製を作成
+                        var animations = relatedElements
+                            .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
+                            .ToArray();
+
+                        TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
+                        bool hasDrag = Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0;
+                        if (hasDrag && elems.Length > 0)
+                        {
+                            TimeSpan minSourceStart = elems.Min(m => m.Start);
+                            int minSourceZIndex = elems.Min(m => m.ZIndex);
+                            TimeSpan anchorStart = minSourceStart + deltaStart;
+                            if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
+                            int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
+
+                            viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                        }
+
+                        foreach (var (item, context) in animations)
+                        {
+                            _ = item.AnimationRequest(context);
+                        }
+                    }
+                    else if (elems.Length == 1)
                     {
                         await viewModel.SubmitViewModelChanges();
                     }
@@ -638,13 +674,6 @@ public sealed partial class ElementView : UserControl
                         var animations = relatedElements
                             .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
                             .ToArray();
-
-                        float scale = viewModel.Timeline.Options.Value.Scale;
-                        int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-                        TimeSpan newStart = viewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
-                        TimeSpan deltaStart = newStart - viewModel.Model.Start;
-                        int newIndex = viewModel.Timeline.ToLayerNumber(viewModel.Margin.Value);
-                        int deltaIndex = newIndex - viewModel.Model.ZIndex;
 
                         viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
                         history.Commit(CommandNames.MoveElement);

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -701,29 +701,49 @@ public sealed partial class ElementView : UserControl
                     .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
                     .ToArray();
 
-                try
+                bool duplicated = false;
+                if (elems.Length > 0)
                 {
-                    if (elems.Length > 0)
+                    TimeSpan minSourceStart = elems.Min(m => m.Start);
+                    int minSourceZIndex = elems.Min(m => m.ZIndex);
+                    TimeSpan anchorStart = minSourceStart + deltaStart;
+                    if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
+                    int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
+
+                    // Skip the duplicate when the copy would land on top of any source clip.
+                    if (DuplicateHelper.WouldOverlapSources(elems, anchorStart, anchorZIndex))
                     {
-                        TimeSpan minSourceStart = elems.Min(m => m.Start);
-                        int minSourceZIndex = elems.Min(m => m.ZIndex);
-                        TimeSpan anchorStart = minSourceStart + deltaStart;
-                        if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
-                        int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
-
-                        // Skip the duplicate when the copy would land on top of any source clip.
-                        if (DuplicateHelper.WouldOverlapSources(elems, anchorStart, anchorZIndex))
-                        {
-                            s_logger.LogDebug(
-                                "Alt+drag duplicate cancelled: copy would overlap source clip(s) at start={Start}, zIndex={ZIndex}.",
-                                anchorStart, anchorZIndex);
-                            ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
-                            return;
-                        }
-
-                        viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                        s_logger.LogDebug(
+                            "Alt+drag duplicate cancelled: copy would overlap source clip(s) at start={Start}, zIndex={ZIndex}.",
+                            anchorStart, anchorZIndex);
+                        ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
+                        return;
                     }
 
+                    duplicated = viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                }
+
+                if (!duplicated && elems.Length > 0 && (deltaStart != TimeSpan.Zero || deltaIndex != 0))
+                {
+                    // Duplicate failed (notification already raised by ViewModel). Alt is
+                    // a copy gesture, so fall back to a plain move so the drag is not lost.
+                    try
+                    {
+                        viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
+                        history.Commit(CommandNames.MoveElement);
+                        NotificationService.ShowWarning(Strings.Duplicate_Failed, Strings.Duplicate_FallbackToMove);
+                    }
+                    catch (Exception ex)
+                    {
+                        ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
+                        s_logger.LogError(ex, "Move fallback also failed.");
+                        NotificationService.ShowError(Strings.Duplicate_Failed, Strings.Duplicate_FallbackFailed);
+                        return;
+                    }
+                }
+
+                try
+                {
                     // Must await: a fire-and-forget AnimationRequest swallows exceptions
                     // and leaves the visual stuck at the dragged position.
                     await Task.WhenAll(
@@ -731,25 +751,9 @@ public sealed partial class ElementView : UserControl
                 }
                 catch (Exception ex)
                 {
-                    // Fall back to a plain move so the drag is not lost. Alt is a copy
-                    // gesture, so notify the user that we silently demoted to move.
-                    s_logger.LogError(ex, "Failed to duplicate; falling back to plain move.");
-                    NotificationService.ShowError(Strings.Duplicate_Failed, ex.Message);
-                    try
-                    {
-                        if (elems.Length > 0 && (deltaStart != TimeSpan.Zero || deltaIndex != 0))
-                        {
-                            viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
-                            history.Commit(CommandNames.MoveElement);
-                            NotificationService.ShowWarning(Strings.Duplicate_Failed, Strings.Duplicate_FallbackToMove);
-                        }
-                    }
-                    catch (Exception ex2)
-                    {
-                        ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
-                        s_logger.LogError(ex2, "Move fallback also failed.");
-                        NotificationService.ShowError(Strings.Duplicate_Failed, Strings.Duplicate_FallbackFailed);
-                    }
+                    // Model state is already committed; just snap the visuals back.
+                    s_logger.LogWarning(ex, "Animation failed after duplicate/move; snapping visuals to model.");
+                    ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
                 }
             }
             else if (duplicate)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -326,7 +326,7 @@ public sealed partial class ElementView : UserControl
 
                 if (view._timeline is { } timeline && _pressed)
                 {
-                    pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
+                    pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
                     point = point.WithX(pointerFrame.TimeToPixel(scale));
                     int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                     double minWidth = TimeSpan.FromSeconds(1d / rate).TimeToPixel(scale);
@@ -387,7 +387,7 @@ public sealed partial class ElementView : UserControl
                 }
 
                 PointerPoint point = e.GetCurrentPoint(view.border);
-                if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Shift
+                if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
@@ -495,7 +495,7 @@ public sealed partial class ElementView : UserControl
                     return;
                 }
 
-                if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Shift))
+                if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Alt))
                 {
                     view.Cursor = null;
                     _resizeType = AlignmentX.Center;
@@ -570,7 +570,7 @@ public sealed partial class ElementView : UserControl
                 float scale = viewModel.Timeline.Options.Value.Scale;
                 TimeSpan pointerFrame = point.X.PixelToTimeSpan(scale);
 
-                pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
+                pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
 
                 TimeSpan newframe = pointerFrame - _start.X.PixelToTimeSpan(scale);
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -543,9 +543,7 @@ public sealed partial class ElementView : UserControl
 
     private sealed class _MoveBehavior : Behavior<ElementView>
     {
-        // OnBorderPointerReleased は async void なので例外が UI スレッドの
-        // SynchronizationContext へ伝播してアプリを落としうる。ハンドラ内部で
-        // 必ず捕捉して logger + 通知へ流すためにここで logger を確保しておく。
+        // Logger for the async void handler; see OnBorderPointerReleased.
         private static readonly ILogger s_logger = Log.CreateLogger<ElementView>();
 
         private bool _pressed;
@@ -627,7 +625,7 @@ public sealed partial class ElementView : UserControl
 
         private void OnBorderPointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (AssociatedObject is { _timeline: { }, border: { }, ViewModel: { } viewModel } view)
+            if (AssociatedObject is { _timeline: { } timeline, border: { }, ViewModel: { } viewModel } view)
             {
                 if (viewModel.Timeline.IsRazorMode.Value)
                 {
@@ -641,24 +639,32 @@ public sealed partial class ElementView : UserControl
                     _pressed = true;
                     _duplicateMode = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
                     _duplicateGhostShown = false;
-                    _ghosts.Clear();
+                    // Drop any orphan ghosts left by a previous Released that took an early return.
+                    RemoveGhosts(timeline);
                     _start = point.Position;
                     e.Handled = true;
                 }
             }
         }
 
-        // AnimationRequest が例外で途中終了すると BorderMargin/Margin/Width が
-        // ドラッグ中の視覚値のまま残ってしまうので、Model 由来の正しい値で上書きする。
-        // ElementViewModel.AnimationRequest が成功時末尾でセットしている値と同じ。
+        // Snap the visual state back to the model when AnimationRequest aborts midway,
+        // otherwise margins/width stay frozen at the dragged position.
         private static void ForceRestoreVisualToModel(IEnumerable<ElementViewModel> targets)
         {
             foreach (ElementViewModel vm in targets)
             {
-                float scale = vm.Timeline.Options.Value.Scale;
-                vm.BorderMargin.Value = new Thickness(vm.Model.Start.TimeToPixel(scale), 0, 0, 0);
-                vm.Margin.Value = new Thickness(0, vm.Timeline.CalculateLayerTop(vm.Model.ZIndex), 0, 0);
-                vm.Width.Value = vm.Model.Length.TimeToPixel(scale);
+                // Never let a per-element NRE escape — we're on the async void handler path.
+                try
+                {
+                    float scale = vm.Timeline.Options.Value.Scale;
+                    vm.BorderMargin.Value = new Thickness(vm.Model.Start.TimeToPixel(scale), 0, 0, 0);
+                    vm.Margin.Value = new Thickness(0, vm.Timeline.CalculateLayerTop(vm.Model.ZIndex), 0, 0);
+                    vm.Width.Value = vm.Model.Length.TimeToPixel(scale);
+                }
+                catch (Exception ex)
+                {
+                    s_logger.LogWarning(ex, "Failed to restore visual state to model for element {Id}.", vm.Model.Id);
+                }
             }
         }
 
@@ -708,39 +714,40 @@ public sealed partial class ElementView : UserControl
                         viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
                     }
 
-                    // 旧実装は fire-and-forget で AnimationRequest を投げており、
-                    // Task 内の例外が unobserved となって視覚位置がドラッグ中のまま
-                    // 取り残されることがあった。await + 失敗時のフォールバックで防ぐ。
+                    // Must await: a fire-and-forget AnimationRequest swallows exceptions
+                    // and leaves the visual stuck at the dragged position.
                     await Task.WhenAll(
                         animations.Select(a => a.ViewModel.AnimationRequest(a.Context)));
                 }
                 catch (Exception ex)
                 {
-                    // 複製が失敗してもユーザーのドラッグ操作を捨てない: 元要素を
-                    // ドロップ位置で MoveElement として確定させる。視覚は既にドロップ
-                    // 位置にあるためアニメ不要。Move 自体も失敗した場合のみ視覚を
-                    // モデルへ強制リストアする。
+                    // Fall back to a plain move so the drag is not lost. Alt is a copy
+                    // gesture, so notify the user that we silently demoted to move.
                     s_logger.LogError(ex, "Failed to duplicate; falling back to plain move.");
-                    NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
+                    NotificationService.ShowError(Strings.Duplicate_Failed, ex.Message);
                     try
                     {
                         if (elems.Length > 0 && (deltaStart != TimeSpan.Zero || deltaIndex != 0))
                         {
                             viewModel.Scene.MoveChildren(deltaIndex, deltaStart, elems);
                             history.Commit(CommandNames.MoveElement);
+                            NotificationService.ShowWarning(Strings.Duplicate_Failed, Strings.Duplicate_FallbackToMove);
                         }
                     }
                     catch (Exception ex2)
                     {
                         ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
                         s_logger.LogError(ex2, "Move fallback also failed.");
+                        NotificationService.ShowError(Strings.Duplicate_Failed, Strings.Duplicate_FallbackFailed);
                     }
                 }
             }
             else if (duplicate)
             {
-                // Alt 押下でドラッグ閾値未満のまま離した = 複製なしで no-op。
-                // PointerMoved の段階で視覚を動かしている可能性があるためモデル値へ戻す。
+                // PointerMoved may have shifted the visual already; snap it back.
+                s_logger.LogDebug(
+                    "Alt+drag duplicate cancelled below threshold (deltaStart={DeltaStart}, deltaIndex={DeltaIndex}).",
+                    deltaStart, deltaIndex);
                 ForceRestoreVisualToModel(relatedElements);
             }
             else if (elems.Length == 1)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -15,10 +15,13 @@ using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
 using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings.Extensions;
 using Setter = Avalonia.Styling.Setter;
 
@@ -538,6 +541,11 @@ public sealed partial class ElementView : UserControl
 
     private sealed class _MoveBehavior : Behavior<ElementView>
     {
+        // OnBorderPointerReleased は async void なので例外が UI スレッドの
+        // SynchronizationContext へ伝播してアプリを落としうる。ハンドラ内部で
+        // 必ず捕捉して logger + 通知へ流すためにここで logger を確保しておく。
+        private static readonly ILogger s_logger = Log.CreateLogger<ElementView>();
+
         private bool _pressed;
         private bool _duplicateMode;
         private Point _start;
@@ -617,6 +625,20 @@ public sealed partial class ElementView : UserControl
             }
         }
 
+        // AnimationRequest が例外で途中終了すると BorderMargin/Margin/Width が
+        // ドラッグ中の視覚値のまま残ってしまうので、Model 由来の正しい値で上書きする。
+        // ElementViewModel.AnimationRequest が成功時末尾でセットしている値と同じ。
+        private static void ForceRestoreVisualToModel(IEnumerable<ElementViewModel> targets)
+        {
+            foreach (ElementViewModel vm in targets)
+            {
+                float scale = vm.Timeline.Options.Value.Scale;
+                vm.BorderMargin.Value = new Thickness(vm.Model.Start.TimeToPixel(scale), 0, 0, 0);
+                vm.Margin.Value = new Thickness(0, vm.Timeline.CalculateLayerTop(vm.Model.ZIndex), 0, 0);
+                vm.Width.Value = vm.Model.Length.TimeToPixel(scale);
+            }
+        }
+
         private async void OnBorderPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
             if (_pressed)
@@ -647,22 +669,35 @@ public sealed partial class ElementView : UserControl
                             .Select(x => (ViewModel: x, Context: x.PrepareAnimation()))
                             .ToArray();
 
-                        TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
-                        bool hasDrag = Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0;
-                        if (hasDrag && elems.Length > 0)
+                        try
                         {
-                            TimeSpan minSourceStart = elems.Min(m => m.Start);
-                            int minSourceZIndex = elems.Min(m => m.ZIndex);
-                            TimeSpan anchorStart = minSourceStart + deltaStart;
-                            if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
-                            int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
+                            TimeSpan minFrame = TimeSpan.FromSeconds(1d / rate);
+                            bool hasDrag = Math.Abs(deltaStart.Ticks) >= minFrame.Ticks || deltaIndex != 0;
+                            if (hasDrag && elems.Length > 0)
+                            {
+                                TimeSpan minSourceStart = elems.Min(m => m.Start);
+                                int minSourceZIndex = elems.Min(m => m.ZIndex);
+                                TimeSpan anchorStart = minSourceStart + deltaStart;
+                                if (anchorStart < TimeSpan.Zero) anchorStart = TimeSpan.Zero;
+                                int anchorZIndex = Math.Max(minSourceZIndex + deltaIndex, 0);
 
-                            viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                                viewModel.Timeline.DuplicateElementsAt(elems, anchorStart, anchorZIndex);
+                            }
+
+                            // 旧実装は fire-and-forget で AnimationRequest を投げており、
+                            // Task 内の例外が unobserved となって視覚位置がドラッグ中のまま
+                            // 取り残されることがあった。await + 失敗時の強制リストアで防ぐ。
+                            await Task.WhenAll(
+                                animations.Select(a => a.ViewModel.AnimationRequest(a.Context)));
                         }
-
-                        foreach (var (item, context) in animations)
+                        catch (Exception ex)
                         {
-                            _ = item.AnimationRequest(context);
+                            // 例外が起きるとソースクリップが BorderMargin/Margin = ドラッグ後の
+                            // 視覚位置のまま残り、モデルとずれた表示が次の操作まで続いてしまう。
+                            // Model から再計算して強制的に視覚を巻き戻す。
+                            ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
+                            s_logger.LogError(ex, "Failed to complete duplicate drag.");
+                            NotificationService.ShowError(MessageStrings.UnexpectedError, ex.Message);
                         }
                     }
                     else if (elems.Length == 1)

--- a/src/Beutl.Editor/Services/DuplicateHelper.cs
+++ b/src/Beutl.Editor/Services/DuplicateHelper.cs
@@ -1,0 +1,137 @@
+using System.Collections.Immutable;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.Serialization;
+using Beutl.Utilities;
+
+namespace Beutl.Editor.Services;
+
+public static class DuplicateHelper
+{
+    public static HashSet<Guid> ExpandWithGroupSiblings(
+        IEnumerable<Guid> seedIds,
+        IEnumerable<ImmutableHashSet<Guid>> groups)
+    {
+        var ids = new HashSet<Guid>(seedIds);
+        foreach (ImmutableHashSet<Guid> group in groups)
+        {
+            if (group.Overlaps(ids))
+            {
+                ids.UnionWith(group);
+            }
+        }
+
+        return ids;
+    }
+
+    // 配置探索のシード範囲を返す。Length は最遅 Start ではなく最遅 Range.End から
+    // 算出する: 短い末尾要素が長い先頭要素より早く終わるケースで、検索範囲が
+    // 短すぎて元クリップに被る位置を選んでしまう問題を避けるため。
+    public static (TimeRange Range, int MinZIndex, int MaxZIndex) ComputePlacementRange(
+        IReadOnlyList<Element> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        if (elements.Count == 0)
+        {
+            throw new ArgumentException("Elements must not be empty.", nameof(elements));
+        }
+
+        TimeSpan minStart = elements.Min(e => e.Start);
+        int minZIndex = elements.Min(e => e.ZIndex);
+        TimeSpan maxEnd = elements.Max(e => e.Range.End);
+        int maxZIndex = elements.Max(e => e.ZIndex);
+
+        return (new TimeRange(minStart, maxEnd - minStart), minZIndex, maxZIndex);
+    }
+
+    // 複製要素を Scene に配置する。2-phase commit:
+    //   Phase 1: 全要素にアンカー基準で位置を割り当て、ディスクへ直列化する。
+    //            途中で失敗した場合は書き出し済みファイルを削除して例外を伝播する。
+    //   Phase 2: グループ remap と Scene.AddChild を適用する。全要素の I/O が
+    //            成功しないと Scene 状態へ反映しないため、孤児ファイル + Scene
+    //            未反映の半端状態を回避できる。
+    public static void PlaceDuplicates(
+        Scene scene,
+        Element[] newElements,
+        Element[] sourceElements,
+        TimeSpan anchorStart,
+        int anchorZIndex,
+        string elementFileExtension)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(newElements);
+        ArgumentNullException.ThrowIfNull(sourceElements);
+        ArgumentNullException.ThrowIfNull(elementFileExtension);
+
+        if (newElements.Length == 0) return;
+        if (newElements.Length != sourceElements.Length)
+        {
+            throw new ArgumentException(
+                "newElements and sourceElements must have the same length (positional id mapping).",
+                nameof(sourceElements));
+        }
+
+        if (scene.Uri is null)
+        {
+            throw new InvalidOperationException(
+                "Cannot place duplicates: scene has no Uri. Save the project before duplicating.");
+        }
+
+        TimeSpan minStart = newElements.Min(e => e.Start);
+        int minZIndex = newElements.Min(e => e.ZIndex);
+
+        var stagedFiles = new List<string>(newElements.Length);
+        try
+        {
+            foreach (Element newElement in newElements)
+            {
+                newElement.Start = newElement.Start - minStart + anchorStart;
+                newElement.ZIndex = newElement.ZIndex - minZIndex + anchorZIndex;
+
+                Uri uri = RandomFileNameGenerator.GenerateUri(scene.Uri, elementFileExtension);
+                CoreSerializer.StoreToUri(newElement, uri);
+                stagedFiles.Add(uri.LocalPath);
+            }
+        }
+        catch
+        {
+            // 既に書き出したファイルを best-effort で削除。プロジェクトフォルダに
+            // 孤児 .belm ファイルを残さない。削除自体の失敗は元の例外を覆い隠さない
+            // ようにスローしない (元の I/O エラーの方が原因として重要)。
+            foreach (string path in stagedFiles)
+            {
+                try
+                {
+                    if (File.Exists(path)) File.Delete(path);
+                }
+                catch
+                {
+                }
+            }
+
+            throw;
+        }
+
+        var idMapping = new Dictionary<Guid, Guid>(sourceElements.Length);
+        for (int i = 0; i < sourceElements.Length; i++)
+        {
+            idMapping[sourceElements[i].Id] = newElements[i].Id;
+        }
+
+        List<ImmutableHashSet<Guid>> newGroups = scene.Groups
+            .Select(g => g.Where(id => idMapping.ContainsKey(id))
+                .Select(id => idMapping[id])
+                .ToImmutableHashSet())
+            .Where(g => g.Count >= 2)
+            .ToList();
+        if (newGroups.Count > 0)
+        {
+            scene.Groups.AddRange(newGroups);
+        }
+
+        foreach (Element newElement in newElements)
+        {
+            scene.AddChild(newElement);
+        }
+    }
+}

--- a/src/Beutl.Editor/Services/DuplicateHelper.cs
+++ b/src/Beutl.Editor/Services/DuplicateHelper.cs
@@ -10,6 +10,7 @@ namespace Beutl.Editor.Services;
 
 public static class DuplicateHelper
 {
+    private const string ElementFileExtension = "belm";
     private static readonly ILogger s_logger = Log.CreateLogger(typeof(DuplicateHelper));
 
     /// <summary>
@@ -46,8 +47,7 @@ public static class DuplicateHelper
         ArgumentNullException.ThrowIfNull(sourceElements);
         if (sourceElements.Count == 0) return false;
 
-        TimeSpan minStart = sourceElements.Min(e => e.Start);
-        int minZIndex = sourceElements.Min(e => e.ZIndex);
+        (TimeSpan minStart, int minZIndex) = ComputeMinOrigin(sourceElements);
 
         foreach (Element src in sourceElements)
         {
@@ -81,12 +81,33 @@ public static class DuplicateHelper
             throw new ArgumentException("Elements must not be empty.", nameof(elements));
         }
 
-        TimeSpan minStart = elements.Min(e => e.Start);
-        int minZIndex = elements.Min(e => e.ZIndex);
-        TimeSpan maxEnd = elements.Max(e => e.Range.End);
-        int maxZIndex = elements.Max(e => e.ZIndex);
+        TimeSpan minStart = TimeSpan.MaxValue;
+        TimeSpan maxEnd = TimeSpan.MinValue;
+        int minZIndex = int.MaxValue;
+        int maxZIndex = int.MinValue;
+        foreach (Element e in elements)
+        {
+            if (e.Start < minStart) minStart = e.Start;
+            TimeSpan end = e.Range.End;
+            if (end > maxEnd) maxEnd = end;
+            if (e.ZIndex < minZIndex) minZIndex = e.ZIndex;
+            if (e.ZIndex > maxZIndex) maxZIndex = e.ZIndex;
+        }
 
         return (new TimeRange(minStart, maxEnd - minStart), minZIndex, maxZIndex);
+    }
+
+    private static (TimeSpan MinStart, int MinZIndex) ComputeMinOrigin(IReadOnlyList<Element> elements)
+    {
+        TimeSpan minStart = TimeSpan.MaxValue;
+        int minZIndex = int.MaxValue;
+        foreach (Element e in elements)
+        {
+            if (e.Start < minStart) minStart = e.Start;
+            if (e.ZIndex < minZIndex) minZIndex = e.ZIndex;
+        }
+
+        return (minStart, minZIndex);
     }
 
     /// <summary>
@@ -109,13 +130,11 @@ public static class DuplicateHelper
         Element[] newElements,
         Element[] sourceElements,
         TimeSpan anchorStart,
-        int anchorZIndex,
-        string elementFileExtension)
+        int anchorZIndex)
     {
         ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(newElements);
         ArgumentNullException.ThrowIfNull(sourceElements);
-        ArgumentNullException.ThrowIfNull(elementFileExtension);
 
         if (newElements.Length == 0) return;
         if (newElements.Length != sourceElements.Length)
@@ -131,8 +150,7 @@ public static class DuplicateHelper
                 "Cannot place duplicates: scene has no Uri. Save the project before duplicating.");
         }
 
-        TimeSpan minStart = newElements.Min(e => e.Start);
-        int minZIndex = newElements.Min(e => e.ZIndex);
+        (TimeSpan minStart, int minZIndex) = ComputeMinOrigin(newElements);
 
         var stagedFiles = new List<string>(newElements.Length);
         try
@@ -142,7 +160,7 @@ public static class DuplicateHelper
                 newElement.Start = newElement.Start - minStart + anchorStart;
                 newElement.ZIndex = newElement.ZIndex - minZIndex + anchorZIndex;
 
-                Uri uri = RandomFileNameGenerator.GenerateUri(scene.Uri, elementFileExtension);
+                Uri uri = RandomFileNameGenerator.GenerateUri(scene.Uri, ElementFileExtension);
                 CoreSerializer.StoreToUri(newElement, uri);
                 stagedFiles.Add(uri.LocalPath);
             }

--- a/src/Beutl.Editor/Services/DuplicateHelper.cs
+++ b/src/Beutl.Editor/Services/DuplicateHelper.cs
@@ -1,13 +1,21 @@
 ﻿using System.Collections.Immutable;
+using Beutl.Logging;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;
 using Beutl.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.Editor.Services;
 
 public static class DuplicateHelper
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(DuplicateHelper));
+
+    /// <summary>
+    /// Expands the seed set to include every member of any group that overlaps it,
+    /// so partial group selections still duplicate the whole group.
+    /// </summary>
     public static HashSet<Guid> ExpandWithGroupSiblings(
         IEnumerable<Guid> seedIds,
         IEnumerable<ImmutableHashSet<Guid>> groups)
@@ -24,9 +32,11 @@ public static class DuplicateHelper
         return ids;
     }
 
-    // 配置探索のシード範囲を返す。Length は最遅 Start ではなく最遅 Range.End から
-    // 算出する: 短い末尾要素が長い先頭要素より早く終わるケースで、検索範囲が
-    // 短すぎて元クリップに被る位置を選んでしまう問題を避けるため。
+    /// <summary>
+    /// Returns the seed range for placement search. Uses the latest Range.End (not the
+    /// latest Start) so a short trailing element does not shrink the range and let the
+    /// spiral search land on top of a longer leading element.
+    /// </summary>
     public static (TimeRange Range, int MinZIndex, int MaxZIndex) ComputePlacementRange(
         IReadOnlyList<Element> elements)
     {
@@ -44,12 +54,21 @@ public static class DuplicateHelper
         return (new TimeRange(minStart, maxEnd - minStart), minZIndex, maxZIndex);
     }
 
-    // 複製要素を Scene に配置する。2-phase commit:
-    //   Phase 1: 全要素にアンカー基準で位置を割り当て、ディスクへ直列化する。
-    //            途中で失敗した場合は書き出し済みファイルを削除して例外を伝播する。
-    //   Phase 2: グループ remap と Scene.AddChild を適用する。全要素の I/O が
-    //            成功しないと Scene 状態へ反映しないため、孤児ファイル + Scene
-    //            未反映の半端状態を回避できる。
+    /// <summary>
+    /// Places duplicated elements onto the scene. <paramref name="sourceElements"/> and
+    /// <paramref name="newElements"/> use a positional zip mapping
+    /// (<c>sourceElements[i] -&gt; newElements[i]</c>); <paramref name="scene"/>.<see cref="Scene.Uri"/>
+    /// must be non-null.
+    /// </summary>
+    /// <remarks>
+    /// Two phases:
+    /// <list type="bullet">
+    /// <item>Phase 1 stages every element to disk. On failure, staged files are deleted
+    /// best-effort and the scene is left untouched.</item>
+    /// <item>Phase 2 remaps groups and calls <see cref="Scene.AddChild"/>. Not atomic:
+    /// a failure here can leave partial children and staged files behind.</item>
+    /// </list>
+    /// </remarks>
     public static void PlaceDuplicates(
         Scene scene,
         Element[] newElements,
@@ -93,19 +112,22 @@ public static class DuplicateHelper
                 stagedFiles.Add(uri.LocalPath);
             }
         }
-        catch
+        catch (Exception originalEx)
         {
-            // 既に書き出したファイルを best-effort で削除。プロジェクトフォルダに
-            // 孤児 .belm ファイルを残さない。削除自体の失敗は元の例外を覆い隠さない
-            // ようにスローしない (元の I/O エラーの方が原因として重要)。
+            // Best-effort cleanup. Don't mask the original exception with delete errors,
+            // but log them so orphan files can be tracked.
             foreach (string path in stagedFiles)
             {
                 try
                 {
                     if (File.Exists(path)) File.Delete(path);
                 }
-                catch
+                catch (Exception deleteEx)
                 {
+                    s_logger.LogWarning(
+                        deleteEx,
+                        "Failed to delete staged duplicate file during rollback; orphan file may remain. Path={Path} OriginalCause={Original}",
+                        path, originalEx.Message);
                 }
             }
 

--- a/src/Beutl.Editor/Services/DuplicateHelper.cs
+++ b/src/Beutl.Editor/Services/DuplicateHelper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Serialization;

--- a/src/Beutl.Editor/Services/DuplicateHelper.cs
+++ b/src/Beutl.Editor/Services/DuplicateHelper.cs
@@ -33,6 +33,41 @@ public static class DuplicateHelper
     }
 
     /// <summary>
+    /// Returns true when placing duplicates of <paramref name="sourceElements"/> at the
+    /// given anchor would land on a source clip (same ZIndex, intersecting TimeRange).
+    /// Used by Alt+drag to skip the duplicate when the user has not moved far enough
+    /// for the copy to clear the originals.
+    /// </summary>
+    public static bool WouldOverlapSources(
+        IReadOnlyList<Element> sourceElements,
+        TimeSpan anchorStart,
+        int anchorZIndex)
+    {
+        ArgumentNullException.ThrowIfNull(sourceElements);
+        if (sourceElements.Count == 0) return false;
+
+        TimeSpan minStart = sourceElements.Min(e => e.Start);
+        int minZIndex = sourceElements.Min(e => e.ZIndex);
+
+        foreach (Element src in sourceElements)
+        {
+            TimeSpan newStart = src.Start - minStart + anchorStart;
+            int newZIndex = src.ZIndex - minZIndex + anchorZIndex;
+            var newRange = new TimeRange(newStart, src.Length);
+
+            foreach (Element other in sourceElements)
+            {
+                if (other.ZIndex == newZIndex && other.Range.Intersects(newRange))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns the seed range for placement search. Uses the latest Range.End (not the
     /// latest Start) so a short trailing element does not shrink the range and let the
     /// spiral search land on top of a longer leading element.

--- a/src/Beutl.Editor/Services/ObjectRegenerator.cs
+++ b/src/Beutl.Editor/Services/ObjectRegenerator.cs
@@ -23,7 +23,10 @@ public static class ObjectRegenerator
             .ToArray();
 
         // JsonObjectに変換
-        var jsonObject = CoreSerializer.SerializeToJsonObject(obj);
+        var jsonObject = CoreSerializer.SerializeToJsonObject(obj, new CoreSerializerOptions
+        {
+            Mode = CoreSerializationMode.EmbedReferencedObjects
+        });
 
         // UTF-8に書き込む
         JsonSerializerOptions options = JsonHelper.SerializerOptions;

--- a/src/Beutl.Editor/Services/ObjectRegenerator.cs
+++ b/src/Beutl.Editor/Services/ObjectRegenerator.cs
@@ -57,8 +57,8 @@ public static class ObjectRegenerator
             int index;
             while ((index = localBuffer.IndexOf(oldStr)) >= 0)
             {
-                localBuffer = localBuffer.Slice(index);
-                newStr.CopyTo(localBuffer);
+                newStr.CopyTo(localBuffer.Slice(index));
+                localBuffer = localBuffer.Slice(index + newStr.Length);
             }
         }
     }

--- a/src/Beutl.Editor/Services/ObjectRegenerator.cs
+++ b/src/Beutl.Editor/Services/ObjectRegenerator.cs
@@ -22,7 +22,8 @@ public static class ObjectRegenerator
             .Distinct()
             .ToArray();
 
-        // JsonObjectに変換
+        // ICoreObjects with a Uri serialize as a file reference by default, hiding their
+        // inner Ids from the JSON. Embed them so GuidToUtf8 can rewrite every Id.
         var jsonObject = CoreSerializer.SerializeToJsonObject(obj, new CoreSerializerOptions
         {
             Mode = CoreSerializationMode.EmbedReferencedObjects
@@ -62,6 +63,13 @@ public static class ObjectRegenerator
         }
     }
 
+    private static JsonObject ParseRegeneratedBuffer(Span<byte> buffer)
+    {
+        return JsonNode.Parse(buffer)?.AsObject()
+            ?? throw new InvalidOperationException(
+                $"ObjectRegenerator: serialized payload could not be parsed as JsonObject. Bytes={buffer.Length}");
+    }
+
     public static void Regenerate<T>(T obj, out T newInstance)
         where T : class, ICoreObject, new()
     {
@@ -70,7 +78,7 @@ public static class ObjectRegenerator
 
         Span<byte> buffer = PooledArrayBufferWriter<byte>.GetArray(output).AsSpan().Slice(0, output.WrittenCount);
 
-        JsonObject jsonObj = JsonNode.Parse(buffer)!.AsObject();
+        JsonObject jsonObj = ParseRegeneratedBuffer(buffer);
         var instance = new T();
 
         CoreSerializer.PopulateFromJsonObject(instance, jsonObj);
@@ -93,7 +101,7 @@ public static class ObjectRegenerator
         RegenerateCore(obj, output);
 
         Span<byte> buffer = PooledArrayBufferWriter<byte>.GetArray(output).AsSpan().Slice(0, output.WrittenCount);
-        JsonObject jsonObj = JsonNode.Parse(buffer)!.AsObject();
+        JsonObject jsonObj = ParseRegeneratedBuffer(buffer);
 
         var instance = (ICoreSerializable)Activator.CreateInstance(actualType)!;
         CoreSerializer.PopulateFromJsonObject(instance, actualType, jsonObj);
@@ -110,7 +118,7 @@ public static class ObjectRegenerator
 
         Span<byte> buffer = PooledArrayBufferWriter<byte>.GetArray(output).AsSpan().Slice(0, output.WrittenCount);
 
-        JsonObject jsonObj = JsonNode.Parse(buffer)!.AsObject();
+        JsonObject jsonObj = ParseRegeneratedBuffer(buffer);
         var instance = new ListWrapper<T>();
 
         CoreSerializer.PopulateFromJsonObject(instance, jsonObj);
@@ -123,7 +131,7 @@ public static class ObjectRegenerator
         Span<char> utf16 = stackalloc char[DefaultGuidStringSize];
 
         if (!id.TryFormat(utf16, out _))
-            throw new Exception("Failed to 'Guid.TryFormat'.");
+            throw new InvalidOperationException($"Failed to format Guid {id} as UTF-16 in a {DefaultGuidStringSize}-char span.");
 
         Encoding.UTF8.GetBytes(utf16, utf8);
     }

--- a/src/Beutl.Language/CommandNames.ja.resx
+++ b/src/Beutl.Language/CommandNames.ja.resx
@@ -33,6 +33,9 @@
   <data name="SplitElement" xml:space="preserve">
     <value>要素を分割</value>
   </data>
+  <data name="DuplicateElement" xml:space="preserve">
+    <value>要素を複製</value>
+  </data>
   <data name="ChangeElementColor" xml:space="preserve">
     <value>要素の色を変更</value>
   </data>

--- a/src/Beutl.Language/CommandNames.resx
+++ b/src/Beutl.Language/CommandNames.resx
@@ -38,6 +38,9 @@
   <data name="SplitElement" xml:space="preserve">
     <value>Split Element</value>
   </data>
+  <data name="DuplicateElement" xml:space="preserve">
+    <value>Duplicate Element</value>
+  </data>
   <data name="ChangeElementColor" xml:space="preserve">
     <value>Change Element Color</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -840,6 +840,24 @@
   <data name="Duplicate_Description" xml:space="preserve">
     <value>選択したアイテムを複製します。</value>
   </data>
+  <data name="Duplicate_Failed" xml:space="preserve">
+    <value>複製に失敗しました</value>
+  </data>
+  <data name="Duplicate_ProjectNotSaved" xml:space="preserve">
+    <value>クリップを複製する前にプロジェクトを保存してください。</value>
+  </data>
+  <data name="Duplicate_IOFailed" xml:space="preserve">
+    <value>複製した要素のディスクへの書き込みに失敗しました。</value>
+  </data>
+  <data name="Duplicate_NoEmptySlot" xml:space="preserve">
+    <value>タイムラインに空きが見つからなかったため、既存のクリップと重なる位置に複製を配置しました。</value>
+  </data>
+  <data name="Duplicate_FallbackToMove" xml:space="preserve">
+    <value>複製に失敗したため、元のクリップを移動だけ行いました。</value>
+  </data>
+  <data name="Duplicate_FallbackFailed" xml:space="preserve">
+    <value>移動のフォールバックも失敗しました。タイムラインの状態と表示が一致しない可能性があります。</value>
+  </data>
   <data name="AboutBeutl" xml:space="preserve">
     <value>Beutlについて</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -237,6 +237,9 @@
   <data name="Split" xml:space="preserve">
     <value>分割</value>
   </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>複製</value>
+  </data>
   <data name="RazorTool" xml:space="preserve">
     <value>レーザーモード</value>
   </data>
@@ -833,6 +836,9 @@
   </data>
   <data name="Cut_Description" xml:space="preserve">
     <value>選択したアイテムをカットします。</value>
+  </data>
+  <data name="Duplicate_Description" xml:space="preserve">
+    <value>選択したアイテムを複製します。</value>
   </data>
   <data name="AboutBeutl" xml:space="preserve">
     <value>Beutlについて</value>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -167,6 +167,9 @@
   <data name="Split" xml:space="preserve">
     <value>Split</value>
   </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
   <data name="RazorTool" xml:space="preserve">
     <value>Razor Tool</value>
   </data>
@@ -838,6 +841,9 @@
   </data>
   <data name="Cut_Description" xml:space="preserve">
     <value>Cut the selected item.</value>
+  </data>
+  <data name="Duplicate_Description" xml:space="preserve">
+    <value>Duplicate the selected item.</value>
   </data>
   <data name="AboutBeutl" xml:space="preserve">
     <value>About Beutl</value>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -845,6 +845,24 @@
   <data name="Duplicate_Description" xml:space="preserve">
     <value>Duplicate the selected item.</value>
   </data>
+  <data name="Duplicate_Failed" xml:space="preserve">
+    <value>Failed to duplicate</value>
+  </data>
+  <data name="Duplicate_ProjectNotSaved" xml:space="preserve">
+    <value>Save the project before duplicating clips.</value>
+  </data>
+  <data name="Duplicate_IOFailed" xml:space="preserve">
+    <value>Could not write the duplicated element to disk.</value>
+  </data>
+  <data name="Duplicate_NoEmptySlot" xml:space="preserve">
+    <value>Could not find an empty slot on the timeline; the duplicate was placed where it may overlap an existing clip.</value>
+  </data>
+  <data name="Duplicate_FallbackToMove" xml:space="preserve">
+    <value>Duplicate failed; falling back to a plain move of the original clips.</value>
+  </data>
+  <data name="Duplicate_FallbackFailed" xml:space="preserve">
+    <value>The move fallback also failed; the timeline state may not match what you see.</value>
+  </data>
   <data name="AboutBeutl" xml:space="preserve">
     <value>About Beutl</value>
   </data>

--- a/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
@@ -211,4 +211,73 @@ public class DuplicateHelperTests
                 anchorZIndex: 0,
                 elementFileExtension: "belm"));
     }
+
+    [Test]
+    public void PlaceDuplicates_ThrowsArgumentException_WhenLengthsMismatch()
+    {
+        // Positional zip mapping breaking silently would corrupt group remap.
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element source = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            Element newA = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            Element newB = CreateElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
+            ClassicAssert.Throws<ArgumentException>(
+                () => DuplicateHelper.PlaceDuplicates(
+                    scene,
+                    newElements: [newA, newB],
+                    sourceElements: [source],
+                    anchorStart: TimeSpan.Zero,
+                    anchorZIndex: 0,
+                    elementFileExtension: "belm"));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PlaceDuplicates_LeavesSceneUntouched_OnPhase1Failure()
+    {
+        // Asserts the Phase 1 invariant: scene.Children/Groups stay untouched on failure.
+        // Forces Phase 1 to fail by placing a file where StoreToUri expects a directory,
+        // so Directory.CreateDirectory throws.
+        string basePath = GetTempPath();
+        try
+        {
+            Directory.CreateDirectory(basePath);
+            string blocked = Path.Combine(basePath, "blocked");
+            File.WriteAllText(blocked, "not a directory");
+
+            var scene = new Scene(100, 100, string.Empty)
+            {
+                Uri = new Uri(Path.Combine(blocked, "test.scene"))
+            };
+            int sceneChildrenBefore = scene.Children.Count;
+            int sceneGroupsBefore = scene.Groups.Count;
+
+            Element source = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            Element newOne = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+            ClassicAssert.Throws<IOException>(
+                () => DuplicateHelper.PlaceDuplicates(
+                    scene,
+                    newElements: [newOne],
+                    sourceElements: [source],
+                    anchorStart: TimeSpan.Zero,
+                    anchorZIndex: 0,
+                    elementFileExtension: "belm"));
+
+            // Scene 状態は無変更で抜けている
+            ClassicAssert.AreEqual(sceneChildrenBefore, scene.Children.Count);
+            ClassicAssert.AreEqual(sceneGroupsBefore, scene.Groups.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
@@ -121,8 +121,7 @@ public class DuplicateHelperTests
                 newElements: [newA, newB, newC],
                 sourceElements: [a, b, c],
                 anchorStart: TimeSpan.FromSeconds(10),
-                anchorZIndex: 1,
-                elementFileExtension: "belm");
+                anchorZIndex: 1);
 
             ClassicAssert.AreEqual(6, scene.Children.Count);
             ClassicAssert.AreEqual(2, scene.Groups.Count);
@@ -178,8 +177,7 @@ public class DuplicateHelperTests
                 newElements: [newX, newY],
                 sourceElements: [x, y],
                 anchorStart: TimeSpan.FromSeconds(20),
-                anchorZIndex: 0,
-                elementFileExtension: "belm");
+                anchorZIndex: 0);
 
             // sourceX の新規 ID は newX.Id でなければならない (位置 zip)。
             // 順序が swap してしまうと sourceX -> newY.Id になり、後続のグループ remap で
@@ -275,8 +273,7 @@ public class DuplicateHelperTests
                 newElements: [newOne],
                 sourceElements: [source],
                 anchorStart: TimeSpan.Zero,
-                anchorZIndex: 0,
-                elementFileExtension: "belm"));
+                anchorZIndex: 0));
     }
 
     [Test]
@@ -297,8 +294,7 @@ public class DuplicateHelperTests
                     newElements: [newA, newB],
                     sourceElements: [source],
                     anchorStart: TimeSpan.Zero,
-                    anchorZIndex: 0,
-                    elementFileExtension: "belm"));
+                    anchorZIndex: 0));
         }
         finally
         {
@@ -335,8 +331,7 @@ public class DuplicateHelperTests
                     newElements: [newOne],
                     sourceElements: [source],
                     anchorStart: TimeSpan.Zero,
-                    anchorZIndex: 0,
-                    elementFileExtension: "belm"));
+                    anchorZIndex: 0));
 
             // Scene 状態は無変更で抜けている
             ClassicAssert.AreEqual(sceneChildrenBefore, scene.Children.Count);

--- a/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
@@ -194,6 +194,73 @@ public class DuplicateHelperTests
     }
 
     [Test]
+    public void WouldOverlapSources_ReturnsTrue_WhenAnchorLandsInsideSource()
+    {
+        // Single 5s clip at t=0..5 on layer 0. Anchor at t=3 → new range 3..8 still
+        // overlaps the original on the same layer.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5), zIndex: 0);
+
+        bool result = DuplicateHelper.WouldOverlapSources([a], TimeSpan.FromSeconds(3), anchorZIndex: 0);
+
+        ClassicAssert.IsTrue(result);
+    }
+
+    [Test]
+    public void WouldOverlapSources_ReturnsFalse_WhenAnchorIsExactlyAtSourceEnd()
+    {
+        // [0,5) and [5,10) on layer 0 are adjacent but not intersecting.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5), zIndex: 0);
+
+        bool result = DuplicateHelper.WouldOverlapSources([a], TimeSpan.FromSeconds(5), anchorZIndex: 0);
+
+        ClassicAssert.IsFalse(result);
+    }
+
+    [Test]
+    public void WouldOverlapSources_ReturnsFalse_WhenLayerDiffers()
+    {
+        // Same time range but different ZIndex — no overlap.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5), zIndex: 0);
+
+        bool result = DuplicateHelper.WouldOverlapSources([a], TimeSpan.FromSeconds(0), anchorZIndex: 1);
+
+        ClassicAssert.IsFalse(result);
+    }
+
+    [Test]
+    public void WouldOverlapSources_ReturnsTrue_WhenAnyMemberOverlaps()
+    {
+        // a: [0,2), b: [10,12) on layer 0. Shift by +1 → new a: [1,3), new b: [11,13).
+        // new a overlaps source a.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(2), zIndex: 0);
+        Element b = CreateElement(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2), zIndex: 0);
+
+        bool result = DuplicateHelper.WouldOverlapSources([a, b], TimeSpan.FromSeconds(1), anchorZIndex: 0);
+
+        ClassicAssert.IsTrue(result);
+    }
+
+    [Test]
+    public void WouldOverlapSources_ReturnsFalse_WhenAllNewRangesClearSources()
+    {
+        // a: [0,2), b: [4,6) on layer 0. Anchor at t=10 → new a: [10,12), new b: [14,16).
+        // Neither intersects any source on the same layer.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(2), zIndex: 0);
+        Element b = CreateElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2), zIndex: 0);
+
+        bool result = DuplicateHelper.WouldOverlapSources([a, b], TimeSpan.FromSeconds(10), anchorZIndex: 0);
+
+        ClassicAssert.IsFalse(result);
+    }
+
+    [Test]
+    public void WouldOverlapSources_ReturnsFalse_OnEmptyInput()
+    {
+        ClassicAssert.IsFalse(
+            DuplicateHelper.WouldOverlapSources([], TimeSpan.Zero, anchorZIndex: 0));
+    }
+
+    [Test]
     public void PlaceDuplicates_ThrowsInvalidOperation_WhenSceneUriIsNull()
     {
         var scene = new Scene(100, 100, string.Empty);

--- a/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using Beutl.Editor.Services;
 using Beutl.ProjectSystem;
 using NUnit.Framework.Legacy;

--- a/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/DuplicateHelperTests.cs
@@ -1,0 +1,214 @@
+using System.Collections.Immutable;
+using Beutl.Editor.Services;
+using Beutl.ProjectSystem;
+using NUnit.Framework.Legacy;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class DuplicateHelperTests
+{
+    private static string GetTempPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"beutl_duplicate_helper_{Guid.NewGuid():N}");
+    }
+
+    private static Scene CreateScene(string basePath)
+    {
+        Directory.CreateDirectory(basePath);
+        return new Scene(100, 100, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(basePath, "test.scene"))
+        };
+    }
+
+    private static Element CreateElement(TimeSpan start, TimeSpan length, int zIndex = 0, Guid? id = null, string? basePath = null)
+    {
+        var element = new Element
+        {
+            Start = start,
+            Length = length,
+            ZIndex = zIndex,
+        };
+        if (basePath is not null)
+        {
+            element.Uri = new Uri(Path.Combine(basePath, $"{Guid.NewGuid():N}.belm"));
+        }
+        if (id.HasValue) element.Id = id.Value;
+        return element;
+    }
+
+    [Test]
+    public void ComputePlacementRange_UsesRangeEnd_NotMaxStart()
+    {
+        // A starts at 0s, length 10s — ends at 10s
+        // B starts at 1s, length 1s — ends at 2s
+        // The placement search seed range should span A's full duration (10s),
+        // not just maxStart-minStart (1s). Otherwise the spiral search picks
+        // a "next slot" that overlaps A.
+        Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(10));
+        Element b = CreateElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
+        var (range, minZ, maxZ) = DuplicateHelper.ComputePlacementRange([a, b]);
+
+        ClassicAssert.AreEqual(TimeSpan.FromSeconds(0), range.Start);
+        ClassicAssert.AreEqual(TimeSpan.FromSeconds(10), range.Duration);
+        ClassicAssert.AreEqual(0, minZ);
+        ClassicAssert.AreEqual(0, maxZ);
+    }
+
+    [Test]
+    public void ExpandWithGroupSiblings_IncludesAllMembers_WhenOneIsSelected()
+    {
+        Guid a = Guid.NewGuid();
+        Guid b = Guid.NewGuid();
+        Guid c = Guid.NewGuid();
+        Guid unrelated = Guid.NewGuid();
+        var group = ImmutableHashSet.Create(a, b, c);
+
+        HashSet<Guid> expanded = DuplicateHelper.ExpandWithGroupSiblings(
+            seedIds: [a],
+            groups: [group, ImmutableHashSet.Create(unrelated)]);
+
+        ClassicAssert.AreEqual(3, expanded.Count);
+        ClassicAssert.IsTrue(expanded.Contains(a));
+        ClassicAssert.IsTrue(expanded.Contains(b));
+        ClassicAssert.IsTrue(expanded.Contains(c));
+        ClassicAssert.IsFalse(expanded.Contains(unrelated));
+    }
+
+    [Test]
+    public void ExpandWithGroupSiblings_LeavesSeedUntouched_WhenNoGroupOverlaps()
+    {
+        Guid a = Guid.NewGuid();
+        Guid b = Guid.NewGuid();
+        var otherGroup = ImmutableHashSet.Create(Guid.NewGuid(), Guid.NewGuid());
+
+        HashSet<Guid> expanded = DuplicateHelper.ExpandWithGroupSiblings(
+            seedIds: [a, b],
+            groups: [otherGroup]);
+
+        ClassicAssert.AreEqual(2, expanded.Count);
+        ClassicAssert.IsTrue(expanded.Contains(a));
+        ClassicAssert.IsTrue(expanded.Contains(b));
+    }
+
+    [Test]
+    public void PlaceDuplicates_RemapsGroupsToNewIds_PreservingMembership()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Guid sourceA = Guid.NewGuid();
+            Guid sourceB = Guid.NewGuid();
+            Guid sourceC = Guid.NewGuid();
+            Element a = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), zIndex: 0, id: sourceA, basePath: basePath);
+            Element b = CreateElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0, id: sourceB, basePath: basePath);
+            Element c = CreateElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0, id: sourceC, basePath: basePath);
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+            scene.Children.Add(c);
+            scene.Groups.Add(ImmutableHashSet.Create(sourceA, sourceB, sourceC));
+
+            // 新規要素は正規化済みの位置を持つ前提 (ObjectRegenerator が新しい Id を振った状態)
+            Element newA = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element newB = CreateElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element newC = CreateElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+
+            DuplicateHelper.PlaceDuplicates(
+                scene,
+                newElements: [newA, newB, newC],
+                sourceElements: [a, b, c],
+                anchorStart: TimeSpan.FromSeconds(10),
+                anchorZIndex: 1,
+                elementFileExtension: "belm");
+
+            ClassicAssert.AreEqual(6, scene.Children.Count);
+            ClassicAssert.AreEqual(2, scene.Groups.Count);
+
+            // 元グループは変更されない
+            ImmutableHashSet<Guid> originalGroup = scene.Groups[0];
+            ClassicAssert.IsTrue(originalGroup.SetEquals([sourceA, sourceB, sourceC]));
+
+            // 新規グループは新 ID 3 つを含み、元 ID とは交差しない
+            ImmutableHashSet<Guid> newGroup = scene.Groups[1];
+            ClassicAssert.AreEqual(3, newGroup.Count);
+            ClassicAssert.IsTrue(newGroup.SetEquals([newA.Id, newB.Id, newC.Id]));
+            ClassicAssert.IsFalse(newGroup.Overlaps([sourceA, sourceB, sourceC]));
+
+            // アンカー位置からの相対配置が保たれている
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(10), newA.Start);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(11), newB.Start);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(12), newC.Start);
+            ClassicAssert.AreEqual(1, newA.ZIndex);
+            ClassicAssert.AreEqual(1, newB.ZIndex);
+            ClassicAssert.AreEqual(1, newC.ZIndex);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PlaceDuplicates_PositionalIdMapping_PreservesOrder()
+    {
+        // idMapping は sourceElements[i] -> newElements[i] の位置zipで作る。
+        // ObjectRegenerator の順序保存が暗黙の契約。並びが崩れるとグループ remap も崩れる。
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Guid sourceX = Guid.NewGuid();
+            Guid sourceY = Guid.NewGuid();
+            Element x = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), id: sourceX, basePath: basePath);
+            Element y = CreateElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), id: sourceY, basePath: basePath);
+            scene.Children.Add(x);
+            scene.Children.Add(y);
+            // X と Y を別グループに置く
+            scene.Groups.Add(ImmutableHashSet.Create(sourceX, Guid.NewGuid()));
+            scene.Groups.Add(ImmutableHashSet.Create(sourceY, Guid.NewGuid()));
+
+            Element newX = CreateElement(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+            Element newY = CreateElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+
+            DuplicateHelper.PlaceDuplicates(
+                scene,
+                newElements: [newX, newY],
+                sourceElements: [x, y],
+                anchorStart: TimeSpan.FromSeconds(20),
+                anchorZIndex: 0,
+                elementFileExtension: "belm");
+
+            // sourceX の新規 ID は newX.Id でなければならない (位置 zip)。
+            // 順序が swap してしまうと sourceX -> newY.Id になり、後続のグループ remap で
+            // X のグループに「Y のクローン」が入る silent corruption が発生する。
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(20), newX.Start);
+            ClassicAssert.AreEqual(TimeSpan.FromSeconds(25), newY.Start);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PlaceDuplicates_ThrowsInvalidOperation_WhenSceneUriIsNull()
+    {
+        var scene = new Scene(100, 100, string.Empty);
+        ClassicAssert.IsNull(scene.Uri);
+
+        Element source = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        Element newOne = CreateElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+        ClassicAssert.Throws<InvalidOperationException>(
+            () => DuplicateHelper.PlaceDuplicates(
+                scene,
+                newElements: [newOne],
+                sourceElements: [source],
+                anchorStart: TimeSpan.Zero,
+                anchorZIndex: 0,
+                elementFileExtension: "belm"));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ObjectRegeneratorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ObjectRegeneratorTests.cs
@@ -1,0 +1,96 @@
+using Beutl.Editor.Services;
+using Beutl.ProjectSystem;
+using NUnit.Framework.Legacy;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class ObjectRegeneratorTests
+{
+    [Test]
+    public void Regenerate_AssignsNewId_OnTopLevelElement()
+    {
+        var src = new Element
+        {
+            Start = TimeSpan.FromSeconds(0),
+            Length = TimeSpan.FromSeconds(1),
+            ZIndex = 0,
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.belm")),
+        };
+        Guid srcId = src.Id;
+
+        ObjectRegenerator.Regenerate(src, out Element regenerated);
+
+        ClassicAssert.AreNotEqual(Guid.Empty, regenerated.Id);
+        ClassicAssert.AreNotEqual(srcId, regenerated.Id);
+    }
+
+    [Test]
+    public void Regenerate_AssignsNewIdsToEmbeddedChildren()
+    {
+        // Element has a Uri, so the default ReadWrite mode would emit only a file
+        // reference and hide child Ids. Embed mode expands them so Ids get rewritten.
+        var src = new Element
+        {
+            Start = TimeSpan.FromSeconds(0),
+            Length = TimeSpan.FromSeconds(1),
+            ZIndex = 0,
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.belm")),
+        };
+        var child = new PortalObject();
+        src.AddObject(child);
+        Guid srcId = src.Id;
+        Guid childId = child.Id;
+
+        ObjectRegenerator.Regenerate(src, out Element regenerated);
+
+        ClassicAssert.AreNotEqual(srcId, regenerated.Id);
+        ClassicAssert.AreEqual(1, regenerated.Objects.Count, "Embed mode should re-materialize child objects.");
+        Guid regeneratedChildId = regenerated.Objects[0].Id;
+        ClassicAssert.AreNotEqual(Guid.Empty, regeneratedChildId);
+        ClassicAssert.AreNotEqual(childId, regeneratedChildId);
+    }
+
+    [Test]
+    public void Regenerate_Array_PreservesOrderAndAssignsNewIds()
+    {
+        // PlaceDuplicates relies on positional zip (sourceElements[i] -> newElements[i]).
+        // If Regenerate reorders the array, group remap silently corrupts.
+        var a = new Element
+        {
+            Start = TimeSpan.FromSeconds(0),
+            Length = TimeSpan.FromSeconds(1),
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.belm")),
+        };
+        var b = new Element
+        {
+            Start = TimeSpan.FromSeconds(5),
+            Length = TimeSpan.FromSeconds(2),
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.belm")),
+        };
+        var c = new Element
+        {
+            Start = TimeSpan.FromSeconds(10),
+            Length = TimeSpan.FromSeconds(3),
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.belm")),
+        };
+        Guid[] originalIds = [a.Id, b.Id, c.Id];
+
+        ObjectRegenerator.Regenerate([a, b, c], out Element[] regenerated);
+
+        ClassicAssert.AreEqual(3, regenerated.Length);
+
+        // Order preserved (identified by Start).
+        ClassicAssert.AreEqual(a.Start, regenerated[0].Start);
+        ClassicAssert.AreEqual(b.Start, regenerated[1].Start);
+        ClassicAssert.AreEqual(c.Start, regenerated[2].Start);
+
+        // All Ids regenerated, no duplicates.
+        for (int i = 0; i < regenerated.Length; i++)
+        {
+            ClassicAssert.AreNotEqual(originalIds[i], regenerated[i].Id);
+        }
+        var idSet = new HashSet<Guid>(regenerated.Select(r => r.Id));
+        ClassicAssert.AreEqual(3, idSet.Count);
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ObjectRegeneratorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ObjectRegeneratorTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor.Services;
+﻿using Beutl.Editor.Services;
 using Beutl.ProjectSystem;
 using NUnit.Framework.Legacy;
 


### PR DESCRIPTION
## Description

- Add a dedicated Duplicate gesture for timeline clips so users can
  clone selections in a single step instead of round-tripping through
  Copy + Paste. Bound to Ctrl+D / Cmd+D and to Alt+drag, matching
  the conventions used by Premiere, DaVinci Resolve and similar NLEs.
- Extract the regenerate-and-place core out of PasteElementList into a
  shared PlaceAndAddDuplicates helper so paste and the new duplicate
  paths stay in lock-step (id remap, group remap, file serialization).
- Ctrl+D expands the selection through Scene.Groups so it stays
  consistent with Copy/Cut/Alt-drag duplication; Alt+drag drops the
  copy at the cursor while the source clips animate back to their
  original position.

## Breaking changes

- Alt+drag on a clip body now creates a duplicate at the drop
  position. Previously, Alt+drag moved the clip with snap disabled.
  Snap is still disabled while the Alt+drag is in flight, so users
  who relied on the no-snap effect during the drag are unaffected;
  users who relied on the resulting move will need to drop Alt and
  drag normally instead.

## Fixed issues

None.