### PR TITLE
feat: Add goto timecode for player playhead seeking

### DIFF
--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -13,6 +13,12 @@ namespace Beutl.Controls;
 // nullable is enabled per-type because the surrounding Player class predates
 // nullable annotations; enabling at file scope would force a broad rewrite of
 // its private fields.
+/// <summary>
+/// Event args for <see cref="Player.CurrentTimeSubmitted"/>. Subscribers must call
+/// <see cref="Accept"/> to consume the submission (closes the editor) or
+/// <see cref="Reject"/> with a localized message to keep the editor open and
+/// display the message as a validation tooltip.
+/// </summary>
 public sealed class TimecodeSubmittedEventArgs : EventArgs
 {
     public TimecodeSubmittedEventArgs(string input)
@@ -195,6 +201,10 @@ public class Player : RangeBase
         }
     }
 
+    /// <summary>
+    /// Enters timecode-editing mode for the current time display. No-op if the
+    /// control template has not been applied yet.
+    /// </summary>
     public void BeginEditCurrentTime()
     {
         if (_currentTimeTextBox == null) return;

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -4,8 +4,24 @@ using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace Beutl.Controls;
+
+public sealed class TimecodeSubmittedEventArgs : EventArgs
+{
+    public TimecodeSubmittedEventArgs(string input)
+    {
+        Input = input;
+    }
+
+    public string Input { get; }
+
+    public bool Handled { get; set; }
+
+    public string Error { get; set; }
+}
 
 public class Player : RangeBase
 {
@@ -72,11 +88,15 @@ public class Player : RangeBase
     private Slider _slider;
     private ContentPresenter _innerLeftPresenter;
     private ContentPresenter _contentPresenter;
+    private TextBlock _currentTimeTextBlock;
+    private TextBox _currentTimeTextBox;
     private ICommand _playButtonCommand;
     private ICommand _nextButtonCommand;
     private ICommand _previousButtonCommand;
     private ICommand _endButtonCommand;
     private ICommand _startButtonCommand;
+
+    public event EventHandler<TimecodeSubmittedEventArgs> CurrentTimeSubmitted;
 
     public string Duration
     {
@@ -158,6 +178,63 @@ public class Player : RangeBase
         }
     }
 
+    public void BeginEditCurrentTime()
+    {
+        if (_currentTimeTextBox == null) return;
+
+        _currentTimeTextBox.Classes.Remove("invalid");
+        ToolTip.SetTip(_currentTimeTextBox, null);
+        _currentTimeTextBox.Text = _currentTime;
+        _currentTimeTextBox.IsVisible = true;
+        if (_currentTimeTextBlock != null)
+        {
+            _currentTimeTextBlock.IsVisible = false;
+        }
+        _currentTimeTextBox.Focus();
+        _currentTimeTextBox.SelectAll();
+    }
+
+    private void EndEditCurrentTime()
+    {
+        if (_currentTimeTextBox == null) return;
+        _currentTimeTextBox.IsVisible = false;
+        _currentTimeTextBox.Classes.Remove("invalid");
+        ToolTip.SetTip(_currentTimeTextBox, null);
+        if (_currentTimeTextBlock != null)
+        {
+            _currentTimeTextBlock.IsVisible = true;
+        }
+    }
+
+    private void SubmitCurrentTimeEdit()
+    {
+        if (_currentTimeTextBox == null) return;
+        string input = _currentTimeTextBox.Text ?? string.Empty;
+        var handler = CurrentTimeSubmitted;
+        if (handler == null)
+        {
+            EndEditCurrentTime();
+            return;
+        }
+
+        var args = new TimecodeSubmittedEventArgs(input);
+        handler(this, args);
+
+        if (args.Handled)
+        {
+            EndEditCurrentTime();
+        }
+        else
+        {
+            _currentTimeTextBox.Classes.Add("invalid");
+            if (!string.IsNullOrEmpty(args.Error))
+            {
+                ToolTip.SetTip(_currentTimeTextBox, args.Error);
+            }
+            _currentTimeTextBox.SelectAll();
+        }
+    }
+
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -169,6 +246,8 @@ public class Player : RangeBase
         _slider = e.NameScope.Find<Slider>("PART_Slider");
         _innerLeftPresenter = e.NameScope.Find<ContentPresenter>("InnerLeftPresenter");
         _contentPresenter = e.NameScope.Find<ContentPresenter>("ContentPresenter");
+        _currentTimeTextBlock = e.NameScope.Find<TextBlock>("PART_CurrentTimeTextBlock");
+        _currentTimeTextBox = e.NameScope.Find<TextBox>("PART_CurrentTimeTextBox");
 
         _playButton.Click += (s, e) => PlayButtonCommand?.Execute(null);
         _nextButton.Click += (s, e) => NextButtonCommand?.Execute(null);
@@ -176,7 +255,55 @@ public class Player : RangeBase
         _endButton.Click += (s, e) => EndButtonCommand?.Execute(null);
         _startButton.Click += (s, e) => StartButtonCommand?.Execute(null);
 
+        if (_currentTimeTextBlock != null)
+        {
+            _currentTimeTextBlock.PointerPressed += OnCurrentTimeTextBlockPointerPressed;
+        }
+
+        if (_currentTimeTextBox != null)
+        {
+            _currentTimeTextBox.IsVisible = false;
+            _currentTimeTextBox.KeyDown += OnCurrentTimeTextBoxKeyDown;
+            _currentTimeTextBox.LostFocus += OnCurrentTimeTextBoxLostFocus;
+            _currentTimeTextBox.GetObservable(TextBox.TextProperty).Subscribe(_ =>
+            {
+                _currentTimeTextBox.Classes.Remove("invalid");
+                ToolTip.SetTip(_currentTimeTextBox, null);
+            });
+        }
+
         _innerLeftPresenter.GetObservable(BoundsProperty).Subscribe(OnInnerLeftBoundsChanged);
+    }
+
+    private void OnCurrentTimeTextBlockPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(_currentTimeTextBlock).Properties.IsLeftButtonPressed)
+        {
+            BeginEditCurrentTime();
+            e.Handled = true;
+        }
+    }
+
+    private void OnCurrentTimeTextBoxKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            SubmitCurrentTimeEdit();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            EndEditCurrentTime();
+            e.Handled = true;
+        }
+    }
+
+    private void OnCurrentTimeTextBoxLostFocus(object sender, RoutedEventArgs e)
+    {
+        if (_currentTimeTextBox != null && _currentTimeTextBox.IsVisible)
+        {
+            EndEditCurrentTime();
+        }
     }
 
     private void OnInnerLeftBoundsChanged(Rect rect)

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -8,6 +8,8 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 
+using Microsoft.Extensions.Logging;
+
 namespace Beutl.Controls;
 
 // nullable is enabled per-type because the surrounding Player class predates
@@ -99,6 +101,8 @@ public class Player : RangeBase
             nameof(StartButtonCommand),
             owner => owner.StartButtonCommand,
             (owner, obj) => owner.StartButtonCommand = obj);
+
+    private static readonly ILogger s_logger = Beutl.Logging.Log.CreateLogger<Player>();
 
     private string _currentTime = string.Empty;
     private bool _isPlaying;
@@ -238,6 +242,14 @@ public class Player : RangeBase
         if (_currentTimeTextBox == null) return;
         string input = _currentTimeTextBox.Text ?? string.Empty;
         var handler = CurrentTimeSubmitted;
+
+        if (handler == null)
+        {
+            // The editor stays open with the fallback tooltip below; surface the
+            // misconfiguration so it is detectable in telemetry rather than
+            // silently masquerading as a user input error.
+            s_logger.LogWarning("CurrentTimeSubmitted has no subscribers; timecode '{Input}' cannot be processed.", input);
+        }
 
         TimecodeSubmittedEventArgs args = new TimecodeSubmittedEventArgs(input);
         try

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 using Microsoft.Extensions.Logging;
 
@@ -102,6 +103,9 @@ public class Player : RangeBase
             owner => owner.StartButtonCommand,
             (owner, obj) => owner.StartButtonCommand = obj);
 
+    public static readonly StyledProperty<IReadOnlyList<PlayerMarkerEntry>> MarkersProperty =
+        AvaloniaProperty.Register<Player, IReadOnlyList<PlayerMarkerEntry>>(nameof(Markers));
+
     private static readonly ILogger s_logger = Beutl.Logging.Log.CreateLogger<Player>();
 
     private string _currentTime = string.Empty;
@@ -119,6 +123,9 @@ public class Player : RangeBase
     private TextBlock _currentTimeTextBlock;
     private TextBox _currentTimeTextBox;
     private IDisposable _currentTimeTextBoxTextSubscription;
+    private Popup _markerPopup;
+    private ListBox _markerListBox;
+    private IDisposable _markersChangeSubscription;
     private ICommand _playButtonCommand;
     private ICommand _nextButtonCommand;
     private ICommand _previousButtonCommand;
@@ -199,6 +206,12 @@ public class Player : RangeBase
         set => SetAndRaise(StartButtonCommandProperty, ref _startButtonCommand, value);
     }
 
+    public IReadOnlyList<PlayerMarkerEntry> Markers
+    {
+        get => GetValue(MarkersProperty);
+        set => SetValue(MarkersProperty, value);
+    }
+
     public void SetSeekBarOpacity(double opacity)
     {
         if (_slider != null)
@@ -228,6 +241,7 @@ public class Player : RangeBase
         {
             _currentTimeTextBlock.IsVisible = false;
         }
+        CloseMarkerPopup();
         _currentTimeTextBox.Focus();
         _currentTimeTextBox.SelectAll();
     }
@@ -242,6 +256,70 @@ public class Player : RangeBase
         {
             _currentTimeTextBlock.IsVisible = true;
         }
+        CloseMarkerPopup();
+    }
+
+    private void CloseMarkerPopup()
+    {
+        if (_markerPopup != null)
+        {
+            _markerPopup.IsOpen = false;
+        }
+    }
+
+    private bool IsMarkerPopupOpen => _markerPopup != null && _markerPopup.IsOpen;
+
+    private void UpdateMarkerPopup(string text)
+    {
+        if (_markerPopup == null || _markerListBox == null) return;
+        if (string.IsNullOrEmpty(text) || text[0] != '@')
+        {
+            _markerPopup.IsOpen = false;
+            return;
+        }
+
+        // Match the prefix-trimming rule used by GotoTimecodeParser.TryParseMarker
+        // so the popup never lists an entry the parser would reject.
+        string prefix = text.Substring(1).TrimStart();
+        IReadOnlyList<PlayerMarkerEntry> source = Markers;
+        if (source == null || source.Count == 0)
+        {
+            _markerPopup.IsOpen = false;
+            return;
+        }
+
+        var filtered = new List<PlayerMarkerEntry>(source.Count);
+        for (int i = 0; i < source.Count; i++)
+        {
+            PlayerMarkerEntry m = source[i];
+            if (m == null) continue;
+            string name = m.Name ?? string.Empty;
+            if (prefix.Length == 0
+                || name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                filtered.Add(m);
+            }
+        }
+
+        if (filtered.Count == 0)
+        {
+            _markerPopup.IsOpen = false;
+            return;
+        }
+
+        _markerListBox.ItemsSource = filtered;
+        _markerListBox.SelectedIndex = 0;
+        _markerPopup.IsOpen = true;
+    }
+
+    private void CommitMarkerSelection()
+    {
+        if (_markerListBox == null || _currentTimeTextBox == null) return;
+        if (_markerListBox.SelectedItem is not PlayerMarkerEntry selected) return;
+
+        _currentTimeTextBox.Text = "@" + (selected.Name ?? string.Empty);
+        _markerPopup.IsOpen = false;
+        SubmitCurrentTimeEdit();
     }
 
     private void SubmitCurrentTimeEdit()
@@ -314,8 +392,14 @@ public class Player : RangeBase
             _currentTimeTextBox.KeyDown -= OnCurrentTimeTextBoxKeyDown;
             _currentTimeTextBox.LostFocus -= OnCurrentTimeTextBoxLostFocus;
         }
+        if (_markerListBox != null)
+        {
+            _markerListBox.PointerReleased -= OnMarkerListBoxPointerReleased;
+        }
         _currentTimeTextBoxTextSubscription?.Dispose();
         _currentTimeTextBoxTextSubscription = null;
+        _markersChangeSubscription?.Dispose();
+        _markersChangeSubscription = null;
 
         _playButton = e.NameScope.Find<ToggleButton>("PART_PlayButton");
         _nextButton = e.NameScope.Find<RepeatButton>("PART_NextButton");
@@ -327,6 +411,8 @@ public class Player : RangeBase
         _contentPresenter = e.NameScope.Find<ContentPresenter>("ContentPresenter");
         _currentTimeTextBlock = e.NameScope.Find<TextBlock>("PART_CurrentTimeTextBlock");
         _currentTimeTextBox = e.NameScope.Find<TextBox>("PART_CurrentTimeTextBox");
+        _markerPopup = e.NameScope.Find<Popup>("PART_MarkerPopup");
+        _markerListBox = e.NameScope.Find<ListBox>("PART_MarkerListBox");
 
         _playButton.Click += (s, e) => PlayButtonCommand?.Execute(null);
         _nextButton.Click += (s, e) => NextButtonCommand?.Execute(null);
@@ -346,12 +432,35 @@ public class Player : RangeBase
             _currentTimeTextBox.LostFocus += OnCurrentTimeTextBoxLostFocus;
             _currentTimeTextBoxTextSubscription = _currentTimeTextBox
                 .GetObservable(TextBox.TextProperty)
-                .Subscribe(_ =>
+                .Subscribe(text =>
                 {
                     _currentTimeTextBox.Classes.Remove("invalid");
                     ToolTip.SetTip(_currentTimeTextBox, null);
+                    // TextBox が非表示の間（編集モード外）のスプリアス通知でポップアップを開かない。
+                    if (_currentTimeTextBox.IsVisible)
+                    {
+                        UpdateMarkerPopup(text);
+                    }
                 });
         }
+
+        if (_markerListBox != null)
+        {
+            _markerListBox.PointerReleased += OnMarkerListBoxPointerReleased;
+        }
+
+        // マーカーソースが差し替わったら現在の入力に基づいて再フィルタする。
+        _markersChangeSubscription = this.GetObservable(MarkersProperty).Subscribe(_ =>
+        {
+            if (_currentTimeTextBox != null && _currentTimeTextBox.IsVisible)
+            {
+                UpdateMarkerPopup(_currentTimeTextBox.Text);
+            }
+            else
+            {
+                CloseMarkerPopup();
+            }
+        });
 
         _innerLeftPresenter.GetObservable(BoundsProperty).Subscribe(OnInnerLeftBoundsChanged);
     }
@@ -367,6 +476,33 @@ public class Player : RangeBase
 
     private void OnCurrentTimeTextBoxKeyDown(object sender, KeyEventArgs e)
     {
+        // IME 変換中のキー入力は IME に委ね、ポップアップ操作・確定処理に横取りしない。
+        if (e.Key == Key.ImeProcessed) return;
+
+        if (IsMarkerPopupOpen)
+        {
+            switch (e.Key)
+            {
+                case Key.Down:
+                    MoveMarkerSelection(1);
+                    e.Handled = true;
+                    return;
+                case Key.Up:
+                    MoveMarkerSelection(-1);
+                    e.Handled = true;
+                    return;
+                case Key.Enter:
+                    CommitMarkerSelection();
+                    e.Handled = true;
+                    return;
+                case Key.Escape:
+                    // ポップアップだけ閉じ、編集モードは継続する。
+                    CloseMarkerPopup();
+                    e.Handled = true;
+                    return;
+            }
+        }
+
         if (e.Key == Key.Enter)
         {
             SubmitCurrentTimeEdit();
@@ -377,6 +513,48 @@ public class Player : RangeBase
             EndEditCurrentTime();
             e.Handled = true;
         }
+    }
+
+    private void MoveMarkerSelection(int delta)
+    {
+        if (_markerListBox == null) return;
+        int count = _markerListBox.ItemCount;
+        if (count == 0) return;
+        int current = _markerListBox.SelectedIndex;
+        int next = Math.Clamp(current + delta, 0, count - 1);
+        if (next != current)
+        {
+            _markerListBox.SelectedIndex = next;
+        }
+        if (_markerListBox.SelectedItem is { } item)
+        {
+            _markerListBox.ScrollIntoView(item);
+        }
+    }
+
+    private void OnMarkerListBoxPointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        if (e.InitialPressMouseButton != MouseButton.Left) return;
+        if (e.Source is not Visual source) return;
+
+        // 起点アイテム経由で取得することで、SelectedItem 反映前のクリックでも誤確定しない。
+        ListBoxItem item = FindListBoxItem(source);
+        if (item == null || item.DataContext is not PlayerMarkerEntry entry) return;
+
+        _markerListBox.SelectedItem = entry;
+        e.Handled = true;
+        CommitMarkerSelection();
+    }
+
+    private static ListBoxItem FindListBoxItem(Visual source)
+    {
+        Visual current = source;
+        while (current != null)
+        {
+            if (current is ListBoxItem item) return item;
+            current = current.GetVisualParent();
+        }
+        return null;
     }
 
     private void OnCurrentTimeTextBoxLostFocus(object sender, RoutedEventArgs e)

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -105,6 +105,7 @@ public class Player : RangeBase
     private static readonly ILogger s_logger = Beutl.Logging.Log.CreateLogger<Player>();
 
     private string _currentTime = string.Empty;
+    private string _editStartText = string.Empty;
     private bool _isPlaying;
     private bool _isLoopEnabled;
     private ToggleButton _playButton;
@@ -216,6 +217,11 @@ public class Player : RangeBase
         _currentTimeTextBox.Classes.Remove("invalid");
         ToolTip.SetTip(_currentTimeTextBox, null);
         _currentTimeTextBox.Text = _currentTime;
+        // Snapshot the text the editor was opened with; CurrentTime is bound to
+        // the live playhead and may advance under the user during playback, so
+        // SubmitCurrentTimeEdit cannot compare against the latest _currentTime
+        // to decide whether the user edited the value.
+        _editStartText = _currentTime;
         _currentTimeTextBox.IsVisible = true;
         if (_currentTimeTextBlock != null)
         {
@@ -245,9 +251,10 @@ public class Player : RangeBase
         // No-op when the user pressed Enter without editing the displayed text.
         // The CurrentTime string format (hh\:mm\:ss\.ff) day-wraps for timelines
         // >= 24h, so re-parsing it would silently jump the playhead backwards
-        // by one day. Treating an unchanged input as a cancel is also the
-        // expected UX for editing controls.
-        if (string.Equals(input, _currentTime, StringComparison.Ordinal))
+        // by one day. Compare against the snapshot taken at edit start, not the
+        // live _currentTime, because the playhead may have advanced while the
+        // editor was open during playback.
+        if (string.Equals(input, _editStartText, StringComparison.Ordinal))
         {
             EndEditCurrentTime();
             return;

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -10,6 +10,9 @@ using Avalonia.Interactivity;
 
 namespace Beutl.Controls;
 
+// nullable is enabled per-type because the surrounding Player class predates
+// nullable annotations; enabling at file scope would force a broad rewrite of
+// its private fields.
 public sealed class TimecodeSubmittedEventArgs : EventArgs
 {
     public TimecodeSubmittedEventArgs(string input)
@@ -19,9 +22,21 @@ public sealed class TimecodeSubmittedEventArgs : EventArgs
 
     public string Input { get; }
 
-    public bool Handled { get; set; }
+    public bool Handled { get; private set; }
 
-    public string? Error { get; set; }
+    public string? Error { get; private set; }
+
+    public void Accept()
+    {
+        Handled = true;
+        Error = null;
+    }
+
+    public void Reject(string error)
+    {
+        Handled = false;
+        Error = error ?? string.Empty;
+    }
 }
 #nullable restore
 

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -118,6 +118,7 @@ public class Player : RangeBase
     private ContentPresenter _contentPresenter;
     private TextBlock _currentTimeTextBlock;
     private TextBox _currentTimeTextBox;
+    private IDisposable _currentTimeTextBoxTextSubscription;
     private ICommand _playButtonCommand;
     private ICommand _nextButtonCommand;
     private ICommand _previousButtonCommand;
@@ -300,6 +301,22 @@ public class Player : RangeBase
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
+
+        // Detach handlers / dispose subscriptions from any previous template so
+        // re-applying the template (e.g. when the control template is reassigned)
+        // doesn't double-wire handlers or leak the observable subscription.
+        if (_currentTimeTextBlock != null)
+        {
+            _currentTimeTextBlock.PointerPressed -= OnCurrentTimeTextBlockPointerPressed;
+        }
+        if (_currentTimeTextBox != null)
+        {
+            _currentTimeTextBox.KeyDown -= OnCurrentTimeTextBoxKeyDown;
+            _currentTimeTextBox.LostFocus -= OnCurrentTimeTextBoxLostFocus;
+        }
+        _currentTimeTextBoxTextSubscription?.Dispose();
+        _currentTimeTextBoxTextSubscription = null;
+
         _playButton = e.NameScope.Find<ToggleButton>("PART_PlayButton");
         _nextButton = e.NameScope.Find<RepeatButton>("PART_NextButton");
         _previousButton = e.NameScope.Find<RepeatButton>("PART_PreviousButton");
@@ -327,11 +344,13 @@ public class Player : RangeBase
             _currentTimeTextBox.IsVisible = false;
             _currentTimeTextBox.KeyDown += OnCurrentTimeTextBoxKeyDown;
             _currentTimeTextBox.LostFocus += OnCurrentTimeTextBoxLostFocus;
-            _currentTimeTextBox.GetObservable(TextBox.TextProperty).Subscribe(_ =>
-            {
-                _currentTimeTextBox.Classes.Remove("invalid");
-                ToolTip.SetTip(_currentTimeTextBox, null);
-            });
+            _currentTimeTextBoxTextSubscription = _currentTimeTextBox
+                .GetObservable(TextBox.TextProperty)
+                .Subscribe(_ =>
+                {
+                    _currentTimeTextBox.Classes.Remove("invalid");
+                    ToolTip.SetTip(_currentTimeTextBox, null);
+                });
         }
 
         _innerLeftPresenter.GetObservable(BoundsProperty).Subscribe(OnInnerLeftBoundsChanged);

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -213,28 +213,19 @@ public class Player : RangeBase
         if (_currentTimeTextBox == null) return;
         string input = _currentTimeTextBox.Text ?? string.Empty;
         var handler = CurrentTimeSubmitted;
-        if (handler == null)
+
+        TimecodeSubmittedEventArgs args = new TimecodeSubmittedEventArgs(input);
+        handler?.Invoke(this, args);
+
+        if (args.Handled)
         {
             EndEditCurrentTime();
             return;
         }
 
-        var args = new TimecodeSubmittedEventArgs(input);
-        handler(this, args);
-
-        if (args.Handled)
-        {
-            EndEditCurrentTime();
-        }
-        else
-        {
-            _currentTimeTextBox.Classes.Add("invalid");
-            if (!string.IsNullOrEmpty(args.Error))
-            {
-                ToolTip.SetTip(_currentTimeTextBox, args.Error);
-            }
-            _currentTimeTextBox.SelectAll();
-        }
+        _currentTimeTextBox.Classes.Add("invalid");
+        ToolTip.SetTip(_currentTimeTextBox, !string.IsNullOrEmpty(args.Error) ? args.Error : "Cannot process timecode submission.");
+        _currentTimeTextBox.SelectAll();
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -241,6 +241,18 @@ public class Player : RangeBase
     {
         if (_currentTimeTextBox == null) return;
         string input = _currentTimeTextBox.Text ?? string.Empty;
+
+        // No-op when the user pressed Enter without editing the displayed text.
+        // The CurrentTime string format (hh\:mm\:ss\.ff) day-wraps for timelines
+        // >= 24h, so re-parsing it would silently jump the playhead backwards
+        // by one day. Treating an unchanged input as a cancel is also the
+        // expected UX for editing controls.
+        if (string.Equals(input, _currentTime, StringComparison.Ordinal))
+        {
+            EndEditCurrentTime();
+            return;
+        }
+
         var handler = CurrentTimeSubmitted;
 
         if (handler == null)

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -261,7 +261,7 @@ public class Player : RangeBase
         }
 
         _currentTimeTextBox.Classes.Add("invalid");
-        ToolTip.SetTip(_currentTimeTextBox, !string.IsNullOrEmpty(args.Error) ? args.Error : "Cannot process timecode submission.");
+        ToolTip.SetTip(_currentTimeTextBox, !string.IsNullOrEmpty(args.Error) ? args.Error : Beutl.Language.MessageStrings.UnexpectedError);
         _currentTimeTextBox.SelectAll();
     }
 

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿#nullable enable
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
@@ -13,15 +14,16 @@ public sealed class TimecodeSubmittedEventArgs : EventArgs
 {
     public TimecodeSubmittedEventArgs(string input)
     {
-        Input = input;
+        Input = input ?? string.Empty;
     }
 
     public string Input { get; }
 
     public bool Handled { get; set; }
 
-    public string Error { get; set; }
+    public string? Error { get; set; }
 }
+#nullable restore
 
 public class Player : RangeBase
 {

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -256,13 +256,14 @@ public class Player : RangeBase
         {
             handler?.Invoke(this, args);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // Subscribers must not let exceptions escape into the Avalonia
             // event loop (it would either crash the app or be swallowed by the
-            // global unhandled-exception handler with no UI feedback). If a
-            // handler throws, treat it as a rejection and let the view show
-            // the fallback tooltip below.
+            // global unhandled-exception handler with no UI feedback). Log the
+            // exception so the stack trace is recoverable, then reject the
+            // submission and let the view show the fallback tooltip below.
+            s_logger.LogError(ex, "A CurrentTimeSubmitted subscriber threw while processing '{Input}'.", input);
             args.Reject(string.Empty);
         }
 

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -230,7 +230,19 @@ public class Player : RangeBase
         var handler = CurrentTimeSubmitted;
 
         TimecodeSubmittedEventArgs args = new TimecodeSubmittedEventArgs(input);
-        handler?.Invoke(this, args);
+        try
+        {
+            handler?.Invoke(this, args);
+        }
+        catch (Exception)
+        {
+            // Subscribers must not let exceptions escape into the Avalonia
+            // event loop (it would either crash the app or be swallowed by the
+            // global unhandled-exception handler with no UI feedback). If a
+            // handler throws, treat it as a rejection and let the view show
+            // the fallback tooltip below.
+            args.Reject(string.Empty);
+        }
 
         if (args.Handled)
         {

--- a/src/Beutl.Controls/PlayerMarkerEntry.cs
+++ b/src/Beutl.Controls/PlayerMarkerEntry.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 namespace Beutl.Controls;
 
 public sealed class PlayerMarkerEntry

--- a/src/Beutl.Controls/PlayerMarkerEntry.cs
+++ b/src/Beutl.Controls/PlayerMarkerEntry.cs
@@ -1,0 +1,15 @@
+#nullable enable
+namespace Beutl.Controls;
+
+public sealed class PlayerMarkerEntry
+{
+    public PlayerMarkerEntry(string name, string timeText)
+    {
+        Name = name ?? string.Empty;
+        TimeText = timeText ?? string.Empty;
+    }
+
+    public string Name { get; }
+
+    public string TimeText { get; }
+}

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -28,6 +28,10 @@
                             <Style Selector="icons|SymbolIcon">
                                 <Setter Property="FontSize" Value="20" />
                             </Style>
+                            <Style Selector="TextBox.invalid">
+                                <Setter Property="BorderBrush" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                            </Style>
                         </Grid.Styles>
 
                         <Slider Name="PART_Slider"
@@ -40,9 +44,19 @@
                                    Grid.Row="1"
                                    HorizontalAlignment="Left"
                                    VerticalAlignment="Center"
+                                   Cursor="IBeam"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource AccentFillColorDefaultBrush}"
                                    Text="{TemplateBinding CurrentTime}" />
+
+                        <TextBox Name="PART_CurrentTimeTextBox"
+                                 Grid.Row="1"
+                                 MinWidth="120"
+                                 Padding="4,2"
+                                 HorizontalAlignment="Left"
+                                 VerticalAlignment="Center"
+                                 FontWeight="SemiBold"
+                                 IsVisible="False" />
 
                         <TextBlock Name="PART_DurationTextBlock"
                                    Grid.Row="1"

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -55,6 +55,7 @@
                                  Padding="4,2"
                                  HorizontalAlignment="Left"
                                  VerticalAlignment="Center"
+                                 controls:TextBoxAttachment.EnterDownBehavior="None"
                                  FontWeight="SemiBold"
                                  IsVisible="False" />
 

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Beutl.Controls"
                     xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:lang="using:Beutl.Language"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>
         <controls:Player Width="600"
@@ -57,7 +58,8 @@
                                  VerticalAlignment="Center"
                                  controls:TextBoxAttachment.EnterDownBehavior="None"
                                  FontWeight="SemiBold"
-                                 IsVisible="False" />
+                                 IsVisible="False"
+                                 Watermark="{x:Static lang:Strings.GotoTimecode_InputHint}" />
 
                         <TextBlock Name="PART_DurationTextBlock"
                                    Grid.Row="1"

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -61,6 +61,44 @@
                                  IsVisible="False"
                                  Watermark="{x:Static lang:Strings.GotoTimecode_InputHint}" />
 
+                        <Popup Name="PART_MarkerPopup"
+                               Grid.Row="1"
+                               IsLightDismissEnabled="False"
+                               Placement="Top"
+                               PlacementTarget="{Binding ElementName=PART_CurrentTimeTextBox}">
+                            <Border Padding="0"
+                                    Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
+                                    BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    BoxShadow="0 4 16 0 #40000000"
+                                    CornerRadius="4">
+                                <ListBox Name="PART_MarkerListBox"
+                                         MinWidth="200"
+                                         MaxHeight="240"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Focusable="False">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate x:DataType="controls:PlayerMarkerEntry">
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBlock Grid.Column="0"
+                                                           FontWeight="SemiBold"
+                                                           Text="{Binding Name}"
+                                                           VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="1"
+                                                           Margin="12,0,0,0"
+                                                           FontSize="11"
+                                                           VerticalAlignment="Center"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                           Text="{Binding TimeText}" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </Border>
+                        </Popup>
+
                         <TextBlock Name="PART_DurationTextBlock"
                                    Grid.Row="1"
                                    HorizontalAlignment="Right"

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -819,6 +819,18 @@
   <data name="ToggleLoop_Description" xml:space="preserve">
     <value>ループ再生のオン/オフを切り替えます。</value>
   </data>
+  <data name="GotoTimecode" xml:space="preserve">
+    <value>タイムコードへジャンプ</value>
+  </data>
+  <data name="GotoTimecode_Description" xml:space="preserve">
+    <value>現在のタイムコードを編集して再生ヘッドを移動します。絶対時刻 (00:01:23.45)、フレーム (60f / #60)、相対 (+5s / -10f / +1m)、マーカー名 (@Intro) を受け付けます。</value>
+  </data>
+  <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
+    <value>タイムコードの形式が無効です。</value>
+  </data>
+  <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
+    <value>マーカーが見つかりません。</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>コピーしたデータをペーストします。</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -834,6 +834,9 @@
   <data name="GotoTimecode_NoScene" xml:space="preserve">
     <value>シーンが読み込まれていません。</value>
   </data>
+  <data name="GotoTimecode_OutOfRange" xml:space="preserve">
+    <value>タイムコードが範囲外です。</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>コピーしたデータをペーストします。</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -831,6 +831,9 @@
   <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
     <value>マーカーが見つかりません。</value>
   </data>
+  <data name="GotoTimecode_NoScene" xml:space="preserve">
+    <value>シーンが読み込まれていません。</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>コピーしたデータをペーストします。</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -825,6 +825,9 @@
   <data name="GotoTimecode_Description" xml:space="preserve">
     <value>現在のタイムコードを編集して再生ヘッドを移動します。絶対時刻 (00:01:23.45)、フレーム (60f / #60)、相対 (+5s / -10f / +1m)、マーカー名 (@Intro) を受け付けます。</value>
   </data>
+  <data name="GotoTimecode_InputHint" xml:space="preserve">
+    <value>00:01:23 / 60f / +5s / @マーカー</value>
+  </data>
   <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
     <value>タイムコードの形式が無効です。</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -836,6 +836,9 @@
   <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
     <value>Marker not found.</value>
   </data>
+  <data name="GotoTimecode_NoScene" xml:space="preserve">
+    <value>No scene is loaded.</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>Paste the copied data.</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -830,6 +830,9 @@
   <data name="GotoTimecode_Description" xml:space="preserve">
     <value>Edit the current timecode to seek. Accepts absolute (00:01:23.45), frame (60f or #60), relative (+5s/-10f/+1m) or marker name (@Intro).</value>
   </data>
+  <data name="GotoTimecode_InputHint" xml:space="preserve">
+    <value>00:01:23 / 60f / +5s / @marker</value>
+  </data>
   <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
     <value>Invalid timecode format.</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -824,6 +824,18 @@
   <data name="ToggleLoop_Description" xml:space="preserve">
     <value>Toggle loop playback.</value>
   </data>
+  <data name="GotoTimecode" xml:space="preserve">
+    <value>Goto timecode</value>
+  </data>
+  <data name="GotoTimecode_Description" xml:space="preserve">
+    <value>Edit the current timecode to seek. Accepts absolute (00:01:23.45), frame (60f or #60), relative (+5s/-10f/+1m) or marker name (@Intro).</value>
+  </data>
+  <data name="GotoTimecode_InvalidFormat" xml:space="preserve">
+    <value>Invalid timecode format.</value>
+  </data>
+  <data name="GotoTimecode_MarkerNotFound" xml:space="preserve">
+    <value>Marker not found.</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>Paste the copied data.</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -839,6 +839,9 @@
   <data name="GotoTimecode_NoScene" xml:space="preserve">
     <value>No scene is loaded.</value>
   </data>
+  <data name="GotoTimecode_OutOfRange" xml:space="preserve">
+    <value>Timecode is out of range.</value>
+  </data>
   <data name="Paste_Description" xml:space="preserve">
     <value>Paste the copied data.</value>
   </data>

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Beutl.ProjectSystem;
 
 namespace Beutl;

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -207,4 +207,16 @@ public static class GotoTimecodeParser
     {
         if (value < TimeSpan.Zero) value = TimeSpan.Zero;
     }
+
+    public static TimeSpan ClampToSceneRange(TimeSpan ts, TimeSpan sceneStart, TimeSpan sceneDuration, int frameRate)
+    {
+        if (frameRate <= 0) frameRate = 30;
+
+        TimeSpan frame = TimeSpan.FromSeconds(1d / frameRate);
+        TimeSpan max = sceneStart + sceneDuration - frame;
+        if (max < sceneStart) max = sceneStart;
+        if (ts < sceneStart) return sceneStart;
+        if (ts > max) return max;
+        return ts;
+    }
 }

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -186,6 +186,15 @@ public static class GotoTimecodeParser
             return false;
         }
 
+        // The leading +/- is consumed into `sign`; reject a second sign so
+        // "+-5s" / "--5s" don't silently parse as a negated delta and reverse
+        // the requested seek direction.
+        if (numberPart.Length == 0 || numberPart[0] == '+' || numberPart[0] == '-')
+        {
+            error = GotoTimecodeError.InvalidFormat;
+            return false;
+        }
+
         if (!double.TryParse(numberPart, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
             || double.IsNaN(value) || double.IsInfinity(value))
         {

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -9,6 +9,7 @@ public enum GotoTimecodeError
     InvalidFormat,
     MarkerNotFound,
     NoScene,
+    OutOfRange,
 }
 
 public static class GotoTimecodeParser
@@ -151,6 +152,12 @@ public static class GotoTimecodeParser
         char unit = text[^1];
         string numberPart = text[1..^1].Trim();
 
+        if (unit is not ('s' or 'S' or 'm' or 'M' or 'f' or 'F'))
+        {
+            error = GotoTimecodeError.InvalidFormat;
+            return false;
+        }
+
         if (!double.TryParse(numberPart, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
             || double.IsNaN(value) || double.IsInfinity(value))
         {
@@ -164,15 +171,17 @@ public static class GotoTimecodeParser
             {
                 's' or 'S' => TimeSpan.FromSeconds(value),
                 'm' or 'M' => TimeSpan.FromMinutes(value),
-                'f' or 'F' => value.ToTimeSpan(frameRate),
-                _ => throw new FormatException(),
+                _ /* 'f' or 'F' */ => value.ToTimeSpan(frameRate),
             };
 
             result = currentTime + (sign == -1 ? -delta : delta);
         }
-        catch (Exception ex) when (ex is OverflowException or FormatException or ArgumentException)
+        catch (OverflowException)
         {
-            error = GotoTimecodeError.InvalidFormat;
+            // The numeric value parsed but cannot be expressed as a TimeSpan
+            // (either FromSeconds/FromMinutes overflowed, or the addition to
+            // currentTime exceeded TimeSpan.MaxValue/MinValue).
+            error = GotoTimecodeError.OutOfRange;
             return false;
         }
 

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -28,6 +28,11 @@ public static class GotoTimecodeParser
 {
     private static readonly string[] s_absoluteFormats =
     [
+        // d.hh:mm:ss[.f...] — needed for >=24h timelines, since hh wraps to 0-23.
+        @"d\.hh\:mm\:ss\.fff",
+        @"d\.hh\:mm\:ss\.ff",
+        @"d\.hh\:mm\:ss\.f",
+        @"d\.hh\:mm\:ss",
         @"hh\:mm\:ss\.fff",
         @"hh\:mm\:ss\.ff",
         @"hh\:mm\:ss\.f",

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -207,16 +207,4 @@ public static class GotoTimecodeParser
     {
         if (value < TimeSpan.Zero) value = TimeSpan.Zero;
     }
-
-    public static TimeSpan ClampToSceneRange(TimeSpan ts, TimeSpan sceneStart, TimeSpan sceneDuration, int frameRate)
-    {
-        if (frameRate <= 0) frameRate = 30;
-
-        TimeSpan frame = TimeSpan.FromSeconds(1d / frameRate);
-        TimeSpan max = sceneStart + sceneDuration - frame;
-        if (max < sceneStart) max = sceneStart;
-        if (ts < sceneStart) return sceneStart;
-        if (ts > max) return max;
-        return ts;
-    }
 }

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -3,6 +3,14 @@ using Beutl.ProjectSystem;
 
 namespace Beutl;
 
+public enum GotoTimecodeError
+{
+    None,
+    InvalidFormat,
+    MarkerNotFound,
+    NoScene,
+}
+
 public static class GotoTimecodeParser
 {
     private static readonly string[] s_absoluteFormats =
@@ -31,14 +39,14 @@ public static class GotoTimecodeParser
         TimeSpan currentTime,
         IReadOnlyList<SceneMarker> markers,
         out TimeSpan result,
-        out string? error)
+        out GotoTimecodeError error)
     {
         result = TimeSpan.Zero;
-        error = null;
+        error = GotoTimecodeError.None;
 
         if (string.IsNullOrWhiteSpace(input))
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -75,7 +83,7 @@ public static class GotoTimecodeParser
             return true;
         }
 
-        error = "GotoTimecode_InvalidFormat";
+        error = GotoTimecodeError.InvalidFormat;
         return false;
     }
 
@@ -108,13 +116,13 @@ public static class GotoTimecodeParser
         return true;
     }
 
-    private static bool TryParseFrame(string text, int frameRate, out TimeSpan result, out string? error)
+    private static bool TryParseFrame(string text, int frameRate, out TimeSpan result, out GotoTimecodeError error)
     {
         result = TimeSpan.Zero;
-        error = null;
+        error = GotoTimecodeError.None;
         if (!int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int frame))
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -128,14 +136,14 @@ public static class GotoTimecodeParser
         int frameRate,
         TimeSpan currentTime,
         out TimeSpan result,
-        out string? error)
+        out GotoTimecodeError error)
     {
         result = TimeSpan.Zero;
-        error = null;
+        error = GotoTimecodeError.None;
 
         if (text.Length < 3)
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -146,7 +154,7 @@ public static class GotoTimecodeParser
         if (!double.TryParse(numberPart, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
             || double.IsNaN(value) || double.IsInfinity(value))
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -164,7 +172,7 @@ public static class GotoTimecodeParser
         }
         catch (Exception ex) when (ex is OverflowException or FormatException or ArgumentException)
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -176,14 +184,14 @@ public static class GotoTimecodeParser
         string name,
         IReadOnlyList<SceneMarker> markers,
         out TimeSpan result,
-        out string? error)
+        out GotoTimecodeError error)
     {
         result = TimeSpan.Zero;
-        error = null;
+        error = GotoTimecodeError.None;
 
         if (name.Length == 0)
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = GotoTimecodeError.InvalidFormat;
             return false;
         }
 
@@ -199,7 +207,7 @@ public static class GotoTimecodeParser
             }
         }
 
-        error = "GotoTimecode_MarkerNotFound";
+        error = GotoTimecodeError.MarkerNotFound;
         return false;
     }
 

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -150,27 +150,24 @@ public static class GotoTimecodeParser
             return false;
         }
 
-        TimeSpan delta;
-        switch (unit)
+        try
         {
-            case 's':
-            case 'S':
-                delta = TimeSpan.FromSeconds(value);
-                break;
-            case 'm':
-            case 'M':
-                delta = TimeSpan.FromMinutes(value);
-                break;
-            case 'f':
-            case 'F':
-                delta = value.ToTimeSpan(frameRate);
-                break;
-            default:
-                error = "GotoTimecode_InvalidFormat";
-                return false;
+            TimeSpan delta = unit switch
+            {
+                's' or 'S' => TimeSpan.FromSeconds(value),
+                'm' or 'M' => TimeSpan.FromMinutes(value),
+                'f' or 'F' => value.ToTimeSpan(frameRate),
+                _ => throw new FormatException(),
+            };
+
+            result = currentTime + (sign == -1 ? -delta : delta);
+        }
+        catch (Exception ex) when (ex is OverflowException or FormatException or ArgumentException)
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
         }
 
-        result = currentTime + (sign == -1 ? -delta : delta);
         ClampNonNegative(ref result);
         return true;
     }

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -1,0 +1,213 @@
+using System.Globalization;
+using Beutl.ProjectSystem;
+
+namespace Beutl;
+
+public static class GotoTimecodeParser
+{
+    private static readonly string[] s_absoluteFormats =
+    [
+        @"hh\:mm\:ss\.fff",
+        @"hh\:mm\:ss\.ff",
+        @"hh\:mm\:ss\.f",
+        @"hh\:mm\:ss",
+        @"h\:mm\:ss\.fff",
+        @"h\:mm\:ss\.ff",
+        @"h\:mm\:ss\.f",
+        @"h\:mm\:ss",
+        @"mm\:ss\.fff",
+        @"mm\:ss\.ff",
+        @"mm\:ss\.f",
+        @"mm\:ss",
+        @"m\:ss\.fff",
+        @"m\:ss\.ff",
+        @"m\:ss\.f",
+        @"m\:ss",
+    ];
+
+    public static bool TryParse(
+        string? input,
+        int frameRate,
+        TimeSpan currentTime,
+        IReadOnlyList<SceneMarker> markers,
+        out TimeSpan result,
+        out string? error)
+    {
+        result = TimeSpan.Zero;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
+
+        if (frameRate <= 0)
+        {
+            frameRate = 30;
+        }
+
+        string text = input.Trim();
+
+        if (text.StartsWith('@'))
+        {
+            return TryParseMarker(text[1..].Trim(), markers, out result, out error);
+        }
+
+        if (text.StartsWith('#'))
+        {
+            return TryParseFrame(text[1..].Trim(), frameRate, out result, out error);
+        }
+
+        if (text.Length > 0 && (text[0] == '+' || text[0] == '-'))
+        {
+            return TryParseRelative(text, frameRate, currentTime, out result, out error);
+        }
+
+        if (TryParseFrameSuffix(text, frameRate, out result))
+        {
+            return true;
+        }
+
+        if (TryParseAbsolute(text, out result))
+        {
+            ClampNonNegative(ref result);
+            return true;
+        }
+
+        error = "GotoTimecode_InvalidFormat";
+        return false;
+    }
+
+    private static bool TryParseAbsolute(string text, out TimeSpan result)
+    {
+        if (TimeSpan.TryParseExact(text, s_absoluteFormats, CultureInfo.InvariantCulture, out result))
+        {
+            return true;
+        }
+
+        result = TimeSpan.Zero;
+        return false;
+    }
+
+    private static bool TryParseFrameSuffix(string text, int frameRate, out TimeSpan result)
+    {
+        result = TimeSpan.Zero;
+        if (text.Length < 2) return false;
+        char last = text[^1];
+        if (last != 'f' && last != 'F') return false;
+
+        string numberPart = text[..^1].Trim();
+        if (!int.TryParse(numberPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out int frame))
+        {
+            return false;
+        }
+
+        if (frame < 0) frame = 0;
+        result = frame.ToTimeSpan(frameRate);
+        return true;
+    }
+
+    private static bool TryParseFrame(string text, int frameRate, out TimeSpan result, out string? error)
+    {
+        result = TimeSpan.Zero;
+        error = null;
+        if (!int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int frame))
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
+
+        if (frame < 0) frame = 0;
+        result = frame.ToTimeSpan(frameRate);
+        return true;
+    }
+
+    private static bool TryParseRelative(
+        string text,
+        int frameRate,
+        TimeSpan currentTime,
+        out TimeSpan result,
+        out string? error)
+    {
+        result = TimeSpan.Zero;
+        error = null;
+
+        if (text.Length < 3)
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
+
+        int sign = text[0] == '-' ? -1 : 1;
+        char unit = text[^1];
+        string numberPart = text[1..^1].Trim();
+
+        if (!double.TryParse(numberPart, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+            || double.IsNaN(value) || double.IsInfinity(value))
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
+
+        TimeSpan delta;
+        switch (unit)
+        {
+            case 's':
+            case 'S':
+                delta = TimeSpan.FromSeconds(value);
+                break;
+            case 'm':
+            case 'M':
+                delta = TimeSpan.FromMinutes(value);
+                break;
+            case 'f':
+            case 'F':
+                delta = value.ToTimeSpan(frameRate);
+                break;
+            default:
+                error = "GotoTimecode_InvalidFormat";
+                return false;
+        }
+
+        result = currentTime + (sign == -1 ? -delta : delta);
+        ClampNonNegative(ref result);
+        return true;
+    }
+
+    private static bool TryParseMarker(
+        string name,
+        IReadOnlyList<SceneMarker> markers,
+        out TimeSpan result,
+        out string? error)
+    {
+        result = TimeSpan.Zero;
+        error = null;
+
+        if (name.Length == 0)
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
+
+        for (int i = 0; i < markers.Count; i++)
+        {
+            SceneMarker marker = markers[i];
+            if (!string.IsNullOrEmpty(marker.Name)
+                && marker.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+            {
+                result = marker.Time;
+                ClampNonNegative(ref result);
+                return true;
+            }
+        }
+
+        error = "GotoTimecode_MarkerNotFound";
+        return false;
+    }
+
+    private static void ClampNonNegative(ref TimeSpan value)
+    {
+        if (value < TimeSpan.Zero) value = TimeSpan.Zero;
+    }
+}

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -45,15 +45,12 @@ public static class GotoTimecodeParser
         result = TimeSpan.Zero;
         error = GotoTimecodeError.None;
 
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(frameRate);
+
         if (string.IsNullOrWhiteSpace(input))
         {
             error = GotoTimecodeError.InvalidFormat;
             return false;
-        }
-
-        if (frameRate <= 0)
-        {
-            frameRate = 30;
         }
 
         string text = input.Trim();

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -12,6 +12,18 @@ public enum GotoTimecodeError
     OutOfRange,
 }
 
+/// <summary>
+/// Parses goto-timecode expressions used by the player's "edit current time" input.
+/// </summary>
+/// <remarks>
+/// Accepted forms (case-insensitive where applicable):
+/// <list type="bullet">
+/// <item><c>@&lt;prefix&gt;</c> — first marker whose name starts with the prefix.</item>
+/// <item><c>#&lt;int&gt;</c> or <c>&lt;int&gt;f</c> — absolute frame number.</item>
+/// <item><c>+&lt;num&gt;{s|m|f}</c> or <c>-&lt;num&gt;{s|m|f}</c> — relative seek in seconds, minutes, or frames.</item>
+/// <item><c>hh:mm:ss[.fff]</c> or <c>mm:ss[.fff]</c> — absolute time.</item>
+/// </list>
+/// </remarks>
 public static class GotoTimecodeParser
 {
     private static readonly string[] s_absoluteFormats =
@@ -34,6 +46,17 @@ public static class GotoTimecodeParser
         @"m\:ss",
     ];
 
+    /// <summary>
+    /// Resolves a goto-timecode expression to a non-negative <see cref="TimeSpan"/> relative to the timeline origin.
+    /// </summary>
+    /// <param name="input">The user-entered expression (see class remarks for accepted forms).</param>
+    /// <param name="frameRate">Frame rate used for frame-based and relative-frame inputs; must be positive.</param>
+    /// <param name="currentTime">Current playhead time used as the base for relative expressions.</param>
+    /// <param name="markers">Markers searched for <c>@</c>-prefixed inputs.</param>
+    /// <param name="result">On success, the resolved time (clamped to <see cref="TimeSpan.Zero"/>).</param>
+    /// <param name="error">On failure, the reason for the failure.</param>
+    /// <returns><see langword="true"/> if <paramref name="input"/> resolved successfully.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="frameRate"/> is zero or negative.</exception>
     public static bool TryParse(
         string? input,
         int frameRate,

--- a/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
+++ b/src/Beutl.ProjectSystem/GotoTimecodeParser.cs
@@ -121,18 +121,21 @@ public static class GotoTimecodeParser
 
     private static bool TryParseFrameSuffix(string text, int frameRate, out TimeSpan result)
     {
+        // Negative inputs are routed to TryParseRelative before this method runs,
+        // so a negative frame number here would only originate from an
+        // out-of-int.MinValue overflow that int.TryParse already rejects.
         result = TimeSpan.Zero;
         if (text.Length < 2) return false;
         char last = text[^1];
         if (last != 'f' && last != 'F') return false;
 
         string numberPart = text[..^1].Trim();
-        if (!int.TryParse(numberPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out int frame))
+        if (!int.TryParse(numberPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out int frame)
+            || frame < 0)
         {
             return false;
         }
 
-        if (frame < 0) frame = 0;
         result = frame.ToTimeSpan(frameRate);
         return true;
     }
@@ -147,7 +150,12 @@ public static class GotoTimecodeParser
             return false;
         }
 
-        if (frame < 0) frame = 0;
+        if (frame < 0)
+        {
+            error = GotoTimecodeError.OutOfRange;
+            return false;
+        }
+
         result = frame.ToTimeSpan(frameRate);
         return true;
     }
@@ -205,7 +213,12 @@ public static class GotoTimecodeParser
             return false;
         }
 
-        ClampNonNegative(ref result);
+        if (result < TimeSpan.Zero)
+        {
+            error = GotoTimecodeError.OutOfRange;
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -82,6 +82,10 @@ public sealed class SceneEditorExtension : EditorExtension
         [
             new ContextCommandKeyGesture("OemQuestion")
         ]),
+        new("GotoTimecode", Strings.GotoTimecode, Strings.GotoTimecode_Description,
+        [
+            new ContextCommandKeyGesture("G")
+        ]),
     ];
 
     public override bool TryCreateEditor(CoreObject obj, [NotNullWhen(true)] out Control? editor)

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -140,6 +140,9 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             case "PreviousMarker" when !isFromTextBox:
                 SeekToAdjacentMarker(forward: false);
                 break;
+            case "GotoTimecode" when !isFromTextBox:
+                Player.RequestEditTimecode();
+                break;
             default:
                 if (execution.KeyEventArgs != null)
                     execution.KeyEventArgs.Handled = false;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -567,7 +567,15 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
-        _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
+        try
+        {
+            _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
+        }
+        catch (OverflowException)
+        {
+            error = GotoTimecodeError.OutOfRange;
+            return false;
+        }
         return true;
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -553,11 +553,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         BeginEditTimecodeRequested.OnNext(Unit.Default);
     }
 
-    public bool TryGotoTimecode(string input, out string? error)
+    public bool TryGotoTimecode(string input, out GotoTimecodeError error)
     {
         if (Scene == null)
         {
-            error = "GotoTimecode_NoScene";
+            error = GotoTimecodeError.NoScene;
             return false;
         }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1334,6 +1334,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         _currentFrameSubscription?.Dispose();
         AfterRendered.Dispose();
         _audioFramePushed.Dispose();
+        BeginEditTimecodeRequested.Dispose();
         PreviewInvalidated = null;
         Scene = null!;
         PreviewImage.Value?.Dispose();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -546,6 +546,36 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         return (Scene.Start, Scene.Start + Scene.Duration);
     }
 
+    public Subject<Unit> BeginEditTimecodeRequested { get; } = new();
+
+    public void RequestEditTimecode()
+    {
+        BeginEditTimecodeRequested.OnNext(Unit.Default);
+    }
+
+    public bool TryGotoTimecode(string input, out string? error)
+    {
+        int rate = GetFrameRate();
+        IReadOnlyList<SceneMarker> markers = Scene?.Markers ?? (IReadOnlyList<SceneMarker>)Array.Empty<SceneMarker>();
+
+        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, markers, out TimeSpan ts, out error))
+        {
+            return false;
+        }
+
+        if (Scene != null)
+        {
+            TimeSpan frame = TimeSpan.FromSeconds(1d / rate);
+            TimeSpan max = Scene.Start + Scene.Duration - frame;
+            if (max < Scene.Start) max = Scene.Start;
+            if (ts < Scene.Start) ts = Scene.Start;
+            if (ts > max) ts = max;
+        }
+
+        _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
+        return true;
+    }
+
     public void ToggleLoop()
     {
         IsLoopEnabled.Value = !IsLoopEnabled.Value;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -568,7 +568,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
 
         int rate = GetFrameRate();
-        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out target, out error))
+        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out TimeSpan parsed, out error))
         {
             _logger.LogDebug(
                 "Goto-timecode parse failed. ({SceneId}, Input={Input}, Error={Error})",
@@ -576,24 +576,29 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
+        // Frame-snap up front so ApplyTimecodeSeek cannot fail later — without
+        // this, the parser-accepted value could be returned to the view, the
+        // editor would close on Accept(), and the actual seek would silently
+        // no-op when RoundToRate overflowed.
+        try
+        {
+            target = parsed.RoundToRate(rate);
+        }
+        catch (OverflowException ex)
+        {
+            _logger.LogWarning(ex,
+                "RoundToRate overflowed for goto-timecode target. ({SceneId}, Parsed={Parsed}, Rate={Rate})",
+                _editViewModel.SceneId, parsed, rate);
+            error = GotoTimecodeError.OutOfRange;
+            return false;
+        }
         return true;
     }
 
     public void ApplyTimecodeSeek(TimeSpan target)
     {
-        int rate = GetFrameRate();
-        try
-        {
-            _editorClock.CurrentTime.Value = target.RoundToRate(rate);
-        }
-        catch (OverflowException ex)
-        {
-            // The parser accepted this value but RoundToRate cannot represent it;
-            // log the drift between the parser's accepted domain and RoundToRate's.
-            _logger.LogWarning(ex,
-                "RoundToRate overflowed for goto-timecode target. ({SceneId}, Target={Target}, Rate={Rate})",
-                _editViewModel.SceneId, target, rate);
-        }
+        // target is already frame-snapped by TryParseTimecode.
+        _editorClock.CurrentTime.Value = target;
     }
 
     public void ToggleLoop()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -555,27 +555,30 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public bool TryGotoTimecode(string input, out string? error)
     {
-        int rate = GetFrameRate();
-        IReadOnlyList<SceneMarker> markers = Scene?.Markers ?? (IReadOnlyList<SceneMarker>)Array.Empty<SceneMarker>();
+        if (Scene == null)
+        {
+            error = "GotoTimecode_InvalidFormat";
+            return false;
+        }
 
-        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, markers, out TimeSpan ts, out error))
+        int rate = GetFrameRate();
+        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out TimeSpan ts, out error))
         {
             return false;
         }
 
-        ts = ts.RoundToRate(rate);
-
-        if (Scene != null)
-        {
-            TimeSpan frame = TimeSpan.FromSeconds(1d / rate);
-            TimeSpan max = Scene.Start + Scene.Duration - frame;
-            if (max < Scene.Start) max = Scene.Start;
-            if (ts < Scene.Start) ts = Scene.Start;
-            if (ts > max) ts = max;
-        }
-
-        _editorClock.CurrentTime.Value = ts;
+        _editorClock.CurrentTime.Value = ClampToSceneRange(ts.RoundToRate(rate), Scene.Start, Scene.Duration, rate);
         return true;
+    }
+
+    internal static TimeSpan ClampToSceneRange(TimeSpan ts, TimeSpan sceneStart, TimeSpan sceneDuration, int frameRate)
+    {
+        TimeSpan frame = TimeSpan.FromSeconds(1d / Math.Max(frameRate, 1));
+        TimeSpan max = sceneStart + sceneDuration - frame;
+        if (max < sceneStart) max = sceneStart;
+        if (ts < sceneStart) return sceneStart;
+        if (ts > max) return max;
+        return ts;
     }
 
     public void ToggleLoop()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -563,6 +563,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
+        ts = ts.RoundToRate(rate);
+
         if (Scene != null)
         {
             TimeSpan frame = TimeSpan.FromSeconds(1d / rate);
@@ -572,7 +574,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             if (ts > max) ts = max;
         }
 
-        _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
+        _editorClock.CurrentTime.Value = ts;
         return true;
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -553,21 +553,22 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         BeginEditTimecodeRequested.OnNext(Unit.Default);
     }
 
-    public bool TryGotoTimecode(string input, out GotoTimecodeError error)
+    public bool TryParseTimecode(string input, out TimeSpan target, out GotoTimecodeError error)
     {
+        target = TimeSpan.Zero;
         if (Scene == null)
         {
             // The view should not raise the event without a scene; surface the
             // state mismatch so it is visible in telemetry.
             _logger.LogWarning(
-                "TryGotoTimecode invoked with no scene loaded. ({SceneId}, Input={Input})",
+                "TryParseTimecode invoked with no scene loaded. ({SceneId}, Input={Input})",
                 _editViewModel.SceneId, input);
             error = GotoTimecodeError.NoScene;
             return false;
         }
 
         int rate = GetFrameRate();
-        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out TimeSpan ts, out error))
+        if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out target, out error))
         {
             _logger.LogDebug(
                 "Goto-timecode parse failed. ({SceneId}, Input={Input}, Error={Error})",
@@ -575,22 +576,24 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
+        return true;
+    }
+
+    public void ApplyTimecodeSeek(TimeSpan target)
+    {
+        int rate = GetFrameRate();
         try
         {
-            _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
+            _editorClock.CurrentTime.Value = target.RoundToRate(rate);
         }
         catch (OverflowException ex)
         {
-            // Reaching this catch means the parser produced a value that the
-            // RoundToRate conversion cannot represent — the parser contract
-            // and RoundToRate's domain have drifted apart. Surface it.
+            // The parser accepted this value but RoundToRate cannot represent it;
+            // log the drift between the parser's accepted domain and RoundToRate's.
             _logger.LogWarning(ex,
-                "RoundToRate overflowed for a goto-timecode that passed the parser. ({SceneId}, Input={Input}, Parsed={Parsed}, Rate={Rate})",
-                _editViewModel.SceneId, input, ts, rate);
-            error = GotoTimecodeError.OutOfRange;
-            return false;
+                "RoundToRate overflowed for goto-timecode target. ({SceneId}, Target={Target}, Rate={Rate})",
+                _editViewModel.SceneId, target, rate);
         }
-        return true;
     }
 
     public void ToggleLoop()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -592,6 +592,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             error = GotoTimecodeError.OutOfRange;
             return false;
         }
+
+        TimeSpan endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
+        if (target < Scene.Start || target > endTime)
+        {
+            _logger.LogDebug(
+                "Goto-timecode target out of scene range. ({SceneId}, Target={Target}, Range=[{Start}, {End}])",
+                _editViewModel.SceneId, target, Scene.Start, endTime);
+            error = GotoTimecodeError.OutOfRange;
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -567,8 +567,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
-        _editorClock.CurrentTime.Value = GotoTimecodeParser.ClampToSceneRange(
-            ts.RoundToRate(rate), Scene.Start, Scene.Duration, rate);
+        _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
         return true;
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -579,8 +579,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         {
             _editorClock.CurrentTime.Value = ts.RoundToRate(rate);
         }
-        catch (OverflowException)
+        catch (OverflowException ex)
         {
+            // Reaching this catch means the parser produced a value that the
+            // RoundToRate conversion cannot represent — the parser contract
+            // and RoundToRate's domain have drifted apart. Surface it.
+            _logger.LogWarning(ex,
+                "RoundToRate overflowed for a goto-timecode that passed the parser. ({SceneId}, Input={Input}, Parsed={Parsed}, Rate={Rate})",
+                _editViewModel.SceneId, input, ts, rate);
             error = GotoTimecodeError.OutOfRange;
             return false;
         }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -7,6 +7,7 @@ using Beutl.Composition;
 using Beutl.Configuration;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PathEditorTab.ViewModels;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Rendering.Cache;
@@ -610,6 +611,15 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         // target is already frame-snapped by TryParseTimecode.
         _editorClock.CurrentTime.Value = target;
+
+        // 再生ヘッドがビューポート外へ飛ぶ場合に追従する。EditViewModel.CommandHandler の
+        // 既存スクロール呼び出しと同形。
+        if (_editViewModel.FindToolTab<TimelineTabViewModel>() is { } timeline)
+        {
+            int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);
+            timeline.ScrollTo.Execute(
+                (new Beutl.Media.TimeRange(target, TimeSpan.FromTicks(1)), currentZIndex));
+        }
     }
 
     public void ToggleLoop()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -567,18 +567,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             return false;
         }
 
-        _editorClock.CurrentTime.Value = ClampToSceneRange(ts.RoundToRate(rate), Scene.Start, Scene.Duration, rate);
+        _editorClock.CurrentTime.Value = GotoTimecodeParser.ClampToSceneRange(
+            ts.RoundToRate(rate), Scene.Start, Scene.Duration, rate);
         return true;
-    }
-
-    internal static TimeSpan ClampToSceneRange(TimeSpan ts, TimeSpan sceneStart, TimeSpan sceneDuration, int frameRate)
-    {
-        TimeSpan frame = TimeSpan.FromSeconds(1d / Math.Max(frameRate, 1));
-        TimeSpan max = sceneStart + sceneDuration - frame;
-        if (max < sceneStart) max = sceneStart;
-        if (ts < sceneStart) return sceneStart;
-        if (ts > max) return max;
-        return ts;
     }
 
     public void ToggleLoop()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -557,7 +557,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         if (Scene == null)
         {
-            error = "GotoTimecode_InvalidFormat";
+            error = "GotoTimecode_NoScene";
             return false;
         }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -557,6 +557,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     {
         if (Scene == null)
         {
+            // The view should not raise the event without a scene; surface the
+            // state mismatch so it is visible in telemetry.
+            _logger.LogWarning(
+                "TryGotoTimecode invoked with no scene loaded. ({SceneId}, Input={Input})",
+                _editViewModel.SceneId, input);
             error = GotoTimecodeError.NoScene;
             return false;
         }
@@ -564,6 +569,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         int rate = GetFrameRate();
         if (!GotoTimecodeParser.TryParse(input, rate, _editorClock.CurrentTime.Value, Scene.Markers, out TimeSpan ts, out error))
         {
+            _logger.LogDebug(
+                "Goto-timecode parse failed. ({SceneId}, Input={Input}, Error={Error})",
+                _editViewModel.SceneId, input, error);
             return false;
         }
 

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -103,6 +103,8 @@ public partial class PlayerView : UserControl
                 return Beutl.Language.Strings.GotoTimecode_InvalidFormat;
             case "GotoTimecode_MarkerNotFound":
                 return Beutl.Language.Strings.GotoTimecode_MarkerNotFound;
+            case "GotoTimecode_NoScene":
+                return Beutl.Language.Strings.GotoTimecode_NoScene;
             default:
                 _logger.LogWarning("Unknown timecode error key '{Key}'; falling back to invalid-format message.", errorKey);
                 return Beutl.Language.Strings.GotoTimecode_InvalidFormat;

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -78,18 +78,30 @@ public partial class PlayerView : UserControl
     {
         if (DataContext is not PlayerViewModel vm)
         {
-            _logger.LogWarning("Timecode submitted but DataContext is not PlayerViewModel; ignoring.");
-            e.Reject(Beutl.Language.Strings.GotoTimecode_InvalidFormat);
+            // A wrong DataContext on a PlayerView event handler is a wiring bug,
+            // not a user error — log at Error level so it surfaces in telemetry,
+            // and show a generic "unexpected error" message instead of the
+            // misleading "Invalid timecode format".
+            _logger.LogError("Timecode submitted but DataContext is not PlayerViewModel; ignoring.");
+            e.Reject(Beutl.Language.MessageStrings.UnexpectedError);
             return;
         }
 
-        if (vm.TryGotoTimecode(e.Input, out GotoTimecodeError error))
+        try
         {
-            e.Accept();
+            if (vm.TryGotoTimecode(e.Input, out GotoTimecodeError error))
+            {
+                e.Accept();
+            }
+            else
+            {
+                e.Reject(LookupLocalizedError(error));
+            }
         }
-        else
+        catch (Exception ex)
         {
-            e.Reject(LookupLocalizedError(error));
+            _logger.LogError(ex, "Unexpected error while applying timecode '{Input}'.", e.Input);
+            e.Reject(Beutl.Language.MessageStrings.UnexpectedError);
         }
     }
 

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -70,6 +70,36 @@ public partial class PlayerView : UserControl
         DragDrop.SetAllowDrop(framePanel, true);
         framePanel.AddHandler(DragDrop.DragOverEvent, OnFrameDragOver);
         framePanel.AddHandler(DragDrop.DropEvent, OnFrameDrop);
+
+        Player.CurrentTimeSubmitted += OnPlayerCurrentTimeSubmitted;
+    }
+
+    private void OnPlayerCurrentTimeSubmitted(object? sender, Beutl.Controls.TimecodeSubmittedEventArgs e)
+    {
+        if (DataContext is not PlayerViewModel vm)
+        {
+            return;
+        }
+
+        if (vm.TryGotoTimecode(e.Input, out string? errorKey))
+        {
+            e.Handled = true;
+        }
+        else
+        {
+            e.Handled = false;
+            e.Error = LookupLocalizedError(errorKey);
+        }
+    }
+
+    private static string? LookupLocalizedError(string? errorKey)
+    {
+        return errorKey switch
+        {
+            "GotoTimecode_InvalidFormat" => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
+            "GotoTimecode_MarkerNotFound" => Beutl.Language.Strings.GotoTimecode_MarkerNotFound,
+            _ => null,
+        };
     }
 
     private void SetupImageControl()
@@ -182,6 +212,11 @@ public partial class PlayerView : UserControl
         {
             vm.PreviewInvalidated += Player_PreviewInvalidated;
             Disposable.Create(vm, x => x.PreviewInvalidated -= Player_PreviewInvalidated)
+                .DisposeWith(_disposables);
+
+            vm.BeginEditTimecodeRequested
+                .ObserveOnUIDispatcher()
+                .Subscribe(_ => Player.BeginEditCurrentTime())
                 .DisposeWith(_disposables);
 
             vm.FrameMatrix

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -79,19 +79,17 @@ public partial class PlayerView : UserControl
         if (DataContext is not PlayerViewModel vm)
         {
             _logger.LogWarning("Timecode submitted but DataContext is not PlayerViewModel; ignoring.");
-            e.Handled = false;
-            e.Error = Beutl.Language.Strings.GotoTimecode_InvalidFormat;
+            e.Reject(Beutl.Language.Strings.GotoTimecode_InvalidFormat);
             return;
         }
 
         if (vm.TryGotoTimecode(e.Input, out GotoTimecodeError error))
         {
-            e.Handled = true;
+            e.Accept();
         }
         else
         {
-            e.Handled = false;
-            e.Error = LookupLocalizedError(error);
+            e.Reject(LookupLocalizedError(error));
         }
     }
 

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -1,4 +1,8 @@
-﻿using Avalonia;
+﻿using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -238,6 +242,15 @@ public partial class PlayerView : UserControl
                 .Subscribe(_ => Player.BeginEditCurrentTime())
                 .DisposeWith(_disposables);
 
+            if (vm.Scene is { } scene)
+            {
+                WirePlayerMarkers(scene).DisposeWith(_disposables);
+            }
+            else
+            {
+                Player.Markers = Array.Empty<PlayerMarkerEntry>();
+            }
+
             vm.FrameMatrix
                 .ObserveOnUIDispatcher()
                 .Select(matrix => (matrix, image, framePanel.Children?.FirstOrDefault()!))
@@ -441,6 +454,89 @@ public partial class PlayerView : UserControl
             _transformHandleResource = null;
             _transformHandleResourceTarget = null;
         });
+    }
+
+    private IDisposable WirePlayerMarkers(Scene scene)
+    {
+        var disposables = new CompositeDisposable();
+        var markerSubscriptions = new Dictionary<SceneMarker, IDisposable>();
+
+        void Refresh()
+        {
+            var snapshot = new PlayerMarkerEntry[scene.Markers.Count];
+            for (int i = 0; i < scene.Markers.Count; i++)
+            {
+                SceneMarker m = scene.Markers[i];
+                snapshot[i] = new PlayerMarkerEntry(
+                    m.Name ?? string.Empty,
+                    // Player の CurrentTime 表示 (hh\:mm\:ss\.ff) と桁を揃える。
+                    m.Time.ToString(@"hh\:mm\:ss\.ff", CultureInfo.InvariantCulture));
+            }
+            Player.Markers = snapshot;
+        }
+
+        void Subscribe(SceneMarker marker)
+        {
+            if (markerSubscriptions.ContainsKey(marker)) return;
+            void OnMarkerPropertyChanged(object? s, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == nameof(SceneMarker.Name)
+                    || e.PropertyName == nameof(SceneMarker.Time))
+                {
+                    Refresh();
+                }
+            }
+            marker.PropertyChanged += OnMarkerPropertyChanged;
+            markerSubscriptions[marker] = Disposable.Create(
+                () => marker.PropertyChanged -= OnMarkerPropertyChanged);
+        }
+
+        void Unsubscribe(SceneMarker marker)
+        {
+            if (markerSubscriptions.Remove(marker, out IDisposable? sub))
+            {
+                sub.Dispose();
+            }
+        }
+
+        foreach (SceneMarker marker in scene.Markers)
+        {
+            Subscribe(marker);
+        }
+
+        void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (object? item in e.OldItems)
+                {
+                    if (item is SceneMarker marker) Unsubscribe(marker);
+                }
+            }
+            if (e.NewItems != null)
+            {
+                foreach (object? item in e.NewItems)
+                {
+                    if (item is SceneMarker marker) Subscribe(marker);
+                }
+            }
+            Refresh();
+        }
+
+        scene.Markers.CollectionChanged += OnCollectionChanged;
+        disposables.Add(Disposable.Create(
+            () => scene.Markers.CollectionChanged -= OnCollectionChanged));
+        disposables.Add(Disposable.Create(() =>
+        {
+            foreach (IDisposable sub in markerSubscriptions.Values)
+            {
+                sub.Dispose();
+            }
+            markerSubscriptions.Clear();
+        }));
+
+        Refresh();
+        return disposables;
     }
 
     private void Player_PreviewInvalidated(object? sender, EventArgs e)

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -98,6 +98,7 @@ public partial class PlayerView : UserControl
         GotoTimecodeError.InvalidFormat => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
         GotoTimecodeError.MarkerNotFound => Beutl.Language.Strings.GotoTimecode_MarkerNotFound,
         GotoTimecodeError.NoScene => Beutl.Language.Strings.GotoTimecode_NoScene,
+        GotoTimecodeError.OutOfRange => Beutl.Language.Strings.GotoTimecode_OutOfRange,
         _ => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
     };
 

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -84,32 +84,24 @@ public partial class PlayerView : UserControl
             return;
         }
 
-        if (vm.TryGotoTimecode(e.Input, out string? errorKey))
+        if (vm.TryGotoTimecode(e.Input, out GotoTimecodeError error))
         {
             e.Handled = true;
         }
         else
         {
             e.Handled = false;
-            e.Error = LookupLocalizedError(errorKey);
+            e.Error = LookupLocalizedError(error);
         }
     }
 
-    private string LookupLocalizedError(string? errorKey)
+    private string LookupLocalizedError(GotoTimecodeError error) => error switch
     {
-        switch (errorKey)
-        {
-            case "GotoTimecode_InvalidFormat":
-                return Beutl.Language.Strings.GotoTimecode_InvalidFormat;
-            case "GotoTimecode_MarkerNotFound":
-                return Beutl.Language.Strings.GotoTimecode_MarkerNotFound;
-            case "GotoTimecode_NoScene":
-                return Beutl.Language.Strings.GotoTimecode_NoScene;
-            default:
-                _logger.LogWarning("Unknown timecode error key '{Key}'; falling back to invalid-format message.", errorKey);
-                return Beutl.Language.Strings.GotoTimecode_InvalidFormat;
-        }
-    }
+        GotoTimecodeError.InvalidFormat => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
+        GotoTimecodeError.MarkerNotFound => Beutl.Language.Strings.GotoTimecode_MarkerNotFound,
+        GotoTimecodeError.NoScene => Beutl.Language.Strings.GotoTimecode_NoScene,
+        _ => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
+    };
 
     private void SetupImageControl()
     {

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -78,6 +78,9 @@ public partial class PlayerView : UserControl
     {
         if (DataContext is not PlayerViewModel vm)
         {
+            _logger.LogWarning("Timecode submitted but DataContext is not PlayerViewModel; ignoring.");
+            e.Handled = false;
+            e.Error = Beutl.Language.Strings.GotoTimecode_InvalidFormat;
             return;
         }
 
@@ -92,14 +95,18 @@ public partial class PlayerView : UserControl
         }
     }
 
-    private static string? LookupLocalizedError(string? errorKey)
+    private string LookupLocalizedError(string? errorKey)
     {
-        return errorKey switch
+        switch (errorKey)
         {
-            "GotoTimecode_InvalidFormat" => Beutl.Language.Strings.GotoTimecode_InvalidFormat,
-            "GotoTimecode_MarkerNotFound" => Beutl.Language.Strings.GotoTimecode_MarkerNotFound,
-            _ => null,
-        };
+            case "GotoTimecode_InvalidFormat":
+                return Beutl.Language.Strings.GotoTimecode_InvalidFormat;
+            case "GotoTimecode_MarkerNotFound":
+                return Beutl.Language.Strings.GotoTimecode_MarkerNotFound;
+            default:
+                _logger.LogWarning("Unknown timecode error key '{Key}'; falling back to invalid-format message.", errorKey);
+                return Beutl.Language.Strings.GotoTimecode_InvalidFormat;
+        }
     }
 
     private void SetupImageControl()

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -74,7 +74,7 @@ public partial class PlayerView : UserControl
         Player.CurrentTimeSubmitted += OnPlayerCurrentTimeSubmitted;
     }
 
-    private void OnPlayerCurrentTimeSubmitted(object? sender, Beutl.Controls.TimecodeSubmittedEventArgs e)
+    private async void OnPlayerCurrentTimeSubmitted(object? sender, Beutl.Controls.TimecodeSubmittedEventArgs e)
     {
         if (DataContext is not PlayerViewModel vm)
         {
@@ -87,21 +87,28 @@ public partial class PlayerView : UserControl
             return;
         }
 
+        // Parse synchronously so Player.SubmitCurrentTimeEdit sees the final
+        // Handled/Error state before its post-Invoke check. The actual seek
+        // is applied after awaiting Pause if playback is running, otherwise
+        // the playback timer would overwrite the new playhead on its next tick.
+        if (!vm.TryParseTimecode(e.Input, out TimeSpan target, out GotoTimecodeError error))
+        {
+            e.Reject(LookupLocalizedError(error));
+            return;
+        }
+
+        e.Accept();
         try
         {
-            if (vm.TryGotoTimecode(e.Input, out GotoTimecodeError error))
+            if (vm.IsPlaying.Value)
             {
-                e.Accept();
+                await vm.Pause();
             }
-            else
-            {
-                e.Reject(LookupLocalizedError(error));
-            }
+            vm.ApplyTimecodeSeek(target);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while applying timecode '{Input}'.", e.Input);
-            e.Reject(Beutl.Language.MessageStrings.UnexpectedError);
         }
     }
 

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -170,58 +170,6 @@ public class GotoTimecodeParserTests
     }
 
     [Test]
-    public void ClampToSceneRange_Below_ClampsToStart()
-    {
-        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
-            TimeSpan.Zero, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10), FrameRate);
-
-        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(1)));
-    }
-
-    [Test]
-    public void ClampToSceneRange_Above_ClampsToLastFrame()
-    {
-        TimeSpan start = TimeSpan.Zero;
-        TimeSpan duration = TimeSpan.FromSeconds(10);
-        TimeSpan frame = TimeSpan.FromSeconds(1d / FrameRate);
-
-        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
-            TimeSpan.FromHours(1), start, duration, FrameRate);
-
-        Assert.That(result, Is.EqualTo(start + duration - frame));
-    }
-
-    [Test]
-    public void ClampToSceneRange_Within_ReturnsUnchanged()
-    {
-        TimeSpan ts = TimeSpan.FromSeconds(5);
-        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
-            ts, TimeSpan.Zero, TimeSpan.FromSeconds(10), FrameRate);
-
-        Assert.That(result, Is.EqualTo(ts));
-    }
-
-    [Test]
-    public void ClampToSceneRange_DurationBelowOneFrame_CollapsesToStart()
-    {
-        TimeSpan start = TimeSpan.FromSeconds(2);
-        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
-            TimeSpan.FromSeconds(5), start, TimeSpan.Zero, FrameRate);
-
-        Assert.That(result, Is.EqualTo(start));
-    }
-
-    [Test]
-    public void ClampToSceneRange_NonZeroSceneStart_RaisesBelowToStart()
-    {
-        TimeSpan start = TimeSpan.FromSeconds(3);
-        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
-            TimeSpan.Zero, start, TimeSpan.FromSeconds(5), FrameRate);
-
-        Assert.That(result, Is.EqualTo(start));
-    }
-
-    [Test]
     public void TryParse_NegativeFrameSuffix_ClampsToZero()
     {
         bool ok = GotoTimecodeParser.TryParse(

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -26,6 +26,20 @@ public class GotoTimecodeParserTests
         Assert.That(result, Is.EqualTo(new TimeSpan(0, h, m, s, ms)));
     }
 
+    [TestCase("1.00:00:05", 1, 0, 0, 5, 0)]
+    [TestCase("2.13:45:30.50", 2, 13, 45, 30, 500)]
+    public void TryParse_AbsoluteWithDayPrefix_Succeeds(string input, int d, int h, int m, int s, int ms)
+    {
+        // Required so users can type a >=24h timecode that the current-time
+        // display would render as a day-wrapped value otherwise.
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out GotoTimecodeError error);
+
+        Assert.That(ok, Is.True);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.None));
+        Assert.That(result, Is.EqualTo(new TimeSpan(d, h, m, s, ms)));
+    }
+
     [TestCase("60f", 60)]
     [TestCase("0f", 0)]
     [TestCase("1234F", 1234)]

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -1,0 +1,191 @@
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class GotoTimecodeParserTests
+{
+    private const int FrameRate = 30;
+
+    private static readonly IReadOnlyList<SceneMarker> EmptyMarkers = Array.Empty<SceneMarker>();
+
+    [TestCase("00:00:05", 0, 0, 5, 0)]
+    [TestCase("00:01:23.45", 0, 1, 23, 450)]
+    [TestCase("1:02:03", 1, 2, 3, 0)]
+    [TestCase("12:34", 0, 12, 34, 0)]
+    [TestCase("5:00", 0, 5, 0, 0)]
+    [TestCase("0:05.250", 0, 0, 5, 250)]
+    public void TryParse_Absolute_Succeeds(string input, int h, int m, int s, int ms)
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out string? error);
+
+        Assert.That(ok, Is.True);
+        Assert.That(error, Is.Null);
+        Assert.That(result, Is.EqualTo(new TimeSpan(0, h, m, s, ms)));
+    }
+
+    [TestCase("60f", 60)]
+    [TestCase("0f", 0)]
+    [TestCase("1234F", 1234)]
+    [TestCase("#90", 90)]
+    [TestCase("#0", 0)]
+    public void TryParse_Frame_ReturnsFrameDuration(string input, int frame)
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out string? error);
+
+        Assert.That(ok, Is.True);
+        Assert.That(error, Is.Null);
+        Assert.That(result, Is.EqualTo(frame.ToTimeSpan(FrameRate)));
+    }
+
+    [Test]
+    public void TryParse_RelativeSeconds_AddsToCurrent()
+    {
+        TimeSpan current = TimeSpan.FromSeconds(10);
+        bool ok = GotoTimecodeParser.TryParse(
+            "+5s", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(15)));
+    }
+
+    [Test]
+    public void TryParse_RelativeNegativeSeconds_SubtractsFromCurrent()
+    {
+        TimeSpan current = TimeSpan.FromSeconds(10);
+        bool ok = GotoTimecodeParser.TryParse(
+            "-3s", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(7)));
+    }
+
+    [Test]
+    public void TryParse_RelativeMinutes_AddsToCurrent()
+    {
+        TimeSpan current = TimeSpan.FromMinutes(1);
+        bool ok = GotoTimecodeParser.TryParse(
+            "+2m", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromMinutes(3)));
+    }
+
+    [Test]
+    public void TryParse_RelativeFrames_AddsFramesToCurrent()
+    {
+        TimeSpan current = 30.ToTimeSpan(FrameRate);
+        bool ok = GotoTimecodeParser.TryParse(
+            "+15f", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(45.ToTimeSpan(FrameRate)));
+    }
+
+    [Test]
+    public void TryParse_RelativeUnderflow_ClampsToZero()
+    {
+        TimeSpan current = TimeSpan.FromSeconds(1);
+        bool ok = GotoTimecodeParser.TryParse(
+            "-10s", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void TryParse_MarkerByName_ReturnsMarkerTime()
+    {
+        var markers = new[]
+        {
+            new SceneMarker(TimeSpan.FromSeconds(2), "Intro"),
+            new SceneMarker(TimeSpan.FromSeconds(10), "Outro"),
+        };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            "@outro", FrameRate, TimeSpan.Zero, markers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+
+    [Test]
+    public void TryParse_MarkerByPrefix_MatchesFirstHit()
+    {
+        var markers = new[]
+        {
+            new SceneMarker(TimeSpan.FromSeconds(2), "Intro"),
+            new SceneMarker(TimeSpan.FromSeconds(5), "Interlude"),
+        };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            "@in", FrameRate, TimeSpan.Zero, markers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void TryParse_MarkerNotFound_ReturnsError()
+    {
+        var markers = new[]
+        {
+            new SceneMarker(TimeSpan.FromSeconds(2), "Intro"),
+        };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            "@missing", FrameRate, TimeSpan.Zero, markers, out _, out string? error);
+
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo("GotoTimecode_MarkerNotFound"));
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("abc")]
+    [TestCase("+5x")]
+    [TestCase("+abcs")]
+    [TestCase("#abc")]
+    [TestCase("@")]
+    [TestCase("+")]
+    public void TryParse_InvalidInput_ReturnsError(string input)
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+    }
+
+    [Test]
+    public void TryParse_NullInput_ReturnsError()
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            null, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+    }
+
+    [Test]
+    public void TryParse_NegativeFrameSuffix_ClampsToZero()
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            "-10f", FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void TryParse_FrameRateZero_DefaultsTo30()
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            "30f", frameRate: 0, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -185,13 +185,13 @@ public class GotoTimecodeParserTests
     [TestCase("+1e20m")]
     [TestCase("+1e20f")]
     [TestCase("+99999999999999s")]
-    public void TryParse_RelativeOutOfRange_ReturnsErrorWithoutThrowing(string input)
+    public void TryParse_RelativeOutOfRange_ReturnsOutOfRangeWithoutThrowing(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(
             input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out GotoTimecodeError error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo(GotoTimecodeError.InvalidFormat));
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.OutOfRange));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -218,6 +218,11 @@ public class GotoTimecodeParserTests
     [TestCase("+-5s")]
     [TestCase("--5s")]
     [TestCase("+-1m")]
+    [TestCase("+-5f")]
+    [TestCase("--5f")]
+    [TestCase("-+5s")]
+    [TestCase("-+5m")]
+    [TestCase("-+5f")]
     public void TryParse_InvalidInput_ReturnsError(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -143,6 +143,54 @@ public class GotoTimecodeParserTests
         Assert.That(error, Is.EqualTo(GotoTimecodeError.MarkerNotFound));
     }
 
+    [Test]
+    public void TryParse_MarkerByPrefix_TimeOrderDoesNotOverrideDeclarationOrder()
+    {
+        // Tie-breaker contract: when multiple markers share a prefix, the first
+        // in declaration order wins regardless of which has the earlier Time.
+        var markers = new[]
+        {
+            new SceneMarker(TimeSpan.FromSeconds(10), "Interlude"),
+            new SceneMarker(TimeSpan.FromSeconds(2), "Intro"),
+        };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            "@in", FrameRate, TimeSpan.Zero, markers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+
+    [TestCase("@INTRO")]
+    [TestCase("@Intro")]
+    [TestCase("@intro")]
+    public void TryParse_MarkerName_IsCaseInsensitive(string input)
+    {
+        var markers = new[] { new SceneMarker(TimeSpan.FromSeconds(2), "Intro") };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, markers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void TryParse_MarkerWithEmptyName_IsSkipped()
+    {
+        var markers = new[]
+        {
+            new SceneMarker(TimeSpan.FromSeconds(1), ""),
+            new SceneMarker(TimeSpan.FromSeconds(5), "Outro"),
+        };
+
+        bool ok = GotoTimecodeParser.TryParse(
+            "@outro", FrameRate, TimeSpan.Zero, markers, out TimeSpan result, out _);
+
+        Assert.That(ok, Is.True);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(5)));
+    }
+
     [TestCase("")]
     [TestCase("   ")]
     [TestCase("abc")]
@@ -151,6 +199,8 @@ public class GotoTimecodeParserTests
     [TestCase("#abc")]
     [TestCase("@")]
     [TestCase("+")]
+    [TestCase("100")]
+    [TestCase("1.5")]
     public void TryParse_InvalidInput_ReturnsError(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -179,6 +179,31 @@ public class GotoTimecodeParserTests
         Assert.That(result, Is.EqualTo(TimeSpan.Zero));
     }
 
+    [TestCase("+1e20s")]
+    [TestCase("-1e20s")]
+    [TestCase("+1e20m")]
+    [TestCase("+1e20f")]
+    [TestCase("+99999999999999s")]
+    public void TryParse_RelativeOutOfRange_ReturnsErrorWithoutThrowing(string input)
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+    }
+
+    [Test]
+    public void TryParse_RelativeOverflowOnAddition_ReturnsErrorWithoutThrowing()
+    {
+        bool ok = GotoTimecodeParser.TryParse(
+            "+9999999d.99999h", FrameRate, TimeSpan.MaxValue / 2, EmptyMarkers,
+            out _, out string? _);
+
+        // Either succeeds with a clamped result, or returns false with InvalidFormat — must not throw.
+        Assert.That(ok, Is.False.Or.True);
+    }
+
     [Test]
     public void TryParse_FrameRateZero_DefaultsTo30()
     {

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -170,6 +170,58 @@ public class GotoTimecodeParserTests
     }
 
     [Test]
+    public void ClampToSceneRange_Below_ClampsToStart()
+    {
+        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
+            TimeSpan.Zero, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10), FrameRate);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void ClampToSceneRange_Above_ClampsToLastFrame()
+    {
+        TimeSpan start = TimeSpan.Zero;
+        TimeSpan duration = TimeSpan.FromSeconds(10);
+        TimeSpan frame = TimeSpan.FromSeconds(1d / FrameRate);
+
+        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
+            TimeSpan.FromHours(1), start, duration, FrameRate);
+
+        Assert.That(result, Is.EqualTo(start + duration - frame));
+    }
+
+    [Test]
+    public void ClampToSceneRange_Within_ReturnsUnchanged()
+    {
+        TimeSpan ts = TimeSpan.FromSeconds(5);
+        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
+            ts, TimeSpan.Zero, TimeSpan.FromSeconds(10), FrameRate);
+
+        Assert.That(result, Is.EqualTo(ts));
+    }
+
+    [Test]
+    public void ClampToSceneRange_DurationBelowOneFrame_CollapsesToStart()
+    {
+        TimeSpan start = TimeSpan.FromSeconds(2);
+        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
+            TimeSpan.FromSeconds(5), start, TimeSpan.Zero, FrameRate);
+
+        Assert.That(result, Is.EqualTo(start));
+    }
+
+    [Test]
+    public void ClampToSceneRange_NonZeroSceneStart_RaisesBelowToStart()
+    {
+        TimeSpan start = TimeSpan.FromSeconds(3);
+        TimeSpan result = GotoTimecodeParser.ClampToSceneRange(
+            TimeSpan.Zero, start, TimeSpan.FromSeconds(5), FrameRate);
+
+        Assert.That(result, Is.EqualTo(start));
+    }
+
+    [Test]
     public void TryParse_NegativeFrameSuffix_ClampsToZero()
     {
         bool ok = GotoTimecodeParser.TryParse(

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -1,4 +1,4 @@
-using Beutl;
+﻿using Beutl;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.ProjectSystem;

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -1,3 +1,4 @@
+using Beutl;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.ProjectSystem;
@@ -18,10 +19,10 @@ public class GotoTimecodeParserTests
     public void TryParse_Absolute_Succeeds(string input, int h, int m, int s, int ms)
     {
         bool ok = GotoTimecodeParser.TryParse(
-            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out string? error);
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out GotoTimecodeError error);
 
         Assert.That(ok, Is.True);
-        Assert.That(error, Is.Null);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.None));
         Assert.That(result, Is.EqualTo(new TimeSpan(0, h, m, s, ms)));
     }
 
@@ -33,10 +34,10 @@ public class GotoTimecodeParserTests
     public void TryParse_Frame_ReturnsFrameDuration(string input, int frame)
     {
         bool ok = GotoTimecodeParser.TryParse(
-            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out string? error);
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out GotoTimecodeError error);
 
         Assert.That(ok, Is.True);
-        Assert.That(error, Is.Null);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.None));
         Assert.That(result, Is.EqualTo(frame.ToTimeSpan(FrameRate)));
     }
 
@@ -136,10 +137,10 @@ public class GotoTimecodeParserTests
         };
 
         bool ok = GotoTimecodeParser.TryParse(
-            "@missing", FrameRate, TimeSpan.Zero, markers, out _, out string? error);
+            "@missing", FrameRate, TimeSpan.Zero, markers, out _, out GotoTimecodeError error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo("GotoTimecode_MarkerNotFound"));
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.MarkerNotFound));
     }
 
     [TestCase("")]
@@ -153,20 +154,20 @@ public class GotoTimecodeParserTests
     public void TryParse_InvalidInput_ReturnsError(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(
-            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out GotoTimecodeError error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.InvalidFormat));
     }
 
     [Test]
     public void TryParse_NullInput_ReturnsError()
     {
         bool ok = GotoTimecodeParser.TryParse(
-            null, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+            null, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out GotoTimecodeError error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.InvalidFormat));
     }
 
     [Test]
@@ -187,10 +188,10 @@ public class GotoTimecodeParserTests
     public void TryParse_RelativeOutOfRange_ReturnsErrorWithoutThrowing(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(
-            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out string? error);
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out GotoTimecodeError error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo("GotoTimecode_InvalidFormat"));
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.InvalidFormat));
     }
 
     [Test]
@@ -198,7 +199,7 @@ public class GotoTimecodeParserTests
     {
         bool ok = GotoTimecodeParser.TryParse(
             "+9999999d.99999h", FrameRate, TimeSpan.MaxValue / 2, EmptyMarkers,
-            out _, out string? _);
+            out _, out GotoTimecodeError _);
 
         // Either succeeds with a clamped result, or returns false with InvalidFormat — must not throw.
         Assert.That(ok, Is.False.Or.True);

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -201,6 +201,9 @@ public class GotoTimecodeParserTests
     [TestCase("+")]
     [TestCase("100")]
     [TestCase("1.5")]
+    [TestCase("+-5s")]
+    [TestCase("--5s")]
+    [TestCase("+-1m")]
     public void TryParse_InvalidInput_ReturnsError(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -86,14 +86,14 @@ public class GotoTimecodeParserTests
     }
 
     [Test]
-    public void TryParse_RelativeUnderflow_ClampsToZero()
+    public void TryParse_RelativeUnderflow_ReturnsOutOfRange()
     {
         TimeSpan current = TimeSpan.FromSeconds(1);
         bool ok = GotoTimecodeParser.TryParse(
-            "-10s", FrameRate, current, EmptyMarkers, out TimeSpan result, out _);
+            "-10s", FrameRate, current, EmptyMarkers, out _, out GotoTimecodeError error);
 
-        Assert.That(ok, Is.True);
-        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.OutOfRange));
     }
 
     [Test]
@@ -220,14 +220,15 @@ public class GotoTimecodeParserTests
         Assert.That(error, Is.EqualTo(GotoTimecodeError.InvalidFormat));
     }
 
-    [Test]
-    public void TryParse_NegativeFrameSuffix_ClampsToZero()
+    [TestCase("-10f")]
+    [TestCase("#-30")]
+    public void TryParse_NegativeFrame_ReturnsOutOfRange(string input)
     {
         bool ok = GotoTimecodeParser.TryParse(
-            "-10f", FrameRate, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out _);
+            input, FrameRate, TimeSpan.Zero, EmptyMarkers, out _, out GotoTimecodeError error);
 
-        Assert.That(ok, Is.True);
-        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.OutOfRange));
     }
 
     [TestCase("+1e20s")]

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -205,13 +205,12 @@ public class GotoTimecodeParserTests
         Assert.That(ok, Is.False.Or.True);
     }
 
-    [Test]
-    public void TryParse_FrameRateZero_DefaultsTo30()
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void TryParse_NonPositiveFrameRate_Throws(int frameRate)
     {
-        bool ok = GotoTimecodeParser.TryParse(
-            "30f", frameRate: 0, TimeSpan.Zero, EmptyMarkers, out TimeSpan result, out _);
-
-        Assert.That(ok, Is.True);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            GotoTimecodeParser.TryParse(
+                "30f", frameRate, TimeSpan.Zero, EmptyMarkers, out _, out _));
     }
 }

--- a/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/GotoTimecodeParserTests.cs
@@ -246,14 +246,18 @@ public class GotoTimecodeParserTests
     }
 
     [Test]
-    public void TryParse_RelativeOverflowOnAddition_ReturnsErrorWithoutThrowing()
+    public void TryParse_RelativeOverflowOnAddition_ReturnsOutOfRange()
     {
+        // The delta on its own (5e11 s ≈ 1.585e4 years) fits in a TimeSpan,
+        // but adding it to a currentTime near TimeSpan.MaxValue overflows the
+        // sum. That distinguishes addition-overflow from the FromSeconds /
+        // FromMinutes overflow that the other OutOfRange cases exercise.
+        TimeSpan current = TimeSpan.FromTicks(TimeSpan.MaxValue.Ticks / 2);
         bool ok = GotoTimecodeParser.TryParse(
-            "+9999999d.99999h", FrameRate, TimeSpan.MaxValue / 2, EmptyMarkers,
-            out _, out GotoTimecodeError _);
+            "+5e11s", FrameRate, current, EmptyMarkers, out _, out GotoTimecodeError error);
 
-        // Either succeeds with a clamped result, or returns false with InvalidFormat — must not throw.
-        Assert.That(ok, Is.False.Or.True);
+        Assert.That(ok, Is.False);
+        Assert.That(error, Is.EqualTo(GotoTimecodeError.OutOfRange));
     }
 
     [TestCase(0)]


### PR DESCRIPTION
## Description
- Adds an inline timecode editor on the Player so users can seek the playhead to an arbitrary point without dragging the slider. Implements the "タイムコード入力でジャンプ" backlog item on b-editor/projects/9.
- Supports four input forms: absolute time (`00:01:23.45`), frame number (`60f` / `#60`), relative offset (`+5s` / `-10f` / `+1m`), and marker-name lookup (`@Intro`, prefix-matched).
- The `G` shortcut focuses the editor; `Escape` cancels; invalid input shows a red border and a tooltip without moving the playhead. The seek is clamped to the scene range and snapped to the project frame rate.

## Breaking changes
None.

## Fixed issues
None. (Implements a Backlog item from project b-editor/projects/9; no tracking issue.)