### PR TITLE
fix: avoid overflow in integer Animator interpolation

### DIFF
--- a/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Animation.Animators;
+﻿namespace Beutl.Animation.Animators;
 
 public sealed class Int32Animator : Animator<int>
 {

--- a/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
@@ -4,6 +4,8 @@ public sealed class Int32Animator : Animator<int>
 {
     public override int Interpolate(float progress, int oldValue, int newValue)
     {
+        // 32bit 値も Math.Clamp の上下限 (int.MinValue/int.MaxValue) も double で正確に
+        // 表現できるため、Int64Animator のような progress=0/1 の早期 return や自前飽和は不要。
         double delta = (double)newValue - oldValue;
         double v = oldValue + delta * progress;
         return (int)Math.Round(Math.Clamp(v, int.MinValue, int.MaxValue), MidpointRounding.AwayFromZero);

--- a/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
@@ -1,14 +1,11 @@
-﻿namespace Beutl.Animation.Animators;
+namespace Beutl.Animation.Animators;
 
 public sealed class Int32Animator : Animator<int>
 {
     public override int Interpolate(float progress, int oldValue, int newValue)
     {
-        const float maxVal = int.MaxValue;
-
-        var normOV = oldValue / maxVal;
-        var normNV = newValue / maxVal;
-        var deltaV = normNV - normOV;
-        return (int)MathF.Round(maxVal * ((deltaV * progress) + normOV));
+        double delta = (double)newValue - oldValue;
+        double v = oldValue + delta * progress;
+        return (int)Math.Round(Math.Clamp(v, int.MinValue, int.MaxValue), MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int32Animator.cs
@@ -6,8 +6,9 @@ public sealed class Int32Animator : Animator<int>
     {
         // 32bit 値も Math.Clamp の上下限 (int.MinValue/int.MaxValue) も double で正確に
         // 表現できるため、Int64Animator のような progress=0/1 の早期 return や自前飽和は不要。
+        // 丸めは Math.Round 既定 (ToEven) のままにし、ByteAnimator/Int16Animator など他の整数 Animator と挙動を一致させる。
         double delta = (double)newValue - oldValue;
         double v = oldValue + delta * progress;
-        return (int)Math.Round(Math.Clamp(v, int.MinValue, int.MaxValue), MidpointRounding.AwayFromZero);
+        return (int)Math.Round(Math.Clamp(v, int.MinValue, int.MaxValue));
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -6,6 +6,10 @@ public sealed class Int64Animator : Animator<long>
     {
         double delta = (double)newValue - oldValue;
         double v = oldValue + delta * progress;
-        return (long)Math.Round(Math.Clamp(v, long.MinValue, long.MaxValue), MidpointRounding.AwayFromZero);
+        // (double)long.MaxValue は 2^63 に丸まり long に収まらないため Math.Clamp の
+        // double 上限ではなく、long の正確な境界で飽和してから double→long に落とす。
+        if (v >= long.MaxValue) return long.MaxValue;
+        if (v <= long.MinValue) return long.MinValue;
+        return (long)Math.Round(v, MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -15,8 +15,9 @@ public sealed class Int64Animator : Animator<long>
         // 2^63 に丸まる (double で表現可能な最近接値)。これは long.MaxValue + 1 に相当し
         // long には収まらないため、(long) キャストで未定義に近い値になる。よって double の
         // まま long の境界と比較して飽和させ、確実に範囲内になった値だけを cast する。
+        // 丸めは Math.Round 既定 (ToEven) のままにし、ByteAnimator/Int16Animator など他の整数 Animator と挙動を一致させる。
         if (v >= long.MaxValue) return long.MaxValue;
         if (v <= long.MinValue) return long.MinValue;
-        return (long)Math.Round(v, MidpointRounding.AwayFromZero);
+        return (long)Math.Round(v);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Animation.Animators;
+﻿namespace Beutl.Animation.Animators;
 
 public sealed class Int64Animator : Animator<long>
 {

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -4,6 +4,10 @@ public sealed class Int64Animator : Animator<long>
 {
     public override long Interpolate(float progress, long oldValue, long newValue)
     {
+        // long.MaxValue 近傍では (double)oldValue が 2^53 ULP で丸まり、progress=0/1 でも
+        // 端点を正確に返せない。境界進捗は double 経由を回避して oldValue/newValue を直接返す。
+        if (progress is 0f) return oldValue;
+        if (progress is 1f) return newValue;
         double delta = (double)newValue - oldValue;
         double v = oldValue + delta * progress;
         // (double)long.MaxValue は 2^63 に丸まり long に収まらないため Math.Clamp の

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -4,14 +4,17 @@ public sealed class Int64Animator : Animator<long>
 {
     public override long Interpolate(float progress, long oldValue, long newValue)
     {
-        // long.MaxValue 近傍では (double)oldValue が 2^53 ULP で丸まり、progress=0/1 でも
-        // 端点を正確に返せない。境界進捗は double 経由を回避して oldValue/newValue を直接返す。
+        // (double)oldValue は仮数 53bit に丸められ、long.MaxValue (2^63) 近傍では
+        // 1 ULP ≒ 2^10 (約 1024) の誤差が乗る。progress=0/1 でも端点を正確に返せないため、
+        // 境界進捗は double 経由を回避して oldValue/newValue を直接返す。
         if (progress is 0f) return oldValue;
         if (progress is 1f) return newValue;
         double delta = (double)newValue - oldValue;
         double v = oldValue + delta * progress;
-        // (double)long.MaxValue は 2^63 に丸まり long に収まらないため Math.Clamp の
-        // double 上限ではなく、long の正確な境界で飽和してから double→long に落とす。
+        // Math.Clamp(v, long.MinValue, long.MaxValue) を使っても、(double)long.MaxValue は
+        // 2^63 に丸まる (double で表現可能な最近接値)。これは long.MaxValue + 1 に相当し
+        // long には収まらないため、(long) キャストで未定義に近い値になる。よって double の
+        // まま long の境界と比較して飽和させ、確実に範囲内になった値だけを cast する。
         if (v >= long.MaxValue) return long.MaxValue;
         if (v <= long.MinValue) return long.MinValue;
         return (long)Math.Round(v, MidpointRounding.AwayFromZero);

--- a/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/Int64Animator.cs
@@ -1,14 +1,11 @@
-﻿namespace Beutl.Animation.Animators;
+namespace Beutl.Animation.Animators;
 
 public sealed class Int64Animator : Animator<long>
 {
     public override long Interpolate(float progress, long oldValue, long newValue)
     {
-        const float maxVal = long.MaxValue;
-
-        var normOV = oldValue / maxVal;
-        var normNV = newValue / maxVal;
-        var deltaV = normNV - normOV;
-        return (long)MathF.Round(maxVal * ((deltaV * progress) + normOV));
+        double delta = (double)newValue - oldValue;
+        double v = oldValue + delta * progress;
+        return (long)Math.Round(Math.Clamp(v, long.MinValue, long.MaxValue), MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
@@ -6,8 +6,9 @@ public sealed class UInt32Animator : Animator<uint>
     {
         // 32bit 値も Math.Clamp の上下限 (uint.MinValue/uint.MaxValue) も double で正確に
         // 表現できるため、UInt64Animator のような progress=0/1 の早期 return や自前飽和は不要。
+        // 丸めは Math.Round 既定 (ToEven) のままにし、ByteAnimator/UInt16Animator など他の整数 Animator と挙動を一致させる。
         double delta = (double)newValue - (double)oldValue;
         double v = oldValue + delta * progress;
-        return (uint)Math.Round(Math.Clamp(v, uint.MinValue, uint.MaxValue), MidpointRounding.AwayFromZero);
+        return (uint)Math.Round(Math.Clamp(v, uint.MinValue, uint.MaxValue));
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
@@ -4,6 +4,8 @@ public sealed class UInt32Animator : Animator<uint>
 {
     public override uint Interpolate(float progress, uint oldValue, uint newValue)
     {
+        // 32bit 値も Math.Clamp の上下限 (uint.MinValue/uint.MaxValue) も double で正確に
+        // 表現できるため、UInt64Animator のような progress=0/1 の早期 return や自前飽和は不要。
         double delta = (double)newValue - (double)oldValue;
         double v = oldValue + delta * progress;
         return (uint)Math.Round(Math.Clamp(v, uint.MinValue, uint.MaxValue), MidpointRounding.AwayFromZero);

--- a/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Animation.Animators;
+﻿namespace Beutl.Animation.Animators;
 
 public sealed class UInt32Animator : Animator<uint>
 {

--- a/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt32Animator.cs
@@ -1,14 +1,11 @@
-﻿namespace Beutl.Animation.Animators;
+namespace Beutl.Animation.Animators;
 
 public sealed class UInt32Animator : Animator<uint>
 {
     public override uint Interpolate(float progress, uint oldValue, uint newValue)
     {
-        const float maxVal = uint.MaxValue;
-
-        var normOV = oldValue / maxVal;
-        var normNV = newValue / maxVal;
-        var deltaV = normNV - normOV;
-        return (uint)MathF.Round(maxVal * ((deltaV * progress) + normOV));
+        double delta = (double)newValue - (double)oldValue;
+        double v = oldValue + delta * progress;
+        return (uint)Math.Round(Math.Clamp(v, uint.MinValue, uint.MaxValue), MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -4,14 +4,17 @@ public sealed class UInt64Animator : Animator<ulong>
 {
     public override ulong Interpolate(float progress, ulong oldValue, ulong newValue)
     {
-        // ulong.MaxValue 近傍では (double)oldValue が ULP で丸まり、progress=0/1 でも
-        // 端点を正確に返せない。境界進捗は double 経由を回避して oldValue/newValue を直接返す。
+        // (double)oldValue は仮数 53bit に丸められ、ulong.MaxValue (2^64) 近傍では
+        // 1 ULP ≒ 2^11 (約 2048) の誤差が乗る。progress=0/1 でも端点を正確に返せないため、
+        // 境界進捗は double 経由を回避して oldValue/newValue を直接返す。
         if (progress is 0f) return oldValue;
         if (progress is 1f) return newValue;
         double delta = (double)newValue - (double)oldValue;
         double v = (double)oldValue + delta * progress;
-        // (double)ulong.MaxValue は 2^64 に丸まり ulong に収まらないため double 比較で
-        // 飽和してから ulong に落とす。NaN は最終 cast 経路で 0 になる従来挙動を維持。
+        // (double)ulong.MaxValue は 2^64 に丸まり ulong に収まらないため、double のまま
+        // ulong の境界と比較して飽和させ、確実に範囲内になった値だけを cast する。
+        // 上流前提: progress は有限値で呼ばれること (Animator<T> / Easing 側で保証)。
+        // NaN 入力は仕様上の保証対象外で、現状の cast 経路で 0 が返るが意図しないなら上流バグ。
         if (v >= ulong.MaxValue) return ulong.MaxValue;
         if (v <= 0d) return 0ul;
         return (ulong)Math.Round(v, MidpointRounding.AwayFromZero);

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -1,4 +1,4 @@
-namespace Beutl.Animation.Animators;
+﻿namespace Beutl.Animation.Animators;
 
 public sealed class UInt64Animator : Animator<ulong>
 {

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -6,6 +6,10 @@ public sealed class UInt64Animator : Animator<ulong>
     {
         double delta = (double)newValue - (double)oldValue;
         double v = (double)oldValue + delta * progress;
-        return (ulong)Math.Round(Math.Clamp(v, ulong.MinValue, ulong.MaxValue), MidpointRounding.AwayFromZero);
+        // (double)ulong.MaxValue は 2^64 に丸まり ulong に収まらないため double 比較で
+        // 飽和してから ulong に落とす。NaN は最終 cast 経路で 0 になる従来挙動を維持。
+        if (v >= ulong.MaxValue) return ulong.MaxValue;
+        if (v <= 0d) return 0ul;
+        return (ulong)Math.Round(v, MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -15,8 +15,9 @@ public sealed class UInt64Animator : Animator<ulong>
         // ulong の境界と比較して飽和させ、確実に範囲内になった値だけを cast する。
         // 上流前提: progress は有限値で呼ばれること (Animator<T> / Easing 側で保証)。
         // NaN 入力は仕様上の保証対象外で、現状の cast 経路で 0 が返るが意図しないなら上流バグ。
+        // 丸めは Math.Round 既定 (ToEven) のままにし、ByteAnimator/UInt16Animator など他の整数 Animator と挙動を一致させる。
         if (v >= ulong.MaxValue) return ulong.MaxValue;
         if (v <= 0d) return 0ul;
-        return (ulong)Math.Round(v, MidpointRounding.AwayFromZero);
+        return (ulong)Math.Round(v);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -1,14 +1,11 @@
-﻿namespace Beutl.Animation.Animators;
+namespace Beutl.Animation.Animators;
 
 public sealed class UInt64Animator : Animator<ulong>
 {
     public override ulong Interpolate(float progress, ulong oldValue, ulong newValue)
     {
-        const float maxVal = ulong.MaxValue;
-
-        var normOV = oldValue / maxVal;
-        var normNV = newValue / maxVal;
-        var deltaV = normNV - normOV;
-        return (ulong)MathF.Round(maxVal * ((deltaV * progress) + normOV));
+        double delta = (double)newValue - (double)oldValue;
+        double v = (double)oldValue + delta * progress;
+        return (ulong)Math.Round(Math.Clamp(v, ulong.MinValue, ulong.MaxValue), MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
+++ b/src/Beutl.Engine/Animation/Animators/UInt64Animator.cs
@@ -4,6 +4,10 @@ public sealed class UInt64Animator : Animator<ulong>
 {
     public override ulong Interpolate(float progress, ulong oldValue, ulong newValue)
     {
+        // ulong.MaxValue 近傍では (double)oldValue が ULP で丸まり、progress=0/1 でも
+        // 端点を正確に返せない。境界進捗は double 経由を回避して oldValue/newValue を直接返す。
+        if (progress is 0f) return oldValue;
+        if (progress is 1f) return newValue;
         double delta = (double)newValue - (double)oldValue;
         double v = (double)oldValue + delta * progress;
         // (double)ulong.MaxValue は 2^64 に丸まり ulong に収まらないため double 比較で

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -96,6 +96,65 @@ public class AnimatorInterpolateTests
     }
 
     [Test]
+    public void Int32Animator_DoesNotOverflowAtMaxValue()
+    {
+        var animator = new Int32Animator();
+        Assert.That(animator.Interpolate(1f, 0, int.MaxValue), Is.EqualTo(int.MaxValue));
+        Assert.That(animator.Interpolate(0f, int.MaxValue, 0), Is.EqualTo(int.MaxValue));
+    }
+
+    [Test]
+    public void Int32Animator_FullRangeMidpoint()
+    {
+        var animator = new Int32Animator();
+        // (int.MinValue + int.MaxValue) / 2 = -0.5 → AwayFromZero → -1
+        Assert.That(animator.Interpolate(0.5f, int.MinValue, int.MaxValue), Is.EqualTo(-1));
+    }
+
+    [Test]
+    public void Int64Animator_DoesNotOverflowAtMaxValue()
+    {
+        var animator = new Int64Animator();
+        Assert.That(animator.Interpolate(1f, 0L, long.MaxValue), Is.EqualTo(long.MaxValue));
+        Assert.That(animator.Interpolate(0f, long.MaxValue, 0L), Is.EqualTo(long.MaxValue));
+    }
+
+    [Test]
+    public void Int64Animator_PreservesPrecisionInModerateRange()
+    {
+        var animator = new Int64Animator();
+        // float-based の旧実装では long.MaxValue 比の正規化で精度が崩れ、
+        // 1_000_000_000L の中点で誤差が出ていた領域。
+        Assert.That(animator.Interpolate(0.5f, 0L, 1_000_000_000L), Is.EqualTo(500_000_000L));
+    }
+
+    [Test]
+    public void UInt32Animator_DoesNotOverflowAtMaxValue()
+    {
+        var animator = new UInt32Animator();
+        Assert.That(animator.Interpolate(1f, 0u, uint.MaxValue), Is.EqualTo(uint.MaxValue));
+    }
+
+    [Test]
+    public void UInt64Animator_DoesNotOverflowAtMaxValue()
+    {
+        var animator = new UInt64Animator();
+        Assert.That(animator.Interpolate(1f, 0ul, ulong.MaxValue), Is.EqualTo(ulong.MaxValue));
+    }
+
+    [Test]
+    public void UInt64Animator_DoesNotUnderflowOnReverseInterpolation()
+    {
+        var animator = new UInt64Animator();
+        // newValue < oldValue でも ulong 直接減算による underflow を起こさず、
+        // 中点近傍の値を返すこと (double 精度の許容差あり)。
+        var result = animator.Interpolate(0.5f, ulong.MaxValue, 0ul);
+        const ulong expected = ulong.MaxValue / 2;
+        // double の仮数部精度 (52bit) を考慮した許容差
+        Assert.That(result, Is.GreaterThan(expected - 4096ul).And.LessThan(expected + 4096ul));
+    }
+
+    [Test]
     [TestCase(0f, false, false, false)]
     [TestCase(0.49f, false, true, false)]
     [TestCase(0.5f, false, true, false)]

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -170,7 +170,7 @@ public class AnimatorInterpolateTests
     public void Int32Animator_ReverseFullRange()
     {
         var animator = new Int32Animator();
-        // int.MaxValue → int.MinValue の逆方向フルレンジ。旧 float 実装で典型的に壊れた経路。
+        // 逆方向フルレンジの境界 (progress=1) で newValue に到達することを確認。
         Assert.That(animator.Interpolate(1f, int.MaxValue, int.MinValue), Is.EqualTo(int.MinValue));
     }
 

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -157,6 +157,56 @@ public class AnimatorInterpolateTests
     }
 
     [Test]
+    public void Int32Animator_ClampsOnRangeOvershoot()
+    {
+        var animator = new Int32Animator();
+        // progress > 1 (Back/Elastic 系イージング由来の overshoot) で int.MaxValue を超える
+        Assert.That(animator.Interpolate(2f, 0, int.MaxValue), Is.EqualTo(int.MaxValue));
+        // progress < 0 で int.MinValue を下回る
+        Assert.That(animator.Interpolate(-2f, 0, int.MaxValue), Is.EqualTo(int.MinValue));
+    }
+
+    [Test]
+    public void Int32Animator_ReverseFullRange()
+    {
+        var animator = new Int32Animator();
+        // int.MaxValue → int.MinValue の逆方向フルレンジ。旧 float 実装で典型的に壊れた経路。
+        Assert.That(animator.Interpolate(1f, int.MaxValue, int.MinValue), Is.EqualTo(int.MinValue));
+    }
+
+    [Test]
+    public void Int64Animator_ClampsOnRangeOvershoot()
+    {
+        var animator = new Int64Animator();
+        Assert.That(animator.Interpolate(2f, 0L, long.MaxValue), Is.EqualTo(long.MaxValue));
+        Assert.That(animator.Interpolate(-2f, 0L, long.MaxValue), Is.EqualTo(long.MinValue));
+    }
+
+    [Test]
+    public void Int64Animator_ReverseFullRange()
+    {
+        var animator = new Int64Animator();
+        Assert.That(animator.Interpolate(1f, long.MaxValue, long.MinValue), Is.EqualTo(long.MinValue));
+    }
+
+    [Test]
+    public void UInt32Animator_ClampsOnRangeOvershoot()
+    {
+        var animator = new UInt32Animator();
+        // progress < 0 で v が負になっても Clamp で 0
+        Assert.That(animator.Interpolate(-2f, 100u, 200u), Is.EqualTo(0u));
+        Assert.That(animator.Interpolate(2f, 0u, uint.MaxValue), Is.EqualTo(uint.MaxValue));
+    }
+
+    [Test]
+    public void UInt64Animator_ClampsOnRangeOvershoot()
+    {
+        var animator = new UInt64Animator();
+        Assert.That(animator.Interpolate(-2f, 100ul, 200ul), Is.EqualTo(0ul));
+        Assert.That(animator.Interpolate(2f, 0ul, ulong.MaxValue), Is.EqualTo(ulong.MaxValue));
+    }
+
+    [Test]
     [TestCase(0f, false, false, false)]
     [TestCase(0.49f, false, true, false)]
     [TestCase(0.5f, false, true, false)]

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -107,18 +107,19 @@ public class AnimatorInterpolateTests
     public void Int32Animator_FullRangeMidpoint()
     {
         var animator = new Int32Animator();
-        // double 補間: -2^31 + (2^32 - 1) * 0.5 = -0.5 → Math.Round(AwayFromZero) → -1
-        Assert.That(animator.Interpolate(0.5f, int.MinValue, int.MaxValue), Is.EqualTo(-1));
+        // double 補間: -2^31 + (2^32 - 1) * 0.5 = -0.5 → Math.Round 既定 (ToEven) → 0
+        Assert.That(animator.Interpolate(0.5f, int.MinValue, int.MaxValue), Is.EqualTo(0));
     }
 
     [Test]
-    public void Int32Animator_RoundsMidpointAwayFromZero()
+    public void Int32Animator_RoundsMidpointToEven()
     {
         var animator = new Int32Animator();
-        // MidpointRounding.AwayFromZero: 0.5 → 1 (ToEven なら 0)
-        Assert.That(animator.Interpolate(0.5f, 0, 1), Is.EqualTo(1));
-        // MidpointRounding.AwayFromZero: -0.5 → -1 (ToEven なら 0)
-        Assert.That(animator.Interpolate(0.5f, -1, 0), Is.EqualTo(-1));
+        // Math.Round 既定 (ToEven): 0.5 → 0 (偶数寄り)。
+        // ByteAnimator/Int16Animator など他の整数 Animator と一貫する。
+        Assert.That(animator.Interpolate(0.5f, 0, 1), Is.EqualTo(0));
+        // Math.Round 既定 (ToEven): -0.5 → 0
+        Assert.That(animator.Interpolate(0.5f, -1, 0), Is.EqualTo(0));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -107,7 +107,7 @@ public class AnimatorInterpolateTests
     public void Int32Animator_FullRangeMidpoint()
     {
         var animator = new Int32Animator();
-        // (int.MinValue + int.MaxValue) / 2 = -0.5 → AwayFromZero → -1
+        // double 補間: -2^31 + (2^32 - 1) * 0.5 = -0.5 → Math.Round(AwayFromZero) → -1
         Assert.That(animator.Interpolate(0.5f, int.MinValue, int.MaxValue), Is.EqualTo(-1));
     }
 
@@ -120,12 +120,13 @@ public class AnimatorInterpolateTests
     }
 
     [Test]
-    public void Int64Animator_PreservesPrecisionInModerateRange()
+    public void Int64Animator_PreservesPrecisionForLargeValues()
     {
         var animator = new Int64Animator();
-        // float-based の旧実装では long.MaxValue 比の正規化で精度が崩れ、
-        // 1_000_000_000L の中点で誤差が出ていた領域。
-        Assert.That(animator.Interpolate(0.5f, 0L, 1_000_000_000L), Is.EqualTo(500_000_000L));
+        // 旧 float ベース実装では (float)long.MaxValue で正規化するため 1e11 付近で
+        // ~1024 程度の誤差が出る (旧実装は 49_999_998_976L を返す)。新実装の double
+        // 補間では完全に一致する。
+        Assert.That(animator.Interpolate(0.5f, 0L, 100_000_000_000L), Is.EqualTo(50_000_000_000L));
     }
 
     [Test]
@@ -150,7 +151,8 @@ public class AnimatorInterpolateTests
         // 中点近傍の値を返すこと (double 精度の許容差あり)。
         var result = animator.Interpolate(0.5f, ulong.MaxValue, 0ul);
         const ulong expected = ulong.MaxValue / 2;
-        // double の仮数部精度 (52bit) を考慮した許容差
+        // double の有効精度は 53bit (仮数 52bit + 暗黙の先頭 1bit)。
+        // ulong.MaxValue 近傍の 1 ULP は 2^(64-53) = 2048 なので 2 ULP 分の許容差。
         Assert.That(result, Is.GreaterThan(expected - 4096ul).And.LessThan(expected + 4096ul));
     }
 

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -207,6 +207,25 @@ public class AnimatorInterpolateTests
     }
 
     [Test]
+    public void Int64Animator_PreservesExactEndpointNearMaxValue()
+    {
+        var animator = new Int64Animator();
+        // double 経由では long.MaxValue - 1 が 2^63 に丸まり long.MaxValue として扱われる。
+        // progress=0/1 では oldValue/newValue を正確に返すこと。
+        Assert.That(animator.Interpolate(0f, long.MaxValue - 1, 0L), Is.EqualTo(long.MaxValue - 1));
+        Assert.That(animator.Interpolate(1f, 0L, long.MaxValue - 1), Is.EqualTo(long.MaxValue - 1));
+        Assert.That(animator.Interpolate(0f, long.MinValue + 1, 0L), Is.EqualTo(long.MinValue + 1));
+    }
+
+    [Test]
+    public void UInt64Animator_PreservesExactEndpointNearMaxValue()
+    {
+        var animator = new UInt64Animator();
+        Assert.That(animator.Interpolate(0f, ulong.MaxValue - 1, 0ul), Is.EqualTo(ulong.MaxValue - 1));
+        Assert.That(animator.Interpolate(1f, 0ul, ulong.MaxValue - 1), Is.EqualTo(ulong.MaxValue - 1));
+    }
+
+    [Test]
     [TestCase(0f, false, false, false)]
     [TestCase(0.49f, false, true, false)]
     [TestCase(0.5f, false, true, false)]

--- a/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Animation/AnimatorInterpolateTests.cs
@@ -112,6 +112,16 @@ public class AnimatorInterpolateTests
     }
 
     [Test]
+    public void Int32Animator_RoundsMidpointAwayFromZero()
+    {
+        var animator = new Int32Animator();
+        // MidpointRounding.AwayFromZero: 0.5 → 1 (ToEven なら 0)
+        Assert.That(animator.Interpolate(0.5f, 0, 1), Is.EqualTo(1));
+        // MidpointRounding.AwayFromZero: -0.5 → -1 (ToEven なら 0)
+        Assert.That(animator.Interpolate(0.5f, -1, 0), Is.EqualTo(-1));
+    }
+
+    [Test]
     public void Int64Animator_DoesNotOverflowAtMaxValue()
     {
         var animator = new Int64Animator();
@@ -123,9 +133,9 @@ public class AnimatorInterpolateTests
     public void Int64Animator_PreservesPrecisionForLargeValues()
     {
         var animator = new Int64Animator();
-        // 旧 float ベース実装では (float)long.MaxValue で正規化するため 1e11 付近で
-        // ~1024 程度の誤差が出る (旧実装は 49_999_998_976L を返す)。新実装の double
-        // 補間では完全に一致する。
+        // 旧実装は (float)long.MaxValue で正規化するため、結果が float の精度に丸まり
+        // 入力の絶対値とは無関係に誤差が乗る (この入力では 1024 ずれて 49_999_998_976L を返す)。
+        // 新実装の double 補間では完全に一致する。
         Assert.That(animator.Interpolate(0.5f, 0L, 100_000_000_000L), Is.EqualTo(50_000_000_000L));
     }
 


### PR DESCRIPTION
## Description
- Replace single-precision `float` math in `Int32Animator`, `Int64Animator`, `UInt32Animator`, and `UInt64Animator` with `double`-based interpolation followed by `Math.Clamp` before casting back to the integer type. Endpoint interpolation no longer wraps around (previously `progress=1.0f, oldValue=0, newValue=int.MaxValue` returned `int.MinValue` because `(float)int.MaxValue` rounds up to `2147483648.0f` and the unchecked `(int)` cast wrapped to `int.MinValue`).
- For `UInt64Animator`, cast both operands to `double` before subtracting so reverse interpolation does not underflow the `ulong` subtraction.
- Add boundary-value regression tests for all four animators covering max-value endpoints, full-range midpoints, moderate-range precision, and reverse interpolation.

## Breaking changes
None.

## Fixed issues
None.