### PR TITLE
feat: Add next/previous key frame seek commands

### DIFF
--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -783,6 +783,21 @@
   <data name="PreviousMarker_Description" xml:space="preserve">
     <value>前のマーカーへ移動します。</value>
   </data>
+  <data name="NextKeyFrame" xml:space="preserve">
+    <value>次のキーフレーム</value>
+  </data>
+  <data name="NextKeyFrame_Description" xml:space="preserve">
+    <value>選択中の要素（未選択の場合はシーン全体）内で次のキーフレームへ移動します。</value>
+  </data>
+  <data name="PreviousKeyFrame" xml:space="preserve">
+    <value>前のキーフレーム</value>
+  </data>
+  <data name="PreviousKeyFrame_Description" xml:space="preserve">
+    <value>選択中の要素（未選択の場合はシーン全体）内で前のキーフレームへ移動します。</value>
+  </data>
+  <data name="NoKeyFrameToSeek" xml:space="preserve">
+    <value>移動先のキーフレームがありません。</value>
+  </data>
   <data name="ShuttleForward" xml:space="preserve">
     <value>シャトル早送り</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -789,19 +789,19 @@
     <value>Seek to the previous marker.</value>
   </data>
   <data name="NextKeyFrame" xml:space="preserve">
-    <value>Next key frame</value>
+    <value>Next keyframe</value>
   </data>
   <data name="NextKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the next key frame within the selected element (or scene-wide if none).</value>
+    <value>Seek to the next keyframe within the selected element (or scene-wide if none).</value>
   </data>
   <data name="PreviousKeyFrame" xml:space="preserve">
-    <value>Previous key frame</value>
+    <value>Previous keyframe</value>
   </data>
   <data name="PreviousKeyFrame_Description" xml:space="preserve">
-    <value>Seek to the previous key frame within the selected element (or scene-wide if none).</value>
+    <value>Seek to the previous keyframe within the selected element (or scene-wide if none).</value>
   </data>
   <data name="NoKeyFrameToSeek" xml:space="preserve">
-    <value>No key frame to seek.</value>
+    <value>No keyframe to seek.</value>
   </data>
   <data name="ShuttleForward" xml:space="preserve">
     <value>Shuttle forward</value>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -788,6 +788,21 @@
   <data name="PreviousMarker_Description" xml:space="preserve">
     <value>Seek to the previous marker.</value>
   </data>
+  <data name="NextKeyFrame" xml:space="preserve">
+    <value>Next key frame</value>
+  </data>
+  <data name="NextKeyFrame_Description" xml:space="preserve">
+    <value>Seek to the next key frame within the selected element (or scene-wide if none).</value>
+  </data>
+  <data name="PreviousKeyFrame" xml:space="preserve">
+    <value>Previous key frame</value>
+  </data>
+  <data name="PreviousKeyFrame_Description" xml:space="preserve">
+    <value>Seek to the previous key frame within the selected element (or scene-wide if none).</value>
+  </data>
+  <data name="NoKeyFrameToSeek" xml:space="preserve">
+    <value>No key frame to seek.</value>
+  </data>
   <data name="ShuttleForward" xml:space="preserve">
     <value>Shuttle forward</value>
   </data>

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -58,6 +58,16 @@ public sealed class SceneEditorExtension : EditorExtension
             new ContextCommandKeyGesture("Ctrl+Left"),
             new ContextCommandKeyGesture("Alt+Left", OSPlatform.OSX)
         ]),
+        new("NextKeyFrame", Strings.NextKeyFrame, Strings.NextKeyFrame_Description,
+        [
+            new ContextCommandKeyGesture("Ctrl+Shift+Right"),
+            new ContextCommandKeyGesture("Cmd+Shift+Right", OSPlatform.OSX)
+        ]),
+        new("PreviousKeyFrame", Strings.PreviousKeyFrame, Strings.PreviousKeyFrame_Description,
+        [
+            new ContextCommandKeyGesture("Ctrl+Shift+Left"),
+            new ContextCommandKeyGesture("Cmd+Shift+Left", OSPlatform.OSX)
+        ]),
         new("ShuttleForward", Strings.ShuttleForward, Strings.ShuttleForward_Description,
         [
             new ContextCommandKeyGesture("L")

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -1,8 +1,12 @@
 ﻿using System.Reactive.Subjects;
 using Avalonia.Controls;
+using Beutl.Animation;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Services;
+using Beutl.Language;
 using Beutl.Media;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Beutl.ViewModels;
@@ -143,6 +147,12 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             case "GotoTimecode" when !isFromTextBox:
                 Player.RequestEditTimecode();
                 break;
+            case "NextKeyFrame" when !isFromTextBox:
+                SeekToAdjacentKeyFrame(forward: true);
+                break;
+            case "PreviousKeyFrame" when !isFromTextBox:
+                SeekToAdjacentKeyFrame(forward: false);
+                break;
             default:
                 if (execution.KeyEventArgs != null)
                     execution.KeyEventArgs.Handled = false;
@@ -198,14 +208,66 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
 
         if (target != null)
         {
-            _editorClock.CurrentTime.Value = target.Value;
+            SeekAndScroll(target.Value);
+        }
+    }
 
-            // ターゲットの位置までタイムラインを横スクロールさせる
-            if (FindToolTab<TimelineTabViewModel>() is { } timeline)
+    private void SeekToAdjacentKeyFrame(bool forward)
+    {
+        TimeSpan current = _editorClock.CurrentTime.Value;
+
+        // 探索範囲: 選択中の Element → 親 Element → Scene 全 Element
+        CoreObject? sel = _editorSelection.SelectedObject.Value;
+        Element? scope = sel as Element
+            ?? (sel as IHierarchical)?.FindHierarchicalParent<Element>();
+        IReadOnlyList<Element> roots = scope != null
+            ? new[] { scope }
+            : Scene.Children.ToArray();
+
+        TimeSpan? target = null;
+        foreach (Element el in roots)
+        {
+            var searcher = new ObjectSearcher(el, o => o is KeyFrameAnimation);
+            foreach (KeyFrameAnimation anim in searcher.SearchAll().OfType<KeyFrameAnimation>())
             {
-                int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);
-                timeline.ScrollTo.Execute((new TimeRange(target.Value, TimeSpan.FromTicks(1)), currentZIndex));
+                TimeSpan offset = anim.UseGlobalClock ? TimeSpan.Zero : el.Start;
+                foreach (IKeyFrame kf in anim.KeyFrames)
+                {
+                    TimeSpan time = kf.KeyTime + offset;
+                    if (forward)
+                    {
+                        if (time > current && (target == null || time < target.Value))
+                            target = time;
+                    }
+                    else
+                    {
+                        if (time < current && (target == null || time > target.Value))
+                            target = time;
+                    }
+                }
             }
+        }
+
+        if (target == null)
+        {
+            NotificationService.ShowInformation(
+                forward ? Strings.NextKeyFrame : Strings.PreviousKeyFrame,
+                Strings.NoKeyFrameToSeek);
+            return;
+        }
+
+        SeekAndScroll(target.Value);
+    }
+
+    private void SeekAndScroll(TimeSpan time)
+    {
+        _editorClock.CurrentTime.Value = time;
+
+        // ターゲットの位置までタイムラインを横スクロールさせる
+        if (FindToolTab<TimelineTabViewModel>() is { } timeline)
+        {
+            int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);
+            timeline.ScrollTo.Execute((new TimeRange(time, TimeSpan.FromTicks(1)), currentZIndex));
         }
     }
 }

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -216,10 +216,16 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     {
         TimeSpan current = _editorClock.CurrentTime.Value;
 
-        // 探索範囲のフォールバックチェーン: 選択中の Element → 直近の親 Element → Scene 全 Element (いずれか1つのみ)
+        // 探索範囲のフォールバックチェーン: 選択中の Element → 直近の親 Element → Scene 全 Element (Scene のみ複数 root)
         CoreObject? sel = _editorSelection.SelectedObject.Value;
         Element? scope = sel as Element
             ?? (sel as IHierarchical)?.FindHierarchicalParent<Element>();
+        if (sel != null && scope == null)
+        {
+            _logger.LogDebug(
+                "Key frame seek: selection ({Type}) could not be resolved to an Element; falling back to scene-wide search.",
+                sel.GetType().Name);
+        }
         IReadOnlyList<Element> roots = scope != null
             ? new[] { scope }
             : Scene.Children.ToArray();
@@ -233,11 +239,11 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             foreach (KeyFrameAnimation anim in EnumerateKeyFrameAnimations(el))
             {
                 // UseGlobalClock=false の場合、KeyFrameAnimation<T>.GetAnimatedValue は直近の親
-                // EngineObject.TimeRange.Start でローカル時刻を解釈する (KeyFrameAnimation{T}.cs:35)。
-                // time-anchored で Element.Start とズレるケースに備え、実際の owner から offset を取る。
+                // EngineObject.TimeRange.Start でローカル時刻を解釈する。実際の owner から offset を取り、
+                // owner が見つからない場合は GetAnimatedValue の挙動 (_parent==null 時はグローバル扱い) に揃える。
                 TimeSpan offset = anim.UseGlobalClock
                     ? TimeSpan.Zero
-                    : anim.FindHierarchicalParent<EngineObject>()?.TimeRange.Start ?? el.Start;
+                    : anim.FindHierarchicalParent<EngineObject>()?.TimeRange.Start ?? TimeSpan.Zero;
                 foreach (IKeyFrame kf in anim.KeyFrames)
                 {
                     TimeSpan time = kf.KeyTime + offset;

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Beutl.Animation;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Engine;
 using Beutl.Language;
 using Beutl.Media;
 using Beutl.ProjectSystem;
@@ -231,7 +232,12 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             // では届かない。Hierarchical ツリーを直接辿る必要がある。
             foreach (KeyFrameAnimation anim in EnumerateKeyFrameAnimations(el))
             {
-                TimeSpan offset = anim.UseGlobalClock ? TimeSpan.Zero : el.Start;
+                // UseGlobalClock=false の場合、KeyFrameAnimation<T>.GetAnimatedValue は直近の親
+                // EngineObject.TimeRange.Start でローカル時刻を解釈する (KeyFrameAnimation{T}.cs:35)。
+                // time-anchored で Element.Start とズレるケースに備え、実際の owner から offset を取る。
+                TimeSpan offset = anim.UseGlobalClock
+                    ? TimeSpan.Zero
+                    : anim.FindHierarchicalParent<EngineObject>()?.TimeRange.Start ?? el.Start;
                 foreach (IKeyFrame kf in anim.KeyFrames)
                 {
                     TimeSpan time = kf.KeyTime + offset;

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -234,16 +234,11 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
                 foreach (IKeyFrame kf in anim.KeyFrames)
                 {
                     TimeSpan time = kf.KeyTime + offset;
-                    if (forward)
-                    {
-                        if (time > current && (target == null || time < target.Value))
-                            target = time;
-                    }
-                    else
-                    {
-                        if (time < current && (target == null || time > target.Value))
-                            target = time;
-                    }
+                    bool inDirection = forward ? time > current : time < current;
+                    bool isCloser = target == null
+                        || (forward ? time < target.Value : time > target.Value);
+                    if (inDirection && isCloser)
+                        target = time;
                 }
             }
         }

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -2,9 +2,12 @@
 using Avalonia.Controls;
 using Beutl.Animation;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Services;
 using Beutl.Engine;
+using Beutl.Extensibility;
 using Beutl.Language;
 using Beutl.Media;
+using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Microsoft.Extensions.Logging;
@@ -233,9 +236,6 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         TimeSpan? target = null;
         foreach (Element el in roots)
         {
-            // KeyFrameAnimation は AnimatableProperty.SetOwnerObject 等で HierarchicalChildren に
-            // attach されるため、ObjectSearcher (CoreProperty/EngineObject.Properties.CurrentValue 経由)
-            // では届かない。Hierarchical ツリーを直接辿る必要がある。
             foreach (KeyFrameAnimation anim in EnumerateKeyFrameAnimations(el))
             {
                 // UseGlobalClock=false の場合、KeyFrameAnimation<T>.GetAnimatedValue は直近の親
@@ -278,22 +278,33 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         }
     }
 
-    private static IEnumerable<KeyFrameAnimation> EnumerateKeyFrameAnimations(IHierarchical root)
+    // GraphEditorTabViewModel.Refresh と同じ二段サーチで KeyFrameAnimation を収集する:
+    //   1. EngineObject.Properties.Animation (通常プロパティのアニメーション)
+    //   2. IDynamicPort 経由の INodeMember.Property.Animation (ノードグラフ動的ポートのアニメーション)
+    // 後者は NodePropertyAdapter.Animation を hierarchical child として attach しないため、
+    // EngineObject.Properties だけを辿るパスからは取りこぼされる。
+    private static IEnumerable<KeyFrameAnimation> EnumerateKeyFrameAnimations(Element root)
     {
-        var visited = new HashSet<IHierarchical>();
-        var stack = new Stack<IHierarchical>();
-        stack.Push(root);
-        while (stack.Count > 0)
+        var visited = new HashSet<KeyFrameAnimation>();
+
+        var enginePass = new ObjectSearcher(root, v => v is EngineObject);
+        foreach (EngineObject obj in enginePass.SearchAll().OfType<EngineObject>())
         {
-            IHierarchical node = stack.Pop();
-            if (!visited.Add(node))
-                continue;
+            foreach (IProperty property in obj.Properties)
+            {
+                if (property.Animation is KeyFrameAnimation kfa && visited.Add(kfa))
+                    yield return kfa;
+            }
+        }
 
-            if (node is KeyFrameAnimation kfa)
+        var portPass = new ObjectSearcher(root, v => v is IDynamicPort);
+        foreach (INodeMember member in portPass.SearchAll().OfType<INodeMember>())
+        {
+            if (member.Property is IAnimatablePropertyAdapter { Animation: KeyFrameAnimation kfa }
+                && visited.Add(kfa))
+            {
                 yield return kfa;
-
-            foreach (IHierarchical child in node.HierarchicalChildren)
-                stack.Push(child);
+            }
         }
     }
 }

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -263,7 +263,6 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     {
         _editorClock.CurrentTime.Value = time;
 
-        // ターゲットの位置までタイムラインを横スクロールさせる
         if (FindToolTab<TimelineTabViewModel>() is { } timeline)
         {
             int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -236,14 +236,8 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         TimeSpan? target = null;
         foreach (Element el in roots)
         {
-            foreach (KeyFrameAnimation anim in EnumerateKeyFrameAnimations(el))
+            foreach ((KeyFrameAnimation anim, TimeSpan offset) in EnumerateKeyFrameAnimations(el))
             {
-                // UseGlobalClock=false の場合、KeyFrameAnimation<T>.GetAnimatedValue は直近の親
-                // EngineObject.TimeRange.Start でローカル時刻を解釈する。実際の owner から offset を取り、
-                // owner が見つからない場合は GetAnimatedValue の挙動 (_parent==null 時はグローバル扱い) に揃える。
-                TimeSpan offset = anim.UseGlobalClock
-                    ? TimeSpan.Zero
-                    : anim.FindHierarchicalParent<EngineObject>()?.TimeRange.Start ?? TimeSpan.Zero;
                 foreach (IKeyFrame kf in anim.KeyFrames)
                 {
                     TimeSpan time = kf.KeyTime + offset;
@@ -278,12 +272,19 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         }
     }
 
-    // GraphEditorTabViewModel.Refresh と同じ二段サーチで KeyFrameAnimation を収集する:
-    //   1. EngineObject.Properties.Animation (通常プロパティのアニメーション)
-    //   2. IDynamicPort 経由の INodeMember.Property.Animation (ノードグラフ動的ポートのアニメーション)
-    // 後者は NodePropertyAdapter.Animation を hierarchical child として attach しないため、
-    // EngineObject.Properties だけを辿るパスからは取りこぼされる。
-    private static IEnumerable<KeyFrameAnimation> EnumerateKeyFrameAnimations(Element root)
+    // KeyFrameAnimation をタイムライン絶対時刻に正規化するための offset と一緒に列挙する。
+    //   1. EngineObject.Properties.Animation (通常プロパティ): AnimatableProperty.SetOwnerObject
+    //      で animation が hierarchical child として attach されるため、所有 EngineObject の
+    //      TimeRange.Start を offset に使う (UseGlobalClock=false 時)。これは
+    //      KeyFrameAnimation<T>.GetAnimatedValue の挙動と一致する。
+    //   2. INodeMember.Property.Animation (ノードグラフ): NodePropertyAdapter.Animation は
+    //      hierarchical child として attach されないため、animation 経由では owner を辿れない。
+    //      代わりに NodeMember の親 GraphNode を辿り、GraphSnapshot.LoadAnimatedValues
+    //      ("time - node.Start" でローカル時刻を解釈する) と同じ offset を使う。
+    //      IEnginePropertyBackedInputPort はエンジン側プロパティが pass 1 で拾われるため、
+    //      二重カウントしないよう除外する。
+    private static IEnumerable<(KeyFrameAnimation Animation, TimeSpan Offset)>
+        EnumerateKeyFrameAnimations(Element root)
     {
         var visited = new HashSet<KeyFrameAnimation>();
 
@@ -293,17 +294,28 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             foreach (IProperty property in obj.Properties)
             {
                 if (property.Animation is KeyFrameAnimation kfa && visited.Add(kfa))
-                    yield return kfa;
+                {
+                    TimeSpan offset = kfa.UseGlobalClock
+                        ? TimeSpan.Zero
+                        : kfa.FindHierarchicalParent<EngineObject>()?.TimeRange.Start ?? TimeSpan.Zero;
+                    yield return (kfa, offset);
+                }
             }
         }
 
-        var portPass = new ObjectSearcher(root, v => v is IDynamicPort);
-        foreach (INodeMember member in portPass.SearchAll().OfType<INodeMember>())
+        var memberPass = new ObjectSearcher(root, v => v is INodeMember);
+        foreach (INodeMember member in memberPass.SearchAll().OfType<INodeMember>())
         {
+            if (member is IEnginePropertyBackedInputPort)
+                continue;
+
             if (member.Property is IAnimatablePropertyAdapter { Animation: KeyFrameAnimation kfa }
                 && visited.Add(kfa))
             {
-                yield return kfa;
+                TimeSpan offset = kfa.UseGlobalClock
+                    ? TimeSpan.Zero
+                    : member.FindHierarchicalParent<GraphNode>()?.Start ?? TimeSpan.Zero;
+                yield return (kfa, offset);
             }
         }
     }

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -216,7 +216,7 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     {
         TimeSpan current = _editorClock.CurrentTime.Value;
 
-        // 探索範囲: 選択中の Element → 親 Element → Scene 全 Element
+        // 探索範囲のフォールバックチェーン: 選択中の Element → 直近の親 Element → Scene 全 Element (いずれか1つのみ)
         CoreObject? sel = _editorSelection.SelectedObject.Value;
         Element? scope = sel as Element
             ?? (sel as IHierarchical)?.FindHierarchicalParent<Element>();

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -2,7 +2,6 @@
 using Avalonia.Controls;
 using Beutl.Animation;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
-using Beutl.Editor.Services;
 using Beutl.Language;
 using Beutl.Media;
 using Beutl.ProjectSystem;
@@ -227,8 +226,10 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         TimeSpan? target = null;
         foreach (Element el in roots)
         {
-            var searcher = new ObjectSearcher(el, o => o is KeyFrameAnimation);
-            foreach (KeyFrameAnimation anim in searcher.SearchAll().OfType<KeyFrameAnimation>())
+            // KeyFrameAnimation は AnimatableProperty.SetOwnerObject 等で HierarchicalChildren に
+            // attach されるため、ObjectSearcher (CoreProperty/EngineObject.Properties.CurrentValue 経由)
+            // では届かない。Hierarchical ツリーを直接辿る必要がある。
+            foreach (KeyFrameAnimation anim in EnumerateKeyFrameAnimations(el))
             {
                 TimeSpan offset = anim.UseGlobalClock ? TimeSpan.Zero : el.Start;
                 foreach (IKeyFrame kf in anim.KeyFrames)
@@ -262,6 +263,25 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         {
             int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);
             timeline.ScrollTo.Execute((new TimeRange(time, TimeSpan.FromTicks(1)), currentZIndex));
+        }
+    }
+
+    private static IEnumerable<KeyFrameAnimation> EnumerateKeyFrameAnimations(IHierarchical root)
+    {
+        var visited = new HashSet<IHierarchical>();
+        var stack = new Stack<IHierarchical>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            IHierarchical node = stack.Pop();
+            if (!visited.Add(node))
+                continue;
+
+            if (node is KeyFrameAnimation kfa)
+                yield return kfa;
+
+            foreach (IHierarchical child in node.HierarchicalChildren)
+                stack.Push(child);
         }
     }
 }


### PR DESCRIPTION
## Description

- Add `NextKeyFrame` / `PreviousKeyFrame` context commands that seek the playhead to the nearest keyframe within the currently selected element (with fallback to the whole scene when nothing is selected).
- Collect every `KeyFrameAnimation.KeyTime` under the search scope via a two-pass `ObjectSearcher`: one sweep over `EngineObject.Properties.Animation` for regular animatable properties, plus a second sweep over `IDynamicPort`/`INodeMember.Property.Animation` so node-graph keyframes (which are not attached as hierarchical children) are included. Times are normalized against the nearest `EngineObject` ancestor's `TimeRange.Start` when `UseGlobalClock` is false so absolute positions match the timeline.
- Bind the commands to `Ctrl+Shift+Right` / `Ctrl+Shift+Left` (and `Cmd+Shift+Right` / `Cmd+Shift+Left` on macOS) to complement the existing marker navigation shortcuts.
- Surface an information notification when no keyframe is available in the requested direction; suppress the shortcut while a `TextBox` has focus.

## Breaking changes

None

## Fixed issues

Addresses the keyframe portion of the project board item "次/前のキーフレーム・マーカーへジャンプ" (`b-editor/projects/9`). The marker portion was already implemented previously.