### PR TITLE
refactor: introduce ISceneEditorContext for explicit deps

### DIFF
--- a/src/Beutl.Editor.Components/AudioVisualizerTab/AudioVisualizerTabExtension.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/AudioVisualizerTabExtension.cs
@@ -24,8 +24,14 @@ public sealed class AudioVisualizerTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new AudioVisualizerTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new AudioVisualizerTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/AudioVisualizerTabExtension.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/AudioVisualizerTabExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.AudioVisualizerTab.ViewModels;
 using Beutl.Editor.Components.AudioVisualizerTab.Views;
 using FluentAvalonia.UI.Controls;
@@ -29,7 +30,13 @@ public sealed class AudioVisualizerTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new AudioVisualizerTabViewModel(editorContext, Instance);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new AudioVisualizerTabViewModel(sceneContext, Instance);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.AudioVisualizerTab.ViewModels;
@@ -15,18 +15,18 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
     public const SpectrumDisplayShape DefaultSpectrumShape = SpectrumDisplayShape.Bar;
 
     private readonly CompositeDisposable _disposables = [];
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly IPreviewPlayer _player;
     private readonly IEditorClock _clock;
     private readonly AudioVisualizerTabExtension _extension;
     private int _composeInFlight;
 
-    public AudioVisualizerTabViewModel(IEditorContext editorContext, AudioVisualizerTabExtension extension)
+    public AudioVisualizerTabViewModel(ISceneEditorContext editorContext, AudioVisualizerTabExtension extension)
     {
         _editorContext = editorContext;
         _extension = extension;
-        _player = editorContext.GetRequiredService<IPreviewPlayer>();
-        _clock = editorContext.GetRequiredService<IEditorClock>();
+        _player = editorContext.Player;
+        _clock = editorContext.Clock;
 
         _player.AudioFramePushed
             .Subscribe(OnAudioFrameReceived)

--- a/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml.cs
+++ b/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Beutl.Controls.Converters;
+using Beutl.Editor;
 using Beutl.Editor.Components.ColorGradingProperties.ViewModels;
 using Beutl.Editor.Components.ColorGradingTab.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,7 +42,7 @@ public sealed partial class ColorGradingPropertiesEditor : UserControl
     private void OpenTabClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is ColorGradingPropertiesViewModel context &&
-            context.GetService<IEditorContext>() is { } editorContext &&
+            context.GetService<IEditorContext>() is ISceneEditorContext editorContext &&
             context.TryGetColorGrading() is { } colorGrading)
         {
             var toolTab = editorContext.FindToolTab<ColorGradingTabViewModel>() ??

--- a/src/Beutl.Editor.Components/ColorGradingTab/ColorGradingTabExtension.cs
+++ b/src/Beutl.Editor.Components/ColorGradingTab/ColorGradingTabExtension.cs
@@ -23,8 +23,14 @@ public sealed class ColorGradingTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new ColorGradingTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new ColorGradingTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/ColorGradingTab/ColorGradingTabExtension.cs
+++ b/src/Beutl.Editor.Components/ColorGradingTab/ColorGradingTabExtension.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.ColorGradingTab.ViewModels;
 using Beutl.Editor.Components.ColorGradingTab.Views;
 
@@ -28,7 +29,13 @@ public sealed class ColorGradingTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new ColorGradingTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new ColorGradingTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Graphics.Effects;
@@ -21,10 +22,10 @@ public record ColorGradingWheelMode(string Name, int Value)
 public sealed class ColorGradingTabViewModel : IToolContext, IPropertyEditorContextVisitor
 {
     private readonly CompositeDisposable _disposables = [];
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly CompositeDisposable _effectDisposables = [];
 
-    public ColorGradingTabViewModel(IEditorContext editorContext)
+    public ColorGradingTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
 
@@ -148,8 +149,8 @@ public sealed class ColorGradingTabViewModel : IToolContext, IPropertyEditorCont
             && effectIdValue.TryGetValue(out string? effectIdStr)
             && Guid.TryParse(effectIdStr, out Guid effectId))
         {
-            var scene = _editorContext.GetService<Scene>();
-            var colorGrading = scene?.FindById(effectId) as ColorGrading;
+            Scene scene = _editorContext.Scene;
+            var colorGrading = scene.FindById(effectId) as ColorGrading;
             Effect.Value = colorGrading;
         }
 

--- a/src/Beutl.Editor.Components/ColorScopesTab/ColorScopesTabExtension.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ColorScopesTabExtension.cs
@@ -23,8 +23,14 @@ public sealed class ColorScopesTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new ColorScopesTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new ColorScopesTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/ColorScopesTab/ColorScopesTabExtension.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ColorScopesTabExtension.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.ColorScopesTab.ViewModels;
 using Beutl.Editor.Components.ColorScopesTab.Views;
 
@@ -28,7 +29,13 @@ public sealed class ColorScopesTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new ColorScopesTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new ColorScopesTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Media;
 using Beutl.Media.Source;
-using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.ColorScopesTab.ViewModels;
@@ -10,13 +10,13 @@ namespace Beutl.Editor.Components.ColorScopesTab.ViewModels;
 public sealed class ColorScopesTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly IPreviewPlayer _player;
 
-    public ColorScopesTabViewModel(IEditorContext editorContext)
+    public ColorScopesTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
-        _player = editorContext.GetRequiredService<IPreviewPlayer>();
+        _player = editorContext.Player;
         SourceBitmap.Value = _player.PreviewImage.Value;
 
         // Update scope after rendering is complete

--- a/src/Beutl.Editor.Components/CurvesTab/CurvesTabExtension.cs
+++ b/src/Beutl.Editor.Components/CurvesTab/CurvesTabExtension.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.CurvesTab.ViewModels;
 using Beutl.Editor.Components.CurvesTab.Views;
 
@@ -28,7 +29,13 @@ public sealed class CurvesTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new CurvesTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new CurvesTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/CurvesTab/CurvesTabExtension.cs
+++ b/src/Beutl.Editor.Components/CurvesTab/CurvesTabExtension.cs
@@ -23,8 +23,14 @@ public sealed class CurvesTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new CurvesTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new CurvesTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 using Beutl.Controls.Curves;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Graphics;
@@ -17,15 +18,15 @@ public sealed class CurvesTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly CompositeDisposable _effectDisposables = [];
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly IPreviewPlayer _player;
     private readonly Scene _scene;
 
-    public CurvesTabViewModel(IEditorContext editorContext)
+    public CurvesTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
-        _player = editorContext.GetService<IPreviewPlayer>()!;
-        _scene = editorContext.GetService<Scene>()!;
+        _player = editorContext.Player;
+        _scene = editorContext.Scene;
 
         SourceBitmap.Value = _player.PreviewImage.Value;
 
@@ -269,7 +270,7 @@ public sealed class CurvesTabViewModel : IToolContext
     public object? GetService(Type serviceType)
     {
         if (serviceType == typeof(HistoryManager))
-            return _editorContext.GetService<HistoryManager>();
+            return _editorContext.HistoryManager;
 
         if (serviceType == typeof(Element))
             return Effect.Value?.FindHierarchicalParent<Element>();
@@ -328,7 +329,7 @@ public sealed class CurvesTabViewModel : IToolContext
         if (effect == null)
             return;
 
-        var history = _editorContext.GetService<HistoryManager>()!;
+        HistoryManager history = _editorContext.HistoryManager;
 
         MasterCurve.Value = CreateCurve(effect.MasterCurve, history);
         RedCurve.Value = CreateCurve(effect.RedCurve, history);

--- a/src/Beutl.Editor.Components/ElementPropertyTab/ElementPropertyTabExtension.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/ElementPropertyTabExtension.cs
@@ -27,8 +27,14 @@ public sealed class ElementPropertyTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new ElementPropertyTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new ElementPropertyTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/ElementPropertyTab/ElementPropertyTabExtension.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/ElementPropertyTabExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.ElementPropertyTab.ViewModels;
 using Beutl.Editor.Components.ElementPropertyTab.Views;
 
@@ -32,7 +33,13 @@ public sealed class ElementPropertyTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new ElementPropertyTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new ElementPropertyTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/ElementPropertyTab/ViewModels/ElementPropertyTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/ViewModels/ElementPropertyTabViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Specialized;
 using System.Text.Json.Nodes;
 
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.ProjectSystem;
@@ -15,14 +16,14 @@ namespace Beutl.Editor.Components.ElementPropertyTab.ViewModels;
 public sealed class ElementPropertyTabViewModel : IToolContext
 {
     private readonly IDisposable _disposable0;
-    private IEditorContext _editorContext;
+    private ISceneEditorContext _editorContext;
     private IDisposable? _disposable1;
     private Element? _oldElement;
 
-    public ElementPropertyTabViewModel(IEditorContext editorContext)
+    public ElementPropertyTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
-        Element = editorContext.GetRequiredService<IEditorSelection>().SelectedObject
+        Element = editorContext.Selection.SelectedObject
             .Select(x => x as Element)
             .ToReactiveProperty();
 
@@ -111,7 +112,7 @@ public sealed class ElementPropertyTabViewModel : IToolContext
 
     public ToolTabExtension Extension => ElementPropertyTabExtension.Instance;
 
-    public IEditorContext ParentContext => _editorContext;
+    public ISceneEditorContext ParentContext => _editorContext;
 
     public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
 

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/ElementPropertyTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/ElementPropertyTabView.axaml.cs
@@ -58,7 +58,7 @@ public sealed partial class ElementPropertyTabView : UserControl
             && DataContext is ElementPropertyTabViewModel vm
             && vm.Element.Value is Element element)
         {
-            HistoryManager history = vm.GetRequiredService<HistoryManager>();
+            HistoryManager history = vm.ParentContext.HistoryManager;
             element.AddObject((EngineObject)Activator.CreateInstance(item)!);
             history.Commit(CommandNames.AddObject);
 

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml.cs
@@ -135,7 +135,7 @@ public sealed partial class EngineObjectPropertyView : UserControl
                     Element.Value: { } element
                 } viewModel)
             {
-                HistoryManager history = viewModel.GetRequiredService<HistoryManager>();
+                HistoryManager history = viewModel.ParentContext.HistoryManager;
                 element.Objects.Move(oldIndex, newIndex);
                 history.Commit(CommandNames.MoveObject);
             }

--- a/src/Beutl.Editor.Components/GraphEditorTab/GraphEditorTabExtension.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/GraphEditorTabExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.GraphEditorTab.ViewModels;
 using Beutl.Editor.Components.GraphEditorTab.Views;
 
@@ -28,7 +29,13 @@ public sealed class GraphEditorTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new GraphEditorTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new GraphEditorTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/GraphEditorTab/GraphEditorTabExtension.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/GraphEditorTabExtension.cs
@@ -23,8 +23,14 @@ public sealed class GraphEditorTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new GraphEditorTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new GraphEditorTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
@@ -4,8 +4,10 @@ using Beutl.Animation;
 using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.GraphEditorTab.ViewModels;
@@ -14,6 +16,7 @@ public sealed record GraphEditorItemViewModel(string Name, KeyFrameAnimation Obj
 
 public sealed class GraphEditorTabViewModel : IToolContext
 {
+    private readonly ILogger _logger = Log.CreateLogger<GraphEditorTabViewModel>();
     private readonly ISceneEditorContext _editorContext;
     private readonly CompositeDisposable _disposables = [];
     private readonly CompositeDisposable _animationDisposables = [];
@@ -189,8 +192,9 @@ public sealed class GraphEditorTabViewModel : IToolContext
                 Select(Items.FirstOrDefault(i => i.Object.Id == anmId)?.Object);
             }
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to restore GraphEditorTab state.");
         }
     }
 

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
@@ -1,11 +1,11 @@
 ﻿using System.Text.Json.Nodes;
 using Avalonia.Threading;
 using Beutl.Animation;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
-using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.GraphEditorTab.ViewModels;
@@ -14,12 +14,12 @@ public sealed record GraphEditorItemViewModel(string Name, KeyFrameAnimation Obj
 
 public sealed class GraphEditorTabViewModel : IToolContext
 {
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly CompositeDisposable _disposables = [];
     private readonly CompositeDisposable _animationDisposables = [];
     private bool _disposed;
 
-    public GraphEditorTabViewModel(IEditorContext editorContext)
+    public GraphEditorTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
         Element.Subscribe(_ => Refresh()).DisposeWith(_disposables);
@@ -180,7 +180,7 @@ public sealed class GraphEditorTabViewModel : IToolContext
     {
         try
         {
-            var scene = _editorContext.GetRequiredService<Scene>();
+            Scene scene = _editorContext.Scene;
             if (json.TryGetPropertyValueAsJsonValue("elementId", out Guid elmId)
                 && json.TryGetPropertyValueAsJsonValue("animationId", out Guid anmId)
                 && scene.FindById(elmId) is Element elm)

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorViewModel.cs
@@ -8,6 +8,7 @@ using Avalonia.Threading;
 using Beutl.Animation;
 using Beutl.Animation.Easings;
 using Beutl.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Services;
 using Beutl.Logging;
@@ -21,7 +22,7 @@ using Reactive.Bindings;
 namespace Beutl.Editor.Components.GraphEditorTab.ViewModels;
 
 public sealed class GraphEditorViewModel<T>(
-    IEditorContext editorContext,
+    ISceneEditorContext editorContext,
     KeyFrameAnimation<T> animation,
     Element? element)
     : GraphEditorViewModel(editorContext, animation, element)
@@ -70,18 +71,18 @@ public abstract class GraphEditorViewModel : IDisposable
     private bool _editting;
     private TimeSpan _pointerPosition;
 
-    protected GraphEditorViewModel(IEditorContext editorContext, IKeyFrameAnimation animation, Element? element)
+    protected GraphEditorViewModel(ISceneEditorContext editorContext, IKeyFrameAnimation animation, Element? element)
     {
         _logger.LogInformation("Initializing GraphEditorViewModel");
         EditorContext = editorContext;
         Element = element;
         Animation = animation;
 
-        var timelineOptions = editorContext.GetRequiredService<ITimelineOptionsProvider>();
-        _editorClock = editorContext.GetRequiredService<IEditorClock>();
+        ITimelineOptionsProvider timelineOptions = editorContext.TimelineOptions;
+        _editorClock = editorContext.Clock;
         Options = timelineOptions.Options;
         Scene = timelineOptions.Scene;
-        HistoryManager = editorContext.GetRequiredService<HistoryManager>();
+        HistoryManager = editorContext.HistoryManager;
 
         UseGlobalClock = ((CoreObject)animation).GetObservable(KeyFrameAnimation.UseGlobalClockProperty)
             .ToReadOnlyReactivePropertySlim()
@@ -216,7 +217,7 @@ public abstract class GraphEditorViewModel : IDisposable
 
     public GraphEditorViewViewModelFactory? Factory { get; }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public HistoryManager HistoryManager { get; }
 

--- a/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml.cs
@@ -117,8 +117,8 @@ public partial class GraphEditorView : UserControl
         var mode = GlobalConfiguration.Instance.EditorConfig.TimelineAutoScrollMode;
         if (mode == TimelineAutoScrollMode.None) return;
 
-        var previewPlayer = viewModel.EditorContext.GetService<IPreviewPlayer>();
-        if (previewPlayer == null || !previewPlayer.IsPlaying.Value) return;
+        IPreviewPlayer previewPlayer = viewModel.EditorContext.Player;
+        if (!previewPlayer.IsPlaying.Value) return;
 
         float scale = viewModel.Options.Value.Scale;
         double seekBarPixel = currentTime.TimeToPixel(scale);

--- a/src/Beutl.Editor.Components/NodeGraphTab/NodeGraphTabExtension.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/NodeGraphTabExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.NodeGraphTab.ViewModels;
 using Beutl.Editor.Components.NodeGraphTab.Views;
 
@@ -26,7 +27,13 @@ public sealed class NodeGraphTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new NodeGraphTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new NodeGraphTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/NodeGraphTab/NodeGraphTabExtension.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/NodeGraphTabExtension.cs
@@ -21,8 +21,14 @@ public sealed class NodeGraphTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new NodeGraphTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new NodeGraphTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/GraphNodeViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/GraphNodeViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Beutl.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.NodeGraph;
 using Beutl.NodeGraph.Nodes.Group;
@@ -82,7 +83,7 @@ public sealed class GraphNodeViewModel : IDisposable, IJsonSerializable, IProper
                     tree.Disconnect(connection);
                 }
                 tree.Nodes.Remove(GraphNode);
-                EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.RemoveNode);
+                EditorContext.HistoryManager.Commit(CommandNames.RemoveNode);
             }
         });
 
@@ -91,7 +92,7 @@ public sealed class GraphNodeViewModel : IDisposable, IJsonSerializable, IProper
 
     public GraphNode GraphNode { get; }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public NodeGraphViewModel NodeGraphViewModel { get; }
 
@@ -220,13 +221,13 @@ public sealed class GraphNodeViewModel : IDisposable, IJsonSerializable, IProper
 
         GraphNode.Position = (Position.Value.X, Position.Value.Y);
 
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveNode);
+        EditorContext.HistoryManager.Commit(CommandNames.MoveNode);
     }
 
     public void UpdateName(string? name)
     {
         GraphNode.Name = name!;
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.RenameNode);
+        EditorContext.HistoryManager.Commit(CommandNames.RenameNode);
     }
 
     public void WriteToJson(JsonObject json)

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphTabViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphTabViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 using Beutl.Collections.Pooled;
+using Beutl.Editor;
 using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,7 @@ public sealed class NodeGraphNavigationItem : IDisposable, IJsonSerializable
         NodeGraph = nodeGraph;
     }
 
-    public NodeGraphNavigationItem(ReadOnlyReactivePropertySlim<string> name, GraphModel nodeGraph, IEditorContext editorContext)
+    public NodeGraphNavigationItem(ReadOnlyReactivePropertySlim<string> name, GraphModel nodeGraph, ISceneEditorContext editorContext)
     {
         NodeGraph = nodeGraph;
         _lazyViewModel = new Lazy<NodeGraphViewModel>(() => new NodeGraphViewModel(NodeGraph, editorContext));
@@ -58,9 +59,9 @@ public sealed class NodeGraphTabViewModel : IToolContext
 {
     private readonly ReactiveProperty<bool> _isSelected = new(false);
     private readonly CompositeDisposable _disposables = [];
-    private IEditorContext _editorContext;
+    private ISceneEditorContext _editorContext;
 
-    public NodeGraphTabViewModel(IEditorContext editorContext)
+    public NodeGraphTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
 
@@ -216,7 +217,7 @@ public sealed class NodeGraphTabViewModel : IToolContext
 
     private string ViewStateDirectory()
     {
-        Scene scene = _editorContext.GetRequiredService<Scene>();
+        Scene scene = _editorContext.Scene;
         string directory = Path.GetDirectoryName(scene.Uri!.LocalPath)!;
 
         directory = Path.Combine(directory, Constants.BeutlFolder, Constants.ViewStateFolder);
@@ -279,7 +280,7 @@ public sealed class NodeGraphTabViewModel : IToolContext
 
     public void ReadFromJson(JsonObject json)
     {
-        Scene scene = _editorContext.GetRequiredService<Scene>();
+        Scene scene = _editorContext.Scene;
         if (Model.Value == null
             && json.TryGetPropertyValue("ModelId", out JsonNode? idNode)
             && (idNode as JsonValue)?.TryGetValue(out Guid id) == true)

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Nodes;
 using Avalonia;
+using Beutl.Editor;
 using Beutl.NodeGraph;
 using Beutl.NodeGraph.Nodes.Group;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +12,7 @@ public sealed class NodeGraphViewModel : IDisposable, IJsonSerializable
 {
     private readonly CompositeDisposable _disposables = [];
 
-    public NodeGraphViewModel(GraphModel graph, IEditorContext editorContext)
+    public NodeGraphViewModel(GraphModel graph, ISceneEditorContext editorContext)
     {
         NodeGraph = graph;
         EditorContext = editorContext;
@@ -68,7 +69,7 @@ public sealed class NodeGraphViewModel : IDisposable, IJsonSerializable
             .DisposeWith(_disposables);
     }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public CoreList<GraphNodeViewModel> Nodes { get; } = [];
 
@@ -113,7 +114,7 @@ public sealed class NodeGraphViewModel : IDisposable, IJsonSerializable
         }
 
         NodeGraph.Nodes.Add(node);
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.AddNode);
+        EditorContext.HistoryManager.Commit(CommandNames.AddNode);
     }
 
     public void Dispose()

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeMonitorViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeMonitorViewModel.cs
@@ -24,7 +24,7 @@ public class NodeMonitorViewModel : NodeMemberViewModel
             .DisposeWith(_disposables);
 
         // IsPlaying, IsExpanded -> IsEnabled 連動
-        var previewPlayer = nodeViewModel.EditorContext.GetRequiredService<IPreviewPlayer>();
+        IPreviewPlayer previewPlayer = nodeViewModel.EditorContext.Player;
 
         previewPlayer.IsPlaying.CombineLatest(nodeViewModel.IsExpanded)
             // IsPlayingがfalseで、かつIsExpandedがtrueのときのみ有効

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodePortViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodePortViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Beutl.Collections;
 using Beutl.Controls;
+using Beutl.Editor;
 using Beutl.NodeGraph;
 using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
@@ -12,7 +13,7 @@ namespace Beutl.Editor.Components.NodeGraphTab.ViewModels;
 
 public class NodePortViewModel : NodeMemberViewModel
 {
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly CompositeDisposable _disposables = new();
     private IDisposable? _connectionsSubscription;
 
@@ -181,7 +182,7 @@ public class NodePortViewModel : NodeMemberViewModel
 
     public bool TryConnect(NodePortViewModel target)
     {
-        HistoryManager history = _editorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = _editorContext.HistoryManager;
         if (target.Model == null ^ Model == null)
         {
             // どちらかがNull
@@ -226,7 +227,7 @@ public class NodePortViewModel : NodeMemberViewModel
 
     public bool TryDisconnect(NodePortViewModel target, ConnectionViewModel? connection)
     {
-        HistoryManager history = _editorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = _editorContext.HistoryManager;
         var graph = GraphNodeViewModel.NodeGraphViewModel.NodeGraph;
         var conn = connection?.Connection;
         if (conn == null && Model != null && target.Model != null
@@ -252,7 +253,7 @@ public class NodePortViewModel : NodeMemberViewModel
 
     public void DisconnectAll()
     {
-        HistoryManager history = _editorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = _editorContext.HistoryManager;
         var graph = GraphNodeViewModel.NodeGraphViewModel.NodeGraph;
 
         var connections = Model switch
@@ -301,7 +302,7 @@ public class NodePortViewModel : NodeMemberViewModel
         }
 
         GraphNode.Items.Remove(generatedNodePort);
-        _editorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.RemovePort);
+        _editorContext.HistoryManager.Commit(CommandNames.RemovePort);
     }
 
     public void MoveConnectionSlot(int oldIndex, int newIndex)
@@ -309,7 +310,7 @@ public class NodePortViewModel : NodeMemberViewModel
         if (Model is IListPort listNodePort)
         {
             listNodePort.MoveConnection(oldIndex, newIndex);
-            _editorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveConnection);
+            _editorContext.HistoryManager.Commit(CommandNames.MoveConnection);
         }
     }
 
@@ -318,13 +319,13 @@ public class NodePortViewModel : NodeMemberViewModel
         var graph = GraphNodeViewModel.NodeGraphViewModel.NodeGraph;
         Connection connection = connVM.Connection;
         graph.Disconnect(connection);
-        _editorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.DisconnectPort);
+        _editorContext.HistoryManager.Commit(CommandNames.DisconnectPort);
     }
 
     public void UpdateName(string? e)
     {
         Model!.Name = e!;
-        _editorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.RenamePort);
+        _editorContext.HistoryManager.Commit(CommandNames.RenamePort);
     }
 
     protected override void OnDispose()

--- a/src/Beutl.Editor.Components/ObjectPropertyTab/ObjectPropertyTabExtension.cs
+++ b/src/Beutl.Editor.Components/ObjectPropertyTab/ObjectPropertyTabExtension.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
 using Beutl.Editor.Components.ObjectPropertyTab.Views;
 
@@ -32,7 +33,13 @@ public sealed class ObjectPropertyTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new ObjectPropertyTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new ObjectPropertyTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/ObjectPropertyTab/ObjectPropertyTabExtension.cs
+++ b/src/Beutl.Editor.Components/ObjectPropertyTab/ObjectPropertyTabExtension.cs
@@ -27,8 +27,14 @@ public sealed class ObjectPropertyTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new ObjectPropertyTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new ObjectPropertyTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/ObjectPropertyTab/ViewModels/ObjectPropertyTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ObjectPropertyTab/ViewModels/ObjectPropertyTabViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +11,7 @@ namespace Beutl.Editor.Components.ObjectPropertyTab.ViewModels;
 public sealed class ObjectPropertyTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
-    private readonly IEditorContext _editorContext;
+    private readonly ISceneEditorContext _editorContext;
     private readonly IPropertiesEditorFactory _factory;
     // インデックスが大きい方が新しい
     private readonly List<IPropertiesEditorViewModel> _cache = new(8);
@@ -18,19 +19,19 @@ public sealed class ObjectPropertyTabViewModel : IToolContext
     private readonly ConditionalWeakTable<ICoreObject, IServiceProvider> _providers = new();
     private readonly ReactivePropertySlim<bool> _canBack = new();
 
-    public ObjectPropertyTabViewModel(IEditorContext editorContext)
+    public ObjectPropertyTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
         _factory = editorContext.GetRequiredService<IPropertiesEditorFactory>();
 
-        editorContext.GetRequiredService<IEditorSelection>().SelectedObject
+        editorContext.Selection.SelectedObject
             .Subscribe(obj => NavigateCore(obj, false, null))
             .DisposeWith(_disposables);
     }
 
     public ToolTabExtension Extension => ObjectPropertyTabExtension.Instance;
 
-    public IEditorContext ParentContext => _editorContext;
+    public ISceneEditorContext ParentContext => _editorContext;
 
     public ReactiveProperty<IPropertiesEditorViewModel?> ChildContext { get; } = new();
 

--- a/src/Beutl.Editor.Components/PathEditorTab/PathEditorTabExtension.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/PathEditorTabExtension.cs
@@ -2,10 +2,9 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.PathEditorTab.ViewModels;
 using Beutl.Editor.Components.PathEditorTab.Views;
-using Beutl.Editor.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Beutl.Editor.Components.PathEditorTab;
 
@@ -24,30 +23,25 @@ public sealed class PathEditorTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        // IEditorContextがITimelineOptionsProviderサービスを提供しているかチェック
-        if (editorContext.GetService<ITimelineOptionsProvider>() != null)
+        if (editorContext is ISceneEditorContext)
         {
             control = new PathEditorTabView();
             return true;
         }
-        else
-        {
-            control = null;
-            return false;
-        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        if (editorContext.GetService<ITimelineOptionsProvider>() != null)
+        if (editorContext is ISceneEditorContext sceneContext)
         {
-            context = new PathEditorTabViewModel(editorContext);
+            context = new PathEditorTabViewModel(sceneContext);
             return true;
         }
-        else
-        {
-            context = null;
-            return false;
-        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/PathEditorTab/Services/IPathEditorContext.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Services/IPathEditorContext.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Editor.Components.PropertyEditors.Services;
+﻿using Beutl.Editor;
+using Beutl.Editor.Components.PropertyEditors.Services;
 using Beutl.Media;
 using Beutl.ProjectSystem;
 
@@ -8,7 +9,7 @@ namespace Beutl.Editor.Components.PathEditorTab.Services;
 
 public interface IPathEditorContext
 {
-    IEditorContext EditorContext { get; }
+    ISceneEditorContext EditorContext { get; }
 
     IReadOnlyReactiveProperty<Element?> Element { get; }
 

--- a/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorTabViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PathEditorTab.Services;
 using Beutl.Editor.Components.PropertyEditors.Services;
@@ -15,11 +16,11 @@ public sealed class PathEditorTabViewModel : IDisposable, IPathEditorContext, IT
     private readonly CompositeDisposable _disposables = [];
     private readonly IEditorClock _clock;
 
-    public PathEditorTabViewModel(IEditorContext editorContext)
+    public PathEditorTabViewModel(ISceneEditorContext editorContext)
     {
         EditorContext = editorContext;
-        _clock = editorContext.GetRequiredService<IEditorClock>();
-        var player = editorContext.GetRequiredService<IPreviewPlayer>();
+        _clock = editorContext.Clock;
+        IPreviewPlayer player = editorContext.Player;
 
         IsPlaying = player.IsPlaying
             .ToReadOnlyReactiveProperty()
@@ -77,7 +78,7 @@ public sealed class PathEditorTabViewModel : IDisposable, IPathEditorContext, IT
             .DisposeWith(_disposables);
     }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public IReactiveProperty<IPathFigureEditorContext?> FigureContext { get; } =
         new ReactiveProperty<IPathFigureEditorContext?>();

--- a/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorViewModel.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Beutl.Composition;
 using Beutl.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PathEditorTab.Services;
 using Beutl.Editor.Components.PropertyEditors.Services;
@@ -20,11 +21,11 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorContext
     private readonly IEditorClock _clock;
     private readonly Scene _scene;
 
-    public PathEditorViewModel(IEditorContext editorContext, IPreviewPlayer player)
+    public PathEditorViewModel(ISceneEditorContext editorContext, IPreviewPlayer player)
     {
         EditorContext = editorContext;
-        _clock = editorContext.GetRequiredService<IEditorClock>();
-        _scene = editorContext.GetRequiredService<Scene>();
+        _clock = editorContext.Clock;
+        _scene = editorContext.Scene;
 
         SceneWidth = _scene.GetObservable(Scene.FrameSizeProperty)
             .Select(v => v.Width)
@@ -127,7 +128,7 @@ public sealed class PathEditorViewModel : IDisposable, IPathEditorContext
         return matrix;
     }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public IReactiveProperty<IPathFigureEditorContext?> FigureContext { get; } =
         new ReactiveProperty<IPathFigureEditorContext?>();

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
@@ -85,14 +85,14 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
         // 個別にBindingするのではなく、一括で位置を変更する
         this.GetObservable(DataContextProperty)
             .Select(v => v as PathEditorTabViewModel)
-            .Select(v => v?.EditorContext.GetService<IPreviewPlayer>()?.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
+            .Select(v => v?.EditorContext.Player.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
             .Switch()
             .CombineLatest(this.GetObservable(ScaleProperty), this.GetObservable(MatrixProperty))
             .Subscribe(_ => UpdateThumbPosition());
 
         this.GetObservable(DataContextProperty)
             .Select(v => v as PathEditorTabViewModel)
-            .Select(v => v?.EditorContext.GetService<IPreviewPlayer>()?.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
+            .Select(v => v?.EditorContext.Player.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
             .Switch()
             .CombineLatest(view.GetObservable(PathGeometryControl.FigureProperty))
             .Subscribe(_ => UpdateBackgroundGeometry());
@@ -180,7 +180,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
         {
             if (DataContext is PathEditorTabViewModel viewModel)
             {
-                var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+                IEditorClock clock = viewModel.EditorContext.Clock;
                 foreach (Thumb thumb in canvas.Children.OfType<Thumb>())
                 {
                     if (thumb.DataContext is PathSegment segment)
@@ -324,7 +324,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
             && DataContext is PathEditorTabViewModel { Element.Value: { } element } viewModel
             && _dragStates?.Count > 0)
         {
-            viewModel.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.EditPathPoint);
+            viewModel.EditorContext.HistoryManager.Commit(CommandNames.EditPathPoint);
         }
 
         _dragStates = null;
@@ -515,7 +515,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
             && viewModel.PathFigure.Value is { } figure
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)
         {
-            var clock = viewModel.GetRequiredService<IEditorClock>();
+            IEditorClock clock = viewModel.EditorContext.Clock;
             int index = figure.Segments.Count;
             BtlPoint lastPoint = default;
             if (index > 0)

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
@@ -75,7 +75,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
         // TODO: Scale, Matrixが変わった時に位置がずれる
         this.GetObservable(DataContextProperty)
             .Select(v => v as PathEditorViewModel)
-            .Select(v => v?.EditorContext.GetService<IPreviewPlayer>()?.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
+            .Select(v => v?.EditorContext.Player.AfterRendered ?? Observable.ReturnThenNever(Unit.Default))
             .Switch()
             .CombineLatest(this.GetObservable(ScaleProperty), this.GetObservable(MatrixProperty))
             .Subscribe(_ => UpdateThumbPosition());
@@ -101,7 +101,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
         {
             if (DataContext is PathEditorViewModel viewModel)
             {
-                var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+                IEditorClock clock = viewModel.EditorContext.Clock;
                 foreach (Thumb thumb in canvas.Children.OfType<Thumb>())
                 {
                     if (thumb.DataContext is PathSegment segment)
@@ -251,7 +251,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
             && viewModel.PathFigure.Value is { } figure
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)
         {
-            var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+            IEditorClock clock = viewModel.EditorContext.Clock;
             int index = figure.Segments.Count;
             BtlPoint lastPoint = default;
             if (index > 0)

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathPointDragBehavior.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathPointDragBehavior.cs
@@ -77,7 +77,7 @@ public sealed class PathPointDragBehavior : Behavior<Thumb>
         if (parent is { DataContext: IPathEditorContext { Element.Value: { } element } viewModel })
         {
             parent.SkipUpdatePosition = false;
-            viewModel.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.EditPathPoint);
+            viewModel.EditorContext.HistoryManager.Commit(CommandNames.EditPathPoint);
         }
 
         _coordDragStates = null;
@@ -290,13 +290,13 @@ public sealed class PathPointDragBehavior : Behavior<Thumb>
                                 Set(c.Previous);
                                 Set(c.Next);
 
-                                var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+                                IEditorClock clock = viewModel.EditorContext.Clock;
                                 UpdateThumbPosition(c.Thumb,
                                     c.GetInterpolatedValue(clock.CurrentTime.Value));
                             }
                             else
                             {
-                                var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+                                IEditorClock clock = viewModel.EditorContext.Clock;
                                 var ctx = new CompositionContext(clock.CurrentTime.Value);
                                 BtlPoint point =
                                     _dragState.GetInterpolatedValue(clock.CurrentTime.Value);
@@ -536,8 +536,8 @@ public sealed class PathPointDragBehavior : Behavior<Thumb>
         PathSegment segment,
         IProperty<BtlPoint> property)
     {
-        var scene = viewModel.EditorContext.GetRequiredService<Scene>();
-        var clock = viewModel.EditorContext.GetRequiredService<IEditorClock>();
+        Scene scene = viewModel.EditorContext.Scene;
+        IEditorClock clock = viewModel.EditorContext.Clock;
         ProjectSystem.Element? element = viewModel.Element.Value;
         int rate = scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
         TimeSpan globalkeyTime = clock.CurrentTime.Value;

--- a/src/Beutl.Editor.Components/SceneSettingsTab/SceneSettingsTabExtension.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/SceneSettingsTabExtension.cs
@@ -25,8 +25,14 @@ public sealed class SceneSettingsTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new SceneSettingsTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new SceneSettingsTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/SceneSettingsTab/SceneSettingsTabExtension.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/SceneSettingsTabExtension.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls;
 
+using Beutl.Editor;
 using Beutl.Editor.Components.SceneSettingsTab.ViewModels;
 using Beutl.Editor.Components.SceneSettingsTab.Views;
 
@@ -30,7 +31,13 @@ public sealed class SceneSettingsTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new SceneSettingsTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new SceneSettingsTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -14,15 +14,15 @@ namespace Beutl.Editor.Components.SceneSettingsTab.ViewModels;
 public sealed class SceneSettingsTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposable = [];
-    private IEditorContext _editorContext;
+    private ISceneEditorContext _editorContext;
     private Scene _scene;
     private ITimelineOptionsProvider _optionsProvider;
 
-    public SceneSettingsTabViewModel(IEditorContext editorContext)
+    public SceneSettingsTabViewModel(ISceneEditorContext editorContext)
     {
         _editorContext = editorContext;
-        _scene = editorContext.GetService<Scene>()!;
-        _optionsProvider = editorContext.GetService<ITimelineOptionsProvider>()!;
+        _scene = editorContext.Scene;
+        _optionsProvider = editorContext.TimelineOptions;
         IObservable<Media.PixelSize> frameSize = _scene.GetObservable(Scene.FrameSizeProperty);
         Width = frameSize.Select(v => v.Width)
             .ToReactiveProperty()
@@ -76,7 +76,7 @@ public sealed class SceneSettingsTabViewModel : IToolContext
                         || start != _scene.Start
                         || duration != _scene.Duration)
                     {
-                        HistoryManager history = _editorContext.GetService<HistoryManager>()!;
+                        HistoryManager history = _editorContext.HistoryManager;
                         _scene.FrameSize = new Media.PixelSize(Width.Value, Height.Value);
                         _scene.Start = start;
                         _scene.Duration = duration;

--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -89,8 +89,14 @@ public sealed class TimelineTabExtension : ToolTabExtension
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
     {
-        control = new TimelineTabView();
-        return true;
+        if (editorContext is ISceneEditorContext)
+        {
+            control = new TimelineTabView();
+            return true;
+        }
+
+        control = null;
+        return false;
     }
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)

--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
+using Beutl.Editor;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Components.TimelineTab.Views;
 
@@ -94,7 +95,13 @@ public sealed class TimelineTabExtension : ToolTabExtension
 
     public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
     {
-        context = new TimelineTabViewModel(editorContext);
-        return true;
+        if (editorContext is ISceneEditorContext sceneContext)
+        {
+            context = new TimelineTabViewModel(sceneContext);
+            return true;
+        }
+
+        context = null;
+        return false;
     }
 }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -117,7 +117,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             .Subscribe(c =>
             {
                 Model.AccentColor = c.ToBtlColor();
-                Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.ChangeElementColor);
+                Timeline.EditorContext.HistoryManager.Commit(CommandNames.ChangeElementColor);
             })
             .AddTo(_disposables);
 
@@ -440,7 +440,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         int zindex = Timeline.ToLayerNumber(Margin.Value);
 
         Scene.MoveChild(zindex, start, length, Model);
-        Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+        Timeline.EditorContext.HistoryManager.Commit(CommandNames.MoveElement);
 
         await AnimationRequest(context);
     }
@@ -502,7 +502,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
 
     private void OnExclude()
     {
-        var history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        var history = Timeline.EditorContext.HistoryManager;
         // IsSelectedがtrueのものをまとめて削除する。
         foreach (ElementViewModel element in GetGroupOrSelectedElements())
         {
@@ -513,7 +513,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
 
     private void OnDelete()
     {
-        var history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        var history = Timeline.EditorContext.HistoryManager;
         foreach (ElementViewModel element in GetGroupOrSelectedElements())
         {
             Scene.DeleteChild(element.Model);
@@ -597,7 +597,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             }
         }
 
-        Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.GroupElements);
+        Timeline.EditorContext.HistoryManager.Commit(CommandNames.GroupElements);
     }
 
     private void OnUngroupSelectedElements()
@@ -605,7 +605,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         IReadOnlyCollection<Guid> ids = GetSelectedIdsOrSelf();
         RemoveIdsFromElementSets(ids);
 
-        Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.UngroupElements);
+        Timeline.EditorContext.HistoryManager.Commit(CommandNames.UngroupElements);
     }
 
     private void OnSetAttached(ImmutableHashSet<Guid> group)
@@ -639,7 +639,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         {
             if (await SetClipboard([.. targets]))
             {
-                var history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                var history = Timeline.EditorContext.HistoryManager;
                 foreach (ElementViewModel target in targets)
                 {
                     Scene.RemoveChild(target.Model);
@@ -740,7 +740,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             }
         }
 
-        Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.SplitElement);
+        Timeline.EditorContext.HistoryManager.Commit(CommandNames.SplitElement);
     }
 
     private async void OnChangeToOriginalDuration()
@@ -764,7 +764,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             }
 
             Scene.MoveChild(Model.ZIndex, Model.Start, duration, Model);
-            Timeline.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.MoveElement);
+            Timeline.EditorContext.HistoryManager.Commit(CommandNames.MoveElement);
 
             await AnimationRequest(context);
         }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/InlineAnimationLayerViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/InlineAnimationLayerViewModel.cs
@@ -37,7 +37,7 @@ public sealed class InlineAnimationLayerViewModel<T>(
                 kfAnimation.KeyFrames.FirstOrDefault(v => Math.Abs(v.KeyTime.Ticks - keyTime.Ticks) <= threshold.Ticks);
             if (keyFrame != null)
             {
-                HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                HistoryManager history = Timeline.EditorContext.HistoryManager;
                 keyFrame.Easing = easing;
                 history.Commit(CommandNames.ChangeEasing);
             }
@@ -51,7 +51,7 @@ public sealed class InlineAnimationLayerViewModel<T>(
     public override void InsertKeyFrame(Easing easing, TimeSpan keyTime)
     {
         if (Property.Animation is not KeyFrameAnimation<T> animation) return;
-        HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = Timeline.EditorContext.HistoryManager;
 
         AnimationOperations.InsertKeyFrame(
             animation: animation,
@@ -251,7 +251,7 @@ public abstract class InlineAnimationLayerViewModel : IDisposable
 
         try
         {
-            HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+            HistoryManager history = Timeline.EditorContext.HistoryManager;
             KeyFrameAnimation animation = (KeyFrameAnimation)Property.Animation!;
 
             if (discriminator.GenericTypeArguments[0] != animation.ValueType)
@@ -304,7 +304,7 @@ public abstract class InlineAnimationLayerViewModel : IDisposable
 
         try
         {
-            HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+            HistoryManager history = Timeline.EditorContext.HistoryManager;
             KeyFrameAnimation animation = (KeyFrameAnimation)Property.Animation!;
 
             KeyFrame newKeyFrame = (KeyFrame)Activator.CreateInstance(discriminator)!;
@@ -344,7 +344,7 @@ public abstract class InlineAnimationLayerViewModel : IDisposable
 
     public void DeleteAnimation()
     {
-        HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = Timeline.EditorContext.HistoryManager;
 
         Property.Animation = null;
         history.Commit(CommandNames.DeleteAnimation);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/InlineKeyFrameViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/InlineKeyFrameViewModel.cs
@@ -107,7 +107,7 @@ public sealed class InlineKeyFrameViewModel : IDisposable
 
                 KeyFrame newKeyFrame = (KeyFrame)Activator.CreateInstance(type)!;
                 CoreSerializer.PopulateFromJsonObject(newKeyFrame, jsonObj);
-                HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                HistoryManager history = Timeline.EditorContext.HistoryManager;
 
                 if (type.GenericTypeArguments[0] != Parent.Property.PropertyType)
                 {
@@ -140,7 +140,7 @@ public sealed class InlineKeyFrameViewModel : IDisposable
 
     private void Remove()
     {
-        HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = Timeline.EditorContext.HistoryManager;
         AnimationOperations.RemoveKeyFrame(
             animation: Animation,
             keyframe: Model,
@@ -153,7 +153,7 @@ public sealed class InlineKeyFrameViewModel : IDisposable
         float scale = Timeline.Options.Value.Scale;
         Project? proj = Timeline.Scene.FindHierarchicalParent<Project>();
         int rate = proj?.GetFrameRate() ?? 30;
-        HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = Timeline.EditorContext.HistoryManager;
 
         TimeSpan time = Left.Value.PixelToTimeSpan(scale).RoundToRate(rate);
         SplineEasingHelper.Move(Animation, Model, time);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/LayerHeaderViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/LayerHeaderViewModel.cs
@@ -43,7 +43,7 @@ public sealed class LayerHeaderViewModel : IDisposable
         SwitchEnabledCommand = new ReactiveCommand()
             .WithSubscribe(() =>
             {
-                HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                HistoryManager history = Timeline.EditorContext.HistoryManager;
                 try
                 {
                     _skipSubscription = true;
@@ -213,7 +213,7 @@ public sealed class LayerHeaderViewModel : IDisposable
 
     public void SetColor(Color color)
     {
-        HistoryManager history = Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = Timeline.EditorContext.HistoryManager;
         var model = GetOrCreateModel();
         model.Color = color.ToBtlColor();
         history.Commit(CommandNames.ChangeLayerColor);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -9,6 +9,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using Beutl.Animation;
 using Beutl.Configuration;
+using Beutl.Editor;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.TimelineTab.Models;
 using Beutl.Editor.Services;
@@ -38,18 +39,18 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
     private bool _isDisposed;
 
-    public TimelineTabViewModel(IEditorContext editorContext)
+    public TimelineTabViewModel(ISceneEditorContext editorContext)
     {
         _logger.LogInformation("Initializing TimelineTabViewModel.");
         EditorContext = editorContext;
-        var timelineOptions = editorContext.GetRequiredService<ITimelineOptionsProvider>();
-        var editorClock = editorContext.GetRequiredService<IEditorClock>();
+        ITimelineOptionsProvider timelineOptions = editorContext.TimelineOptions;
+        IEditorClock editorClock = editorContext.Clock;
         Scene = timelineOptions.Scene;
         Scale = timelineOptions.Scale;
         Options = timelineOptions.Options;
         CurrentTime = editorClock.CurrentTime;
         MaximumTime = editorClock.MaximumTime;
-        BufferStatus = editorContext.GetRequiredService<IBufferStatus>();
+        BufferStatus = editorContext.BufferStatus;
         FrameSelectionRange = new FrameSelectionRange(Scale).DisposeWith(_disposables);
 
         SeekBarMargin = CurrentTime
@@ -86,7 +87,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
-        AddElement.Subscribe(desc => editorContext.GetRequiredService<IElementAdder>().AddElement(desc)).AddTo(_disposables);
+        AddElement.Subscribe(desc => editorContext.ElementAdder.AddElement(desc)).AddTo(_disposables);
 
         Paste.Subscribe(PasteCore)
             .AddTo(_disposables);
@@ -256,7 +257,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             Scene.Start = time;
         }
 
-        EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.ChangeSceneStart);
+        EditorContext.HistoryManager.Commit(CommandNames.ChangeSceneStart);
 
         _logger.LogInformation("Scene start adjusted to {Time}.", time);
     }
@@ -281,7 +282,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
             Scene.Duration = Scene.Start - time;
             Scene.Start = time;
-            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.ChangeSceneDuration);
+            EditorContext.HistoryManager.Commit(CommandNames.ChangeSceneDuration);
         }
         else
         {
@@ -293,7 +294,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             }
 
             Scene.Duration = time;
-            EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.ChangeSceneDuration);
+            EditorContext.HistoryManager.Commit(CommandNames.ChangeSceneDuration);
             _logger.LogInformation("Scene duration adjusted to {Time}.", time);
         }
     }
@@ -330,7 +331,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public IBufferStatus BufferStatus { get; }
 
-    public IEditorContext EditorContext { get; }
+    public ISceneEditorContext EditorContext { get; }
 
     public ReadOnlyReactivePropertySlim<double> PanelWidth { get; }
 
@@ -544,7 +545,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 RandomFileNameGenerator.GenerateUri(Scene.Uri!, Constants.ElementFileExtension));
         }
 
-        HistoryManager history = EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = EditorContext.HistoryManager;
 
         var idMapping = new Dictionary<Guid, Guid>();
         for (int i = 0; i < oldElements.Length; i++)
@@ -592,7 +593,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         CoreSerializer.StoreToUri(newElement, RandomFileNameGenerator.GenerateUri(
             Scene.Uri!, Constants.ElementFileExtension));
 
-        HistoryManager history = EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = EditorContext.HistoryManager;
         Scene.AddChild(newElement);
         history.Commit(CommandNames.PasteElement);
 
@@ -630,7 +631,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         CoreSerializer.StoreToUri(newElement, RandomFileNameGenerator.GenerateUri(
             dir, Constants.ElementFileExtension));
 
-        HistoryManager history = EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = EditorContext.HistoryManager;
         Scene.AddChild(newElement);
         history.Commit(CommandNames.PasteElement);
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -66,7 +66,7 @@ public sealed partial class ElementView : UserControl
         if (DataContext is not ElementViewModel viewModel) return;
 
         change2OriginalDuration.IsEnabled = viewModel.HasOriginalDuration();
-        splitByCurrent.IsEnabled = viewModel.Model.Range.Contains(viewModel.Timeline.EditorContext.GetRequiredService<IEditorClock>().CurrentTime.Value);
+        splitByCurrent.IsEnabled = viewModel.Model.Range.Contains(viewModel.Timeline.EditorContext.Clock.CurrentTime.Value);
         groupSelectedElements.IsEnabled = viewModel.CanGroupSelectedElements();
         ungroupSelectedElements.IsEnabled = viewModel.CanUngroupSelectedElements();
     }
@@ -171,7 +171,7 @@ public sealed partial class ElementView : UserControl
     private void EnableElementClick(object? sender, RoutedEventArgs e)
     {
         Element model = ViewModel.Model;
-        HistoryManager history = ViewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = ViewModel.Timeline.EditorContext.HistoryManager;
         model.IsEnabled = !model.IsEnabled;
         history.Commit(CommandNames.ChangeElementEnabled);
     }
@@ -260,7 +260,7 @@ public sealed partial class ElementView : UserControl
             return time;
         }
 
-        IEditorClock clock = timeline.EditorContext.GetRequiredService<IEditorClock>();
+        IEditorClock clock = timeline.EditorContext.Clock;
         IEnumerable<TimeSpan> candidates = SnapHelper
             .CollectElementCandidates(timeline.Scene.Children, model, sameZIndex)
             .Concat(SnapHelper.CollectSceneCandidates(timeline.Scene, clock.CurrentTime.Value));
@@ -454,7 +454,7 @@ public sealed partial class ElementView : UserControl
                     }
                     else if (_resizeContexts.Length > 1)
                     {
-                        HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                        HistoryManager history = viewModel.Timeline.EditorContext.HistoryManager;
                         var animations = _resizeContexts
                             .Select(x => (ViewModel: x.ViewModel, Context: x.ViewModel.PrepareAnimation()))
                             .ToArray();
@@ -624,7 +624,7 @@ public sealed partial class ElementView : UserControl
                 if (AssociatedObject is { ViewModel: { } viewModel })
                 {
                     viewModel.Timeline.SnapBarPosition.Value = null;
-                    HistoryManager history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                    HistoryManager history = viewModel.Timeline.EditorContext.HistoryManager;
                     e.Handled = true;
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements();
                     var elems = relatedElements.Select(x => x.Model).ToArray();
@@ -696,7 +696,7 @@ public sealed partial class ElementView : UserControl
 
         private void Select(ElementView obj, TimelineTabViewModel timeline)
         {
-            var selection = timeline.EditorContext.GetRequiredService<IEditorSelection>();
+            IEditorSelection selection = timeline.EditorContext.Selection;
             selection.SelectedObject.Value = obj.ViewModel.Model;
 
             timeline.ClearSelected();
@@ -705,7 +705,7 @@ public sealed partial class ElementView : UserControl
 
         private bool IsSelected(ElementView obj, TimelineTabViewModel timeline)
         {
-            var selection = timeline.EditorContext.GetRequiredService<IEditorSelection>();
+            IEditorSelection selection = timeline.EditorContext.Selection;
             return selection.SelectedObject.Value == obj.ViewModel.Model
                 || timeline.SelectedElements.Contains(obj.ViewModel);
         }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml.cs
@@ -173,7 +173,7 @@ public partial class InlineAnimationLayer : UserControl
                     item.ReflectModelKeyTime();
                 }
                 viewModel.ReflectModelKeyTime();
-                var history = viewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+                var history = viewModel.Timeline.EditorContext.HistoryManager;
                 history.Commit(CommandNames.MoveKeyFrame);
             }
             else

--- a/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
@@ -97,7 +97,7 @@ public sealed partial class LayerHeader : UserControl
 
         int newLayerNum = _newLayer;
         int oldLayerNum = ViewModel.Number.Value;
-        HistoryManager history = ViewModel.Timeline.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = ViewModel.Timeline.EditorContext.HistoryManager;
         new MoveLayerCommand(ViewModel, newLayerNum, oldLayerNum, _elements).Do();
         history.Commit(CommandNames.MoveLayer);
         _elements = [];

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -116,7 +116,7 @@ public sealed partial class TimelineTabView : UserControl
             .Subscribe(OnCurrentTimeChangedForAutoScroll)
             .DisposeWith(_disposables);
 
-        ViewModel.EditorContext.GetRequiredService<Beutl.Editor.Services.IEditorSelection>().SelectedObject.Subscribe(e =>
+        ViewModel.EditorContext.Selection.SelectedObject.Subscribe(e =>
             {
                 if (_selectedElement != null)
                 {
@@ -364,7 +364,7 @@ public sealed partial class TimelineTabView : UserControl
     {
         if (ViewModel == null) return;
         PointerPoint pointerPt = e.GetCurrentPoint(TimelinePanel);
-        HistoryManager history = ViewModel.EditorContext.GetRequiredService<HistoryManager>();
+        HistoryManager history = ViewModel.EditorContext.HistoryManager;
 
         if (pointerPt.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
         {
@@ -559,7 +559,7 @@ public sealed partial class TimelineTabView : UserControl
 
         if (template != null)
         {
-            if (viewModel.EditorContext.GetService<IElementAdder>() is { } adder
+            if (viewModel.EditorContext.ElementAdder is { } adder
                 && (template.BaseType == typeof(Element)
                     || template.BaseType.IsAssignableTo(typeof(EngineObject))))
             {
@@ -690,20 +690,16 @@ public sealed partial class TimelineTabView : UserControl
         if (ViewModel == null) return;
         if (sender is not MenuFlyoutItem { Tag: ObjectTemplateItem template }) return;
 
-        if (ViewModel.EditorContext.GetService(typeof(IElementAdder))
-            is IElementAdder adder)
-        {
-            adder.AddElementFromTemplate(
-                template,
-                ViewModel.ClickedFrame,
-                ViewModel.CalculateClickedLayer());
-        }
+        ViewModel.EditorContext.ElementAdder.AddElementFromTemplate(
+            template,
+            ViewModel.ClickedFrame,
+            ViewModel.CalculateClickedLayer());
     }
 
     private void ShowSceneSettings(object? sender, RoutedEventArgs e)
     {
         if (ViewModel == null) return;
-        IEditorContext editorContext = ViewModel.EditorContext;
+        ISceneEditorContext editorContext = ViewModel.EditorContext;
         SceneSettingsTabViewModel? tab = editorContext.FindToolTab<SceneSettingsTabViewModel>();
         if (tab != null)
         {
@@ -828,8 +824,8 @@ public sealed partial class TimelineTabView : UserControl
         var mode = GlobalConfiguration.Instance.EditorConfig.TimelineAutoScrollMode;
         if (mode == TimelineAutoScrollMode.None) return;
 
-        var previewPlayer = ViewModel.EditorContext.GetService<IPreviewPlayer>();
-        if (previewPlayer == null || !previewPlayer.IsPlaying.Value) return;
+        IPreviewPlayer previewPlayer = ViewModel.EditorContext.Player;
+        if (!previewPlayer.IsPlaying.Value) return;
 
         float scale = ViewModel.Options.Value.Scale;
         double seekBarPixel = currentTime.TimeToPixel(scale);
@@ -886,7 +882,7 @@ public sealed partial class TimelineTabView : UserControl
             marker.Color = initialColor;
             deleted = true;
             ViewModel.Scene.Markers.Remove(marker);
-            ViewModel.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.RemoveMarker);
+            ViewModel.EditorContext.HistoryManager.Commit(CommandNames.RemoveMarker);
         };
 
         flyout.Closed += (_, _) =>
@@ -896,7 +892,7 @@ public sealed partial class TimelineTabView : UserControl
                 || marker.Note != initialNote
                 || marker.Color != initialColor)
             {
-                ViewModel.EditorContext.GetRequiredService<HistoryManager>().Commit(CommandNames.EditMarker);
+                ViewModel.EditorContext.HistoryManager.Commit(CommandNames.EditMarker);
             }
         };
 

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -4,21 +4,34 @@ using Beutl.ProjectSystem;
 
 namespace Beutl.Editor;
 
+/// <summary>
+/// シーン編集器が公開する強い型付けのコンテキスト契約。
+/// 全プロパティはコンストラクタで初期化され、<see cref="System.IDisposable.Dispose"/> が
+/// 呼ばれるまで non-null。Dispose 後の参照動作は未定義。
+/// </summary>
 public interface ISceneEditorContext : IEditorContext
 {
+    /// <summary>編集対象のシーン。</summary>
     Scene Scene { get; }
 
+    /// <summary>undo/redo を管理する履歴マネージャ。</summary>
     HistoryManager HistoryManager { get; }
 
+    /// <summary>再生位置 / 最大時間を保持するクロック。</summary>
     IEditorClock Clock { get; }
 
+    /// <summary>タイムラインで選択中のオブジェクト。</summary>
     IEditorSelection Selection { get; }
 
+    /// <summary>プレビュー用プレイヤ。Dispose 後は <c>AfterRendered</c> 等にアクセスしない。</summary>
     IPreviewPlayer Player { get; }
 
+    /// <summary>新規エレメント追加の入口。</summary>
     IElementAdder ElementAdder { get; }
 
+    /// <summary>フレームキャッシュの状態。</summary>
     IBufferStatus BufferStatus { get; }
 
+    /// <summary>タイムライン表示オプション (スケール / オフセット / レイヤ数 等) のプロバイダ。</summary>
     ITimelineOptionsProvider TimelineOptions { get; }
 }

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -1,0 +1,24 @@
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor;
+
+public interface ISceneEditorContext : IEditorContext
+{
+    Scene Scene { get; }
+
+    HistoryManager HistoryManager { get; }
+
+    IEditorClock Clock { get; }
+
+    IEditorSelection Selection { get; }
+
+    IPreviewPlayer Player { get; }
+
+    IElementAdder ElementAdder { get; }
+
+    IBufferStatus BufferStatus { get; }
+
+    ITimelineOptionsProvider TimelineOptions { get; }
+}

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -6,8 +6,11 @@ namespace Beutl.Editor;
 
 /// <summary>
 /// シーン編集器が公開する強い型付けのコンテキスト契約。
-/// 全プロパティはコンストラクタで初期化され、<see cref="System.IDisposable.Dispose"/> が
-/// 呼ばれるまで non-null。Dispose 後の参照動作は未定義。
+/// 全プロパティはコンストラクタで初期化され、authoritative な teardown
+/// (<see cref="System.IAsyncDisposable.DisposeAsync"/>) が完了するまで non-null。
+/// 破棄後の参照動作は未定義。<see cref="IEditorContext"/> のデフォルト
+/// <see cref="System.IDisposable.Dispose"/> 実装は no-op のため、同期破棄は実際の
+/// クリーンアップを行わない点に注意。
 /// </summary>
 public interface ISceneEditorContext : IEditorContext
 {

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -14,10 +14,12 @@ namespace Beutl.Editor;
 /// </summary>
 /// <remarks>
 /// 全プロパティはコンストラクタで初期化され、authoritative な teardown
-/// (<see cref="System.IAsyncDisposable.DisposeAsync"/>) が完了するまで non-null。
-/// 破棄後の参照動作は未定義。<see cref="IEditorContext"/> のデフォルト
-/// <see cref="System.IDisposable.Dispose"/> 実装は no-op のため、同期破棄は実際の
-/// クリーンアップを行わない点に注意。
+/// (<see cref="System.IAsyncDisposable.DisposeAsync"/>) が呼び出されるまでは non-null。
+/// <c>DisposeAsync</c> 実行中は依存オブジェクトが順次破棄され、一部のプロパティ
+/// (<see cref="Scene"/> / <see cref="Player"/> / <see cref="BufferStatus"/> 等) は
+/// 戻る前に <c>null!</c> 化されるため、<c>DisposeAsync</c> 開始後の参照動作は未定義。
+/// <see cref="IEditorContext"/> のデフォルト <see cref="System.IDisposable.Dispose"/>
+/// 実装は no-op のため、同期破棄は実際のクリーンアップを行わない点にも注意。
 /// </remarks>
 public interface ISceneEditorContext : IEditorContext
 {

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -32,10 +32,10 @@ public interface ISceneEditorContext : IEditorContext
     /// <summary>再生位置 / 最大時間を保持するクロック。</summary>
     IEditorClock Clock { get; }
 
-    /// <summary>タイムラインで選択中のオブジェクト。</summary>
+    /// <summary>エディタ全体で選択中のオブジェクト (タイムライン / プレビュー操作 両方の窓口)。</summary>
     IEditorSelection Selection { get; }
 
-    /// <summary>プレビュー用プレイヤ。Dispose 後は <c>AfterRendered</c> 等にアクセスしない。</summary>
+    /// <summary>プレビュー用プレイヤ。<see cref="System.IAsyncDisposable.DisposeAsync"/> 後はプロパティ自体が <c>null!</c> 化されるため参照しないこと。</summary>
     IPreviewPlayer Player { get; }
 
     /// <summary>新規エレメント追加の入口。</summary>
@@ -44,6 +44,6 @@ public interface ISceneEditorContext : IEditorContext
     /// <summary>フレームキャッシュの状態。</summary>
     IBufferStatus BufferStatus { get; }
 
-    /// <summary>タイムライン表示オプション (スケール / オフセット / レイヤ数 等) のプロバイダ。</summary>
+    /// <summary>タイムライン表示オプション (スケール / オフセット / レイヤ数 / BPM グリッド 等) のプロバイダ。</summary>
     ITimelineOptionsProvider TimelineOptions { get; }
 }

--- a/src/Beutl.Editor/ISceneEditorContext.cs
+++ b/src/Beutl.Editor/ISceneEditorContext.cs
@@ -5,13 +5,20 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor;
 
 /// <summary>
-/// シーン編集器が公開する強い型付けのコンテキスト契約。
+/// シーン編集器が公開する強い型付けのコンテキスト契約。タイムライン / プロパティ /
+/// グラフエディタなどの 1st-party scene tab はこのインターフェース実装を要求する。
+/// <see cref="IEditorContext"/> のみを実装する拡張機能 (例: 独自テキストエディタ)
+/// は scene tab を開けない — これは意図的なゲートで、必要なサービス
+/// (Scene、HistoryManager 等) を提供できない context が runtime で
+/// <c>GetRequiredService</c> 例外を出すのを防ぐ。
+/// </summary>
+/// <remarks>
 /// 全プロパティはコンストラクタで初期化され、authoritative な teardown
 /// (<see cref="System.IAsyncDisposable.DisposeAsync"/>) が完了するまで non-null。
 /// 破棄後の参照動作は未定義。<see cref="IEditorContext"/> のデフォルト
 /// <see cref="System.IDisposable.Dispose"/> 実装は no-op のため、同期破棄は実際の
 /// クリーンアップを行わない点に注意。
-/// </summary>
+/// </remarks>
 public interface ISceneEditorContext : IEditorContext
 {
     /// <summary>編集対象のシーン。</summary>

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -36,7 +36,7 @@ public sealed class BufferedPlayer : IPlayer
         _editViewModel = editViewModel;
         _frameCacheManager = editViewModel.FrameCacheManager.Value;
         _renderer = editViewModel.Renderer.Value;
-        _editorClock = editViewModel.GetRequiredService<IEditorClock>();
+        _editorClock = editViewModel.Clock;
         _scene = scene;
         _isPlaying = isPlaying;
         _rate = rate;

--- a/src/Beutl/ViewModels/BufferStatusViewModel.cs
+++ b/src/Beutl/ViewModels/BufferStatusViewModel.cs
@@ -17,7 +17,7 @@ public sealed class BufferStatusViewModel : IBufferStatus, IDisposable
     public BufferStatusViewModel(EditViewModel editViewModel)
     {
         _editViewModel = editViewModel;
-        var timelineOptionsProvider = editViewModel.GetRequiredService<ITimelineOptionsProvider>();
+        ITimelineOptionsProvider timelineOptionsProvider = editViewModel.TimelineOptions;
 
         Start = StartTime.CombineLatest(timelineOptionsProvider.Scale)
             .Select(v => v.First.TimeToPixel(v.Second))

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -148,7 +148,16 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     private void OpenToolTabFromExtension(ToolTabExtension ext, IToolDock? target)
     {
         if (ext.TryCreateContext(_editViewModel, out IToolContext? tab))
+        {
             OpenToolTab(tab, target);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Tool tab '{ToolTabName}' rejected the editor context (gating failed) ({SceneId})",
+                ext.Name,
+                _sceneId);
+        }
     }
 
     private void EnsureDefaultLayout()
@@ -543,13 +552,32 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     private BeutlToolDockable? RestoreBeutlTool(JsonObject obj)
     {
         if (obj["extension"] is not JsonObject extObj || !extObj.TryGetDiscriminator(out Type? extType))
+        {
+            _logger.LogWarning(
+                "Skipping tool restore: missing or unresolvable extension discriminator ({SceneId})",
+                _sceneId);
             return null;
+        }
 
         var extension = ExtensionProvider.Current.AllExtensions
             .FirstOrDefault(x => x.GetType() == extType) as ToolTabExtension;
-        if (extension is null) return null;
+        if (extension is null)
+        {
+            _logger.LogWarning(
+                "Skipping tool restore: extension '{ToolType}' not found in the current provider ({SceneId})",
+                extType.FullName,
+                _sceneId);
+            return null;
+        }
 
-        if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx)) return null;
+        if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx))
+        {
+            _logger.LogWarning(
+                "Skipping tool restore: '{ToolTabName}' rejected the editor context (gating failed) ({SceneId})",
+                extension.Name,
+                _sceneId);
+            return null;
+        }
 
         try
         {

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -150,7 +150,7 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     private void ToggleMarkerAtCurrentTime()
     {
         int rate = Player.GetFrameRate();
-        TimeSpan time = _editorClock.CurrentTime.Value.RoundToRate(rate);
+        TimeSpan time = Clock.CurrentTime.Value.RoundToRate(rate);
         if (time < TimeSpan.Zero) time = TimeSpan.Zero;
 
         SceneMarker? existing = Scene.Markers
@@ -171,7 +171,7 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
 
     private void SeekToAdjacentMarker(bool forward)
     {
-        TimeSpan current = _editorClock.CurrentTime.Value;
+        TimeSpan current = Clock.CurrentTime.Value;
         TimeSpan? target = null;
         foreach (TimeSpan marker in Scene.Markers.Select(m => m.Time).Union([TimeSpan.Zero, Scene.Start, Scene.Duration + Scene.Start]))
         {
@@ -195,7 +195,7 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
 
         if (target != null)
         {
-            _editorClock.CurrentTime.Value = target.Value;
+            Clock.CurrentTime.Value = target.Value;
 
             // ターゲットの位置までタイムラインを横スクロールさせる
             if (FindToolTab<TimelineTabViewModel>() is { } timeline)

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -5,6 +5,7 @@ using Beutl.Configuration;
 using Beutl.Editor;
 using Beutl.Editor.Observers;
 using Beutl.Editor.Operations;
+using Beutl.Editor.Services;
 using Beutl.Graphics.Rendering.Cache;
 using Beutl.Logging;
 using Beutl.Media;
@@ -20,16 +21,12 @@ using Dispatcher = Avalonia.Threading.Dispatcher;
 
 namespace Beutl.ViewModels;
 
-public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEditorContext
+public sealed partial class EditViewModel : ISceneEditorContext, ISupportAutoSaveEditorContext
 {
     private readonly ILogger _logger = Log.CreateLogger<EditViewModel>();
     private readonly AutoSaveService _autoSaveService = new();
 
     private readonly CompositeDisposable _disposables = [];
-    private readonly TimelineOptionsProviderImpl _timelineOptionsProvider;
-    private readonly EditorClockImpl _editorClock;
-    private readonly EditorSelectionImpl _editorSelection;
-    private readonly ElementAdderImpl _elementAdder;
 
     public EditViewModel(Scene scene)
     {
@@ -38,11 +35,11 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         Scene = scene;
         SceneId = scene.Id.ToString();
 
-        _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
+        TimelineOptions = new TimelineOptionsProviderImpl(scene)
             .DisposeWith(_disposables);
-        _editorClock = new EditorClockImpl(scene)
+        Clock = new EditorClockImpl(scene)
             .DisposeWith(_disposables);
-        _editorSelection = new EditorSelectionImpl()
+        Selection = new EditorSelectionImpl()
             .DisposeWith(_disposables);
 
         Renderer = scene.GetObservable(Scene.FrameSizeProperty).Select(_ => new SceneRenderer(Scene))
@@ -85,7 +82,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         DockHost = new DockHostViewModel(SceneId, this)
             .DisposeWith(_disposables);
 
-        _elementAdder = new ElementAdderImpl(this);
+        ElementAdder = new ElementAdderImpl(this);
 
         _autoSaveService.SaveError
             .Subscribe(_ =>
@@ -306,6 +303,14 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public HistoryManager HistoryManager { get; private set; }
 
+    public IEditorClock Clock { get; }
+
+    public IEditorSelection Selection { get; }
+
+    public IElementAdder ElementAdder { get; }
+
+    public ITimelineOptionsProvider TimelineOptions { get; }
+
     public ReadOnlyReactivePropertySlim<FrameCacheManager> FrameCacheManager { get; private set; }
 
     public EditorExtension Extension => SceneEditorExtension.Instance;
@@ -316,6 +321,10 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     IReactiveProperty<bool> IEditorContext.IsEnabled => IsEnabled;
 
+    IPreviewPlayer ISceneEditorContext.Player => Player;
+
+    IBufferStatus ISceneEditorContext.BufferStatus => BufferStatus;
+
     public DockHostViewModel DockHost { get; }
 
     public async ValueTask DisposeAsync()
@@ -324,7 +333,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
         SaveState();
-        _editorSelection.SelectedObject.Value = null;
+        Selection.SelectedObject.Value = null;
         // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
         DisposeCommandStateNotifier();
         await Player.DisposeAsync();
@@ -382,22 +391,22 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         string viewStateDir = ViewStateDirectory();
         var json = new JsonObject
         {
-            ["selected-object"] = _editorSelection.SelectedObject.Value?.Id,
-            ["max-layer-count"] = _timelineOptionsProvider.Options.Value.MaxLayerCount,
-            ["scale"] = _timelineOptionsProvider.Options.Value.Scale,
-            ["offset"] = new JsonObject { ["x"] = _timelineOptionsProvider.Options.Value.Offset.X, ["y"] = _timelineOptionsProvider.Options.Value.Offset.Y, },
+            ["selected-object"] = Selection.SelectedObject.Value?.Id,
+            ["max-layer-count"] = TimelineOptions.Options.Value.MaxLayerCount,
+            ["scale"] = TimelineOptions.Options.Value.Scale,
+            ["offset"] = new JsonObject { ["x"] = TimelineOptions.Options.Value.Offset.X, ["y"] = TimelineOptions.Options.Value.Offset.Y, },
             ["bpm-grid"] = new JsonObject
             {
-                ["bpm"] = _timelineOptionsProvider.Options.Value.BpmGrid.Bpm,
-                ["subdivisions"] = _timelineOptionsProvider.Options.Value.BpmGrid.Subdivisions,
-                ["offset"] = _timelineOptionsProvider.Options.Value.BpmGrid.Offset.ToString("c"),
-                ["is-enabled"] = _timelineOptionsProvider.Options.Value.BpmGrid.IsEnabled,
+                ["bpm"] = TimelineOptions.Options.Value.BpmGrid.Bpm,
+                ["subdivisions"] = TimelineOptions.Options.Value.BpmGrid.Subdivisions,
+                ["offset"] = TimelineOptions.Options.Value.BpmGrid.Offset.ToString("c"),
+                ["is-enabled"] = TimelineOptions.Options.Value.BpmGrid.IsEnabled,
             }
         };
 
         DockHost.WriteToJson(json);
 
-        json["current-time"] = JsonValue.Create(_editorClock.CurrentTime.Value);
+        json["current-time"] = JsonValue.Create(Clock.CurrentTime.Value);
 
         string name = Path.GetFileNameWithoutExtension(Scene.Uri!.LocalPath);
         json.JsonSave(Path.Combine(viewStateDir, $"{name}.config"));
@@ -423,7 +432,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
                 if (id.HasValue)
                 {
                     var searcher = new ObjectSearcher(Scene, o => o is CoreObject obj && obj.Id == id.Value);
-                    _editorSelection.SelectedObject.Value = searcher.Search() as CoreObject;
+                    Selection.SelectedObject.Value = searcher.Search() as CoreObject;
                 }
             }
             catch (Exception ex)
@@ -476,14 +485,14 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
                 timelineOptions = timelineOptions with { BpmGrid = bpmGrid };
             }
 
-            _timelineOptionsProvider.Options.Value = timelineOptions;
+            TimelineOptions.Options.Value = timelineOptions;
 
             DockHost.ReadFromJson(jsonObject);
 
             if (jsonObject.TryGetPropertyValueAsJsonValue("current-time", out string? currentTimeStr)
                 && TimeSpan.TryParse(currentTimeStr, out TimeSpan currentTime))
             {
-                _editorClock.CurrentTime.Value = currentTime;
+                Clock.CurrentTime.Value = currentTime;
             }
         }
         else
@@ -505,16 +514,16 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             return HistoryManager;
 
         if (serviceType.IsAssignableTo(typeof(ITimelineOptionsProvider)))
-            return _timelineOptionsProvider;
+            return TimelineOptions;
 
         if (serviceType.IsAssignableTo(typeof(IEditorClock)))
-            return _editorClock;
+            return Clock;
 
         if (serviceType.IsAssignableTo(typeof(IEditorSelection)))
-            return _editorSelection;
+            return Selection;
 
         if (serviceType.IsAssignableTo(typeof(IElementAdder)))
-            return _elementAdder;
+            return ElementAdder;
 
         if (serviceType == typeof(PlayerViewModel) || serviceType.IsAssignableTo(typeof(IPreviewPlayer)))
             return Player;

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -440,7 +440,7 @@ public sealed partial class EditViewModel : ISceneEditorContext, ISupportAutoSav
                 _logger.LogWarning(ex, "An error occurred while restoring the selected object.");
             }
 
-            var timelineOptions = new TimelineOptions();
+            var timelineOptions = new ProjectSystem.TimelineOptions();
 
             if (jsonObject.TryGetPropertyValue("max-layer-count", out JsonNode? maxLayer)
                 && maxLayer is JsonValue maxLayerValue

--- a/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Editor;
 using Beutl.Editor.Components.NodeGraphTab.ViewModels;
 using Beutl.NodeGraph;
 using Beutl.NodeGraph.Nodes;
@@ -79,7 +80,7 @@ public sealed class GraphModelEditorViewModel : ValueEditorViewModel<GraphModel?
 
     public void OpenNodeGraphTab()
     {
-        if (this.GetService<IEditorContext>() is not { } editorContext) return;
+        if (this.GetService<IEditorContext>() is not ISceneEditorContext editorContext) return;
         if (Value.Value == null) return;
 
         NodeGraphTabViewModel tab = editorContext.FindToolTab<NodeGraphTabViewModel>()

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -62,8 +62,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     public PlayerViewModel(EditViewModel editViewModel)
     {
         _editViewModel = editViewModel;
-        _editorClock = editViewModel.GetRequiredService<IEditorClock>();
-        _editorSelection = editViewModel.GetRequiredService<IEditorSelection>();
+        _editorClock = editViewModel.Clock;
+        _editorSelection = editViewModel.Selection;
         Scene = editViewModel.Scene;
         _isEnabled = editViewModel.IsEnabled;
         PlayPause = new AsyncReactiveCommand(_isEnabled.AsObservable())

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -4,16 +4,19 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using Beutl.Configuration;
+using Beutl.Logging;
 using Beutl.Services;
 using Beutl.ViewModels;
 using DynamicData;
 using DynamicData.Binding;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings.Extensions;
 
 namespace Beutl.Views;
 
 public sealed partial class MacWindow : Window
 {
+    private readonly ILogger<MacWindow> _logger = Log.CreateLogger<MacWindow>();
     private readonly Dictionary<ToolWindowExtension, List<Window>> _openToolWindows = new();
 
     public MacWindow()
@@ -149,21 +152,30 @@ public sealed partial class MacWindow : Window
         if (viewMenuItem == null || editorTabMenu == null || toolTabMenu == null || toolWindowMenu == null) return;
 
         // ToolTabExtensionをメニューに表示する
-        static NativeMenuItem CreateToolTabMenuItem(ToolTabExtension item)
+        NativeMenuItem CreateToolTabMenuItem(ToolTabExtension item)
         {
             var menuItem = new NativeMenuItem() { Header = item.Header, CommandParameter = item };
 
             menuItem.Click += (s, e) =>
             {
-                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
-                    && s is NativeMenuItem { CommandParameter: ToolTabExtension ext }
-                    && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is not IEditorContext editorContext
+                    || s is not NativeMenuItem { CommandParameter: ToolTabExtension ext })
                 {
-                    bool result = editorContext.OpenToolTab(toolContext);
-                    if (!result)
-                    {
-                        toolContext.Dispose();
-                    }
+                    return;
+                }
+
+                if (!ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                {
+                    _logger.LogWarning(
+                        "Tool tab '{ToolTabName}' rejected the editor context (gating failed)",
+                        ext.Name);
+                    return;
+                }
+
+                bool result = editorContext.OpenToolTab(toolContext);
+                if (!result)
+                {
+                    toolContext.Dispose();
                 }
             };
 

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -166,21 +166,30 @@ public sealed partial class MainView : UserControl
     private void InitExtMenuItems(MainViewModel viewModel)
     {
         // ToolTabExtensionをメニューに表示する
-        static MenuItem CreateToolTabMenuItem(ToolTabExtension item)
+        MenuItem CreateToolTabMenuItem(ToolTabExtension item)
         {
             var menuItem = new MenuItem() { Header = item.Header, DataContext = item };
 
             menuItem.Click += (s, e) =>
             {
-                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
-                    && s is MenuItem { DataContext: ToolTabExtension ext }
-                    && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is not IEditorContext editorContext
+                    || s is not MenuItem { DataContext: ToolTabExtension ext })
                 {
-                    bool result = editorContext.OpenToolTab(toolContext);
-                    if (!result)
-                    {
-                        toolContext.Dispose();
-                    }
+                    return;
+                }
+
+                if (!ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                {
+                    _logger.LogWarning(
+                        "Tool tab '{ToolTabName}' rejected the editor context (gating failed)",
+                        ext.Name);
+                    return;
+                }
+
+                bool result = editorContext.OpenToolTab(toolContext);
+                if (!result)
+                {
+                    toolContext.Dispose();
                 }
             };
 

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -49,8 +49,7 @@ public partial class PlayerView
 
                 if (element != null)
                 {
-                    var editorSelection = editViewModel.GetService<IEditorSelection>();
-                    editorSelection?.SelectedObject.Value = element;
+                    editViewModel.Selection.SelectedObject.Value = element;
                 }
 
                 if (containsFe
@@ -85,7 +84,7 @@ public partial class PlayerView
                 return elements.Length == 0 ? 0 : elements.Max(v => v.ZIndex) + 1;
             }
 
-            var adder = editViewModel.GetRequiredService<IElementAdder>();
+            IElementAdder adder = editViewModel.ElementAdder;
             if (e.DataTransfer.TryGetValue(BeutlDataFormats.EngineObject) is { } typeName
                 && TypeFormat.ToType(typeName) is { } type)
             {

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -1324,8 +1324,8 @@ public partial class PlayerView
             return new MouseControlMove
             {
                 ViewModel = viewModel,
-                Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
-                EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
+                Clock = viewModel.EditViewModel.Clock,
+                EditorSelection = viewModel.EditViewModel.Selection,
                 View = this
             };
         }
@@ -1338,8 +1338,8 @@ public partial class PlayerView
             return new MouseControl3DCamera
             {
                 ViewModel = viewModel,
-                Clock = viewModel.EditViewModel.GetRequiredService<IEditorClock>(),
-                EditorSelection = viewModel.EditViewModel.GetRequiredService<IEditorSelection>(),
+                Clock = viewModel.EditViewModel.Clock,
+                EditorSelection = viewModel.EditViewModel.Selection,
                 View = this
             };
         }


### PR DESCRIPTION
## Description
- Replace IServiceProvider-based lookup on IEditorContext with a typed
  ISceneEditorContext sub-interface exposing Scene, HistoryManager,
  Clock, Selection, Player, ElementAdder, BufferStatus, and TimelineOptions
  as explicit properties so scene-editor dependencies are visible at the
  type level instead of resolved at runtime via GetRequiredService<T>().
- Promote EditViewModel private fields (_editorClock, _editorSelection,
  _elementAdder, _timelineOptionsProvider) to public properties and
  implement ISceneEditorContext; migrate ~99 first-party call sites
  across 11 scene tabs (Timeline, PathEditor, GraphEditor, NodeGraph,
  ElementProperty, ObjectProperty, Curves, ColorScopes, ColorGrading,
  AudioVisualizer, SceneSettings) plus the Player/PlayerView chain.
- Tab extensions now guard with `editorContext is ISceneEditorContext`
  so non-scene IEditorContext implementations (e.g. third-party text
  editors) cleanly opt out instead of failing later at GetRequiredService.

## Breaking changes
None for third-party extensions. IEditorContext in Beutl.Extensibility
is unchanged and still inherits IServiceProvider; existing custom
IEditorContext implementations continue to compile and run. The new
ISceneEditorContext lives in Beutl.Editor and only the first-party
scene editor (EditViewModel) implements it.

## Fixed issues
Addresses the AI Review project Backlog item
"設計改善: IServiceProvider ベースのコンテキスト API を明示化する"
(b-editor/projects/9, item PVTI_lADOBLw8Fs4BW4g5zgs6iJ4).
No linked GitHub issue.