### PR TITLE
docs: expand PR template with guidance and Test plan section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,16 @@
 ## Description
+<!-- What does this PR do and why? Bullet points encouraged. -->
 
 ## Breaking changes
+<!-- Public API / behavior changes that downstream code must adapt to.
+     Write "None" if there are none. -->
 
-## Fixed issues
+## Test plan
+<!-- - Unit/integration tests added or updated (path + brief intent)
+     - Manual repro steps for behavior changes
+     - For UI changes: screenshots or short screen recording (before/after if applicable) -->
+
+## Fixed issues / References
+<!-- - Closes #1234
+     - Project board: b-editor/projects/9 ("item title")
+     - Leave blank if none -->


### PR DESCRIPTION
## Description
- Add HTML-comment guidance under each section of `.github/PULL_REQUEST_TEMPLATE.md` so contributors know what belongs in each one. The comments are stripped from the rendered PR body, so merged PRs stay clean.
- Introduce a `Test plan` section that prompts for unit/integration test pointers, manual repro steps for behavior changes, and screenshots / short recordings for UI changes — a gap that was visible in recent UI-focused PRs.
- Rename `Fixed issues` to `Fixed issues / References` and document the AI Review project board (`b-editor/projects/9`) reference style there, so the recurring "None (tracked on AI Review project board)" pattern has a first-class place to live alongside `Closes #1234`.

## Breaking changes
None. Template-only change; existing PRs in flight are unaffected.

## Test plan
- N/A — Markdown-only change. Verified by re-reading the rendered template and confirming the HTML comments are well-formed.

## Fixed issues / References
None.