### PR TITLE
feat: add Spec-Kit git extension hooks

### DIFF
--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -14,26 +14,54 @@ Create / switch to a `speckit/<NNN>-<slug>` branch and report it back so the
 calling `/speckit-*` skill can record `BRANCH_NAME`, `FEATURE_NUM`, and
 `SPECIFY_FEATURE_DIRECTORY`.
 
-## 1. Parse the slug
+## 1. Parse the slug (and the optional explicit NNN)
 
-Resolve the slug in this order:
+Resolve the input in this order:
 
 1. `$ARGUMENTS` (the literal text after the slash command).
 2. The `GIT_BRANCH_NAME` env / context value, if the parent skill passed it.
 3. The "short name" the parent `/speckit-specify` skill already computed (2-4
    word kebab-case). Ask the user to paste it if it is not in scope.
 
-Strip a leading `NNN-` if present — the numbering step below re-derives it from
-`docs/specs/`. Whatever remains is `<slug>`. Reject anything that contains
-characters outside `[a-z0-9-]` and stop with a clear error.
+If the input matches `^[0-9]{3}-[a-z0-9-]+$` (the form advertised as
+`/speckit-git-branch <NNN>-<slug>`), split it into `EXPLICIT_NNN` and `SLUG`
+and **keep** the user-supplied number — Codex flagged that silently
+re-allocating it makes the documented form misbehave. Otherwise treat the
+whole input as `SLUG` and let §2 allocate `<NNN>`.
+
+Reject any slug that contains characters outside `[a-z0-9-]` and stop with a
+clear error.
 
 ## 2. Number the feature
 
-The next `<NNN>` must avoid collisions with **both** existing spec directories
-**and** already-allocated `speckit/<NNN>-*` branches (local or remote). A
-cancelled run can leave a `speckit/<NNN>-*` branch behind without its
-`docs/specs/<NNN>-*` directory, so directory-only numbering would re-issue
-the same `<NNN>`.
+If `EXPLICIT_NNN` was provided in §1:
+
+```bash
+NNN="$EXPLICIT_NNN"
+
+# Sanity: if a different feature already claims this NNN under a different
+# slug, refuse rather than silently colliding.
+clash=$( {
+  ls -1 docs/specs 2>/dev/null | grep -E "^${NNN}-"
+  git for-each-ref --format='%(refname:short)' \
+      'refs/heads/speckit/*' 'refs/remotes/*/speckit/*' 2>/dev/null \
+    | sed -E 's|.*speckit/||; s|/.*||' \
+    | grep -E "^${NNN}-"
+} | sort -u | grep -v "^${NNN}-${SLUG}\$" || true)
+
+if [ -n "$clash" ]; then
+  echo "Aborting — NNN $NNN is already used by:"
+  echo "$clash"
+  echo "Re-run without the explicit NNN to allocate the next free number."
+  exit 1
+fi
+```
+
+Otherwise allocate. The next `<NNN>` must avoid collisions with **both**
+existing spec directories **and** already-allocated `speckit/<NNN>-*`
+branches (local or remote). A cancelled run can leave a `speckit/<NNN>-*`
+branch behind without its `docs/specs/<NNN>-*` directory, so directory-only
+numbering would re-issue the same `<NNN>`.
 
 ```bash
 # Highest NNN from spec directories.

--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Development flow. Invoked from `.specify/extensions.yml` as the `before_specify`
   hook (`speckit.git.branch`), but you can also run it manually:
   `/speckit-git-branch <slug>` or `/speckit-git-branch <NNN>-<slug>`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git branch:*) Bash(git switch:*) Bash(git checkout:*) Bash(git for-each-ref:*) Bash(git show-ref:*) Bash(ls:*) Bash(printf:*) Bash(grep:*) Bash(awk:*) Bash(sort:*) Bash(tail:*) Bash(sed:*)
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git branch:*) Bash(git switch:*) Bash(git checkout:*) Bash(git for-each-ref:*) Bash(git show-ref:*) Bash(ls:*) Bash(printf:*) Bash(grep:*) Bash(awk:*) Bash(sort:*) Bash(head:*) Bash(tail:*) Bash(sed:*)
 argument-hint: "<slug-or-NNN-slug>"
 ---
 
@@ -18,21 +18,61 @@ calling `/speckit-*` skill can record `BRANCH_NAME`, `FEATURE_NUM`, and
 
 Resolve the input in this order:
 
-1. `$ARGUMENTS` (the literal text after the slash command).
-2. The `GIT_BRANCH_NAME` env / context value, if the parent skill passed it.
+1. **`GIT_BRANCH_NAME` env / context value, when the parent skill explicitly
+   passed it.** Per the upstream `/speckit-specify` contract this is the
+   **exact branch name**, not a slug. If it is set, take it verbatim:
+   - `BRANCH_NAME="$GIT_BRANCH_NAME"`
+   - If `BRANCH_NAME` matches `^speckit/[0-9]{3}-[a-z0-9-]+$`, derive
+     `FEATURE_NUM` and `SLUG` from it and set
+     `SPECIFY_FEATURE_DIRECTORY="docs/specs/${BRANCH_NAME#speckit/}"`.
+   - Otherwise leave `FEATURE_NUM` / `SPECIFY_FEATURE_DIRECTORY` empty and
+     note in the report that the parent skill is responsible for picking
+     a feature directory that matches its own conventions.
+   Skip §3 entirely in this case and jump to §4 with the supplied
+   `BRANCH_NAME`. (The pre-flight checks in §2 still run.)
+2. `$ARGUMENTS` (the literal text after the slash command).
 3. The "short name" the parent `/speckit-specify` skill already computed (2-4
    word kebab-case). Ask the user to paste it if it is not in scope.
+
+For sources #2 and #3 (slug-style input):
 
 If the input matches `^[0-9]{3}-[a-z0-9-]+$` (the form advertised as
 `/speckit-git-branch <NNN>-<slug>`), split it into `EXPLICIT_NNN` and `SLUG`
 and **keep** the user-supplied number — Codex flagged that silently
 re-allocating it makes the documented form misbehave. Otherwise treat the
-whole input as `SLUG` and let §2 allocate `<NNN>`.
+whole input as `SLUG` and let §3 allocate `<NNN>`.
 
 Reject any slug that contains characters outside `[a-z0-9-]` and stop with a
-clear error.
+clear error. (Validation only applies to slug-style input from sources #2
+and #3; the exact-name source #1 path is unrestricted by design.)
 
-## 2. Number the feature
+## 2. Pre-flight checks
+
+Run pre-flight **before** allocating `<NNN>`. If the user is on an older
+feature branch that is missing spec directories that already exist on
+`main`, scanning for the next free number from the current branch would
+pick a `<NNN>` that collides with a directory on `main`; switching to
+`main` first ensures `ls docs/specs` reflects the canonical set.
+
+```bash
+git rev-parse --is-inside-work-tree   # must be true
+git status --porcelain                # report dirty count
+git rev-parse --abbrev-ref HEAD       # current branch
+```
+
+If the working tree is **dirty** (porcelain output non-empty):
+
+> Warn the user that uncommitted changes will follow them onto the new branch.
+> Confirm via AskUserQuestion before proceeding (default: cancel).
+
+If the current branch is **not** `main`:
+
+> Inform the user, list the current branch, and confirm via AskUserQuestion
+> whether to branch from here anyway or switch to `main` first. If the user
+> picks "switch to `main`", run `git switch main` here so the subsequent
+> `<NNN>` scan in §3 sees the canonical spec directories.
+
+## 3. Number the feature
 
 If `EXPLICIT_NNN` was provided in §1:
 
@@ -43,6 +83,7 @@ NNN="$EXPLICIT_NNN"
 # slug, refuse rather than silently colliding.
 clash=$( {
   ls -1 docs/specs 2>/dev/null | grep -E "^${NNN}-"
+  ls -1      specs 2>/dev/null | grep -E "^${NNN}-"
   git for-each-ref --format='%(refname:short)' \
       'refs/heads/speckit/*' 'refs/remotes/*/speckit/*' 2>/dev/null \
     | sed -E 's|.*speckit/||; s|/.*||' \
@@ -61,14 +102,19 @@ Otherwise allocate. The next `<NNN>` must avoid collisions with **both**
 existing spec directories **and** already-allocated `speckit/<NNN>-*`
 branches (local or remote). A cancelled run can leave a `speckit/<NNN>-*`
 branch behind without its `docs/specs/<NNN>-*` directory, so directory-only
-numbering would re-issue the same `<NNN>`.
+numbering would re-issue the same `<NNN>`. Scan both spec roots — the
+Beutl-local default (`docs/specs/`) and the upstream Spec-Kit default
+(`specs/`) — because an explicit `SPECIFY_FEATURE_DIRECTORY` or a
+pre-patch run can leave a feature under `specs/`.
 
 ```bash
-# Highest NNN from spec directories.
-spec_max=$( ls -1 docs/specs 2>/dev/null \
-  | grep -E '^[0-9]{3}-' \
-  | awk -F- '{print $1}' \
-  | sort -n | tail -1 )
+# Highest NNN from spec directories under either root.
+spec_max=$( {
+    ls -1 docs/specs 2>/dev/null
+    ls -1      specs 2>/dev/null
+  } | grep -E '^[0-9]{3}-' \
+    | awk -F- '{print $1}' \
+    | sort -n | tail -1 )
 
 # Highest NNN from local + remote speckit/ branches.
 branch_max=$( git for-each-ref --format='%(refname:short)' \
@@ -90,24 +136,6 @@ Compose:
 - `BRANCH_NAME="speckit/<NNN>-<slug>"`
 - `FEATURE_NUM="<NNN>"`
 - `SPECIFY_FEATURE_DIRECTORY="docs/specs/<NNN>-<slug>"`
-
-## 3. Pre-flight checks
-
-```bash
-git rev-parse --is-inside-work-tree   # must be true
-git status --porcelain                # report dirty count
-git rev-parse --abbrev-ref HEAD       # current branch
-```
-
-If the working tree is **dirty** (porcelain output non-empty):
-
-> Warn the user that uncommitted changes will follow them onto the new branch.
-> Confirm via AskUserQuestion before proceeding (default: cancel).
-
-If the current branch is **not** `main`:
-
-> Inform the user, list the current branch, and confirm via AskUserQuestion
-> whether to branch from here anyway or switch to `main` first.
 
 ## 4. Create or switch the branch
 
@@ -147,6 +175,11 @@ SKILL can parse it:
 ```json
 {"BRANCH_NAME":"speckit/<NNN>-<slug>","FEATURE_NUM":"<NNN>","SPECIFY_FEATURE_DIRECTORY":"docs/specs/<NNN>-<slug>"}
 ```
+
+When §1 took the exact-name `GIT_BRANCH_NAME` path and the branch does not
+match `^speckit/[0-9]{3}-[a-z0-9-]+$`, emit `"FEATURE_NUM":""` and
+`"SPECIFY_FEATURE_DIRECTORY":""` rather than fabricating values; the parent
+skill picks its own feature directory.
 
 > **Important: `SPECIFY_FEATURE_DIRECTORY` is informational.** The
 > upstream `/speckit-specify` workflow generates its own spec directory

--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -111,9 +111,26 @@ If the current branch is **not** `main`:
 
 ## 4. Create or switch the branch
 
+Try local first, then remote tracking, then create. The remote case matters
+when `origin/speckit/<NNN>-<slug>` has been fetched (e.g. you pulled the
+repo without checking the branch out) — silently creating a fresh orphan
+branch with the same name leads to a rejected/divergent push later.
+
 ```bash
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  # Local branch already exists — just switch.
   git switch "$BRANCH_NAME"
+elif git for-each-ref --format='%(refname)' \
+       "refs/remotes/*/$BRANCH_NAME" 2>/dev/null | grep -q .; then
+  # Only a remote tracking ref exists; `git switch <name>` auto-creates a
+  # local branch and sets up tracking when exactly one remote has the
+  # branch. When multiple remotes share the name git refuses; in that
+  # case fall through to the explicit `--track` form.
+  if ! git switch "$BRANCH_NAME" 2>/dev/null; then
+    remote_ref=$(git for-each-ref --format='%(refname)' \
+      "refs/remotes/*/$BRANCH_NAME" 2>/dev/null | head -1)
+    git switch --track "${remote_ref#refs/remotes/}"
+  fi
 else
   git switch -c "$BRANCH_NAME"
 fi

--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -81,14 +81,26 @@ NNN="$EXPLICIT_NNN"
 
 # Sanity: if a different feature already claims this NNN under a different
 # slug, refuse rather than silently colliding.
-clash=$( {
-  ls -1 docs/specs 2>/dev/null | grep -E "^${NNN}-"
-  ls -1      specs 2>/dev/null | grep -E "^${NNN}-"
+#
+# Each `grep -E` below returns 1 on "zero matches", which is the normal
+# case. We swallow *only* that exit code per-source with `|| true`, so a
+# real failure inside any single source still surfaces — unlike a single
+# trailing `|| true` over the whole compound, which would also hide
+# pipeline failures (e.g. git for-each-ref erroring for permission
+# reasons) and let the skill conclude "no clash" by accident.
+clash_candidates=$( {
+  ls -1 docs/specs 2>/dev/null | grep -E "^${NNN}-" || true
+  ls -1      specs 2>/dev/null | grep -E "^${NNN}-" || true
   git for-each-ref --format='%(refname:short)' \
       'refs/heads/speckit/*' 'refs/remotes/*/speckit/*' 2>/dev/null \
     | sed -E 's|.*speckit/||; s|/.*||' \
-    | grep -E "^${NNN}-"
-} | sort -u | grep -v "^${NNN}-${SLUG}\$" || true)
+    | { grep -E "^${NNN}-" || true; }
+} | sort -u)
+
+# Filter out our own intended branch — anything that remains is a clash.
+clash=$(printf '%s\n' "$clash_candidates" \
+        | grep -vFx "${NNN}-${SLUG}" \
+        | grep -v '^$' || true)
 
 if [ -n "$clash" ]; then
   echo "Aborting — NNN $NNN is already used by:"
@@ -144,28 +156,49 @@ when `origin/speckit/<NNN>-<slug>` has been fetched (e.g. you pulled the
 repo without checking the branch out) — silently creating a fresh orphan
 branch with the same name leads to a rejected/divergent push later.
 
+Each `git switch` invocation captures stderr so we can report the real
+reason when something goes wrong. The auto-track path is allowed to fail
+silently (multiple remotes own the same name → fall through to explicit
+`--track`); every other failure aborts and surfaces git's own message.
+
 ```bash
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
   # Local branch already exists — just switch.
-  git switch "$BRANCH_NAME"
+  if ! switch_err=$(git switch "$BRANCH_NAME" 2>&1 >/dev/null); then
+    echo "Aborting — git switch failed:"
+    printf '%s\n' "$switch_err"
+    exit 1
+  fi
 elif git for-each-ref --format='%(refname)' \
        "refs/remotes/*/$BRANCH_NAME" 2>/dev/null | grep -q .; then
   # Only a remote tracking ref exists; `git switch <name>` auto-creates a
   # local branch and sets up tracking when exactly one remote has the
   # branch. When multiple remotes share the name git refuses; in that
-  # case fall through to the explicit `--track` form.
-  if ! git switch "$BRANCH_NAME" 2>/dev/null; then
+  # case fall through to the explicit `--track` form. The auto-track
+  # failure is benign here (the fallback is what handles it) so we
+  # intentionally discard its stderr; the explicit --track call below
+  # is the one that must surface errors.
+  if ! git switch "$BRANCH_NAME" >/dev/null 2>&1; then
     remote_ref=$(git for-each-ref --format='%(refname)' \
       "refs/remotes/*/$BRANCH_NAME" 2>/dev/null | head -1)
-    git switch --track "${remote_ref#refs/remotes/}"
+    if ! switch_err=$(git switch --track "${remote_ref#refs/remotes/}" 2>&1 >/dev/null); then
+      echo "Aborting — git switch --track failed:"
+      printf '%s\n' "$switch_err"
+      exit 1
+    fi
   fi
 else
-  git switch -c "$BRANCH_NAME"
+  if ! switch_err=$(git switch -c "$BRANCH_NAME" 2>&1 >/dev/null); then
+    echo "Aborting — git switch -c failed:"
+    printf '%s\n' "$switch_err"
+    exit 1
+  fi
 fi
 ```
 
-If branch creation fails (e.g. detached HEAD, locked index), abort with the
-captured stderr — do **not** retry, do **not** force.
+Do **not** retry, do **not** force (`git checkout -B`, `git switch -C`,
+or anything similar). The user can resolve whatever git is complaining
+about (detached HEAD, locked index, dirty tree) and re-run the skill.
 
 ## 5. Emit the JSON contract
 

--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Development flow. Invoked from `.specify/extensions.yml` as the `before_specify`
   hook (`speckit.git.branch`), but you can also run it manually:
   `/speckit-git-branch <slug>` or `/speckit-git-branch <NNN>-<slug>`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git branch:*) Bash(git switch:*) Bash(git checkout:*) Bash(ls:*) Bash(printf:*)
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git branch:*) Bash(git switch:*) Bash(git checkout:*) Bash(git for-each-ref:*) Bash(git show-ref:*) Bash(ls:*) Bash(printf:*) Bash(grep:*) Bash(awk:*) Bash(sort:*) Bash(tail:*) Bash(sed:*)
 argument-hint: "<slug-or-NNN-slug>"
 ---
 
@@ -29,15 +29,33 @@ characters outside `[a-z0-9-]` and stop with a clear error.
 
 ## 2. Number the feature
 
+The next `<NNN>` must avoid collisions with **both** existing spec directories
+**and** already-allocated `speckit/<NNN>-*` branches (local or remote). A
+cancelled run can leave a `speckit/<NNN>-*` branch behind without its
+`docs/specs/<NNN>-*` directory, so directory-only numbering would re-issue
+the same `<NNN>`.
+
 ```bash
-ls -1 docs/specs 2>/dev/null \
+# Highest NNN from spec directories.
+spec_max=$( ls -1 docs/specs 2>/dev/null \
   | grep -E '^[0-9]{3}-' \
   | awk -F- '{print $1}' \
-  | sort -n | tail -1
+  | sort -n | tail -1 )
+
+# Highest NNN from local + remote speckit/ branches.
+branch_max=$( git for-each-ref --format='%(refname:short)' \
+    'refs/heads/speckit/*' 'refs/remotes/*/speckit/*' 2>/dev/null \
+  | sed -E 's|.*speckit/||; s|/.*||' \
+  | grep -E '^[0-9]{3}-' \
+  | awk -F- '{print $1}' \
+  | sort -n | tail -1 )
+
+current_max=$(printf '%s\n%s\n' "$spec_max" "$branch_max" \
+  | grep -E '^[0-9]+$' | sort -n | tail -1)
 ```
 
-Increment by one, zero-pad to 3 digits → `<NNN>`. If `docs/specs/` is missing
-or has no numbered entries yet, start at `001`.
+Increment by one, zero-pad to 3 digits → `<NNN>`. If both lookups are empty,
+start at `001`.
 
 Compose:
 
@@ -85,10 +103,27 @@ SKILL can parse it:
 {"BRANCH_NAME":"speckit/<NNN>-<slug>","FEATURE_NUM":"<NNN>","SPECIFY_FEATURE_DIRECTORY":"docs/specs/<NNN>-<slug>"}
 ```
 
-Then, in human-readable text below it, summarise:
+> **Important: `SPECIFY_FEATURE_DIRECTORY` is informational.** The
+> upstream `/speckit-specify` workflow generates its own spec directory
+> name (`Auto-generate it under specs/` — see the SKILL's resolution
+> order) and does **not** auto-consume hook output. To force matching
+> directory and branch numbers, the user must either:
+>
+> 1. Pass `SPECIFY_FEATURE_DIRECTORY=docs/specs/<NNN>-<slug>` (or the
+>    equivalent argument the parent skill accepts) before re-entering
+>    `/speckit-specify`, **or**
+> 2. Accept that the spec directory may use a different `<NNN>` than
+>    the branch when a stray `speckit/<NNN>-*` branch already exists.
+>
+> The Beutl-local `SPECS_DIR` patch in `.specify/scripts/bash/common.sh`
+> only redirects the *root* (`specs/` → `docs/specs/`); the numbering
+> logic upstream is untouched.
+
+Then, in human-readable text below the JSON, summarise:
 
 - branch name and whether it was created or switched
-- the proposed spec directory path
+- the proposed spec directory path (with a one-line note when it differs
+  from what the parent skill is about to generate)
 - whether the working tree had to be carried over
 
 ## Refusals

--- a/.claude/skills/speckit-git-branch/SKILL.md
+++ b/.claude/skills/speckit-git-branch/SKILL.md
@@ -1,0 +1,100 @@
+---
+description: |
+  Create or switch to a `speckit/<NNN>-<slug>` feature branch for the Spec-Driven
+  Development flow. Invoked from `.specify/extensions.yml` as the `before_specify`
+  hook (`speckit.git.branch`), but you can also run it manually:
+  `/speckit-git-branch <slug>` or `/speckit-git-branch <NNN>-<slug>`.
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git branch:*) Bash(git switch:*) Bash(git checkout:*) Bash(ls:*) Bash(printf:*)
+argument-hint: "<slug-or-NNN-slug>"
+---
+
+# Spec-Kit git: feature branch
+
+Create / switch to a `speckit/<NNN>-<slug>` branch and report it back so the
+calling `/speckit-*` skill can record `BRANCH_NAME`, `FEATURE_NUM`, and
+`SPECIFY_FEATURE_DIRECTORY`.
+
+## 1. Parse the slug
+
+Resolve the slug in this order:
+
+1. `$ARGUMENTS` (the literal text after the slash command).
+2. The `GIT_BRANCH_NAME` env / context value, if the parent skill passed it.
+3. The "short name" the parent `/speckit-specify` skill already computed (2-4
+   word kebab-case). Ask the user to paste it if it is not in scope.
+
+Strip a leading `NNN-` if present — the numbering step below re-derives it from
+`docs/specs/`. Whatever remains is `<slug>`. Reject anything that contains
+characters outside `[a-z0-9-]` and stop with a clear error.
+
+## 2. Number the feature
+
+```bash
+ls -1 docs/specs 2>/dev/null \
+  | grep -E '^[0-9]{3}-' \
+  | awk -F- '{print $1}' \
+  | sort -n | tail -1
+```
+
+Increment by one, zero-pad to 3 digits → `<NNN>`. If `docs/specs/` is missing
+or has no numbered entries yet, start at `001`.
+
+Compose:
+
+- `BRANCH_NAME="speckit/<NNN>-<slug>"`
+- `FEATURE_NUM="<NNN>"`
+- `SPECIFY_FEATURE_DIRECTORY="docs/specs/<NNN>-<slug>"`
+
+## 3. Pre-flight checks
+
+```bash
+git rev-parse --is-inside-work-tree   # must be true
+git status --porcelain                # report dirty count
+git rev-parse --abbrev-ref HEAD       # current branch
+```
+
+If the working tree is **dirty** (porcelain output non-empty):
+
+> Warn the user that uncommitted changes will follow them onto the new branch.
+> Confirm via AskUserQuestion before proceeding (default: cancel).
+
+If the current branch is **not** `main`:
+
+> Inform the user, list the current branch, and confirm via AskUserQuestion
+> whether to branch from here anyway or switch to `main` first.
+
+## 4. Create or switch the branch
+
+```bash
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  git switch "$BRANCH_NAME"
+else
+  git switch -c "$BRANCH_NAME"
+fi
+```
+
+If branch creation fails (e.g. detached HEAD, locked index), abort with the
+captured stderr — do **not** retry, do **not** force.
+
+## 5. Emit the JSON contract
+
+Print exactly this to stdout (one line, no surrounding prose) so the calling
+SKILL can parse it:
+
+```json
+{"BRANCH_NAME":"speckit/<NNN>-<slug>","FEATURE_NUM":"<NNN>","SPECIFY_FEATURE_DIRECTORY":"docs/specs/<NNN>-<slug>"}
+```
+
+Then, in human-readable text below it, summarise:
+
+- branch name and whether it was created or switched
+- the proposed spec directory path
+- whether the working tree had to be carried over
+
+## Refusals
+
+- Never delete or rename existing branches.
+- Never push — pushing happens explicitly later via `git push -u origin ...`
+  or the user's own PR-creation flow.
+- Never run `git checkout -B` (force re-create); always go through `switch -c`
+  / `switch`.

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -79,8 +79,14 @@ untracked_paths=$(git ls-files --others --exclude-standard -- docs/specs/ specs/
 # `[a-z0-9-]+` matches the slugs that §1 of speckit-git-branch validates;
 # non-conforming spec directories (e.g. a user-supplied `GIT_BRANCH_NAME`
 # whose suffix has uppercase or underscores) silently fall outside the
-# regex and are skipped here — that is an accepted limitation, not a
-# silent commit, because §2's resolver still picks the directory.
+# regex and are skipped here. That is an accepted limitation, not a
+# silent commit: §2's resolver (feature.json / env var / branch name /
+# pending-file location / highest-NNN glob) never re-applies this
+# regex, so a non-conforming directory is still picked up and
+# committed normally. The corollary is that **the mixed-root duplicate
+# check cannot catch a clash whose slug is non-conforming** — a future
+# maintainer relying on §1's safety net for those features should
+# widen the regex (e.g. `[A-Za-z0-9_-]+`) instead of over-trusting it.
 pending_features=$(printf '%s\n%s\n' "$porcelain_paths" "$untracked_paths" \
   | grep -oE '^(docs/specs|specs)/[0-9]{3}-[a-z0-9-]+/' \
   | sort -u)

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -37,16 +37,23 @@ Each phase maps to one or more artifact paths under the spec directory:
 multi-artifact because the upstream `/speckit-*` SKILLs produce design
 packs and checklist suites alongside the headline file.
 
-If `$ARGUMENTS` is empty, infer from `git status --porcelain --
-docs/specs/` and `git ls-files --others --exclude-standard --
-docs/specs/`: pick the phase whose file(s) are pending. If files from
-multiple distinct phases are pending, **stop** and ask the user to specify
-which phase to commit — this skill deliberately commits one phase at a time.
+If `$ARGUMENTS` is empty, infer from the union of:
+
+- `git status --porcelain -- docs/specs/ specs/`
+- `git ls-files --others --exclude-standard -- docs/specs/ specs/`
+
+Scan both roots — the Beutl-local default (`docs/specs/`) and the upstream
+Spec-Kit default (`specs/`) — for the same reason §2 step 5 scans both:
+an explicit `SPECIFY_FEATURE_DIRECTORY` or a pre-patch run can leave a
+feature under `specs/`. Pick the phase whose file(s) are pending. If
+files from multiple distinct phases are pending, **stop** and ask the
+user to specify which phase to commit — this skill deliberately commits
+one phase at a time.
 
 If `$ARGUMENTS` is empty **and** neither command shows anything pending
-under `docs/specs/` / `specs/`, exit 0 with `nothing to commit — no
-spec-kit artifacts are pending`. Do not guess a phase, do not prompt;
-this is a no-op completion, not a failure.
+under either root, exit 0 with `nothing to commit — no spec-kit
+artifacts are pending`. Do not guess a phase, do not prompt; this is a
+no-op completion, not a failure.
 
 ## 2. Locate the spec directory
 
@@ -193,10 +200,14 @@ done
 
 # 4b. PENDING also includes deletions of mapped paths.
 #     Compose grep alternation from MAPPED_FILES / MAPPED_DIRS so a stray
-#     deletion outside the mapping is never picked up.
+#     deletion outside the mapping is never picked up. The `grep -E
+#     "^(${prefix_re})$"` below already anchors at both ends, so each
+#     alternative is unanchored (no trailing `$` on file entries, no
+#     leading `^` either) — adding a literal `\$` here would produce a
+#     double `$$` anchor that can never match `git ls-files --deleted`.
 prefix_re=""
 for f in $MAPPED_FILES; do
-  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR_REL" "$f" | sed 's|[].[*^$/\\]|\\&|g')\$"
+  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR_REL" "$f" | sed 's|[].[*^$/\\]|\\&|g')"
 done
 for d in $MAPPED_DIRS; do
   prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR_REL" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -43,12 +43,22 @@ If `$ARGUMENTS` is empty, infer from the union of:
 - `git ls-files --others --exclude-standard -- docs/specs/ specs/`
 
 Scan both roots — the Beutl-local default (`docs/specs/`) and the upstream
-Spec-Kit default (`specs/`) — for the same reason §2 step 5 scans both:
+Spec-Kit default (`specs/`) — for the same reason §2 step 4 scans both:
 an explicit `SPECIFY_FEATURE_DIRECTORY` or a pre-patch run can leave a
 feature under `specs/`. Pick the phase whose file(s) are pending. If
 files from multiple distinct phases are pending, **stop** and ask the
 user to specify which phase to commit — this skill deliberately commits
 one phase at a time.
+
+**Mixed-root ambiguity check.** Before picking a phase, also verify that
+the pending paths all live under *one* root. If the same `<NNN>-<slug>`
+feature appears under both `docs/specs/` *and* `specs/` (e.g. someone
+ran `/speckit-specify` once before and once after the Beutl-local
+`SPECS_DIR` patch landed), §2's resolver would pick a single root and
+silently commit only half the artifacts. Detect this by extracting
+`<root>/<NNN>-<slug>/` prefixes from the union output above; if two
+different roots map to the same `<NNN>-<slug>`, stop and ask the user
+which root to use rather than guessing.
 
 If `$ARGUMENTS` is empty **and** neither command shows anything pending
 under either root, exit 0 with `nothing to commit — no spec-kit
@@ -147,7 +157,9 @@ case "$PHASE" in
   checklist) MAPPED_FILES=""
              MAPPED_DIRS="checklists" ;;
   analyze)   MAPPED_FILES="analysis.md"; MAPPED_DIRS="" ;;
-  *)         echo "Unknown phase: $PHASE"; exit 1 ;;
+  *)         echo "Unknown phase: $PHASE"
+             echo "Valid phases: spec | plan | tasks | checklist | analyze"
+             exit 1 ;;
 esac
 
 TARGETS=""
@@ -202,9 +214,9 @@ done
 #     Compose grep alternation from MAPPED_FILES / MAPPED_DIRS so a stray
 #     deletion outside the mapping is never picked up. The `grep -E
 #     "^(${prefix_re})$"` below already anchors at both ends, so each
-#     alternative is unanchored (no trailing `$` on file entries, no
-#     leading `^` either) — adding a literal `\$` here would produce a
-#     double `$$` anchor that can never match `git ls-files --deleted`.
+#     alternative carries no trailing `$` — adding a literal `\$` here
+#     would produce a double `$$` anchor that can never match
+#     `git ls-files --deleted`.
 prefix_re=""
 for f in $MAPPED_FILES; do
   prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR_REL" "$f" | sed 's|[].[*^$/\\]|\\&|g')"
@@ -213,9 +225,16 @@ for d in $MAPPED_DIRS; do
   prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR_REL" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"
 done
 if [ -n "$prefix_re" ]; then
+  # Separate `git ls-files --deleted` from the grep filter so a real
+  # failure inside git (corrupt index, permission error, etc.) is not
+  # masked by grep's "no match" exit code via a single trailing
+  # `|| true` over the whole pipeline. We only want to swallow the
+  # "zero deletions matched" case (grep returning 1), not the rare
+  # case where git itself errors out — that should surface and abort.
+  deleted_all=$(git ls-files --deleted)
   while IFS= read -r dl; do
     [ -n "$dl" ] && PENDING="$PENDING $dl"
-  done < <(git ls-files --deleted | grep -E "^(${prefix_re})$" || true)
+  done < <(printf '%s\n' "$deleted_all" | { grep -E "^(${prefix_re})$" || true; })
 fi
 
 PENDING="${PENDING# }"

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -1,0 +1,122 @@
+---
+description: |
+  Stage and commit the freshly generated spec / plan / tasks file under
+  `docs/specs/<NNN>-<slug>/` as a single Conventional Commit
+  (`docs(specs): <phase> NNN-<slug>`). Invoked from `.specify/extensions.yml`
+  as the `after_specify` / `after_plan` / `after_tasks` hooks; also runnable
+  manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git log:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*)
+argument-hint: "spec|plan|tasks|checklist|analyze"
+---
+
+# Spec-Kit git: phase commit
+
+Make exactly one commit per phase, scoped to `docs/specs/<NNN>-<slug>/`.
+
+## 1. Identify the phase
+
+`$ARGUMENTS` is one of: `spec`, `plan`, `tasks`, `checklist`, `analyze`.
+
+If empty, infer from `git status --porcelain -- docs/specs/` — pick the most
+recently modified `<phase>.md` under the latest `docs/specs/<NNN>-<slug>/`.
+If multiple phases changed, **stop** and ask the user to specify; this skill
+deliberately commits one phase at a time.
+
+## 2. Locate the spec directory
+
+```bash
+SPEC_DIR=$(ls -1d docs/specs/[0-9][0-9][0-9]-* 2>/dev/null | sort | tail -1)
+```
+
+This selects the highest-numbered directory — typically the one just created
+by `/speckit-git-branch` or the previous phase. If `SPEC_DIR` is empty or
+the expected `<phase>.md` does not live under it, stop and report the
+mismatch (do not silently fall back).
+
+Extract the slug:
+
+```bash
+NNN_SLUG=$(basename "$SPEC_DIR")   # e.g. 001-add-foo-button
+NNN=${NNN_SLUG%%-*}                # 001
+SLUG=${NNN_SLUG#*-}                # add-foo-button
+```
+
+## 3. Verify the target file
+
+```bash
+TARGET="$SPEC_DIR/$PHASE.md"
+[ -f "$TARGET" ] || { echo "No $PHASE.md under $SPEC_DIR"; exit 1; }
+```
+
+Check whether it is actually pending:
+
+```bash
+git diff --quiet -- "$TARGET" && git diff --cached --quiet -- "$TARGET" \
+  && { echo "No changes to commit for $TARGET"; exit 0; }
+```
+
+## 4. Stage **only** the spec directory
+
+```bash
+git add -- "$SPEC_DIR"
+```
+
+Then verify nothing outside that directory ended up staged:
+
+```bash
+extras=$(git diff --cached --name-only | grep -v "^${SPEC_DIR%/}/" || true)
+[ -z "$extras" ] || { echo "Aborting — extra files staged: $extras"; exit 1; }
+```
+
+This is the safety rail: we never want this skill to commit unrelated work
+that happens to be sitting in the working tree.
+
+## 5. Compose the commit message
+
+Use a Conventional Commit:
+
+```
+docs(specs): <phase> <NNN>-<slug>
+```
+
+Examples:
+
+- `docs(specs): scaffold 001-add-foo-button` (after_specify)
+- `docs(specs): plan 001-add-foo-button` (after_plan)
+- `docs(specs): tasks 001-add-foo-button` (after_tasks)
+
+For `<phase>=spec`, use the verb `scaffold` instead of `spec` — it reads more
+naturally for the very first commit of a spec. For other phases, use the
+phase name as-is.
+
+Body (optional but recommended): copy the first non-heading line from
+`<phase>.md` so reviewers see what the file is about without opening it.
+
+```bash
+SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$TARGET" | head -c 200)
+```
+
+## 6. Commit
+
+```bash
+git commit -m "$SUBJECT" -m "$SUMMARY"
+```
+
+Do not use `--amend` and do not use `--allow-empty`. Do not push.
+
+## 7. Report
+
+Emit a JSON line so the calling SKILL can record the result, followed by a
+short human summary:
+
+```json
+{"sha":"<short-sha>","path":"docs/specs/<NNN>-<slug>/<phase>.md","subject":"docs(specs): <phase> <NNN>-<slug>"}
+```
+
+## Refusals
+
+- Never `git add` outside `docs/specs/<NNN>-<slug>/`.
+- Never `git push`. The user pushes when they are ready.
+- Never amend a previous commit.
+- Never run `dotnet format` / linters / tests as part of this skill — its
+  scope is exactly one commit of exactly one Markdown file.

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -64,11 +64,23 @@ must be stripped before path matching:
 # Strip the porcelain XY+space prefix and split rename arrows. Spec
 # slugs are kebab-case ([a-z0-9-]), so we do not bother handling
 # porcelain's `-z` NUL-terminated form or quoted paths.
+#
+# Use awk (not `sed s/ -> /\n/`) for the rename split — BSD sed (macOS,
+# default on contributor machines) treats `\n` in the *replacement* as
+# the two literal characters `\n`, not a newline, which would have
+# silently merged `old.md -> new.md` into a single line and dropped the
+# post-rename path from `pending_features`. awk's `split(...)` is
+# portable across BSD and GNU.
 porcelain_paths=$(git status --porcelain -- docs/specs/ specs/ \
   | sed -E 's|^...||' \
-  | sed -E 's| -> |\n|')
+  | awk '{ n = split($0, parts, " -> "); for (i = 1; i <= n; i++) print parts[i] }')
 untracked_paths=$(git ls-files --others --exclude-standard -- docs/specs/ specs/)
 
+# `[a-z0-9-]+` matches the slugs that §1 of speckit-git-branch validates;
+# non-conforming spec directories (e.g. a user-supplied `GIT_BRANCH_NAME`
+# whose suffix has uppercase or underscores) silently fall outside the
+# regex and are skipped here — that is an accepted limitation, not a
+# silent commit, because §2's resolver still picks the directory.
 pending_features=$(printf '%s\n%s\n' "$porcelain_paths" "$untracked_paths" \
   | grep -oE '^(docs/specs|specs)/[0-9]{3}-[a-z0-9-]+/' \
   | sort -u)
@@ -261,6 +273,12 @@ if [ -n "$prefix_re" ]; then
   # `|| true` over the whole pipeline. The brace-grouped `|| true`
   # around grep below is still required: grep returning 1 on "zero
   # matches" is the normal case (most invocations have no deletions).
+  #
+  # `2>&1` folds stderr into the captured stream so that on the error
+  # branch `$deleted_all` carries git's diagnostic; on the success
+  # branch git never writes to stderr, so $deleted_all is the plain
+  # newline-separated list of deleted paths that the loop below
+  # consumes verbatim.
   if ! deleted_all=$(git ls-files --deleted 2>&1); then
     echo "Aborting — git ls-files --deleted failed:"
     printf '%s\n' "$deleted_all"

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -24,15 +24,15 @@ Each phase maps to one or more artifact paths under the spec directory:
 
 | Phase | Artifacts committed |
 |---|---|
-| `spec` | `spec.md` |
+| `spec` | `spec.md` + `checklists/requirements.md` (the requirements checklist `/speckit-specify` writes in the same flow) |
 | `plan` | `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, plus the entire `contracts/` directory (when `/speckit-plan` generated API/IPC contracts for the feature) |
 | `tasks` | `tasks.md` |
-| `checklist` | `checklist.md` |
+| `checklist` | the entire `checklists/` directory (`/speckit-checklist` writes files like `ux.md`, `api.md`, `security.md` under it, not a single `checklist.md`) |
 | `analyze` | `analysis.md` (only when `/speckit-analyze` wrote one) |
 
-`spec` / `tasks` / `checklist` are one-file commits. `plan` is the only
-multi-artifact phase because `/speckit-plan` produces the design pack
-alongside the plan itself.
+`tasks` is a one-file commit. `spec`, `plan`, `checklist` are
+multi-artifact because the upstream `/speckit-*` SKILLs produce design
+packs and checklist suites alongside the headline file.
 
 If `$ARGUMENTS` is empty, infer from `git status --porcelain --
 docs/specs/` and `git ls-files --others --exclude-standard --
@@ -93,11 +93,13 @@ may be absent for a UI-only plan):
 
 ```bash
 case "$PHASE" in
-  spec)      MAPPED_FILES="spec.md"; MAPPED_DIRS="" ;;
+  spec)      MAPPED_FILES="spec.md checklists/requirements.md"
+             MAPPED_DIRS="" ;;
   plan)      MAPPED_FILES="plan.md research.md data-model.md quickstart.md"
              MAPPED_DIRS="contracts" ;;
   tasks)     MAPPED_FILES="tasks.md"; MAPPED_DIRS="" ;;
-  checklist) MAPPED_FILES="checklist.md"; MAPPED_DIRS="" ;;
+  checklist) MAPPED_FILES=""
+             MAPPED_DIRS="checklists" ;;
   analyze)   MAPPED_FILES="analysis.md"; MAPPED_DIRS="" ;;
   *)         echo "Unknown phase: $PHASE"; exit 1 ;;
 esac
@@ -120,13 +122,20 @@ TARGETS="${TARGETS# }"
 ```
 
 Check whether at least one target file is **pending** (untracked, modified,
-or staged). The pending subset is what we will compare against the staged
-set after `git add` — Codex flagged that requiring the full `TARGETS`
-list to match the staged set wrongly aborted partial-file edits in the
-plan phase (e.g. editing only `plan.md` and leaving `research.md`
+staged, or **deleted**). The pending subset is what we will compare against
+the staged set after `git add` — Codex flagged that requiring the full
+`TARGETS` list to match the staged set wrongly aborted partial-file edits
+in the plan phase (e.g. editing only `plan.md` and leaving `research.md`
 unchanged).
 
+Also pick up files that **used to exist** in the mapped layout but were
+deleted in the current working tree (e.g. `quickstart.md` removed during a
+plan rewrite, an obsolete `contracts/*.md`). `TARGETS` is populated only
+from files that still exist, so the deleted set has to come from
+`git ls-files --deleted` filtered by the same mapping prefixes.
+
 ```bash
+# 4a. PENDING from still-existing TARGETS.
 PENDING=""
 for t in $TARGETS; do
   is_pending=""
@@ -139,8 +148,24 @@ for t in $TARGETS; do
   fi
   [ -n "$is_pending" ] && PENDING="$PENDING $t"
 done
-PENDING="${PENDING# }"
 
+# 4b. PENDING also includes deletions of mapped paths.
+#     Compose grep alternation from MAPPED_FILES / MAPPED_DIRS so a stray
+#     deletion outside the mapping is never picked up.
+prefix_re=""
+for f in $MAPPED_FILES; do
+  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR" "$f" | sed 's|[].[*^$/\\]|\\&|g')\$"
+done
+for d in $MAPPED_DIRS; do
+  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"
+done
+if [ -n "$prefix_re" ]; then
+  while IFS= read -r dl; do
+    [ -n "$dl" ] && PENDING="$PENDING $dl"
+  done < <(git ls-files --deleted | grep -E "^(${prefix_re})$" || true)
+fi
+
+PENDING="${PENDING# }"
 [ -n "$PENDING" ] || { echo "No pending changes for phase $PHASE"; exit 0; }
 ```
 
@@ -148,18 +173,35 @@ PENDING="${PENDING# }"
 
 `git add -- "$SPEC_DIR"` would sweep in any other pending edits inside the
 spec directory (the user's draft notes, an old `checklist.md`, a stray
-`scratch.md`). Stage only the pending subset of the mapping:
+`scratch.md`). Stage only the pending subset of the mapping. `git add -A`
+on a path also records deletions, which is what we want:
 
 ```bash
 # shellcheck disable=SC2086
-git add -- $PENDING
+git add -A -- $PENDING
 ```
 
-Then verify the staged set matches the pending subset — no more, no less:
+Then verify the staged set matches the pending subset — no more, no less.
+**Normalize both sides to repo-relative paths** before comparing: when
+`SPEC_DIR` came from an absolute `SPECIFY_FEATURE_DIRECTORY` or
+`.specify/feature.json` value, `PENDING` will hold absolute paths, but
+`git diff --cached --name-only` always reports repo-relative paths.
 
 ```bash
-expected=$(printf '%s\n' $PENDING | sort -u)
+repo_root=$(git rev-parse --show-toplevel)
+
+# Strip the repo prefix from any absolute path; leave repo-relative
+# paths untouched.
+to_rel() {
+  case "$1" in
+    "$repo_root"/*) printf '%s' "${1#$repo_root/}" ;;
+    *)              printf '%s' "$1" ;;
+  esac
+}
+
+expected=$(for p in $PENDING; do to_rel "$p"; echo; done | sort -u | grep -v '^$')
 actual=$(git diff --cached --name-only | sort -u)
+
 if [ "$expected" != "$actual" ]; then
   echo "Aborting — staged set differs from the pending phase targets."
   echo "Expected:"; echo "$expected"

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -1,11 +1,14 @@
 ---
 description: |
-  Stage and commit the freshly generated spec / plan / tasks file under
-  `docs/specs/<NNN>-<slug>/` as a single Conventional Commit
-  (`docs(specs): <phase> NNN-<slug>`). Invoked from `.specify/extensions.yml`
-  as the `after_specify` / `after_plan` / `after_tasks` hooks; also runnable
-  manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git reset:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(printf:*) Bash(sort:*) Bash(tail:*) Bash(test:*) Bash(jq:*) Bash(python3:*) Bash(find:*)
+  Stage and commit the freshly generated phase artifacts under
+  `docs/specs/<NNN>-<slug>/` as a single Conventional Commit. The subject is
+  `docs(specs): <phase> NNN-<slug>`, with one exception: the `spec` phase
+  uses the verb `scaffold` (so the subject reads `docs(specs): scaffold
+  NNN-<slug>`). Invoked from `.specify/extensions.yml` as the
+  `after_specify` / `after_plan` / `after_tasks` hooks; the `checklist` and
+  `analyze` phases are manual-only and have no hook entry.
+  Runnable manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git reset:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(printf:*) Bash(sort:*) Bash(tail:*) Bash(test:*) Bash(jq:*) Bash(python3:*)
 argument-hint: "spec|plan|tasks|checklist|analyze"
 ---
 
@@ -40,6 +43,11 @@ docs/specs/`: pick the phase whose file(s) are pending. If files from
 multiple distinct phases are pending, **stop** and ask the user to specify
 which phase to commit — this skill deliberately commits one phase at a time.
 
+If `$ARGUMENTS` is empty **and** neither command shows anything pending
+under `docs/specs/` / `specs/`, exit 0 with `nothing to commit — no
+spec-kit artifacts are pending`. Do not guess a phase, do not prompt;
+this is a no-op completion, not a failure.
+
 ## 2. Locate the spec directory
 
 Resolve `SPEC_DIR` in this order, mirroring how `setup-plan.sh` /
@@ -51,8 +59,23 @@ over branch name; we then add Beutl-specific fallbacks):
    active feature. Read it with `jq` (or `python3` / `grep+sed` fallback)
    and use the value if the directory exists.
 2. **`SPECIFY_FEATURE_DIRECTORY` from env / context.** If the parent skill
-   or the user passed it explicitly, honour it (sanity-check that it lives
-   under `docs/specs/` or `specs/`).
+   or the user passed it explicitly, honour it — but first verify the path
+   lives under `docs/specs/` or `specs/` (relative or absolute under the
+   repo root). A value pointing elsewhere is almost certainly a typo or an
+   injected override; refuse rather than commit outside the spec tree:
+
+   ```bash
+   repo_root=$(git rev-parse --show-toplevel)
+   case "$SPECIFY_FEATURE_DIRECTORY" in
+     docs/specs/*|specs/*) ;;
+     "$repo_root"/docs/specs/*|"$repo_root"/specs/*) ;;
+     "") ;;  # not set — fall through to the next resolution step.
+     *)
+       echo "Refusing — SPECIFY_FEATURE_DIRECTORY ($SPECIFY_FEATURE_DIRECTORY)"
+       echo "must live under docs/specs/ or specs/."
+       exit 1 ;;
+   esac
+   ```
 3. **Current branch.** If `git rev-parse --abbrev-ref HEAD` matches
    `speckit/<NNN>-<slug>`, prefer `docs/specs/<NNN>-<slug>` (Beutl
    convention) and fall back to `specs/<NNN>-<slug>` only when the former
@@ -99,10 +122,13 @@ esac
 
 Build the `TARGETS` list from the phase → files mapping in §1. For the
 `plan` phase, the mapping includes the whole `contracts/` directory; expand
-it to its leaf files via `find` so the staged set is comparable to what
-`git diff --cached --name-only` reports later. Skip mapped paths that do
-not actually exist (e.g. `analyze` may produce no file at all, `contracts/`
-may be absent for a UI-only plan):
+it to its leaf files via `git ls-files` (cached + untracked, honouring
+`.gitignore`) so editor scratch files / `.DS_Store` / OS junk never leak
+into the staged set the way `find -type f` would. The output is also what
+`git diff --cached --name-only` will report later, so the comparison in §4.3
+stays apples-to-apples. Skip mapped paths that do not actually exist (e.g.
+`analyze` may produce no file at all, `contracts/` may be absent for a
+UI-only plan):
 
 ```bash
 case "$PHASE" in
@@ -125,9 +151,12 @@ done
 for d in $MAPPED_DIRS; do
   dp="$SPEC_DIR/$d"
   [ -d "$dp" ] || continue
+  # cached: tracked files under $dp; others + --exclude-standard: untracked
+  # files that are NOT .gitignore-d. Together this is "files git would touch
+  # if you ran `git add -A -- $dp`", which is exactly the set we want.
   while IFS= read -r leaf; do
     [ -n "$leaf" ] && TARGETS="$TARGETS $leaf"
-  done < <(find "$dp" -type f)
+  done < <(git ls-files --cached --others --exclude-standard -- "$dp")
 done
 TARGETS="${TARGETS# }"
 
@@ -200,6 +229,10 @@ wipe phase files the user had already `git add`-ed before invoking us.
 prestaged=$(git diff --cached --name-only | sort -u)
 
 # 4.2 Stage the pending subset of the mapping.
+# Every entry in $PENDING is a *leaf file path* (TARGETS expansion in §3
+# enumerates leaves via `git ls-files`; §4b adds leaves from
+# `git ls-files --deleted`). `git add -A` on a directory would sweep in
+# sibling files, so never let $PENDING grow to contain a directory.
 # shellcheck disable=SC2086
 git add -A -- $PENDING
 ```
@@ -228,11 +261,14 @@ actual=$(git diff --cached --name-only | sort -u)
 prestaged_phase=$(printf '%s\n' "$prestaged" | grep -Fx -f <(printf '%s\n' "$expected") || true)
 prestaged_other=$(printf '%s\n' "$prestaged" | grep -Fxv -f <(printf '%s\n' "$expected") || true)
 
+# Compute "what this skill added" once, up front. §6's rollback path
+# reuses the same variable so a failed `git commit` un-stages exactly
+# what we added — never what the user pre-staged.
+added_by_us=$(printf '%s\n' "$expected" | grep -Fxv -f <(printf '%s\n' "$prestaged_phase") || true)
+
 if [ -n "$prestaged_other" ]; then
   echo "Aborting — unrelated files were already staged before this skill ran:"
   echo "$prestaged_other"
-  # Only un-stage what *this skill* added (expected - prestaged_phase).
-  added_by_us=$(printf '%s\n' "$expected" | grep -Fxv -f <(printf '%s\n' "$prestaged_phase") || true)
   if [ -n "$added_by_us" ]; then
     # shellcheck disable=SC2086
     git reset --quiet -- $added_by_us
@@ -244,8 +280,6 @@ if [ "$expected" != "$actual" ]; then
   echo "Aborting — staged set differs from the pending phase targets."
   echo "Expected:"; echo "$expected"
   echo "Got:";      echo "$actual"
-  # Restore only the paths we added; leave whatever the user pre-staged.
-  added_by_us=$(printf '%s\n' "$expected" | grep -Fxv -f <(printf '%s\n' "$prestaged_phase") || true)
   if [ -n "$added_by_us" ]; then
     # shellcheck disable=SC2086
     git reset --quiet -- $added_by_us
@@ -299,7 +333,10 @@ else
   fi
 fi
 if [ -n "$PRIMARY" ] && [ -f "$PRIMARY" ]; then
-  SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
+  # First non-empty, non-heading line. We deliberately do NOT skip line 1 —
+  # markdown files that begin with a paragraph (no leading `# Title`) would
+  # otherwise yield an empty summary.
+  SUMMARY=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
 else
   SUMMARY=""
 fi
@@ -307,11 +344,34 @@ fi
 
 ## 6. Commit
 
+Run the commit. Pass `$SUMMARY` as a second `-m` **only when it is
+non-empty** — passing an empty `-m ""` produces a noisy trailing blank
+paragraph in the commit body.
+
 ```bash
-git commit -m "$SUBJECT" -m "$SUMMARY"
+if [ -n "$SUMMARY" ]; then
+  commit_status=0
+  git commit -m "$SUBJECT" -m "$SUMMARY" || commit_status=$?
+else
+  commit_status=0
+  git commit -m "$SUBJECT" || commit_status=$?
+fi
+
+if [ "$commit_status" -ne 0 ]; then
+  echo "Aborting — git commit exited with status $commit_status."
+  echo "A pre-commit hook, GPG signing, or the commit-msg hook likely"
+  echo "rejected the commit. Re-staging is left alone, but anything"
+  echo "this skill added on top of the user's pre-staged set is rolled back"
+  echo "to mirror the symmetric §4.3 abort path."
+  if [ -n "$added_by_us" ]; then
+    # shellcheck disable=SC2086
+    git reset --quiet -- $added_by_us
+  fi
+  exit "$commit_status"
+fi
 ```
 
-Do not use `--amend` and do not use `--allow-empty`. Do not push.
+Do not use `--amend`, `--allow-empty`, or `--no-verify`. Do not push.
 
 ## 7. Report
 

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -5,31 +5,34 @@ description: |
   (`docs(specs): <phase> NNN-<slug>`). Invoked from `.specify/extensions.yml`
   as the `after_specify` / `after_plan` / `after_tasks` hooks; also runnable
   manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(sort:*) Bash(tail:*) Bash(test:*)
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git reset:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(sort:*) Bash(tail:*) Bash(test:*) Bash(jq:*) Bash(python3:*) Bash(find:*)
 argument-hint: "spec|plan|tasks|checklist|analyze"
 ---
 
 # Spec-Kit git: phase commit
 
-Make exactly one commit per phase, scoped to `docs/specs/<NNN>-<slug>/`.
+Make exactly one commit per phase, scoped to the spec directory of the
+active feature. The Beutl-local SPECS_DIR patch redirects to `docs/specs/`,
+but the upstream `/speckit-specify` SKILL still defaults to `specs/` in its
+documented prose, so this skill checks both layouts.
 
 ## 1. Identify the phase
 
 `$ARGUMENTS` is one of: `spec`, `plan`, `tasks`, `checklist`, `analyze`.
 
-Each phase maps to one or more Markdown artifacts:
+Each phase maps to one or more artifact paths under the spec directory:
 
-| Phase | Files committed |
+| Phase | Artifacts committed |
 |---|---|
 | `spec` | `spec.md` |
-| `plan` | `plan.md`, `research.md`, `data-model.md`, `quickstart.md` |
+| `plan` | `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, plus the entire `contracts/` directory (when `/speckit-plan` generated API/IPC contracts for the feature) |
 | `tasks` | `tasks.md` |
 | `checklist` | `checklist.md` |
 | `analyze` | `analysis.md` (only when `/speckit-analyze` wrote one) |
 
 `spec` / `tasks` / `checklist` are one-file commits. `plan` is the only
-multi-file phase because `/speckit-plan` produces the design pack alongside
-the plan itself.
+multi-artifact phase because `/speckit-plan` produces the design pack
+alongside the plan itself.
 
 If `$ARGUMENTS` is empty, infer from `git status --porcelain --
 docs/specs/` and `git ls-files --others --exclude-standard --
@@ -39,26 +42,37 @@ which phase to commit — this skill deliberately commits one phase at a time.
 
 ## 2. Locate the spec directory
 
-Resolve `SPEC_DIR` in this order — falling through silently to the wrong
-directory is the most common way this skill could commit the wrong feature:
+Resolve `SPEC_DIR` in this order, mirroring how `setup-plan.sh` /
+`setup-tasks.sh` resolve `SPECIFY_FEATURE_DIRECTORY` (feature.json wins
+over branch name; we then add Beutl-specific fallbacks):
 
-1. **Current branch.** If `git rev-parse --abbrev-ref HEAD` matches
-   `speckit/<NNN>-<slug>`, use `docs/specs/<NNN>-<slug>`.
-2. **`SPECIFY_FEATURE_DIRECTORY` from context.** If the parent skill or the
-   user passed it via env / argument, honour it (after a sanity check that
-   it lives under `docs/specs/`).
-3. **The phase file's actual location.** Look at `git status --porcelain --
-   docs/specs/` and pick the directory whose `<phase>.md` is pending.
-4. **Last resort** — and only when steps 1-3 yield no answer: take the
-   highest-numbered `docs/specs/<NNN>-*/` directory:
+1. **`.specify/feature.json` `feature_directory`.** When the upstream
+   `/speckit-specify` writes this file, it is the canonical handle on the
+   active feature. Read it with `jq` (or `python3` / `grep+sed` fallback)
+   and use the value if the directory exists.
+2. **`SPECIFY_FEATURE_DIRECTORY` from env / context.** If the parent skill
+   or the user passed it explicitly, honour it (sanity-check that it lives
+   under `docs/specs/` or `specs/`).
+3. **Current branch.** If `git rev-parse --abbrev-ref HEAD` matches
+   `speckit/<NNN>-<slug>`, prefer `docs/specs/<NNN>-<slug>` (Beutl
+   convention) and fall back to `specs/<NNN>-<slug>` only when the former
+   does not exist.
+4. **The phase file's actual location.** Look at `git status --porcelain`
+   and `git ls-files --others --exclude-standard` under both `docs/specs/`
+   and `specs/` and pick the directory whose mapped phase file is pending.
+5. **Last resort** — and only when steps 1-4 yield no answer: take the
+   highest-numbered `<root>/<NNN>-*/` directory across both roots:
 
    ```bash
-   SPEC_DIR=$(ls -1d docs/specs/[0-9][0-9][0-9]-* 2>/dev/null | sort | tail -1)
+   SPEC_DIR=$( {
+     ls -1d docs/specs/[0-9][0-9][0-9]-* 2>/dev/null
+     ls -1d      specs/[0-9][0-9][0-9]-* 2>/dev/null
+   } | sort | tail -1 )
    ```
 
-If the resolved `SPEC_DIR` is empty or the expected `<phase>.md` does not
-live under it, stop and report the mismatch — do not commit to the wrong
-directory by inertia.
+If the resolved `SPEC_DIR` is empty or the expected `<phase>` file(s) do
+not live under it, stop and report the mismatch — do not commit to the
+wrong directory by inertia.
 
 Extract the slug:
 
@@ -70,68 +84,88 @@ SLUG=${NNN_SLUG#*-}                # add-foo-button
 
 ## 3. Verify the target file(s)
 
-Build the `TARGETS` list from the phase → files mapping in §1. Skip any
-mapped file that does not actually exist (e.g. `analyze` may produce no
-file at all in some runs):
+Build the `TARGETS` list from the phase → files mapping in §1. For the
+`plan` phase, the mapping includes the whole `contracts/` directory; expand
+it to its leaf files via `find` so the staged set is comparable to what
+`git diff --cached --name-only` reports later. Skip mapped paths that do
+not actually exist (e.g. `analyze` may produce no file at all, `contracts/`
+may be absent for a UI-only plan):
 
 ```bash
 case "$PHASE" in
-  spec)      MAPPED="spec.md" ;;
-  plan)      MAPPED="plan.md research.md data-model.md quickstart.md" ;;
-  tasks)     MAPPED="tasks.md" ;;
-  checklist) MAPPED="checklist.md" ;;
-  analyze)   MAPPED="analysis.md" ;;
+  spec)      MAPPED_FILES="spec.md"; MAPPED_DIRS="" ;;
+  plan)      MAPPED_FILES="plan.md research.md data-model.md quickstart.md"
+             MAPPED_DIRS="contracts" ;;
+  tasks)     MAPPED_FILES="tasks.md"; MAPPED_DIRS="" ;;
+  checklist) MAPPED_FILES="checklist.md"; MAPPED_DIRS="" ;;
+  analyze)   MAPPED_FILES="analysis.md"; MAPPED_DIRS="" ;;
   *)         echo "Unknown phase: $PHASE"; exit 1 ;;
 esac
 
 TARGETS=""
-for f in $MAPPED; do
+for f in $MAPPED_FILES; do
   p="$SPEC_DIR/$f"
   [ -f "$p" ] && TARGETS="$TARGETS $p"
+done
+for d in $MAPPED_DIRS; do
+  dp="$SPEC_DIR/$d"
+  [ -d "$dp" ] || continue
+  while IFS= read -r leaf; do
+    [ -n "$leaf" ] && TARGETS="$TARGETS $leaf"
+  done < <(find "$dp" -type f)
 done
 TARGETS="${TARGETS# }"
 
 [ -n "$TARGETS" ] || { echo "No $PHASE artifacts under $SPEC_DIR"; exit 1; }
 ```
 
-Check whether at least one target file is actually pending. **Untracked
-files do not show up in `git diff`**, but newly generated files are
-typically untracked on their first commit. Test all three states across
-all targets:
+Check whether at least one target file is **pending** (untracked, modified,
+or staged). The pending subset is what we will compare against the staged
+set after `git add` — Codex flagged that requiring the full `TARGETS`
+list to match the staged set wrongly aborted partial-file edits in the
+plan phase (e.g. editing only `plan.md` and leaving `research.md`
+unchanged).
 
 ```bash
-pending=""
+PENDING=""
 for t in $TARGETS; do
+  is_pending=""
   if git ls-files --others --exclude-standard -- "$t" | grep -q .; then
-    pending="yes"; break
+    is_pending="yes"
+  elif ! git diff --quiet -- "$t"; then
+    is_pending="yes"
+  elif ! git diff --cached --quiet -- "$t"; then
+    is_pending="yes"
   fi
-  if ! git diff --quiet -- "$t" ; then pending="yes"; break; fi
-  if ! git diff --cached --quiet -- "$t" ; then pending="yes"; break; fi
+  [ -n "$is_pending" ] && PENDING="$PENDING $t"
 done
-[ -n "$pending" ] || { echo "No pending changes for phase $PHASE"; exit 0; }
+PENDING="${PENDING# }"
+
+[ -n "$PENDING" ] || { echo "No pending changes for phase $PHASE"; exit 0; }
 ```
 
-## 4. Stage **only** the mapped phase files
+## 4. Stage **only** the pending phase files
 
 `git add -- "$SPEC_DIR"` would sweep in any other pending edits inside the
 spec directory (the user's draft notes, an old `checklist.md`, a stray
-`scratch.md`). Stage only the mapped files:
+`scratch.md`). Stage only the pending subset of the mapping:
 
 ```bash
 # shellcheck disable=SC2086
-git add -- $TARGETS
+git add -- $PENDING
 ```
 
-Then verify the staged set is exactly the targets — no more, no less:
+Then verify the staged set matches the pending subset — no more, no less:
 
 ```bash
-expected=$(printf '%s\n' $TARGETS | sort -u)
+expected=$(printf '%s\n' $PENDING | sort -u)
 actual=$(git diff --cached --name-only | sort -u)
 if [ "$expected" != "$actual" ]; then
-  echo "Aborting — staged set differs from the mapped phase targets."
+  echo "Aborting — staged set differs from the pending phase targets."
   echo "Expected:"; echo "$expected"
   echo "Got:";      echo "$actual"
-  git reset --quiet -- $TARGETS
+  # shellcheck disable=SC2086
+  git reset --quiet -- $PENDING
   exit 1
 fi
 ```
@@ -165,8 +199,8 @@ it. For the multi-file `plan` phase, list the additional artifacts after
 the summary line.
 
 ```bash
-# Primary file is always the first entry in $MAPPED.
-PRIMARY="$SPEC_DIR/$(printf '%s' "$MAPPED" | awk '{print $1}')"
+# Primary file is always the first entry in $MAPPED_FILES.
+PRIMARY="$SPEC_DIR/$(printf '%s' "$MAPPED_FILES" | awk '{print $1}')"
 SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
 ```
 
@@ -190,8 +224,8 @@ files in one commit:
 
 ## Refusals
 
-- Never `git add` outside `docs/specs/<NNN>-<slug>/`.
+- Never `git add` outside the resolved `SPEC_DIR`.
 - Never `git push`. The user pushes when they are ready.
 - Never amend a previous commit.
 - Never run `dotnet format` / linters / tests as part of this skill — its
-  scope is exactly one commit of exactly one Markdown file.
+  scope is exactly one commit of one phase's artifact(s).

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -5,7 +5,7 @@ description: |
   (`docs(specs): <phase> NNN-<slug>`). Invoked from `.specify/extensions.yml`
   as the `after_specify` / `after_plan` / `after_tasks` hooks; also runnable
   manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git log:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*)
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(sort:*) Bash(tail:*) Bash(test:*)
 argument-hint: "spec|plan|tasks|checklist|analyze"
 ---
 
@@ -17,21 +17,48 @@ Make exactly one commit per phase, scoped to `docs/specs/<NNN>-<slug>/`.
 
 `$ARGUMENTS` is one of: `spec`, `plan`, `tasks`, `checklist`, `analyze`.
 
-If empty, infer from `git status --porcelain -- docs/specs/` — pick the most
-recently modified `<phase>.md` under the latest `docs/specs/<NNN>-<slug>/`.
-If multiple phases changed, **stop** and ask the user to specify; this skill
-deliberately commits one phase at a time.
+Each phase maps to one or more Markdown artifacts:
+
+| Phase | Files committed |
+|---|---|
+| `spec` | `spec.md` |
+| `plan` | `plan.md`, `research.md`, `data-model.md`, `quickstart.md` |
+| `tasks` | `tasks.md` |
+| `checklist` | `checklist.md` |
+| `analyze` | `analysis.md` (only when `/speckit-analyze` wrote one) |
+
+`spec` / `tasks` / `checklist` are one-file commits. `plan` is the only
+multi-file phase because `/speckit-plan` produces the design pack alongside
+the plan itself.
+
+If `$ARGUMENTS` is empty, infer from `git status --porcelain --
+docs/specs/` and `git ls-files --others --exclude-standard --
+docs/specs/`: pick the phase whose file(s) are pending. If files from
+multiple distinct phases are pending, **stop** and ask the user to specify
+which phase to commit — this skill deliberately commits one phase at a time.
 
 ## 2. Locate the spec directory
 
-```bash
-SPEC_DIR=$(ls -1d docs/specs/[0-9][0-9][0-9]-* 2>/dev/null | sort | tail -1)
-```
+Resolve `SPEC_DIR` in this order — falling through silently to the wrong
+directory is the most common way this skill could commit the wrong feature:
 
-This selects the highest-numbered directory — typically the one just created
-by `/speckit-git-branch` or the previous phase. If `SPEC_DIR` is empty or
-the expected `<phase>.md` does not live under it, stop and report the
-mismatch (do not silently fall back).
+1. **Current branch.** If `git rev-parse --abbrev-ref HEAD` matches
+   `speckit/<NNN>-<slug>`, use `docs/specs/<NNN>-<slug>`.
+2. **`SPECIFY_FEATURE_DIRECTORY` from context.** If the parent skill or the
+   user passed it via env / argument, honour it (after a sanity check that
+   it lives under `docs/specs/`).
+3. **The phase file's actual location.** Look at `git status --porcelain --
+   docs/specs/` and pick the directory whose `<phase>.md` is pending.
+4. **Last resort** — and only when steps 1-3 yield no answer: take the
+   highest-numbered `docs/specs/<NNN>-*/` directory:
+
+   ```bash
+   SPEC_DIR=$(ls -1d docs/specs/[0-9][0-9][0-9]-* 2>/dev/null | sort | tail -1)
+   ```
+
+If the resolved `SPEC_DIR` is empty or the expected `<phase>.md` does not
+live under it, stop and report the mismatch — do not commit to the wrong
+directory by inertia.
 
 Extract the slug:
 
@@ -41,35 +68,77 @@ NNN=${NNN_SLUG%%-*}                # 001
 SLUG=${NNN_SLUG#*-}                # add-foo-button
 ```
 
-## 3. Verify the target file
+## 3. Verify the target file(s)
+
+Build the `TARGETS` list from the phase → files mapping in §1. Skip any
+mapped file that does not actually exist (e.g. `analyze` may produce no
+file at all in some runs):
 
 ```bash
-TARGET="$SPEC_DIR/$PHASE.md"
-[ -f "$TARGET" ] || { echo "No $PHASE.md under $SPEC_DIR"; exit 1; }
+case "$PHASE" in
+  spec)      MAPPED="spec.md" ;;
+  plan)      MAPPED="plan.md research.md data-model.md quickstart.md" ;;
+  tasks)     MAPPED="tasks.md" ;;
+  checklist) MAPPED="checklist.md" ;;
+  analyze)   MAPPED="analysis.md" ;;
+  *)         echo "Unknown phase: $PHASE"; exit 1 ;;
+esac
+
+TARGETS=""
+for f in $MAPPED; do
+  p="$SPEC_DIR/$f"
+  [ -f "$p" ] && TARGETS="$TARGETS $p"
+done
+TARGETS="${TARGETS# }"
+
+[ -n "$TARGETS" ] || { echo "No $PHASE artifacts under $SPEC_DIR"; exit 1; }
 ```
 
-Check whether it is actually pending:
+Check whether at least one target file is actually pending. **Untracked
+files do not show up in `git diff`**, but newly generated files are
+typically untracked on their first commit. Test all three states across
+all targets:
 
 ```bash
-git diff --quiet -- "$TARGET" && git diff --cached --quiet -- "$TARGET" \
-  && { echo "No changes to commit for $TARGET"; exit 0; }
+pending=""
+for t in $TARGETS; do
+  if git ls-files --others --exclude-standard -- "$t" | grep -q .; then
+    pending="yes"; break
+  fi
+  if ! git diff --quiet -- "$t" ; then pending="yes"; break; fi
+  if ! git diff --cached --quiet -- "$t" ; then pending="yes"; break; fi
+done
+[ -n "$pending" ] || { echo "No pending changes for phase $PHASE"; exit 0; }
 ```
 
-## 4. Stage **only** the spec directory
+## 4. Stage **only** the mapped phase files
+
+`git add -- "$SPEC_DIR"` would sweep in any other pending edits inside the
+spec directory (the user's draft notes, an old `checklist.md`, a stray
+`scratch.md`). Stage only the mapped files:
 
 ```bash
-git add -- "$SPEC_DIR"
+# shellcheck disable=SC2086
+git add -- $TARGETS
 ```
 
-Then verify nothing outside that directory ended up staged:
+Then verify the staged set is exactly the targets — no more, no less:
 
 ```bash
-extras=$(git diff --cached --name-only | grep -v "^${SPEC_DIR%/}/" || true)
-[ -z "$extras" ] || { echo "Aborting — extra files staged: $extras"; exit 1; }
+expected=$(printf '%s\n' $TARGETS | sort -u)
+actual=$(git diff --cached --name-only | sort -u)
+if [ "$expected" != "$actual" ]; then
+  echo "Aborting — staged set differs from the mapped phase targets."
+  echo "Expected:"; echo "$expected"
+  echo "Got:";      echo "$actual"
+  git reset --quiet -- $TARGETS
+  exit 1
+fi
 ```
 
-This is the safety rail: we never want this skill to commit unrelated work
-that happens to be sitting in the working tree.
+If the user wants additional files in the same commit (e.g. supplementary
+notes under `notes/`), they should run a separate `git add` and `git
+commit` themselves — this skill keeps phase commits clean.
 
 ## 5. Compose the commit message
 
@@ -89,11 +158,16 @@ For `<phase>=spec`, use the verb `scaffold` instead of `spec` — it reads more
 naturally for the very first commit of a spec. For other phases, use the
 phase name as-is.
 
-Body (optional but recommended): copy the first non-heading line from
-`<phase>.md` so reviewers see what the file is about without opening it.
+Body (optional but recommended): copy the first non-heading line from the
+**primary** file (`spec.md` / `plan.md` / `tasks.md` / `checklist.md` /
+`analysis.md`) so reviewers see what the commit is about without opening
+it. For the multi-file `plan` phase, list the additional artifacts after
+the summary line.
 
 ```bash
-SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$TARGET" | head -c 200)
+# Primary file is always the first entry in $MAPPED.
+PRIMARY="$SPEC_DIR/$(printf '%s' "$MAPPED" | awk '{print $1}')"
+SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
 ```
 
 ## 6. Commit
@@ -107,10 +181,11 @@ Do not use `--amend` and do not use `--allow-empty`. Do not push.
 ## 7. Report
 
 Emit a JSON line so the calling SKILL can record the result, followed by a
-short human summary:
+short human summary. `paths` is an array because `plan` commits multiple
+files in one commit:
 
 ```json
-{"sha":"<short-sha>","path":"docs/specs/<NNN>-<slug>/<phase>.md","subject":"docs(specs): <phase> <NNN>-<slug>"}
+{"sha":"<short-sha>","paths":["docs/specs/<NNN>-<slug>/<file>", "..."],"subject":"docs(specs): <phase> <NNN>-<slug>"}
 ```
 
 ## Refusals

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -277,15 +277,32 @@ naturally for the very first commit of a spec. For other phases, use the
 phase name as-is.
 
 Body (optional but recommended): copy the first non-heading line from the
-**primary** file (`spec.md` / `plan.md` / `tasks.md` / `checklist.md` /
-`analysis.md`) so reviewers see what the commit is about without opening
-it. For the multi-file `plan` phase, list the additional artifacts after
-the summary line.
+**primary** file (`spec.md` / `plan.md` / `tasks.md` / `analysis.md`, or —
+for the `checklist` phase — `checklists/requirements.md` when present, else
+the most recently modified file under `checklists/`) so reviewers see what
+the commit is about without opening it. For the multi-file `plan` phase,
+list the additional artifacts after the summary line.
 
 ```bash
-# Primary file is always the first entry in $MAPPED_FILES.
-PRIMARY="$SPEC_DIR/$(printf '%s' "$MAPPED_FILES" | awk '{print $1}')"
-SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
+# For phases with a primary mapped file, use the first entry in $MAPPED_FILES.
+# The `checklist` phase has no mapped file (only $MAPPED_DIRS=checklists), so
+# resolve a primary file from the checklists/ directory.
+if [ -n "$MAPPED_FILES" ]; then
+  PRIMARY="$SPEC_DIR/$(printf '%s' "$MAPPED_FILES" | awk '{print $1}')"
+else
+  # checklist phase: prefer checklists/requirements.md, else newest checklist file.
+  if [ -f "$SPEC_DIR/checklists/requirements.md" ]; then
+    PRIMARY="$SPEC_DIR/checklists/requirements.md"
+  else
+    # newest checklist .md file (BSD/GNU ls both honour -t for mtime sort)
+    PRIMARY=$(ls -t "$SPEC_DIR/checklists/"*.md 2>/dev/null | head -n 1)
+  fi
+fi
+if [ -n "$PRIMARY" ] && [ -f "$PRIMARY" ]; then
+  SUMMARY=$(awk 'NR>1 && NF && $0 !~ /^#/ {print; exit}' "$PRIMARY" | head -c 200)
+else
+  SUMMARY=""
+fi
 ```
 
 ## 6. Commit

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -5,7 +5,7 @@ description: |
   (`docs(specs): <phase> NNN-<slug>`). Invoked from `.specify/extensions.yml`
   as the `after_specify` / `after_plan` / `after_tasks` hooks; also runnable
   manually: `/speckit-git-commit spec | plan | tasks | checklist | analyze`.
-allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git reset:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(sort:*) Bash(tail:*) Bash(test:*) Bash(jq:*) Bash(python3:*) Bash(find:*)
+allowed-tools: Bash(git rev-parse:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git reset:*) Bash(git log:*) Bash(git ls-files:*) Bash(ls:*) Bash(head:*) Bash(awk:*) Bash(sed:*) Bash(grep:*) Bash(basename:*) Bash(printf:*) Bash(sort:*) Bash(tail:*) Bash(test:*) Bash(jq:*) Bash(python3:*) Bash(find:*)
 argument-hint: "spec|plan|tasks|checklist|analyze"
 ---
 
@@ -82,6 +82,19 @@ NNN=${NNN_SLUG%%-*}                # 001
 SLUG=${NNN_SLUG#*-}                # add-foo-button
 ```
 
+Also compute the repo-relative form of `SPEC_DIR` once so later steps can
+match it against `git diff --cached --name-only` and `git ls-files --deleted`
+output, both of which report repo-relative paths even when `SPEC_DIR` was
+resolved from an absolute `SPECIFY_FEATURE_DIRECTORY`:
+
+```bash
+repo_root=$(git rev-parse --show-toplevel)
+case "$SPEC_DIR" in
+  "$repo_root"/*) SPEC_DIR_REL="${SPEC_DIR#$repo_root/}" ;;
+  *)              SPEC_DIR_REL="$SPEC_DIR" ;;
+esac
+```
+
 ## 3. Verify the target file(s)
 
 Build the `TARGETS` list from the phase → files mapping in §1. For the
@@ -154,10 +167,10 @@ done
 #     deletion outside the mapping is never picked up.
 prefix_re=""
 for f in $MAPPED_FILES; do
-  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR" "$f" | sed 's|[].[*^$/\\]|\\&|g')\$"
+  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s' "$SPEC_DIR_REL" "$f" | sed 's|[].[*^$/\\]|\\&|g')\$"
 done
 for d in $MAPPED_DIRS; do
-  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"
+  prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR_REL" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"
 done
 if [ -n "$prefix_re" ]; then
   while IFS= read -r dl; do
@@ -173,10 +186,20 @@ PENDING="${PENDING# }"
 
 `git add -- "$SPEC_DIR"` would sweep in any other pending edits inside the
 spec directory (the user's draft notes, an old `checklist.md`, a stray
-`scratch.md`). Stage only the pending subset of the mapping. `git add -A`
-on a path also records deletions, which is what we want:
+`scratch.md`). Stage only the pending subset of the mapping.
+
+Before staging, **snapshot the user's pre-existing index**. If the
+staged-set check fails later, the abort path must only un-stage what this
+skill added — Codex flagged that a blanket `git reset -- $PENDING` would
+wipe phase files the user had already `git add`-ed before invoking us.
+
+`git add -A` on a path also records deletions, which is what we want:
 
 ```bash
+# 4.1 Snapshot what was already staged before we touch the index.
+prestaged=$(git diff --cached --name-only | sort -u)
+
+# 4.2 Stage the pending subset of the mapping.
 # shellcheck disable=SC2086
 git add -A -- $PENDING
 ```
@@ -188,10 +211,7 @@ Then verify the staged set matches the pending subset — no more, no less.
 `git diff --cached --name-only` always reports repo-relative paths.
 
 ```bash
-repo_root=$(git rev-parse --show-toplevel)
-
-# Strip the repo prefix from any absolute path; leave repo-relative
-# paths untouched.
+# 4.3 Use repo_root computed in §2 to normalize PENDING entries.
 to_rel() {
   case "$1" in
     "$repo_root"/*) printf '%s' "${1#$repo_root/}" ;;
@@ -202,12 +222,34 @@ to_rel() {
 expected=$(for p in $PENDING; do to_rel "$p"; echo; done | sort -u | grep -v '^$')
 actual=$(git diff --cached --name-only | sort -u)
 
+# Anything that was staged *before* we ran but is also a pending phase
+# target is fine — it just means the user pre-staged a phase file. Treat
+# those as already accounted for when comparing.
+prestaged_phase=$(printf '%s\n' "$prestaged" | grep -Fx -f <(printf '%s\n' "$expected") || true)
+prestaged_other=$(printf '%s\n' "$prestaged" | grep -Fxv -f <(printf '%s\n' "$expected") || true)
+
+if [ -n "$prestaged_other" ]; then
+  echo "Aborting — unrelated files were already staged before this skill ran:"
+  echo "$prestaged_other"
+  # Only un-stage what *this skill* added (expected - prestaged_phase).
+  added_by_us=$(printf '%s\n' "$expected" | grep -Fxv -f <(printf '%s\n' "$prestaged_phase") || true)
+  if [ -n "$added_by_us" ]; then
+    # shellcheck disable=SC2086
+    git reset --quiet -- $added_by_us
+  fi
+  exit 1
+fi
+
 if [ "$expected" != "$actual" ]; then
   echo "Aborting — staged set differs from the pending phase targets."
   echo "Expected:"; echo "$expected"
   echo "Got:";      echo "$actual"
-  # shellcheck disable=SC2086
-  git reset --quiet -- $PENDING
+  # Restore only the paths we added; leave whatever the user pre-staged.
+  added_by_us=$(printf '%s\n' "$expected" | grep -Fxv -f <(printf '%s\n' "$prestaged_phase") || true)
+  if [ -n "$added_by_us" ]; then
+    # shellcheck disable=SC2086
+    git reset --quiet -- $added_by_us
+  fi
   exit 1
 fi
 ```

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -55,10 +55,38 @@ the pending paths all live under *one* root. If the same `<NNN>-<slug>`
 feature appears under both `docs/specs/` *and* `specs/` (e.g. someone
 ran `/speckit-specify` once before and once after the Beutl-local
 `SPECS_DIR` patch landed), §2's resolver would pick a single root and
-silently commit only half the artifacts. Detect this by extracting
-`<root>/<NNN>-<slug>/` prefixes from the union output above; if two
-different roots map to the same `<NNN>-<slug>`, stop and ask the user
-which root to use rather than guessing.
+silently commit only half the artifacts. Detect with concrete bash —
+do not eyeball the union output, because `git status --porcelain` lines
+carry a 2-char `XY` status column (and a ` -> ` arrow for renames) that
+must be stripped before path matching:
+
+```bash
+# Strip the porcelain XY+space prefix and split rename arrows. Spec
+# slugs are kebab-case ([a-z0-9-]), so we do not bother handling
+# porcelain's `-z` NUL-terminated form or quoted paths.
+porcelain_paths=$(git status --porcelain -- docs/specs/ specs/ \
+  | sed -E 's|^...||' \
+  | sed -E 's| -> |\n|')
+untracked_paths=$(git ls-files --others --exclude-standard -- docs/specs/ specs/)
+
+pending_features=$(printf '%s\n%s\n' "$porcelain_paths" "$untracked_paths" \
+  | grep -oE '^(docs/specs|specs)/[0-9]{3}-[a-z0-9-]+/' \
+  | sort -u)
+
+# If the same NNN-slug appears under both roots, that is the ambiguity.
+mixed=$(printf '%s\n' "$pending_features" \
+  | sed -E 's|^(docs/specs|specs)/||' \
+  | sort \
+  | uniq -d)
+
+if [ -n "$mixed" ]; then
+  echo "Aborting — these features have pending files under both"
+  echo "docs/specs/ AND specs/ (mixed-root):"
+  printf '%s\n' "$mixed" | sed 's/^/  /'
+  echo "Move or remove one copy of each before re-running this skill."
+  exit 1
+fi
+```
 
 If `$ARGUMENTS` is empty **and** neither command shows anything pending
 under either root, exit 0 with `nothing to commit — no spec-kit
@@ -225,13 +253,19 @@ for d in $MAPPED_DIRS; do
   prefix_re="${prefix_re:+$prefix_re|}$(printf '%s/%s/' "$SPEC_DIR_REL" "$d" | sed 's|[].[*^$/\\]|\\&|g').*"
 done
 if [ -n "$prefix_re" ]; then
-  # Separate `git ls-files --deleted` from the grep filter so a real
-  # failure inside git (corrupt index, permission error, etc.) is not
-  # masked by grep's "no match" exit code via a single trailing
-  # `|| true` over the whole pipeline. We only want to swallow the
-  # "zero deletions matched" case (grep returning 1), not the rare
-  # case where git itself errors out — that should surface and abort.
-  deleted_all=$(git ls-files --deleted)
+  # Run `git ls-files --deleted` in its own statement and **check the
+  # exit code explicitly**. A bare `deleted_all=$(git ls-files --deleted)`
+  # discards git's status, so a real failure (corrupt index, lock
+  # contention, permission error) would silently degrade to "no
+  # deletions" — the same class of silent failure as the prior
+  # `|| true` over the whole pipeline. The brace-grouped `|| true`
+  # around grep below is still required: grep returning 1 on "zero
+  # matches" is the normal case (most invocations have no deletions).
+  if ! deleted_all=$(git ls-files --deleted 2>&1); then
+    echo "Aborting — git ls-files --deleted failed:"
+    printf '%s\n' "$deleted_all"
+    exit 1
+  fi
   while IFS= read -r dl; do
     [ -n "$dl" ] && PENDING="$PENDING $dl"
   done < <(printf '%s\n' "$deleted_all" | { grep -E "^(${prefix_re})$" || true; })
@@ -301,7 +335,11 @@ if [ -n "$prestaged_other" ]; then
   echo "$prestaged_other"
   if [ -n "$added_by_us" ]; then
     # shellcheck disable=SC2086
-    git reset --quiet -- $added_by_us
+    if ! reset_err=$(git reset --quiet -- $added_by_us 2>&1); then
+      echo "Warning — rollback (git reset) failed:"
+      printf '%s\n' "$reset_err"
+      echo "The index may be partially staged. Inspect with \`git status\`."
+    fi
   fi
   exit 1
 fi
@@ -312,7 +350,11 @@ if [ "$expected" != "$actual" ]; then
   echo "Got:";      echo "$actual"
   if [ -n "$added_by_us" ]; then
     # shellcheck disable=SC2086
-    git reset --quiet -- $added_by_us
+    if ! reset_err=$(git reset --quiet -- $added_by_us 2>&1); then
+      echo "Warning — rollback (git reset) failed:"
+      printf '%s\n' "$reset_err"
+      echo "The index may be partially staged. Inspect with \`git status\`."
+    fi
   fi
   exit 1
 fi
@@ -391,11 +433,15 @@ if [ "$commit_status" -ne 0 ]; then
   echo "Aborting — git commit exited with status $commit_status."
   echo "A pre-commit hook, GPG signing, or the commit-msg hook likely"
   echo "rejected the commit. Re-staging is left alone, but anything"
-  echo "this skill added on top of the user's pre-staged set is rolled back"
-  echo "to mirror the symmetric §4.3 abort path."
+  echo "this skill added on top of the user's pre-staged set is rolled"
+  echo "back using the same path as §4.3's abort branches."
   if [ -n "$added_by_us" ]; then
     # shellcheck disable=SC2086
-    git reset --quiet -- $added_by_us
+    if ! reset_err=$(git reset --quiet -- $added_by_us 2>&1); then
+      echo "Warning — rollback (git reset) failed:"
+      printf '%s\n' "$reset_err"
+      echo "The index may be partially staged. Inspect with \`git status\`."
+    fi
   fi
   exit "$commit_status"
 fi

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -31,9 +31,13 @@ hooks:
       command: speckit.git.commit
       optional: true
       description: >-
-        Stage and commit the freshly generated spec.md under
-        docs/specs/<NNN>-<slug>/ as `docs(specs): scaffold NNN-<slug>`.
-      prompt: Commit the new spec.md now?
+        Stage and commit the freshly generated spec-phase artifacts under
+        docs/specs/<NNN>-<slug>/ as `docs(specs): scaffold NNN-<slug>`. The
+        spec phase covers spec.md plus checklists/requirements.md when
+        `/speckit-specify` also writes the validation checklist.
+      prompt: >-
+        Commit the spec-phase artifacts (spec.md plus
+        checklists/requirements.md if it was generated) as one commit?
 
   after_plan:
     - extension: beutl-git
@@ -42,12 +46,13 @@ hooks:
       description: >-
         Stage and commit the plan-phase artifacts in a single commit as
         `docs(specs): plan NNN-<slug>`. `/speckit-plan` typically produces
-        plan.md, research.md, data-model.md, and quickstart.md; the skill
-        commits all that exist together. Pass the `plan` argument when
-        running it: `/speckit-git-commit plan`.
+        plan.md, research.md, data-model.md, quickstart.md, and any
+        contracts/ files; the skill commits all that exist together. Pass
+        the `plan` argument when running it: `/speckit-git-commit plan`.
       prompt: >-
         Commit the plan-phase artifacts (plan.md plus any of research.md,
-        data-model.md, quickstart.md that were generated) as one commit?
+        data-model.md, quickstart.md, contracts/* that were generated) as
+        one commit?
 
   after_tasks:
     - extension: beutl-git

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -40,9 +40,14 @@ hooks:
       command: speckit.git.commit
       optional: true
       description: >-
-        Stage and commit the freshly generated plan.md as
-        `docs(specs): plan NNN-<slug>`.
-      prompt: Commit plan.md now?
+        Stage and commit the plan-phase artifacts in a single commit as
+        `docs(specs): plan NNN-<slug>`. `/speckit-plan` typically produces
+        plan.md, research.md, data-model.md, and quickstart.md; the skill
+        commits all that exist together. Pass the `plan` argument when
+        running it: `/speckit-git-commit plan`.
+      prompt: >-
+        Commit the plan-phase artifacts (plan.md plus any of research.md,
+        data-model.md, quickstart.md that were generated) as one commit?
 
   after_tasks:
     - extension: beutl-git

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,0 +1,54 @@
+# Spec-Kit extension hooks for Beutl.
+#
+# This file is consumed by the `/speckit-*` skills under `.claude/skills/`. Each
+# skill checks for `.specify/extensions.yml`, looks up its `hooks.before_<phase>`
+# and `hooks.after_<phase>` entries, and surfaces an "Optional Pre-Hook" / "Optional
+# Post-Hook" prompt to the user. A hook command like `speckit.git.commit` maps to
+# the slash command `/speckit-git-commit`.
+#
+# All hooks here are `optional: true` — the SKILL offers the slash command and
+# waits for the user to opt in. Removing this file disables every hook silently.
+
+extensions:
+  beutl-git:
+    description: Beutl-local git automation for the Spec-Driven Development flow.
+    version: 1
+
+hooks:
+  before_specify:
+    - extension: beutl-git
+      command: speckit.git.branch
+      optional: true
+      description: >-
+        Offer to create a `speckit/<NNN>-<slug>` feature branch before writing
+        the spec. The slug comes from the parent skill's short-name generation.
+      prompt: >-
+        Create a speckit feature branch now? Beutl convention is
+        `speckit/<NNN>-<slug>`, where `<NNN>` matches the spec directory.
+
+  after_specify:
+    - extension: beutl-git
+      command: speckit.git.commit
+      optional: true
+      description: >-
+        Stage and commit the freshly generated spec.md under
+        docs/specs/<NNN>-<slug>/ as `docs(specs): scaffold NNN-<slug>`.
+      prompt: Commit the new spec.md now?
+
+  after_plan:
+    - extension: beutl-git
+      command: speckit.git.commit
+      optional: true
+      description: >-
+        Stage and commit the freshly generated plan.md as
+        `docs(specs): plan NNN-<slug>`.
+      prompt: Commit plan.md now?
+
+  after_tasks:
+    - extension: beutl-git
+      command: speckit.git.commit
+      optional: true
+      description: >-
+        Stage and commit the freshly generated tasks.md as
+        `docs(specs): tasks NNN-<slug>`.
+      prompt: Commit tasks.md now?

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -7,7 +7,14 @@
 # the slash command `/speckit-git-commit`.
 #
 # All hooks here are `optional: true` — the SKILL offers the slash command and
-# waits for the user to opt in. Removing this file disables every hook silently.
+# waits for the user to opt in. Removing or renaming this file disables every
+# hook silently — that is the documented "off switch", but it is also a
+# footgun for typos. If hooks "stopped working" unexpectedly, the first thing
+# to verify is that this file still exists at the path above. The
+# `/speckit-git-commit` skill exposes `checklist` and `analyze` phases too,
+# but they are manual-only by design — there is no `after_checklist` /
+# `after_analyze` hook because those phases run on demand, not on every
+# Spec-Kit cycle.
 
 extensions:
   beutl-git:

--- a/docs/ai-workflow/spec-driven-development.md
+++ b/docs/ai-workflow/spec-driven-development.md
@@ -52,6 +52,29 @@ Spec output lands under `docs/specs/<NNN>-<feature-slug>/` (Beutl-local override
 | Bug fix | Skip Spec-Kit. Fix, then add a regression test. |
 | Trivial refactor / typo fix | Skip Spec-Kit. |
 
+## Git extension hooks (optional)
+
+Spec-Kit ships a hook framework that each `/speckit-*` skill consults before / after running. Beutl registers two hooks under `.specify/extensions.yml`:
+
+- **`before_specify` → `/speckit-git-branch`** — creates a `speckit/<NNN>-<slug>` feature branch matched to the spec directory.
+- **`after_specify` / `after_plan` / `after_tasks` → `/speckit-git-commit`** — commits the freshly generated `spec.md` / `plan.md` / `tasks.md` as a single Conventional Commit (`docs(specs): <phase> <NNN>-<slug>`).
+
+All hooks are declared `optional: true`. The parent skill prints an "Optional Pre-Hook" / "Optional Post-Hook" prompt and waits for you to opt in — declining keeps the legacy "no git automation" behaviour intact. The slash commands are also runnable manually:
+
+```bash
+/speckit-git-branch <slug>          # create speckit/<NNN>-<slug>
+/speckit-git-commit spec            # commit docs/specs/<NNN>-<slug>/spec.md
+/speckit-git-commit plan            # ... plan.md
+/speckit-git-commit tasks           # ... tasks.md
+```
+
+Safety rails (enforced inside each skill):
+
+- `/speckit-git-branch` warns when the working tree is dirty or when you are not branching from `main`. It never deletes or force-resets a branch.
+- `/speckit-git-commit` stages **only** files inside `docs/specs/<NNN>-<slug>/`. If any other file ends up staged, the commit aborts. It never pushes, never amends, never runs linters.
+
+To disable the extension entirely, delete or rename `.specify/extensions.yml`. Every skill skips its hook lookup silently when the file is missing.
+
 ## Beutl-specific constraints
 
 The Beutl `constitution.md` records invariants that every spec must respect:

--- a/docs/ai-workflow/spec-driven-development.md
+++ b/docs/ai-workflow/spec-driven-development.md
@@ -59,7 +59,7 @@ Spec-Kit ships a hook framework that each `/speckit-*` skill consults before / a
 - **`before_specify` → `/speckit-git-branch`** — creates a `speckit/<NNN>-<slug>` feature branch matched to the spec directory.
 - **`after_specify` / `after_plan` / `after_tasks` → `/speckit-git-commit`** — commits the freshly generated phase artifacts as a single Conventional Commit. The subject is `docs(specs): <phase> <NNN>-<slug>`, with one exception: the `spec` phase uses the verb `scaffold` (reads more naturally for the very first commit), so subjects look like `docs(specs): scaffold 001-foo` / `docs(specs): plan 001-foo` / `docs(specs): tasks 001-foo`.
 
-All hooks are declared `optional: true`. The parent skill prints an "Optional Pre-Hook" / "Optional Post-Hook" prompt and waits for you to opt in — declining keeps the legacy "no git automation" behaviour intact. The slash commands are also runnable manually:
+All hooks are declared `optional: true`. The parent skill prints an "Optional Pre-Hook" / "Optional Post-Hook" prompt and waits for you to opt in — declining keeps the legacy "no git automation" behaviour intact. The slash commands are also runnable manually, and `/speckit-git-commit` accepts two extra phases (`checklist`, `analyze`) that are **manual-only** — there is no corresponding `after_checklist` / `after_analyze` hook in `.specify/extensions.yml`, so the user must invoke them explicitly when those artifacts are ready:
 
 ```bash
 /speckit-git-branch <slug>          # create speckit/<NNN>-<slug>
@@ -70,6 +70,12 @@ All hooks are declared `optional: true`. The parent skill prints an "Optional Pr
                                     #   + quickstart.md + contracts/* (when present)
 /speckit-git-commit tasks           # docs(specs): tasks <NNN>-<slug>
                                     #   stages tasks.md
+/speckit-git-commit checklist       # docs(specs): checklist <NNN>-<slug>
+                                    #   stages every file under checklists/
+                                    #   (manual only — no after_checklist hook)
+/speckit-git-commit analyze         # docs(specs): analyze <NNN>-<slug>
+                                    #   stages analysis.md
+                                    #   (manual only — no after_analyze hook)
 ```
 
 Safety rails (enforced inside each skill):

--- a/docs/ai-workflow/spec-driven-development.md
+++ b/docs/ai-workflow/spec-driven-development.md
@@ -57,15 +57,19 @@ Spec output lands under `docs/specs/<NNN>-<feature-slug>/` (Beutl-local override
 Spec-Kit ships a hook framework that each `/speckit-*` skill consults before / after running. Beutl registers two hooks under `.specify/extensions.yml`:
 
 - **`before_specify` → `/speckit-git-branch`** — creates a `speckit/<NNN>-<slug>` feature branch matched to the spec directory.
-- **`after_specify` / `after_plan` / `after_tasks` → `/speckit-git-commit`** — commits the freshly generated `spec.md` / `plan.md` / `tasks.md` as a single Conventional Commit (`docs(specs): <phase> <NNN>-<slug>`).
+- **`after_specify` / `after_plan` / `after_tasks` → `/speckit-git-commit`** — commits the freshly generated phase artifacts as a single Conventional Commit. The subject is `docs(specs): <phase> <NNN>-<slug>`, with one exception: the `spec` phase uses the verb `scaffold` (reads more naturally for the very first commit), so subjects look like `docs(specs): scaffold 001-foo` / `docs(specs): plan 001-foo` / `docs(specs): tasks 001-foo`.
 
 All hooks are declared `optional: true`. The parent skill prints an "Optional Pre-Hook" / "Optional Post-Hook" prompt and waits for you to opt in — declining keeps the legacy "no git automation" behaviour intact. The slash commands are also runnable manually:
 
 ```bash
 /speckit-git-branch <slug>          # create speckit/<NNN>-<slug>
-/speckit-git-commit spec            # commit docs/specs/<NNN>-<slug>/spec.md
-/speckit-git-commit plan            # ... plan.md
-/speckit-git-commit tasks           # ... tasks.md
+/speckit-git-commit spec            # docs(specs): scaffold <NNN>-<slug>
+                                    #   stages spec.md + checklists/requirements.md
+/speckit-git-commit plan            # docs(specs): plan <NNN>-<slug>
+                                    #   stages plan.md + research.md + data-model.md
+                                    #   + quickstart.md + contracts/* (when present)
+/speckit-git-commit tasks           # docs(specs): tasks <NNN>-<slug>
+                                    #   stages tasks.md
 ```
 
 Safety rails (enforced inside each skill):

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -43,6 +43,15 @@ For small bug fixes or behaviour-preserving refactors, skip Spec-Kit entirely.
 
 `docs/ai-workflow/spec-driven-development.md` has the long-form reference, including how the Beutl-local `SPECS_DIR` patch redirects Spec-Kit's default output path here.
 
+## Git workflow (optional)
+
+`.specify/extensions.yml` registers optional git hooks for the flow:
+
+- `before_specify` offers `/speckit-git-branch`, which creates a `speckit/<NNN>-<slug>` branch tied to the spec directory.
+- `after_specify` / `after_plan` / `after_tasks` offer `/speckit-git-commit`, which makes one Conventional Commit per phase (`docs(specs): <phase> <NNN>-<slug>`).
+
+The hooks are presented as Optional Pre/Post-Hooks and only run when you accept. To skip git automation for a run, just decline; to disable it project-wide, delete or rename `.specify/extensions.yml`. See [`docs/ai-workflow/spec-driven-development.md`](../ai-workflow/spec-driven-development.md#git-extension-hooks-optional) for the full contract.
+
 ## Reviewing a spec without driving the flow
 
 To browse existing specs without invoking `/speckit-*`, ask Claude Code to "look at what's already in `docs/specs/`" — the `beutl-spec-explorer` subagent is purpose-built for that traversal and only walks this directory.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -54,7 +54,9 @@ For small bug fixes or behaviour-preserving refactors, skip Spec-Kit entirely.
 `.specify/extensions.yml` registers optional git hooks for the flow:
 
 - `before_specify` offers `/speckit-git-branch`, which creates a `speckit/<NNN>-<slug>` branch tied to the spec directory.
-- `after_specify` / `after_plan` / `after_tasks` offer `/speckit-git-commit`, which makes one Conventional Commit per phase (`docs(specs): <phase> <NNN>-<slug>`).
+- `after_specify` / `after_plan` / `after_tasks` offer `/speckit-git-commit`, which makes one Conventional Commit per phase (`docs(specs): <phase> <NNN>-<slug>`; the `spec` phase uses the verb `scaffold`).
+
+The `checklist` and `analyze` phases of `/speckit-git-commit` are **manual-only** — `.specify/extensions.yml` deliberately has no `after_checklist` / `after_analyze` hook, so files like `analysis.md` and ad-hoc `checklists/*.md` are not auto-committed. Run `/speckit-git-commit checklist` or `/speckit-git-commit analyze` explicitly when you are ready to stage them.
 
 The hooks are presented as Optional Pre/Post-Hooks and only run when you accept. To skip git automation for a run, just decline; to disable it project-wide, delete or rename `.specify/extensions.yml`. See [`docs/ai-workflow/spec-driven-development.md`](../ai-workflow/spec-driven-development.md#git-extension-hooks-optional) for the full contract.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,8 +12,14 @@ docs/specs/
 ├── 001-<short-feature-slug>/
 │   ├── spec.md               # /speckit-specify output
 │   ├── plan.md               # /speckit-plan output
+│   ├── research.md           # /speckit-plan (when produced)
+│   ├── data-model.md         # /speckit-plan (when produced)
+│   ├── quickstart.md         # /speckit-plan (when produced)
+│   ├── contracts/            # /speckit-plan API/IPC contracts (when produced)
 │   ├── tasks.md              # /speckit-tasks output
-│   ├── checklist.md          # optional /speckit-checklist output
+│   ├── analysis.md           # /speckit-analyze (optional)
+│   ├── checklists/           # /speckit-specify writes requirements.md here;
+│   │                         #   /speckit-checklist adds ux.md / api.md / etc.
 │   └── notes/                # free-form supplementary material
 └── 002-<short-feature-slug>/
     └── ...


### PR DESCRIPTION
## Description

The Beutl-vendored Spec-Kit (`0.8.12`) ships a **hook framework** that every `/speckit-*` skill consults — each skill checks `.specify/extensions.yml` for `hooks.before_<phase>` / `hooks.after_<phase>` and turns matching command names (`speckit.git.commit` → `/speckit-git-commit`) into Optional Pre/Post-Hook prompts. The framework was present, but `.specify/extensions.yml` and the git slash commands themselves did not exist, so it was inert. This PR fills the gap with a Beutl-flavoured git extension.

### Feature commits

- `.specify/extensions.yml` registers `speckit.git.branch` on `before_specify` and `speckit.git.commit` on `after_specify` / `after_plan` / `after_tasks`. All entries are `optional: true` — the parent skill surfaces a prompt, the user decides whether to run them. Deleting the YAML file disables the extension project-wide.
- `/speckit-git-branch <slug>` or `<NNN>-<slug>` creates or switches to `speckit/<NNN>-<slug>` matched to the spec directory, honours an explicit `<NNN>` when supplied, warns when the working tree is dirty or branching from anything other than `main`, and emits a JSON line so the parent skill can pick up `BRANCH_NAME` / `FEATURE_NUM` / `SPECIFY_FEATURE_DIRECTORY`.
- `/speckit-git-commit <phase>` produces one Conventional Commit per phase (`docs(specs): <phase> <NNN>-<slug>`) scoped strictly to the spec directory under `docs/specs/` **or** the upstream-default `specs/`. Plan commits sweep `plan.md` + `research.md` + `data-model.md` + `quickstart.md` + `contracts/`, with the staged set compared against the *pending* subset so partial edits do not abort.

Both skills are read-only on the outside world: no `git push`, no `--amend`, no force-resets, no linter or test runs.

### Review fix-ups (Codex)

- `261d6dd87` / `fcf0c2e05` — Round 1: branch numbering also walks `refs/heads/speckit/*`, `SPECIFY_FEATURE_DIRECTORY` documented as informational, `allowed-tools` widened, untracked-file detection added, single-phase file staging.
- `debc9075b` — Round 2: resolve `SPEC_DIR` from `.specify/feature.json` first, scan both `docs/specs/` and `specs/`, honour the explicit `<NNN>-<slug>` form, include `contracts/` in the plan mapping, compare staged set against the pending subset.

### Stacked-PR note

This PR is stacked on top of #1839 (`chore/ai-workflow-enhancements`) because the `docs/specs/README.md` update lives there. Once #1839 merges, GitHub auto-rebases this PR onto `main`.

## Breaking changes

None. Behaviour is identical when `.specify/extensions.yml` is absent or when the user declines the optional hook prompts. No source, CI, or test file is touched.

## Test plan

- [x] YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.specify/extensions.yml'))"` returns OK.
- [x] Skills register: both `/speckit-git-branch` and `/speckit-git-commit` show up in the Claude Code skill list after creation.
- [ ] Dry-run branch creation: `/speckit-git-branch dry-run-slug` on a clean tree creates `speckit/<NNN>-dry-run-slug` and prints the expected JSON contract.
- [ ] Dry-run commit: stage a fake `docs/specs/<NNN>-dry-run-slug/spec.md`, invoke `/speckit-git-commit spec`, observe exactly one commit with subject `docs(specs): scaffold <NNN>-dry-run-slug` and no other paths staged.
- [ ] Plan-phase commit with partial edits: edit only `plan.md` and confirm `/speckit-git-commit plan` commits just the pending subset without aborting on the unchanged design-pack files.
- [ ] End-to-end: walk `/speckit-specify → /speckit-git-branch → /speckit-plan → /speckit-git-commit` on a throwaway spec and confirm each phase commits cleanly without dragging unrelated files in.

## Fixed issues / References

- Builds on #1839, which scaffolds the per-module `CLAUDE.md` anchors, the `/beutl-pre-pr` skill, the self-review Stop hook, the `beutl-review` output style, the project statusline, and `docs/specs/README.md`.