### PR TITLE
fix: localize 3D camera mode tooltips in PlayerView

### DIFF
--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1075,6 +1075,18 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="CropSelection" xml:space="preserve">
     <value>範囲選択</value>
   </data>
+  <data name="Camera3DControl" xml:space="preserve">
+    <value>3Dカメラ操作</value>
+  </data>
+  <data name="Gizmo_Translate" xml:space="preserve">
+    <value>移動</value>
+  </data>
+  <data name="Gizmo_Rotate" xml:space="preserve">
+    <value>回転</value>
+  </data>
+  <data name="Gizmo_Scale" xml:space="preserve">
+    <value>スケール</value>
+  </data>
   <data name="Portal" xml:space="preserve">
     <value>ポータル</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1080,6 +1080,18 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="CropSelection" xml:space="preserve">
     <value>Crop selection</value>
   </data>
+  <data name="Camera3DControl" xml:space="preserve">
+    <value>3D camera control</value>
+  </data>
+  <data name="Gizmo_Translate" xml:space="preserve">
+    <value>Translate</value>
+  </data>
+  <data name="Gizmo_Rotate" xml:space="preserve">
+    <value>Rotate</value>
+  </data>
+  <data name="Gizmo_Scale" xml:space="preserve">
+    <value>Scale</value>
+  </data>
   <data name="Portal" xml:space="preserve">
     <value>Portal</value>
   </data>

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -44,8 +44,7 @@
                 <RadioButton IsChecked="{Binding IsCropMode.Value}" ToolTip.Tip="{x:Static lang:Strings.CropSelection}">
                     <icons:SymbolIcon FontSize="16" Symbol="Crop" />
                 </RadioButton>
-                <!--  Todo: ローカライズ  -->
-                <RadioButton IsChecked="{Binding IsCameraMode.Value}" ToolTip.Tip="3Dカメラ操作">
+                <RadioButton IsChecked="{Binding IsCameraMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Camera3DControl}">
                     <icons:SymbolIcon FontSize="16" Symbol="Video" />
                 </RadioButton>
                 <!--  Gizmo Mode Selection (visible only in Camera Mode)  -->
@@ -57,19 +56,19 @@
                              GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsTranslate}}"
                              IsVisible="{Binding IsCameraMode.Value}"
-                             ToolTip.Tip="移動">
+                             ToolTip.Tip="{x:Static lang:Strings.Gizmo_Translate}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowMove" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsRotate}}"
                              IsVisible="{Binding IsCameraMode.Value}"
-                             ToolTip.Tip="回転">
+                             ToolTip.Tip="{x:Static lang:Strings.Gizmo_Rotate}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowRotateClockwise" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsScale}}"
                              IsVisible="{Binding IsCameraMode.Value}"
-                             ToolTip.Tip="スケール">
+                             ToolTip.Tip="{x:Static lang:Strings.Gizmo_Scale}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowExpand" />
                 </RadioButton>
                 <Border Margin="0,8,0,0"


### PR DESCRIPTION
Replace hard-coded Japanese tooltip strings (3Dカメラ操作, 移動, 回転,
スケール) on the camera-mode RadioButton and the gizmo-mode RadioButtons
with lang:Strings entries so the English and other-locale UIs render
consistently.