### PR TITLE
fix: ensure all FFmpeg native resources are disposed when one Dispose throws

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -309,15 +309,40 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
             {
                 if (headerWritten)
                 {
-                    muxer.FlushCodecs(encoders.Select(i => i.Item1));
-                    muxer.WriteTrailer();
+                    try
+                    {
+                        muxer.FlushCodecs(encoders.Select(i => i.Item1));
+                        muxer.WriteTrailer();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to finalize muxer output for {OutputFile}.", OutputFile);
+                    }
                 }
-                encoders.ForEach(t => t.Item1.Dispose());
-                swr?.Dispose();
-                _filterGraph?.Dispose();
+
+                foreach (var (encoder, _) in encoders)
+                {
+                    DisposeQuietly(encoder, nameof(MediaEncoder));
+                }
+                DisposeQuietly(swr, nameof(SampleConverter));
+                DisposeQuietly(_filterGraph, nameof(MediaFilterGraph));
+
                 _filterGraph = null;
                 _bufferSrcCtx = null;
                 _bufferSinkCtx = null;
+
+                void DisposeQuietly(IDisposable? disposable, string resourceName)
+                {
+                    if (disposable is null) return;
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to dispose {Resource} during FFmpeg encoding cleanup.", resourceName);
+                    }
+                }
             }
         }
     }

--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Extensibility;
+﻿using System.Runtime.ExceptionServices;
+using Beutl.Extensibility;
 using Beutl.Logging;
 using Beutl.Media;
 using FFmpeg.AutoGen.Abstractions;
@@ -264,6 +265,7 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
             (MediaEncoder Encoder, MediaStream Stream)? audioRef = null;
             (MediaEncoder Encoder, MediaStream Stream)? videoRef = null;
             bool headerWritten = false;
+            bool encodeCompletedSuccessfully = false;
             try
             {
                 if (outFormat.AudioCodec != AVCodecID.AV_CODEC_ID_NONE)
@@ -304,9 +306,12 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
                             muxer, swr!, audioRef!.Value.Encoder, audioRef!.Value.Stream, audioFrame, audioState, sampleProvider);
                     }
                 }
+
+                encodeCompletedSuccessfully = true;
             }
             finally
             {
+                Exception? muxerFinalizationError = null;
                 if (headerWritten)
                 {
                     try
@@ -317,6 +322,7 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to finalize muxer output for {OutputFile}.", OutputFile);
+                        muxerFinalizationError = ex;
                     }
                 }
 
@@ -330,6 +336,15 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
                 _filterGraph = null;
                 _bufferSrcCtx = null;
                 _bufferSinkCtx = null;
+
+                // Surface muxer finalization failures to the caller so a truncated
+                // output file is not reported as a successful encode. If the try
+                // block already failed, let that original exception propagate
+                // instead of overwriting it.
+                if (encodeCompletedSuccessfully && muxerFinalizationError is not null)
+                {
+                    ExceptionDispatchInfo.Capture(muxerFinalizationError).Throw();
+                }
 
                 void DisposeQuietly(IDisposable? disposable, string resourceName)
                 {


### PR DESCRIPTION
The `finally` block in `FFmpegEncodingController.Encode` previously called
`encoders.ForEach(t => t.Item1.Dispose())`, `swr?.Dispose()`, and
`_filterGraph?.Dispose()` in sequence. If any earlier Dispose threw, the
remaining ones were skipped, leaking native FFmpeg resources. The same
risk applied to `muxer.FlushCodecs` / `muxer.WriteTrailer`, which could
prevent the cleanup chain from running at all.

Wrap each cleanup step in a local helper that swallows and logs
exceptions, so a failure in one resource never blocks the release of the
others. Muxer finalization failures are logged as Error (output file may
be incomplete); per-resource Dispose failures are logged as Warning.

https://claude.ai/code/session_01CLZV1ArDHwaKnWaBUe4yFz