### PR TITLE
fix: close TOCTOU race in FFmpegInstallNotifier throttle

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
+++ b/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
@@ -60,6 +60,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Beutl.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Update="Properties\Strings.resx" />
     <EmbeddedResource Include="Properties\askpass.js">
       <LogicalName>askpass.js</LogicalName>

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallNotifier.cs
@@ -16,18 +16,26 @@ internal static class FFmpegInstallNotifier
     public static void NotifyMissing()
     {
         s_librariesMissing = true;
-
-        long now = Environment.TickCount64;
-        long last = Interlocked.Read(ref s_lastNotifiedTicks);
-        if (last != 0 && now - last < ThrottleMs)
+        if (!TryAcquireNotifySlot(Environment.TickCount64))
             return;
-        Interlocked.Exchange(ref s_lastNotifiedTicks, now);
 
         NotificationService.ShowError(
             Strings.FFmpegError,
             Strings.Make_sure_you_have_FFmpeg_installed,
             onActionButtonClick: ShowInstallDialog,
             actionButtonText: Strings.Install);
+    }
+
+    // CAS guard: only the thread whose CompareExchange swaps `last` -> `now`
+    // wins the right to fire the notification. Concurrent losers bail so a
+    // single failure observed on multiple background threads (extension load
+    // / encoder setup / FFmpegLoader.Initialize) yields one toast, not many.
+    internal static bool TryAcquireNotifySlot(long now)
+    {
+        long last = Interlocked.Read(ref s_lastNotifiedTicks);
+        if (last != 0 && now - last < ThrottleMs)
+            return false;
+        return Interlocked.CompareExchange(ref s_lastNotifiedTicks, now, last) == last;
     }
 
     public static void MarkInstalled()

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
     <ProjectReference Include="..\..\src\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Extensions.FFmpeg;
+﻿using Beutl.Extensions.FFmpeg;
 
 namespace Beutl.UnitTests.Extensions.FFmpeg;
 

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -1,0 +1,69 @@
+using Beutl.Extensions.FFmpeg;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegInstallNotifierTests
+{
+    [SetUp]
+    public void ResetState()
+    {
+        // MarkInstalled clears the throttle slot (Interlocked.Exchange to 0).
+        FFmpegInstallNotifier.MarkInstalled();
+    }
+
+    [Test]
+    public void TryAcquireNotifySlot_FirstCall_Wins()
+    {
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 1_000), Is.True);
+    }
+
+    [Test]
+    public void TryAcquireNotifySlot_SecondCallWithinWindow_Loses()
+    {
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 1_000), Is.True);
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 1_000), Is.False);
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 5_000), Is.False);
+    }
+
+    [Test]
+    public void TryAcquireNotifySlot_AfterWindowElapsed_WinsAgain()
+    {
+        const long throttleMs = 10_000;
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 1_000), Is.True);
+        Assert.That(FFmpegInstallNotifier.TryAcquireNotifySlot(now: 1_000 + throttleMs), Is.True);
+    }
+
+    // Regression test for the TOCTOU race: when many threads observe the same
+    // pre-throttle state simultaneously, exactly one must acquire the slot.
+    // The pre-fix Read/Exchange split allows >=2 winners; the CAS-based fix
+    // collapses that to 1 deterministically.
+    [Test]
+    public void TryAcquireNotifySlot_UnderConcurrency_OnlyOneWinner()
+    {
+        const int iterations = 25;
+        const int threads = 64;
+
+        for (int i = 0; i < iterations; i++)
+        {
+            FFmpegInstallNotifier.MarkInstalled();
+
+            long now = 1_000_000L + i; // any non-zero value works
+            int winners = 0;
+            using var barrier = new Barrier(threads);
+            var tasks = new Task[threads];
+            for (int t = 0; t < threads; t++)
+            {
+                tasks[t] = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    if (FFmpegInstallNotifier.TryAcquireNotifySlot(now))
+                        Interlocked.Increment(ref winners);
+                });
+            }
+
+            Task.WaitAll(tasks);
+            Assert.That(winners, Is.EqualTo(1), $"iteration {i}: expected exactly one winner");
+        }
+    }
+}


### PR DESCRIPTION
NotifyMissing() previously used Interlocked.Read followed by a separate
Interlocked.Exchange to gate its 10-second cooldown. Because the read
and write were independent atomic operations rather than a single CAS,
two threads could both observe last == 0 (or any stale value outside
the window) and both fall through to NotificationService.ShowError,
producing duplicate toasts when FFmpeg-missing failures surface
concurrently from extension load, encoder setup, and FFmpegLoader.Initialize.

Replace the Read/Exchange pair with Interlocked.CompareExchange: only
the thread whose CAS swaps last -> now wins the right to notify;
concurrent losers bail. Extract the decision into an internal
TryAcquireNotifySlot helper so the throttle is testable without the
UI-marshaling NotificationService sink, and add a regression test
that runs 64 threads through a Barrier across 25 iterations and
asserts exactly one winner per round.