### PR TITLE
docs: improve contributor onboarding and add SECURITY/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for Beutl.
+# Owners are requested for review automatically when matching files change.
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# NOTE: For this to gate merges, enable
+# "Require review from Code Owners" in branch protection for `main`.
+
+# Default owner for everything in the repository.
+*       @yuto-trd
+
+# Area-specific owners can be added below as the maintainer team grows, e.g.:
+# /src/Beutl.Engine/         @yuto-trd
+# /src/Beutl.NodeGraph/      @yuto-trd
+# /.github/workflows/        @yuto-trd

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,21 @@
 ## Description
 <!-- What does this PR do and why? Bullet points encouraged. -->
 
+## Affected areas
+<!-- Check the modules this PR touches. These map to the `area-*` labels. -->
+- [ ] `Beutl.Engine` (rendering / scene / track)
+- [ ] `Beutl.ProjectSystem` (project / document persistence)
+- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
+- [ ] `Beutl.Extensibility` (plugin abstractions)
+- [ ] `Beutl.NodeGraph` (node editor)
+- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
+- [ ] `Beutl.Api` (server API client)
+- [ ] Build / CI / docs only
+
 ## Breaking changes
 <!-- Public API / behavior changes that downstream code must adapt to.
-     Write "None" if there are none. -->
+     Write "None" if there are none. Breaking PRs use a `feat!:` / `refactor!:`
+     title and a `BREAKING CHANGE:` commit footer. -->
 
 ## Test plan
 <!-- - Unit/integration tests added or updated (path + brief intent)
@@ -14,3 +26,11 @@
 <!-- - Closes #1234
      - Project board: b-editor/projects/9 ("item title")
      - Leave blank if none -->
+
+---
+<!--
+Reminders (see CONTRIBUTING.md / AGENTS.md):
+- New logic ships with a NUnit test under `tests/`.
+- New XAML uses compiled bindings (`x:CompileBindings="True"` + `x:DataType`).
+- Do not cross the GPL/MIT boundary: MIT projects must not reference `Beutl.FFmpegWorker`.
+-->

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,13 +1,52 @@
 ## Beutlへの貢献についてのガイドライン
 
+貢献に興味を持っていただきありがとうございます。このガイドでは、ローカルでのビルド方法、テストとフォーマットの手順、そして従っている規約について説明します。
+
+### 前提条件
+
+- **.NET SDK** — [`global.json`](global.json) で `10.0.100` 以上に固定されています（`rollForward: latestFeature`）。CI と同じバージョンが解決されるよう、対応する SDK をインストールしてください。
+- 機能ブランチをプッシュできる **Git**。
+- FFmpeg はビルドの前提条件では**ありません**。`Beutl.FFmpegWorker` という別プロセスとして IPC 経由で動作し、実行時にインストールされます。
+
+Beutl は `net10.0` と `net10.0-windows` をデュアルターゲットにしています。Windows 専用ターゲットは Windows でビルドされます。Linux/macOS で単一フレームワークが必要な場合は `-f net10.0` を使ってください。
+
+### ビルド / テスト / フォーマット
+
+```bash
+dotnet build Beutl.slnx                                            # ビルド
+dotnet test Beutl.slnx -f net10.0 --settings coverlet.runsettings  # テスト
+dotnet format Beutl.slnx                                           # フォーマット
+./build.sh <Target>                                                # Nuke (CI と同等)
+```
+
+`dotnet format` は CI ([Format check](.github/workflows/format-check.yml)) で強制されるため、プッシュ前に実行してください。
+
+### 実行 / デバッグ
+
+アプリのエントリーポイントは `src/Beutl` プロジェクトです。`dotnet run --project src/Beutl` で実行する（または IDE でスタートアッププロジェクトに設定する）ことができます。
+
 ### Pull request
-既に作業中である可能性もあるので、
-PRを送る前にIssueを開くことをおすすめします。
 
-変更内容が少ない場合はIssueを開かなくても良いです。
+既に作業中である可能性もあるので、PRを送る前にIssueを開くことをおすすめします。変更内容が少ない場合はIssueを開かなくても良いです。
 
-履歴を見やすくするために
-**リベースと強制プッシュを忘れないで下さい。**
+履歴を見やすくするために**リベースと強制プッシュを忘れないで下さい。**
+
+PRテンプレートでは概要・影響範囲・テスト計画・破壊的変更の記入を求めています。CI とレビュアーが強制するルールは以下の通りです。
+
+- **新しいロジックには NUnit テストを付ける** — `tests/` 配下（例: `tests/Beutl.UnitTests/`、`tests/SourceGeneratorTest/`）。
+- **新しい XAML はコンパイル済みバインディングを使う**（`x:CompileBindings="True"` + `x:DataType`）。
+- **GPL/MIT の境界を越えない** — MIT プロジェクトは `Beutl.FFmpegWorker` への `ProjectReference` を持たず、IPC 経由でのみアクセスします。
+
+### コミットメッセージ
+
+[Conventional Commits](https://www.conventionalcommits.org/) に従います。
+
+- `fix:` — バグ修正
+- `feat:` — 新機能
+- `refactor:` — 挙動を変えないリファクタリング
+- `docs:` — ドキュメント
+
+破壊的変更は `feat!:` / `refactor!:` のサブジェクトと、移行方法を記した `BREAKING CHANGE:` フッターを使います。
 
 ### コードガイドライン
 
@@ -31,3 +70,7 @@ XAMLファイル
              Text="{Binding Text.Value}" />
 </UserControl>
 ```
+
+### 各モジュールについて
+
+モジュール境界マップと詳細なコントリビューションルールは [`AGENTS.md`](AGENTS.md) を、AI 支援ワークフローのドキュメントは [`docs/ai-workflow/`](docs/ai-workflow/README.md) を参照してください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,66 @@
 ## Guidelines for Contributing to Beutl
 
-### Pull request
-To avoid duplicating work that may already be in progress, it is recommended to open an issue before submitting a PR.
+Thanks for your interest in contributing! This guide covers how to set up a
+local build, how to test and format your changes, and the conventions we follow.
 
-If the changes are minor, you may not need to open an issue.
+### Prerequisites
+
+- **.NET SDK** — version `10.0.100` or newer is pinned in
+  [`global.json`](global.json) (`rollForward: latestFeature`). Install the
+  matching SDK so the build resolves the same version CI uses.
+- **Git** with the ability to push a feature branch.
+- FFmpeg is **not** a build prerequisite: it runs as a separate
+  `Beutl.FFmpegWorker` process reached over IPC, and is installed at runtime.
+
+Beutl dual-targets `net10.0` and `net10.0-windows`. Windows-only targets build
+on Windows; on Linux/macOS use `-f net10.0` where a single framework is needed.
+
+### Build / Test / Format
+
+```bash
+dotnet build Beutl.slnx                                            # build
+dotnet test Beutl.slnx -f net10.0 --settings coverlet.runsettings  # test
+dotnet format Beutl.slnx                                           # format
+./build.sh <Target>                                                # Nuke (same as CI)
+```
+
+`dotnet format` is enforced in CI ([Format check](.github/workflows/format-check.yml)),
+so run it before pushing.
+
+### Running / Debugging
+
+The application entry point is the `src/Beutl` project. Run it with
+`dotnet run --project src/Beutl` (or set it as the startup project in your IDE).
+
+### Pull request
+
+To avoid duplicating work that may already be in progress, it is recommended to
+open an issue before submitting a PR. If the changes are minor, you may not need
+to open an issue.
 
 To keep the history clean, **do not forget to rebase and force push.**
+
+The PR template asks for a description, affected areas, a test plan, and any
+breaking changes — please fill it in. A few rules CI and reviewers enforce:
+
+- **New logic ships with a NUnit test** under `tests/` (e.g.
+  `tests/Beutl.UnitTests/`, `tests/SourceGeneratorTest/`).
+- **New XAML uses compiled bindings** (`x:CompileBindings="True"` +
+  `x:DataType`).
+- **Do not cross the GPL/MIT boundary**: MIT projects must not take a
+  `ProjectReference` to `Beutl.FFmpegWorker`; reach it only via IPC.
+
+### Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `fix:` — bug fix
+- `feat:` — new feature
+- `refactor:` — behavior-preserving refactor
+- `docs:` — documentation
+
+Breaking changes use a `feat!:` / `refactor!:` subject and a `BREAKING CHANGE:`
+footer describing the migration.
 
 ### Code Guidelines
 
@@ -26,3 +81,9 @@ XAML Files
              Text="{Binding Text.Value}" />
 </UserControl>
 ```
+
+### Where things live
+
+See the module boundary map and detailed contributor rules in
+[`AGENTS.md`](AGENTS.md), and the AI-assisted workflow docs under
+[`docs/ai-workflow/`](docs/ai-workflow/README.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-Security fixes are applied to the latest release line. Beutl is currently in a
-`2.0.0` preview cycle; older `1.x` releases receive fixes on a best-effort basis
-only.
+Security fixes are applied to the current preview line (`2.0.x`) and the latest
+stable line (`1.1.x`). Beutl is currently in a `2.0.0` preview cycle. Releases
+older than `1.1` (`< 1.1`) are no longer supported.
 
 | Version          | Supported          |
 | ---------------- | ------------------ |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release line. Beutl is currently in a
+`2.0.0` preview cycle; older `1.x` releases receive fixes on a best-effort basis
+only.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| 2.0.x (preview)  | :white_check_mark: |
+| 1.1.x            | :white_check_mark: |
+| < 1.1            | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or the Discord server.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Provide a description, reproduction steps, affected version, and impact.
+
+We aim to acknowledge a report within a few days and will keep you updated on
+the fix and disclosure timeline. Once a fix is released, we are happy to credit
+you in the advisory unless you prefer to remain anonymous.
+
+## Scope
+
+Beutl ships `Beutl.FFmpegWorker` as a **separate GPL-licensed process** that is
+reached only via IPC (`Beutl.FFmpegIpc`). Vulnerabilities in FFmpeg itself
+should be reported upstream to the FFmpeg project; report issues in Beutl's IPC
+layer or process handling here.
+
+Extensions are distributed through Beutl accounts. If you discover a malicious
+or vulnerable published extension, report it through the same private channel
+above so we can take it down.


### PR DESCRIPTION
## Description
- Lower the barrier for new contributors and tighten repo governance with docs-only changes.
- Add a security reporting policy and automatic reviewer assignment, neither of which existed before.
- Expand the PR template so reviewers (human and the automated Claude review) get test plans and affected-area context up front.

## Affected areas
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Docs/config-only change; no code or build impact.
- Verified all referenced paths exist (`docs/ai-workflow/README.md`, `.github/workflows/format-check.yml`, `src/Beutl` is the `WinExe` entry point).
- After merge, confirm `gh api repos/b-editor/beutl/codeowners/errors` reports no errors and `@yuto-trd` resolves as a code owner.
- Confirm the PR template renders correctly on this PR.

## Fixed issues / References
None.

---
### Follow-up repository settings (outside this PR)
These are required for the new files to take full effect:
- Enable **private vulnerability reporting** (Settings → Code security) — the entry point SECURITY.md points to.
- Enable **Require review from Code Owners** in `main` branch protection so CODEOWNERS gates merges.