### PR TITLE
feat: Add onion skin overlay to the preview player

### DIFF
--- a/.claude/rules/csharp.md
+++ b/.claude/rules/csharp.md
@@ -22,5 +22,6 @@ Other:
 
 - Expression-bodied members are preferred when the body is a single statement.
 - New logic without a corresponding test under `tests/` (NUnit + Moq, in the matching test project) is incomplete.
+  - The top-level `src/Beutl/` app project is not referenced by any test project, so logic that needs tests belongs in a referenced library (e.g. `Beutl.Editor`, `Beutl.Engine`) — not in `src/Beutl/` ViewModels/Views.
 - Source generators live in `src/Beutl.Engine.SourceGenerators/`; if you change them, run `/beutl-build` and verify downstream projects still resolve generated symbols.
 - Style nits (spacing, ordering, var vs explicit) are owned by `.editorconfig` and `dotnet format`. Don't argue with the linter.

--- a/.claude/skills/beutl-tooltab-extension/SKILL.md
+++ b/.claude/skills/beutl-tooltab-extension/SKILL.md
@@ -139,12 +139,12 @@ public static readonly Extension[] PrimitiveExtensions =
 ### Step 4: Add string resources
 
 ```xml
-<!-- src/Beutl.Language/Resources/Strings.resx -->
+<!-- src/Beutl.Language/Strings.resx -->
 <data name="MyToolTab" xml:space="preserve">
   <value>My Tool Tab</value>
 </data>
 
-<!-- src/Beutl.Language/Resources/Strings.ja.resx -->
+<!-- src/Beutl.Language/Strings.ja.resx -->
 <data name="MyToolTab" xml:space="preserve">
   <value>マイツールタブ</value>
 </data>

--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -68,6 +68,11 @@ public sealed partial class EditorConfig : ConfigurationBase
     public static readonly CoreProperty<UIToneMappingOperator> ToneMappingModeProperty;
     public static readonly CoreProperty<float> ToneMappingExposureProperty;
     public static readonly CoreProperty<bool> UseHdrPreviewProperty;
+    public static readonly CoreProperty<bool> IsOnionSkinEnabledProperty;
+    public static readonly CoreProperty<int> OnionSkinPrevCountProperty;
+    public static readonly CoreProperty<int> OnionSkinNextCountProperty;
+    public static readonly CoreProperty<float> OnionSkinPrevOpacityProperty;
+    public static readonly CoreProperty<float> OnionSkinNextOpacityProperty;
 
     static EditorConfig()
     {
@@ -144,6 +149,26 @@ public sealed partial class EditorConfig : ConfigurationBase
 
         UseHdrPreviewProperty = ConfigureProperty<bool, EditorConfig>(nameof(UseHdrPreview))
             .DefaultValue(false)
+            .Register();
+
+        IsOnionSkinEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsOnionSkinEnabled))
+            .DefaultValue(false)
+            .Register();
+
+        OnionSkinPrevCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinPrevCount))
+            .DefaultValue(1)
+            .Register();
+
+        OnionSkinNextCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinNextCount))
+            .DefaultValue(0)
+            .Register();
+
+        OnionSkinPrevOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinPrevOpacity))
+            .DefaultValue(0.35f)
+            .Register();
+
+        OnionSkinNextOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinNextOpacity))
+            .DefaultValue(0.35f)
             .Register();
     }
 
@@ -252,6 +277,36 @@ public sealed partial class EditorConfig : ConfigurationBase
     {
         get => GetValue(UseHdrPreviewProperty);
         set => SetValue(UseHdrPreviewProperty, value);
+    }
+
+    public bool IsOnionSkinEnabled
+    {
+        get => GetValue(IsOnionSkinEnabledProperty);
+        set => SetValue(IsOnionSkinEnabledProperty, value);
+    }
+
+    public int OnionSkinPrevCount
+    {
+        get => GetValue(OnionSkinPrevCountProperty);
+        set => SetValue(OnionSkinPrevCountProperty, value);
+    }
+
+    public int OnionSkinNextCount
+    {
+        get => GetValue(OnionSkinNextCountProperty);
+        set => SetValue(OnionSkinNextCountProperty, value);
+    }
+
+    public float OnionSkinPrevOpacity
+    {
+        get => GetValue(OnionSkinPrevOpacityProperty);
+        set => SetValue(OnionSkinPrevOpacityProperty, value);
+    }
+
+    public float OnionSkinNextOpacity
+    {
+        get => GetValue(OnionSkinNextOpacityProperty);
+        set => SetValue(OnionSkinNextOpacityProperty, value);
     }
 
     public CoreDictionary<string, LibraryTabDisplayMode> LibraryTabDisplayModes { get; } = new()

--- a/src/Beutl.Controls/Player.cs
+++ b/src/Beutl.Controls/Player.cs
@@ -52,7 +52,7 @@ public sealed class TimecodeSubmittedEventArgs : EventArgs
 public class Player : RangeBase
 {
     public static readonly StyledProperty<string> DurationProperty = AvaloniaProperty.Register<Player, string>(nameof(Duration));
-    public static readonly StyledProperty<object> ContentProperty = AvaloniaProperty.Register<Player, object>(nameof(InnerLeftContent));
+    public static readonly StyledProperty<object> ContentProperty = AvaloniaProperty.Register<Player, object>(nameof(Content));
     public static readonly StyledProperty<object> InnerLeftContentProperty = AvaloniaProperty.Register<Player, object>(nameof(InnerLeftContent));
     public static readonly StyledProperty<object> InnerRightContentProperty = AvaloniaProperty.Register<Player, object>(nameof(InnerRightContent));
     public static readonly DirectProperty<Player, string> CurrentTimeProperty =

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -24,6 +24,11 @@
                                       VerticalAlignment="Stretch"
                                       Content="{TemplateBinding InnerLeftContent}" />
 
+                    <ContentPresenter Name="InnerRightPresenter"
+                                      HorizontalAlignment="Right"
+                                      VerticalAlignment="Stretch"
+                                      Content="{TemplateBinding InnerRightContent}" />
+
                     <Grid Grid.Row="1" RowDefinitions="Auto,Auto">
                         <Grid.Styles>
                             <Style Selector="icons|SymbolIcon">

--- a/src/Beutl.Editor/Services/OnionSkinHelper.cs
+++ b/src/Beutl.Editor/Services/OnionSkinHelper.cs
@@ -1,0 +1,72 @@
+﻿namespace Beutl.Editor.Services;
+
+public readonly record struct OnionSkinSample(TimeSpan Time, bool IsPrev, float Alpha);
+
+public static class OnionSkinHelper
+{
+    // Enumerate the previous/next frame times to render as semi-transparent onion-skin overlays.
+    // Closest frames receive `baseOpacity`; farther frames fade out linearly. Samples outside
+    // [sceneStart, sceneStart + sceneDuration) are omitted so callers do not need to clamp.
+    // Alpha is re-normalized against the number of samples actually emitted so a partial
+    // clamp (e.g. prevCount=3 near the scene start) does not leave a near frame at a lower
+    // opacity than baseOpacity.
+    public static IReadOnlyList<OnionSkinSample> EnumerateOnionSkinTimes(
+        TimeSpan current, TimeSpan sceneStart, TimeSpan sceneDuration,
+        int frameRate, int prevCount, int nextCount,
+        float prevBaseOpacity, float nextBaseOpacity)
+    {
+        if (frameRate <= 0)
+            return [];
+        prevCount = Math.Max(0, prevCount);
+        nextCount = Math.Max(0, nextCount);
+        if (prevCount == 0 && nextCount == 0)
+            return [];
+
+        long tickPerFrame = TimeSpan.FromSeconds(1d / frameRate).Ticks;
+        TimeSpan minTime = sceneStart;
+        TimeSpan maxTime = sceneStart + sceneDuration; // exclusive
+
+        // Collect prev times in oldest→closest order. Alpha is filled in after the actual
+        // emitted count is known so falloff stays continuous when the loop skipped frames
+        // that fell outside the scene range.
+        var prevTimes = new List<TimeSpan>(prevCount);
+        for (int i = prevCount; i >= 1; i--)
+        {
+            TimeSpan t = current - TimeSpan.FromTicks(tickPerFrame * i);
+            if (t < minTime || t >= maxTime)
+                continue;
+            prevTimes.Add(t);
+        }
+
+        var nextTimes = new List<TimeSpan>(nextCount);
+        for (int i = 1; i <= nextCount; i++)
+        {
+            TimeSpan t = current + TimeSpan.FromTicks(tickPerFrame * i);
+            if (t < minTime || t >= maxTime)
+                continue;
+            nextTimes.Add(t);
+        }
+
+        var samples = new List<OnionSkinSample>(prevTimes.Count + nextTimes.Count);
+
+        int prevEmitted = prevTimes.Count;
+        for (int j = 0; j < prevEmitted; j++)
+        {
+            // j=0 (oldest) → 1/N, j=prevEmitted-1 (closest) → 1.0
+            float falloff = prevEmitted == 1 ? 1f : (float)(j + 1) / prevEmitted;
+            float alpha = Math.Clamp(prevBaseOpacity * falloff, 0f, 1f);
+            samples.Add(new OnionSkinSample(prevTimes[j], true, alpha));
+        }
+
+        int nextEmitted = nextTimes.Count;
+        for (int j = 0; j < nextEmitted; j++)
+        {
+            // j=0 (closest) → 1.0, j=nextEmitted-1 (farthest) → 1/N
+            float falloff = nextEmitted == 1 ? 1f : (float)(nextEmitted - j) / nextEmitted;
+            float alpha = Math.Clamp(nextBaseOpacity * falloff, 0f, 1f);
+            samples.Add(new OnionSkinSample(nextTimes[j], false, alpha));
+        }
+
+        return samples;
+    }
+}

--- a/src/Beutl.Editor/Services/OnionSkinHelper.cs
+++ b/src/Beutl.Editor/Services/OnionSkinHelper.cs
@@ -10,8 +10,13 @@ public static class OnionSkinHelper
     // Alpha is re-normalized against the number of samples actually emitted so a partial
     // clamp (e.g. prevCount=3 near the scene start) does not leave a near frame at a lower
     // opacity than baseOpacity.
+    //
+    // Sample times are derived from absolute frame numbers via the shared frame<->time
+    // conversion (int.ToTimeSpan(rate)), so they land on exactly the same frame grid the
+    // player uses. Stepping by a single rounded per-frame tick would instead accumulate a
+    // sub-frame drift at rates whose frame duration is fractional in ticks (e.g. 24/60 fps).
     public static IReadOnlyList<OnionSkinSample> EnumerateOnionSkinTimes(
-        TimeSpan current, TimeSpan sceneStart, TimeSpan sceneDuration,
+        int currentFrame, TimeSpan sceneStart, TimeSpan sceneDuration,
         int frameRate, int prevCount, int nextCount,
         float prevBaseOpacity, float nextBaseOpacity)
     {
@@ -22,7 +27,6 @@ public static class OnionSkinHelper
         if (prevCount == 0 && nextCount == 0)
             return [];
 
-        long tickPerFrame = TimeSpan.FromSeconds(1d / frameRate).Ticks;
         TimeSpan minTime = sceneStart;
         TimeSpan maxTime = sceneStart + sceneDuration; // exclusive
 
@@ -32,7 +36,7 @@ public static class OnionSkinHelper
         var prevTimes = new List<TimeSpan>(prevCount);
         for (int i = prevCount; i >= 1; i--)
         {
-            TimeSpan t = current - TimeSpan.FromTicks(tickPerFrame * i);
+            TimeSpan t = (currentFrame - i).ToTimeSpan(frameRate);
             if (t < minTime || t >= maxTime)
                 continue;
             prevTimes.Add(t);
@@ -41,7 +45,7 @@ public static class OnionSkinHelper
         var nextTimes = new List<TimeSpan>(nextCount);
         for (int i = 1; i <= nextCount; i++)
         {
-            TimeSpan t = current + TimeSpan.FromTicks(tickPerFrame * i);
+            TimeSpan t = (currentFrame + i).ToTimeSpan(frameRate);
             if (t < minTime || t >= maxTime)
                 continue;
             nextTimes.Add(t);

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1225,4 +1225,28 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="CommandPalette_MenuCategory" xml:space="preserve">
     <value>メニュー</value>
   </data>
+  <data name="OnionSkin" xml:space="preserve">
+    <value>オニオンスキン</value>
+  </data>
+  <data name="OnionSkin_Description" xml:space="preserve">
+    <value>前後のフレームを半透明で重ねて表示します。</value>
+  </data>
+  <data name="ToggleOnionSkin" xml:space="preserve">
+    <value>オニオンスキンを切り替え</value>
+  </data>
+  <data name="ToggleOnionSkin_Description" xml:space="preserve">
+    <value>プレビューでオニオンスキン表示を切り替えます。</value>
+  </data>
+  <data name="OnionSkinPrevCount" xml:space="preserve">
+    <value>前フレーム数</value>
+  </data>
+  <data name="OnionSkinNextCount" xml:space="preserve">
+    <value>後フレーム数</value>
+  </data>
+  <data name="OnionSkinPrevOpacity" xml:space="preserve">
+    <value>前フレーム不透明度</value>
+  </data>
+  <data name="OnionSkinNextOpacity" xml:space="preserve">
+    <value>後フレーム不透明度</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1231,4 +1231,28 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="CommandPalette_MenuCategory" xml:space="preserve">
     <value>Menu</value>
   </data>
+  <data name="OnionSkin" xml:space="preserve">
+    <value>Onion skin</value>
+  </data>
+  <data name="OnionSkin_Description" xml:space="preserve">
+    <value>Show semi-transparent previous and next frames overlaid on the current frame.</value>
+  </data>
+  <data name="ToggleOnionSkin" xml:space="preserve">
+    <value>Toggle onion skin</value>
+  </data>
+  <data name="ToggleOnionSkin_Description" xml:space="preserve">
+    <value>Toggle the onion skin overlay in the preview.</value>
+  </data>
+  <data name="OnionSkinPrevCount" xml:space="preserve">
+    <value>Previous frames</value>
+  </data>
+  <data name="OnionSkinNextCount" xml:space="preserve">
+    <value>Next frames</value>
+  </data>
+  <data name="OnionSkinPrevOpacity" xml:space="preserve">
+    <value>Previous opacity</value>
+  </data>
+  <data name="OnionSkinNextOpacity" xml:space="preserve">
+    <value>Next opacity</value>
+  </data>
 </root>

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -96,6 +96,10 @@ public sealed class SceneEditorExtension : EditorExtension
         [
             new ContextCommandKeyGesture("G")
         ]),
+        new("ToggleOnionSkin", Strings.ToggleOnionSkin, Strings.ToggleOnionSkin_Description,
+        [
+            new ContextCommandKeyGesture("Alt+O")
+        ]),
     ];
 
     public override bool TryCreateEditor(CoreObject obj, [NotNullWhen(true)] out Control? editor)

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -156,6 +156,9 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             case "PreviousKeyFrame" when !isFromTextBox:
                 SeekToAdjacentKeyFrame(forward: false);
                 break;
+            case "ToggleOnionSkin" when !isFromTextBox:
+                Player.IsOnionSkinEnabled.Value = !Player.IsOnionSkinEnabled.Value;
+                break;
             default:
                 if (execution.KeyEventArgs != null)
                     execution.KeyEventArgs.Handled = false;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1318,6 +1318,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             if (token.IsCancellationRequested)
                 return;
 
+            // Snapshot the onion-skin config here on the UI thread (RenderOnRenderThread is
+            // invoked via Dispatcher.UIThread). Reading these CoreProperty getters inside the
+            // render-thread dispatch below would race the UI-thread write-back subscriptions
+            // against CoreObject's non-synchronized value dictionary.
+            EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+            bool onionEnabled = editorConfig.IsOnionSkinEnabled;
+            int onionPrevCount = editorConfig.OnionSkinPrevCount;
+            int onionNextCount = editorConfig.OnionSkinNextCount;
+            float onionPrevOpacity = editorConfig.OnionSkinPrevOpacity;
+            float onionNextOpacity = editorConfig.OnionSkinNextOpacity;
+
             RenderThread.Dispatcher.Dispatch(() =>
             {
                 int frame = 0;
@@ -1338,18 +1349,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     time = frame.ToTimeSpan(rate);
                     Ref<Bitmap>? bitmapRef;
 
-                    EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
-                    useOnionSkin = editorConfig.IsOnionSkinEnabled
+                    useOnionSkin = onionEnabled
                         && !IsPlaying.Value
-                        && (editorConfig.OnionSkinPrevCount > 0 || editorConfig.OnionSkinNextCount > 0);
+                        && (onionPrevCount > 0 || onionNextCount > 0);
 
                     IReadOnlyList<OnionSkinSample> onionSamples = [];
                     if (useOnionSkin)
                     {
                         onionSamples = OnionSkinHelper.EnumerateOnionSkinTimes(
                             time, Scene.Start, Scene.Duration, rate,
-                            editorConfig.OnionSkinPrevCount, editorConfig.OnionSkinNextCount,
-                            editorConfig.OnionSkinPrevOpacity, editorConfig.OnionSkinNextOpacity);
+                            onionPrevCount, onionNextCount,
+                            onionPrevOpacity, onionNextOpacity);
                         onionSampleCount = onionSamples.Count;
                         if (onionSamples.Count == 0)
                         {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1349,16 +1349,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     time = frame.ToTimeSpan(rate);
                     Ref<Bitmap>? bitmapRef;
 
+                    // A side contributes nothing when its opacity is 0, so fold opacity into the
+                    // effective count. When both sides are invisible useOnionSkin stays false and
+                    // the empty-samples fallback below routes through the cheaper cache-aware path.
+                    int effectivePrevCount = onionPrevOpacity > 0f ? onionPrevCount : 0;
+                    int effectiveNextCount = onionNextOpacity > 0f ? onionNextCount : 0;
                     useOnionSkin = onionEnabled
                         && !IsPlaying.Value
-                        && (onionPrevCount > 0 || onionNextCount > 0);
+                        && (effectivePrevCount > 0 || effectiveNextCount > 0);
 
                     IReadOnlyList<OnionSkinSample> onionSamples = [];
                     if (useOnionSkin)
                     {
                         onionSamples = OnionSkinHelper.EnumerateOnionSkinTimes(
                             time, Scene.Start, Scene.Duration, rate,
-                            onionPrevCount, onionNextCount,
+                            effectivePrevCount, effectiveNextCount,
                             onionPrevOpacity, onionNextOpacity);
                         onionSampleCount = onionSamples.Count;
                         if (onionSamples.Count == 0)
@@ -1396,6 +1401,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                                     // current frame; the partial composite is replaced by the queued render.
                                     if (token.IsCancellationRequested)
                                         break;
+
+                                    // Belt-and-suspenders for the mixed case (one side opaque, the
+                                    // other at zero opacity): skip the render/snapshot/blend for any
+                                    // sample that would composite nothing.
+                                    if (sample.Alpha <= 0f)
+                                        continue;
 
                                     var compFrame = renderer.Compositor.EvaluateGraphics(sample.Time);
                                     renderer.Render(compFrame);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -188,6 +188,51 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         ToneMappingExposure = GlobalConfiguration.Instance.EditorConfig.GetObservable(EditorConfig.ToneMappingExposureProperty)
             .ToReactiveProperty()
             .DisposeWith(_disposables);
+
+        EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+
+        IsOnionSkinEnabled = editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        IsOnionSkinEnabled.Subscribe(v => editorConfig.IsOnionSkinEnabled = v).DisposeWith(_disposables);
+
+        // NumericUpDown / Slider expose decimal? and double, so the UI-bound ReactiveProperty
+        // types are widened here and cast back to int / float at the EditorConfig boundary.
+        OnionSkinPrevCount = editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty)
+            .Select(v => (decimal)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinPrevCount.Subscribe(v => editorConfig.OnionSkinPrevCount = (int)v).DisposeWith(_disposables);
+
+        OnionSkinNextCount = editorConfig.GetObservable(EditorConfig.OnionSkinNextCountProperty)
+            .Select(v => (decimal)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinNextCount.Subscribe(v => editorConfig.OnionSkinNextCount = (int)v).DisposeWith(_disposables);
+
+        OnionSkinPrevOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinPrevOpacityProperty)
+            .Select(v => (double)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinPrevOpacity.Subscribe(v => editorConfig.OnionSkinPrevOpacity = (float)v).DisposeWith(_disposables);
+
+        OnionSkinNextOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinNextOpacityProperty)
+            .Select(v => (double)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinNextOpacity.Subscribe(v => editorConfig.OnionSkinNextOpacity = (float)v).DisposeWith(_disposables);
+
+        // Re-render preview whenever any onion-skin setting changes.
+        IsOnionSkinEnabled.CombineLatest(OnionSkinPrevCount, OnionSkinNextCount, OnionSkinPrevOpacity, OnionSkinNextOpacity)
+            .Skip(1)
+            .Subscribe(_ =>
+            {
+                if (!IsPlaying.Value)
+                {
+                    QueueRender();
+                }
+            })
+            .DisposeWith(_disposables);
     }
 
     private void ClearAllGizmoTargets()
@@ -326,6 +371,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     public ReactiveProperty<UIToneMappingOperator> ToneMappingMode { get; }
 
     public ReactiveProperty<float> ToneMappingExposure { get; }
+
+    public ReactiveProperty<bool> IsOnionSkinEnabled { get; }
+
+    public ReactiveProperty<decimal> OnionSkinPrevCount { get; }
+
+    public ReactiveProperty<decimal> OnionSkinNextCount { get; }
+
+    public ReactiveProperty<double> OnionSkinPrevOpacity { get; }
+
+    public ReactiveProperty<double> OnionSkinNextOpacity { get; }
 
     public event EventHandler? PreviewInvalidated;
 
@@ -1265,20 +1320,108 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
             RenderThread.Dispatcher.Dispatch(() =>
             {
+                int frame = 0;
+                bool useOnionSkin = false;
+                int onionSampleCount = 0;
                 try
                 {
                     SceneRenderer renderer = EditViewModel.Renderer.Value;
                     FrameCacheManager cacheManager = EditViewModel.FrameCacheManager.Value;
                     if (renderer is not { IsDisposed: false, IsGraphicsRendering: false })
                         return;
+                    if (Scene is null)
+                        return;
 
                     int rate = GetFrameRate();
                     TimeSpan time = _editorClock.CurrentTime.Value;
-                    int frame = (int)Math.Round(time.ToFrameNumber(rate), MidpointRounding.AwayFromZero);
+                    frame = (int)Math.Round(time.ToFrameNumber(rate), MidpointRounding.AwayFromZero);
                     time = frame.ToTimeSpan(rate);
                     Ref<Bitmap>? bitmapRef;
 
-                    if (cacheManager.TryGet(frame, out var cache))
+                    EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+                    useOnionSkin = editorConfig.IsOnionSkinEnabled
+                        && !IsPlaying.Value
+                        && (editorConfig.OnionSkinPrevCount > 0 || editorConfig.OnionSkinNextCount > 0);
+
+                    IReadOnlyList<OnionSkinSample> onionSamples = [];
+                    if (useOnionSkin)
+                    {
+                        onionSamples = OnionSkinHelper.EnumerateOnionSkinTimes(
+                            time, Scene.Start, Scene.Duration, rate,
+                            editorConfig.OnionSkinPrevCount, editorConfig.OnionSkinNextCount,
+                            editorConfig.OnionSkinPrevOpacity, editorConfig.OnionSkinNextOpacity);
+                        onionSampleCount = onionSamples.Count;
+                        if (onionSamples.Count == 0)
+                        {
+                            // Range clamp emptied everything — fall back to the cache-aware path
+                            // instead of taking the heavier (cache-less) onion branch for nothing.
+                            _logger.LogDebug(
+                                "Onion skin enabled but no samples in range at frame {Frame}; using normal preview.",
+                                frame);
+                            useOnionSkin = false;
+                        }
+                    }
+
+                    if (useOnionSkin)
+                    {
+                        // Render the current frame; its Snapshot bitmap doubles as the composition
+                        // canvas. Onion-composited frames are intentionally NOT pushed into
+                        // cacheManager: the cache is keyed on frame number alone, and an
+                        // onion-disabled re-render would otherwise return the composite.
+                        var currentCompositionFrame = renderer.Compositor.EvaluateGraphics(time);
+                        renderer.Render(currentCompositionFrame);
+                        Bitmap? currentBitmap = null;
+
+                        try
+                        {
+                            currentBitmap = renderer.Snapshot();
+                            using (var canvas = new SKCanvas(currentBitmap.SKBitmap))
+                            {
+                                foreach (var sample in onionSamples)
+                                {
+                                    var compFrame = renderer.Compositor.EvaluateGraphics(sample.Time);
+                                    renderer.Render(compFrame);
+                                    using var snap = renderer.Snapshot();
+                                    using var paint = new SKPaint
+                                    {
+                                        Color = new SKColor(255, 255, 255, (byte)Math.Round(sample.Alpha * 255)),
+                                        BlendMode = SKBlendMode.SrcOver,
+                                    };
+                                    canvas.DrawBitmap(snap.SKBitmap, 0, 0, paint);
+                                }
+
+                                // Restore renderer entries to the playhead BEFORE drawing
+                                // boundaries so the selection box uses the current frame's
+                                // geometry, not the last onion sample's.
+                                renderer.UpdateFrame(renderer.Compositor.EvaluateGraphics(time));
+
+                                DrawBoundaries(renderer, canvas, new(currentBitmap.Width, currentBitmap.Height), true);
+                            }
+
+                            bitmapRef = Ref<Bitmap>.Create(currentBitmap);
+                            currentBitmap = null; // ownership transferred to bitmapRef
+                        }
+                        catch
+                        {
+                            currentBitmap?.Dispose();
+                            // Best-effort: restore the playhead even on failure so later
+                            // HitTest / GetBoundary use the current frame, not a leftover onion
+                            // sample. Guard the restore so it can't mask the original exception.
+                            try
+                            {
+                                renderer.UpdateFrame(renderer.Compositor.EvaluateGraphics(time));
+                            }
+                            catch (Exception restoreEx)
+                            {
+                                _logger.LogError(restoreEx,
+                                    "Failed to restore playhead after onion-skin render failure at frame {Frame}.",
+                                    frame);
+                            }
+
+                            throw;
+                        }
+                    }
+                    else if (cacheManager.TryGet(frame, out var cache))
                     {
                         using (cache)
                         {
@@ -1328,7 +1471,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 {
                     NotificationService.ShowError(MessageStrings.UnexpectedError,
                         MessageStrings.FrameDrawingException);
-                    _logger.LogError(ex, "An exception occurred while drawing the frame.");
+                    _logger.LogError(ex,
+                        "An exception occurred while drawing the frame. onionSkin={UseOnionSkin}, sampleCount={Count}, frame={Frame}.",
+                        useOnionSkin, onionSampleCount, frame);
                 }
             }, ct: token);
         }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1389,6 +1389,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                             {
                                 foreach (var sample in onionSamples)
                                 {
+                                    // A newer QueueRender has superseded this pass (e.g. the user
+                                    // kept scrubbing); stop re-rendering samples instead of grinding
+                                    // through all of them. Break (not return) so the playhead restore
+                                    // and boundary draw below still run, leaving the renderer on the
+                                    // current frame; the partial composite is replaced by the queued render.
+                                    if (token.IsCancellationRequested)
+                                        break;
+
                                     var compFrame = renderer.Compositor.EvaluateGraphics(sample.Time);
                                     renderer.Render(compFrame);
                                     using var snap = renderer.Snapshot();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -266,16 +266,50 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void OnSceneEdited(object? sender, EventArgs e)
     {
-        if (e is ElementEditedEventArgs elementEdited)
+        if (e is ElementEditedEventArgs elementEdited
+            && !IsEditAffectingPreview(elementEdited.AffectedRange))
         {
-            TimeSpan time = _editorClock.CurrentTime.Value;
-            if (!elementEdited.AffectedRange.Any(v => v.Contains(time)))
-            {
-                return;
-            }
+            return;
         }
 
         QueueRender();
+    }
+
+    // The preview only needs to re-render when an edit touches a currently visible frame.
+    // Normally that is just the playhead frame, but while the onion-skin overlay is active the
+    // neighboring sample frames are visible too, so an edit confined to one of them must still
+    // invalidate the preview.
+    private bool IsEditAffectingPreview(IReadOnlyList<TimeRange> affectedRange)
+    {
+        TimeSpan time = _editorClock.CurrentTime.Value;
+        if (affectedRange.Any(v => v.Contains(time)))
+        {
+            return true;
+        }
+
+        EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+        if (!editorConfig.IsOnionSkinEnabled || IsPlaying.Value || Scene is null)
+        {
+            return false;
+        }
+
+        // Mirror the opacity-folding the render path uses: a zero-opacity side contributes
+        // nothing, so it should not keep the preview alive either.
+        int prevCount = editorConfig.OnionSkinPrevOpacity > 0f ? editorConfig.OnionSkinPrevCount : 0;
+        int nextCount = editorConfig.OnionSkinNextOpacity > 0f ? editorConfig.OnionSkinNextCount : 0;
+        if (prevCount == 0 && nextCount == 0)
+        {
+            return false;
+        }
+
+        int rate = GetFrameRate();
+        int frame = (int)Math.Round(time.ToFrameNumber(rate), MidpointRounding.AwayFromZero);
+        IReadOnlyList<OnionSkinSample> samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            frame, Scene.Start, Scene.Duration, rate,
+            prevCount, nextCount,
+            editorConfig.OnionSkinPrevOpacity, editorConfig.OnionSkinNextOpacity);
+
+        return samples.Any(s => affectedRange.Any(v => v.Contains(s.Time)));
     }
 
     public Subject<Unit> AfterRendered { get; } = new();
@@ -1362,7 +1396,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     if (useOnionSkin)
                     {
                         onionSamples = OnionSkinHelper.EnumerateOnionSkinTimes(
-                            time, Scene.Start, Scene.Duration, rate,
+                            frame, Scene.Start, Scene.Duration, rate,
                             effectivePrevCount, effectiveNextCount,
                             onionPrevOpacity, onionNextOpacity);
                         onionSampleCount = onionSamples.Count;
@@ -1427,8 +1461,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                                 DrawBoundaries(renderer, canvas, new(currentBitmap.Width, currentBitmap.Height), true);
                             }
 
+                            // Ownership moves to bitmapRef here; this is the last statement in the
+                            // try, so the catch below only ever disposes currentBitmap on a path
+                            // before this point (no double-dispose).
                             bitmapRef = Ref<Bitmap>.Create(currentBitmap);
-                            currentBitmap = null; // ownership transferred to bitmapRef
                         }
                         catch
                         {

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -139,6 +139,7 @@
                                               OffContent="{x:Static lang:Strings.OnionSkin}"
                                               OnContent="{x:Static lang:Strings.OnionSkin}" />
                                 <Grid ColumnDefinitions="*,Auto"
+                                      IsEnabled="{Binding IsOnionSkinEnabled.Value}"
                                       RowDefinitions="Auto,Auto,Auto,Auto"
                                       RowSpacing="4">
                                     <TextBlock Grid.Row="0"

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -12,6 +12,7 @@
              xmlns:vm="using:Beutl.ViewModels"
              d:DesignHeight="450"
              d:DesignWidth="800"
+             x:CompileBindings="True"
              x:DataType="vm:PlayerViewModel"
              mc:Ignorable="d">
     <Player x:Name="Player"
@@ -120,6 +121,76 @@
                 </RadioButton>
             </StackPanel>
         </Player.InnerLeftContent>
+        <Player.InnerRightContent>
+            <Button Padding="7,6,5,6"
+                    VerticalAlignment="Top"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="{x:Static lang:Strings.OnionSkin}">
+                <icons:SymbolIcon FontSize="16" Symbol="Settings" />
+                    <Button.Flyout>
+                        <Flyout Placement="Left">
+                            <StackPanel MinWidth="240" Spacing="8">
+                                <TextBlock Classes="Body"
+                                           Text="{x:Static lang:Strings.OnionSkin}" />
+                                <TextBlock Classes="Caption"
+                                           Text="{x:Static lang:Strings.OnionSkin_Description}"
+                                           TextWrapping="Wrap" />
+                                <ToggleSwitch IsChecked="{Binding IsOnionSkinEnabled.Value, Mode=TwoWay}"
+                                              OffContent="{x:Static lang:Strings.OnionSkin}"
+                                              OnContent="{x:Static lang:Strings.OnionSkin}" />
+                                <Grid ColumnDefinitions="*,Auto"
+                                      RowDefinitions="Auto,Auto,Auto,Auto"
+                                      RowSpacing="4">
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Static lang:Strings.OnionSkinPrevCount}" />
+                                    <NumericUpDown Grid.Row="0"
+                                                   Grid.Column="1"
+                                                   MinWidth="100"
+                                                   Increment="1"
+                                                   Maximum="10"
+                                                   Minimum="0"
+                                                   Value="{Binding OnionSkinPrevCount.Value, Mode=TwoWay}" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Static lang:Strings.OnionSkinNextCount}" />
+                                    <NumericUpDown Grid.Row="1"
+                                                   Grid.Column="1"
+                                                   MinWidth="100"
+                                                   Increment="1"
+                                                   Maximum="10"
+                                                   Minimum="0"
+                                                   Value="{Binding OnionSkinNextCount.Value, Mode=TwoWay}" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Static lang:Strings.OnionSkinPrevOpacity}" />
+                                    <Slider Grid.Row="2"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Maximum="1"
+                                            Minimum="0"
+                                            TickFrequency="0.05"
+                                            Value="{Binding OnionSkinPrevOpacity.Value, Mode=TwoWay}" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Static lang:Strings.OnionSkinNextOpacity}" />
+                                    <Slider Grid.Row="3"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Maximum="1"
+                                            Minimum="0"
+                                            TickFrequency="0.05"
+                                            Value="{Binding OnionSkinNextOpacity.Value, Mode=TwoWay}" />
+                                </Grid>
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+            </Button>
+        </Player.InnerRightContent>
         <Player.Content>
             <Panel Name="framePanel"
                    Margin="0"

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Configuration\Beutl.Configuration.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -5,6 +5,11 @@ namespace Beutl.UnitTests.Editor;
 
 public class OnionSkinTests
 {
+    // Mirror of the shared frame<->time conversion (int.ToTimeSpan(rate)) so expected sample
+    // times are expressed on the same frame grid the helper now derives them from.
+    private static TimeSpan FrameTime(int frame, int rate) =>
+        TimeSpan.FromTicks(TimeSpan.TicksPerSecond * frame / rate);
+
     [Test]
     public void EditorConfig_DefaultValues_AreSafe()
     {
@@ -40,7 +45,7 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_ZeroCounts_ReturnsEmpty()
     {
         var result = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromSeconds(10),
+            currentFrame: 300,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: 30,
@@ -56,7 +61,7 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_NonPositiveRate_ReturnsEmpty()
     {
         var result = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromSeconds(10),
+            currentFrame: 300,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: 0,
@@ -72,7 +77,7 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_NegativeCounts_TreatedAsZero()
     {
         var result = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromSeconds(10),
+            currentFrame: 300,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: 30,
@@ -87,12 +92,11 @@ public class OnionSkinTests
     [Test]
     public void EnumerateOnionSkinTimes_PrevAndNext_ProducesExpectedShape()
     {
-        TimeSpan current = TimeSpan.FromSeconds(10);
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+        int currentFrame = 300;
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: current,
+            currentFrame: currentFrame,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: rate,
@@ -106,13 +110,13 @@ public class OnionSkinTests
 
         // Order: prev_oldest, prev_closest, next_closest
         Assert.That(samples[0].IsPrev, Is.True);
-        Assert.That(samples[0].Time, Is.EqualTo(current - TimeSpan.FromTicks(tick.Ticks * 2)));
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(currentFrame - 2, rate)));
 
         Assert.That(samples[1].IsPrev, Is.True);
-        Assert.That(samples[1].Time, Is.EqualTo(current - tick));
+        Assert.That(samples[1].Time, Is.EqualTo(FrameTime(currentFrame - 1, rate)));
 
         Assert.That(samples[2].IsPrev, Is.False);
-        Assert.That(samples[2].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[2].Time, Is.EqualTo(FrameTime(currentFrame + 1, rate)));
 
         // Closest prev has full base opacity, oldest prev is dimmer.
         Assert.That(samples[1].Alpha, Is.GreaterThan(samples[0].Alpha));
@@ -123,7 +127,7 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_SinglePrev_UsesFullBaseOpacity()
     {
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromSeconds(10),
+            currentFrame: 300,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: 30,
@@ -140,10 +144,9 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_NearSceneStart_ClampsPrev()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: tick, // only one tick after start; prev=2 would underflow
+            currentFrame: 1, // only one frame after start; prev=2 would underflow
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: rate,
@@ -152,7 +155,7 @@ public class OnionSkinTests
             prevBaseOpacity: 0.5f,
             nextBaseOpacity: 0.5f);
 
-        // Only the i=1 prev sample (at sceneStart) survives the clamp.
+        // Only the i=1 prev sample (frame 0, at sceneStart) survives the clamp.
         Assert.That(samples, Has.Count.EqualTo(1));
         Assert.That(samples[0].IsPrev, Is.True);
         Assert.That(samples[0].Time, Is.EqualTo(TimeSpan.Zero));
@@ -164,11 +167,10 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_PartialPrevClamp_RenormalizesAlpha()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
 
-        // current = 2*tick, prevCount=3 → i=3 underflows, i=1 and i=2 survive.
+        // currentFrame = 2, prevCount=3 → i=3 underflows (frame -1), i=1 and i=2 survive.
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromTicks(tick.Ticks * 2),
+            currentFrame: 2,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: rate,
@@ -188,10 +190,9 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_CurrentAtSceneStart_DropsPrev()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.Zero, // exactly sceneStart
+            currentFrame: 0, // exactly sceneStart
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromSeconds(1),
             frameRate: rate,
@@ -200,21 +201,20 @@ public class OnionSkinTests
             prevBaseOpacity: 0.5f,
             nextBaseOpacity: 0.5f);
 
-        // No prev (would underflow), one next at +tick.
+        // No prev (would underflow), one next at frame 1.
         Assert.That(samples, Has.Count.EqualTo(1));
         Assert.That(samples[0].IsPrev, Is.False);
-        Assert.That(samples[0].Time, Is.EqualTo(tick));
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(1, rate)));
     }
 
     [Test]
     public void EnumerateOnionSkinTimes_CurrentBeforeSceneStart_DropsOutOfRangeSamples()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
 
-        // current sits before sceneStart; next sample at current+tick is also before start.
+        // current sits before sceneStart; the single next sample (frame -1) is also before start.
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: -TimeSpan.FromTicks(tick.Ticks * 2),
+            currentFrame: -2,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromSeconds(1),
             frameRate: rate,
@@ -223,9 +223,7 @@ public class OnionSkinTests
             prevBaseOpacity: 0.5f,
             nextBaseOpacity: 0.5f);
 
-        // Both prev and the +tick next remain outside [0, 1s); only "next" samples could land
-        // inside if we requested enough — here we requested nextCount=1 so the single emitted
-        // next sample sits at -tick which is still outside, so result is empty.
+        // prev (frame -3) and the single next (frame -1) both remain outside [0, 1s), so empty.
         Assert.That(samples, Is.Empty);
     }
 
@@ -233,13 +231,12 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_NearSceneEnd_ClampsNext()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
-        TimeSpan duration = TimeSpan.FromSeconds(2);
-        // current = duration - 2*tick → next=3 means i=1 (ok), i=2 (== duration, excluded), i=3 (over)
-        TimeSpan current = duration - TimeSpan.FromTicks(tick.Ticks * 2);
+        TimeSpan duration = TimeSpan.FromSeconds(2); // exactly 60 frames at 30 fps
+        // currentFrame = 58 → next=3 means frame 59 (ok), frame 60 (== duration, excluded), frame 61 (over)
+        int currentFrame = 58;
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: current,
+            currentFrame: currentFrame,
             sceneStart: TimeSpan.Zero,
             sceneDuration: duration,
             frameRate: rate,
@@ -250,14 +247,14 @@ public class OnionSkinTests
 
         Assert.That(samples, Has.Count.EqualTo(1));
         Assert.That(samples[0].IsPrev, Is.False);
-        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(currentFrame + 1, rate)));
     }
 
     [Test]
     public void EnumerateOnionSkinTimes_AlphaIsClampedAndMonotonic()
     {
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: TimeSpan.FromSeconds(10),
+            currentFrame: 300,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: 30,
@@ -280,12 +277,11 @@ public class OnionSkinTests
     [Test]
     public void EnumerateOnionSkinTimes_NextOnly_ClosestFrameUsesFullBaseOpacity()
     {
-        TimeSpan current = TimeSpan.FromSeconds(10);
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+        int currentFrame = 300;
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: current,
+            currentFrame: currentFrame,
             sceneStart: TimeSpan.Zero,
             sceneDuration: TimeSpan.FromMinutes(1),
             frameRate: rate,
@@ -298,9 +294,9 @@ public class OnionSkinTests
         Assert.That(samples, Has.Count.EqualTo(2));
 
         Assert.That(samples[0].IsPrev, Is.False);
-        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(currentFrame + 1, rate)));
         Assert.That(samples[1].IsPrev, Is.False);
-        Assert.That(samples[1].Time, Is.EqualTo(current + TimeSpan.FromTicks(tick.Ticks * 2)));
+        Assert.That(samples[1].Time, Is.EqualTo(FrameTime(currentFrame + 2, rate)));
 
         // Next-side falloff direction: the closest next frame gets the full base opacity and the
         // farther one fades. Guards against a reversed/off-by-one next-side formula (the prev tests
@@ -314,14 +310,13 @@ public class OnionSkinTests
     public void EnumerateOnionSkinTimes_PartialNextClamp_RenormalizesAlpha()
     {
         int rate = 30;
-        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
-        TimeSpan duration = TimeSpan.FromSeconds(2);
-        // current = duration - 3*tick, nextCount=3 → i=1 and i=2 fall inside [0, duration), while
-        // i=3 lands exactly on duration (excluded by the exclusive end), so 2 next samples emit.
-        TimeSpan current = duration - TimeSpan.FromTicks(tick.Ticks * 3);
+        TimeSpan duration = TimeSpan.FromSeconds(2); // exactly 60 frames at 30 fps
+        // currentFrame = 57, nextCount=3 → frame 58 and 59 fall inside [0, duration), while
+        // frame 60 lands exactly on duration (excluded by the exclusive end), so 2 next samples emit.
+        int currentFrame = 57;
 
         var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            current: current,
+            currentFrame: currentFrame,
             sceneStart: TimeSpan.Zero,
             sceneDuration: duration,
             frameRate: rate,
@@ -332,10 +327,63 @@ public class OnionSkinTests
 
         Assert.That(samples, Has.Count.EqualTo(2));
         // Closest survivor lands on the full base opacity, not (3-0)/3 of a phantom 3rd sample.
-        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(currentFrame + 1, rate)));
         Assert.That(samples[0].Alpha, Is.EqualTo(0.8f).Within(0.0001f));
         // Farther survivor dims against the emitted count (2), not the requested count (3).
-        Assert.That(samples[1].Time, Is.EqualTo(current + TimeSpan.FromTicks(tick.Ticks * 2)));
+        Assert.That(samples[1].Time, Is.EqualTo(FrameTime(currentFrame + 2, rate)));
         Assert.That(samples[1].Alpha, Is.EqualTo(0.8f * 0.5f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_FractionalRate_SamplesLandOnFrameGrid()
+    {
+        // At 24/60 fps a frame is fractional in ticks. Sample times must align with the shared
+        // frame<->time grid (frame.ToTimeSpan(rate)); stepping by a single rounded per-frame tick
+        // would drift sub-frame and could even drop a valid neighbor near the scene start.
+        int rate = 24;
+        int currentFrame = 100;
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            currentFrame: currentFrame,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 3,
+            nextCount: 3,
+            prevBaseOpacity: 0.6f,
+            nextBaseOpacity: 0.6f);
+
+        Assert.That(samples, Has.Count.EqualTo(6));
+
+        // prev: frames 97, 98, 99 (oldest→closest); next: frames 101, 102, 103 (closest→farthest).
+        Assert.That(samples[0].Time, Is.EqualTo(FrameTime(currentFrame - 3, rate)));
+        Assert.That(samples[1].Time, Is.EqualTo(FrameTime(currentFrame - 2, rate)));
+        Assert.That(samples[2].Time, Is.EqualTo(FrameTime(currentFrame - 1, rate)));
+        Assert.That(samples[3].Time, Is.EqualTo(FrameTime(currentFrame + 1, rate)));
+        Assert.That(samples[4].Time, Is.EqualTo(FrameTime(currentFrame + 2, rate)));
+        Assert.That(samples[5].Time, Is.EqualTo(FrameTime(currentFrame + 3, rate)));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_FirstFrameAtFractionalRate_KeepsPreviousAtSceneStart()
+    {
+        // Regression guard for the dropped-neighbor concern: at frame 1 on a fractional-tick rate,
+        // the single previous frame is frame 0 and must land exactly on sceneStart (not slightly
+        // before it, which would be clamped away).
+        int rate = 24;
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            currentFrame: 1,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 1,
+            nextCount: 0,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0f);
+
+        Assert.That(samples, Has.Count.EqualTo(1));
+        Assert.That(samples[0].IsPrev, Is.True);
+        Assert.That(samples[0].Time, Is.EqualTo(TimeSpan.Zero));
     }
 }

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -276,4 +276,66 @@ public class OnionSkinTests
         // Closest prev frame uses the full base opacity.
         Assert.That(samples[^1].Alpha, Is.EqualTo(0.8f).Within(0.0001f));
     }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_NextOnly_ClosestFrameUsesFullBaseOpacity()
+    {
+        TimeSpan current = TimeSpan.FromSeconds(10);
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: current,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 0,
+            nextCount: 2,
+            prevBaseOpacity: 0f,
+            nextBaseOpacity: 0.4f);
+
+        // 2 next samples, ordered closest → farthest.
+        Assert.That(samples, Has.Count.EqualTo(2));
+
+        Assert.That(samples[0].IsPrev, Is.False);
+        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[1].IsPrev, Is.False);
+        Assert.That(samples[1].Time, Is.EqualTo(current + TimeSpan.FromTicks(tick.Ticks * 2)));
+
+        // Next-side falloff direction: the closest next frame gets the full base opacity and the
+        // farther one fades. Guards against a reversed/off-by-one next-side formula (the prev tests
+        // exercise a structurally different expression and cannot protect this branch).
+        Assert.That(samples[0].Alpha, Is.EqualTo(0.4f).Within(0.0001f));
+        Assert.That(samples[1].Alpha, Is.EqualTo(0.4f * 0.5f).Within(0.0001f));
+        Assert.That(samples[0].Alpha, Is.GreaterThan(samples[1].Alpha));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_PartialNextClamp_RenormalizesAlpha()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+        TimeSpan duration = TimeSpan.FromSeconds(2);
+        // current = duration - 3*tick, nextCount=3 → i=1 and i=2 fall inside [0, duration), while
+        // i=3 lands exactly on duration (excluded by the exclusive end), so 2 next samples emit.
+        TimeSpan current = duration - TimeSpan.FromTicks(tick.Ticks * 3);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: current,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: duration,
+            frameRate: rate,
+            prevCount: 0,
+            nextCount: 3,
+            prevBaseOpacity: 0f,
+            nextBaseOpacity: 0.8f);
+
+        Assert.That(samples, Has.Count.EqualTo(2));
+        // Closest survivor lands on the full base opacity, not (3-0)/3 of a phantom 3rd sample.
+        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+        Assert.That(samples[0].Alpha, Is.EqualTo(0.8f).Within(0.0001f));
+        // Farther survivor dims against the emitted count (2), not the requested count (3).
+        Assert.That(samples[1].Time, Is.EqualTo(current + TimeSpan.FromTicks(tick.Ticks * 2)));
+        Assert.That(samples[1].Alpha, Is.EqualTo(0.8f * 0.5f).Within(0.0001f));
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -1,0 +1,279 @@
+﻿using Beutl.Configuration;
+using Beutl.Editor.Services;
+
+namespace Beutl.UnitTests.Editor;
+
+public class OnionSkinTests
+{
+    [Test]
+    public void EditorConfig_DefaultValues_AreSafe()
+    {
+        var config = new EditorConfig();
+
+        Assert.That(config.IsOnionSkinEnabled, Is.False);
+        Assert.That(config.OnionSkinPrevCount, Is.EqualTo(1));
+        Assert.That(config.OnionSkinNextCount, Is.EqualTo(0));
+        Assert.That(config.OnionSkinPrevOpacity, Is.EqualTo(0.35f).Within(0.0001f));
+        Assert.That(config.OnionSkinNextOpacity, Is.EqualTo(0.35f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EditorConfig_SetValues_RoundTripThroughCoreProperty()
+    {
+        var config = new EditorConfig
+        {
+            IsOnionSkinEnabled = true,
+            OnionSkinPrevCount = 3,
+            OnionSkinNextCount = 2,
+            OnionSkinPrevOpacity = 0.6f,
+            OnionSkinNextOpacity = 0.2f,
+        };
+
+        Assert.That(config.IsOnionSkinEnabled, Is.True);
+        Assert.That(config.OnionSkinPrevCount, Is.EqualTo(3));
+        Assert.That(config.OnionSkinNextCount, Is.EqualTo(2));
+        Assert.That(config.OnionSkinPrevOpacity, Is.EqualTo(0.6f).Within(0.0001f));
+        Assert.That(config.OnionSkinNextOpacity, Is.EqualTo(0.2f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_ZeroCounts_ReturnsEmpty()
+    {
+        var result = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromSeconds(10),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: 30,
+            prevCount: 0,
+            nextCount: 0,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_NonPositiveRate_ReturnsEmpty()
+    {
+        var result = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromSeconds(10),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: 0,
+            prevCount: 2,
+            nextCount: 2,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_NegativeCounts_TreatedAsZero()
+    {
+        var result = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromSeconds(10),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: 30,
+            prevCount: -2,
+            nextCount: -1,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_PrevAndNext_ProducesExpectedShape()
+    {
+        TimeSpan current = TimeSpan.FromSeconds(10);
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: current,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 2,
+            nextCount: 1,
+            prevBaseOpacity: 0.4f,
+            nextBaseOpacity: 0.4f);
+
+        // 2 prev (oldest, closest) + 1 next (closest) = 3 samples
+        Assert.That(samples, Has.Count.EqualTo(3));
+
+        // Order: prev_oldest, prev_closest, next_closest
+        Assert.That(samples[0].IsPrev, Is.True);
+        Assert.That(samples[0].Time, Is.EqualTo(current - TimeSpan.FromTicks(tick.Ticks * 2)));
+
+        Assert.That(samples[1].IsPrev, Is.True);
+        Assert.That(samples[1].Time, Is.EqualTo(current - tick));
+
+        Assert.That(samples[2].IsPrev, Is.False);
+        Assert.That(samples[2].Time, Is.EqualTo(current + tick));
+
+        // Closest prev has full base opacity, oldest prev is dimmer.
+        Assert.That(samples[1].Alpha, Is.GreaterThan(samples[0].Alpha));
+        Assert.That(samples[1].Alpha, Is.EqualTo(0.4f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_SinglePrev_UsesFullBaseOpacity()
+    {
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromSeconds(10),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: 30,
+            prevCount: 1,
+            nextCount: 0,
+            prevBaseOpacity: 0.7f,
+            nextBaseOpacity: 0f);
+
+        Assert.That(samples, Has.Count.EqualTo(1));
+        Assert.That(samples[0].Alpha, Is.EqualTo(0.7f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_NearSceneStart_ClampsPrev()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: tick, // only one tick after start; prev=2 would underflow
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 2,
+            nextCount: 0,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        // Only the i=1 prev sample (at sceneStart) survives the clamp.
+        Assert.That(samples, Has.Count.EqualTo(1));
+        Assert.That(samples[0].IsPrev, Is.True);
+        Assert.That(samples[0].Time, Is.EqualTo(TimeSpan.Zero));
+        // Re-normalized: with only one emitted sample, alpha == baseOpacity (no falloff jump).
+        Assert.That(samples[0].Alpha, Is.EqualTo(0.5f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_PartialPrevClamp_RenormalizesAlpha()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        // current = 2*tick, prevCount=3 → i=3 underflows, i=1 and i=2 survive.
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromTicks(tick.Ticks * 2),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: rate,
+            prevCount: 3,
+            nextCount: 0,
+            prevBaseOpacity: 0.8f,
+            nextBaseOpacity: 0f);
+
+        Assert.That(samples, Has.Count.EqualTo(2));
+        // Closest (last) sample should land on full baseOpacity, not (3-1+1)/3 = 0.667.
+        Assert.That(samples[^1].Alpha, Is.EqualTo(0.8f).Within(0.0001f));
+        // Oldest sample dims linearly with the emitted count, not the requested count.
+        Assert.That(samples[0].Alpha, Is.EqualTo(0.8f * 0.5f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_CurrentAtSceneStart_DropsPrev()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.Zero, // exactly sceneStart
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromSeconds(1),
+            frameRate: rate,
+            prevCount: 2,
+            nextCount: 1,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        // No prev (would underflow), one next at +tick.
+        Assert.That(samples, Has.Count.EqualTo(1));
+        Assert.That(samples[0].IsPrev, Is.False);
+        Assert.That(samples[0].Time, Is.EqualTo(tick));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_CurrentBeforeSceneStart_DropsOutOfRangeSamples()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+
+        // current sits before sceneStart; next sample at current+tick is also before start.
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: -TimeSpan.FromTicks(tick.Ticks * 2),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromSeconds(1),
+            frameRate: rate,
+            prevCount: 1,
+            nextCount: 1,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        // Both prev and the +tick next remain outside [0, 1s); only "next" samples could land
+        // inside if we requested enough — here we requested nextCount=1 so the single emitted
+        // next sample sits at -tick which is still outside, so result is empty.
+        Assert.That(samples, Is.Empty);
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_NearSceneEnd_ClampsNext()
+    {
+        int rate = 30;
+        TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
+        TimeSpan duration = TimeSpan.FromSeconds(2);
+        // current = duration - 2*tick → next=3 means i=1 (ok), i=2 (== duration, excluded), i=3 (over)
+        TimeSpan current = duration - TimeSpan.FromTicks(tick.Ticks * 2);
+
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: current,
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: duration,
+            frameRate: rate,
+            prevCount: 0,
+            nextCount: 3,
+            prevBaseOpacity: 0.5f,
+            nextBaseOpacity: 0.5f);
+
+        Assert.That(samples, Has.Count.EqualTo(1));
+        Assert.That(samples[0].IsPrev, Is.False);
+        Assert.That(samples[0].Time, Is.EqualTo(current + tick));
+    }
+
+    [Test]
+    public void EnumerateOnionSkinTimes_AlphaIsClampedAndMonotonic()
+    {
+        var samples = OnionSkinHelper.EnumerateOnionSkinTimes(
+            current: TimeSpan.FromSeconds(10),
+            sceneStart: TimeSpan.Zero,
+            sceneDuration: TimeSpan.FromMinutes(1),
+            frameRate: 30,
+            prevCount: 4,
+            nextCount: 0,
+            prevBaseOpacity: 0.8f,
+            nextBaseOpacity: 0f);
+
+        // Returned order is oldest→closest, so alpha should be non-decreasing.
+        for (int i = 1; i < samples.Count; i++)
+        {
+            Assert.That(samples[i].Alpha, Is.GreaterThanOrEqualTo(samples[i - 1].Alpha));
+            Assert.That(samples[i].Alpha, Is.InRange(0f, 1f));
+        }
+
+        // Closest prev frame uses the full base opacity.
+        Assert.That(samples[^1].Alpha, Is.EqualTo(0.8f).Within(0.0001f));
+    }
+}


### PR DESCRIPTION
## Description
- Adds an onion-skin overlay to the preview player: semi-transparent previous/next frames composited over the current frame to aid animation and keyframe timing.
- Configurable via a settings flyout (enable toggle, previous/next frame counts, previous/next opacity), persisted in `EditorConfig`. The toggle is also wired to the `Alt+O` shortcut (`ToggleOnionSkin` context command).
- Frame-time enumeration and the opacity falloff/renormalization are extracted into a pure, testable `OnionSkinHelper` (in `Beutl.Editor`, MIT) so the math is unit-tested independently of the UI.
- The render path is hardened: the onion config is snapshotted on the UI thread before dispatch, the playhead is restored on every exit path (success, supersede, exception), zero-opacity sides are skipped, superseded passes abort early, and onion composites are intentionally kept out of the frame cache (cache is keyed on frame number alone).

## Breaking changes
- `Beutl.Controls.Player.ContentProperty` was registered with `nameof(InnerLeftContent)` and is corrected to `nameof(Content)`. This fixes a latent property-name collision in the `Player` control template. Migration: any code relying on the previous (incorrect) name-based aliasing of `Content`/`InnerLeftContent` should be re-verified; `Player.Content` now resolves correctly.

## Test plan
- New `tests/Beutl.UnitTests/Editor/OnionSkinTests.cs` covers `OnionSkinHelper.EnumerateOnionSkinTimes` (zero/negative counts, non-positive frame rate, both-side falloff direction, partial-clamp renormalization, scene start/end boundaries, current-before-start) and the `EditorConfig` round-trip of the five new properties.
- Added `Beutl.Configuration` as a `ProjectReference` to `Beutl.UnitTests`.
- Manual: enable onion skin via the player settings flyout, scrub the playhead, and confirm previous/next ghost frames appear and fade with distance; toggle with `Alt+O`; confirm ghosts are not drawn during playback.
- Note: `PlayerViewModel` compositing is not unit-tested by design — `src/Beutl/` is not referenced by any test project, so the testable logic lives in `Beutl.Editor`.

## Fixed issues / References
None