### PR TITLE
fix: harden Dispatcher timer wait and resource disposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ dotnet format Beutl.slnx                                           # format
 ./build.sh <Target>                                                # Nuke (same as CI)
 ```
 
-Claude Code skills are provided as `/beutl-build`, `/beutl-test`, `/beutl-format`, `/beutl-coverage`. They also fire on natural-language requests like "run the tests", "does this still build?", and they will **confirm scope** with AskUserQuestion (whole solution vs single project, verify vs apply, etc.) before executing. Pass arguments (e.g. `/beutl-test <FQN-substring>`) to skip the confirmation.
+Claude Code skills are provided as `/beutl-build`, `/beutl-test`, `/beutl-format`, `/beutl-coverage`. They also fire on natural-language requests like "run the tests", "does this still build?", and they will **confirm scope** with AskUserQuestion (whole solution vs single project, verify vs apply, etc.) before executing. Pass arguments (e.g. `/beutl-test <FQN-substring>`) to skip the confirmation. Before opening a PR, `/beutl-pre-pr` runs the same checks locally that the CI review and the `beutl-reviewer` subagent will run.
 
 ## Module boundary map
 
@@ -34,7 +34,8 @@ Claude Code skills are provided as `/beutl-build`, `/beutl-test`, `/beutl-format
 | `Beutl.Engine` | Core rendering / scene / track (no project dependencies) |
 | `Beutl.Engine.SourceGenerators` | Roslyn source generators |
 | `Beutl.ProjectSystem` | Project / document persistence |
-| `Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls` | Avalonia UI layer |
+| `Beutl.Editor` | Non-UI editor logic — undo/redo, packaging, editing-pipeline services (no Avalonia) |
+| `Beutl.Editor.Components`, `Beutl.Controls` | Avalonia UI layer (views / controls / ViewModels) |
 | `Beutl.Extensibility` | Plugin abstractions |
 | `Beutl.NodeGraph` | Node editor |
 | `Beutl.FFmpegIpc` | **MIT** IPC layer |

--- a/docs/ai-workflow/subagents-and-hooks.md
+++ b/docs/ai-workflow/subagents-and-hooks.md
@@ -36,6 +36,7 @@ All hooks are team-shared (loaded via `.claude/settings.json`). On first launch,
 | Hook | Role | Blocking? |
 |---|---|---|
 | `SessionStart` → `session-start-context.sh` | At startup, inject branch, last 5 commits, and uncommitted changes into context. | no |
+| `SessionStart` → `install-dotnet.sh` | On Claude Code web/cloud sessions, install the .NET SDK if it is missing. | no |
 | `PreToolUse(Bash)` → `block-dangerous-bash.sh` | Deny obvious literal forms of `rm -rf /`, `rm -rf ~`, `rm -rf $HOME` / `${HOME}`, and `git push (--force / -f / --force-with-lease) origin (main / master)`. | **deny** |
 | `PreToolUse(Bash)` → `allow-dotnet-commands.sh` | Auto-allow `dotnet build/test/format/restore/run`, `./build.sh`. | **allow** |
 | `PreToolUse(Edit\|Write\|MultiEdit)` → `check-gpl-mit-boundary.sh` | Inspect the new content fragments of a `.csproj` edit (`new_string`, `content`, `edits[].new_string`) and deny when they include a `<ProjectReference ... Beutl.FFmpegWorker`. | **deny** |

--- a/docs/notes/dispatcher-priority-queue-benchmark.md
+++ b/docs/notes/dispatcher-priority-queue-benchmark.md
@@ -1,0 +1,75 @@
+# Dispatcher priority queue: `Channel.CreateUnboundedPrioritized` vs bucketed `Queue[]`
+
+## Summary
+
+On the `yuto-trd/optimize-dispatcher` branch we evaluated replacing the
+`Beutl.Threading` dispatcher's hand-written priority queue and idle-wait machinery
+with `System.Threading.Channels.Channel.CreateUnboundedPrioritized`. **The change was
+reverted: it was slower, not faster.** The original implementation — three
+`Queue<DispatcherOperation>` buckets, one per `DispatchPriority` — wins on throughput.
+
+Keep this note so the same "use a prioritized Channel to optimize the dispatcher" idea
+is not re-attempted without remembering the measured outcome.
+
+## What was compared
+
+The public `Dispatcher` API (`Spawn` / `Invoke` / `Dispatch` / `Schedule`) is identical
+in both versions, so a single benchmark (`tests/Beutl.Benchmarks/DispatcherBenchmark.cs`)
+runs against both. The "after" implementation was toggled off with
+`git stash push -- src/Beutl.Threading` to measure "before", then restored.
+
+- **before**: `OperationQueue` backed by `Queue<DispatcherOperation>[3]`, idle-wait via a
+  per-cycle `CancellationTokenSource` + `WaitHandle.WaitOne()`, woken by `Post` under a lock.
+- **after**: `OperationQueue` backed by `Channel.CreateUnboundedPrioritized` (a binary-heap
+  `PriorityQueue` internally) with a sequence-number tiebreak for FIFO; idle-wait via
+  `ChannelReader.WaitToReadAsync`.
+
+## Results (Apple M3, .NET 10.0.7, `OperationCount = 1000`)
+
+| Benchmark | before (`Queue[3]`) | after (`Channel`) | Delta |
+|---|---:|---:|---|
+| `DispatchThenDrain` (single-producer Post throughput) | 133 µs ± 9 | 301 µs ± 13 | **~2.3× slower** |
+| `ConcurrentDispatch` (multi-producer Post throughput) | 468 µs ± 29 | 571 µs ± 115 | ~22% slower |
+| `InvokeSequential` (wake-up latency) | 7,059 µs ± 590 | 6,148 µs ± 1,429 | within noise |
+
+Allocations:
+
+| Benchmark | before | after |
+|---|---:|---:|
+| `InvokeSequential` | 521 KB | 750 KB (+44%) |
+| `DispatchThenDrain` | 165 KB | 173 KB |
+| `ConcurrentDispatch` | 168 KB | 176 KB |
+
+(`InvokeSequential` has a very wide confidence interval because every call is a
+cross-thread round-trip; treat its latency as "no measurable win", not a regression.)
+
+## Why the Channel is slower here
+
+1. **Structural (dominant).** `CreateUnboundedPrioritized` keeps a binary-heap
+   `PriorityQueue`, so enqueue/dequeue is `O(log n)` plus a comparer call. With only
+   **three** fixed priority levels, the original bucket array is `O(1)` and simply faster.
+   A prioritized Channel pays off when priorities are many/continuous, not for a 3-level enum.
+2. **Allocation.** Blocking the dispatcher thread on `WaitToReadAsync().AsTask()` allocates
+   a `Task` on every idle cycle, which shows up as the +44 % allocation on `InvokeSequential`.
+3. **Wake-up latency** — the actual goal of moving to a Channel — showed no measurable
+   improvement.
+
+## Takeaway
+
+The value of a prioritized Channel for this dispatcher would have been *simpler/more correct
+wait logic* (dropping the manual `CancellationTokenSource` dance and the `Post` lock), **not**
+speed. Since the branch goal is to optimize, the bucketed `Queue[]` implementation was kept.
+
+## Reproducing
+
+```bash
+# after (current implementation)
+dotnet run -c Release -f net10.0 --project tests/Beutl.Benchmarks -- \
+  --filter '*DispatcherBenchmark*' --artifacts /tmp/dispatcher-bench/after
+
+# before (toggle the implementation off, benchmark code is public-API only so it still builds)
+git stash push -- src/Beutl.Threading
+dotnet run -c Release -f net10.0 --project tests/Beutl.Benchmarks -- \
+  --filter '*DispatcherBenchmark*' --artifacts /tmp/dispatcher-bench/before
+git stash pop
+```

--- a/src/Beutl.Threading/DispatcherOperation.cs
+++ b/src/Beutl.Threading/DispatcherOperation.cs
@@ -38,7 +38,7 @@ internal sealed class DispatcherOperation
             }
             finally
             {
-                // Action() が例外を投げても ExecutionContext を確実に解放する。
+                // Release the ExecutionContext even if Action() throws.
                 ctx.Dispose();
             }
         }

--- a/src/Beutl.Threading/DispatcherOperation.cs
+++ b/src/Beutl.Threading/DispatcherOperation.cs
@@ -32,8 +32,15 @@ internal sealed class DispatcherOperation
 
         if (ExecutionContext is { } ctx)
         {
-            ExecutionContext.Run(ctx, _ => Action(), null);
-            ctx.Dispose();
+            try
+            {
+                ExecutionContext.Run(ctx, _ => Action(), null);
+            }
+            finally
+            {
+                // Action() が例外を投げても ExecutionContext を確実に解放する。
+                ctx.Dispose();
+            }
         }
         else
         {

--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -2,6 +2,9 @@
 
 internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimeProvider timeProvider) : SynchronizationContext
 {
+    // CancelAfter throws when the delay exceeds int.MaxValue milliseconds; clamp to it.
+    private static readonly TimeSpan s_maxCancelAfter = TimeSpan.FromMilliseconds(int.MaxValue);
+
     private readonly OperationQueue _operationQueue = new();
     private readonly TimerQueue _timerQueue = new(timeProvider);
 
@@ -76,7 +79,13 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
         CancellationTokenSource cts;
         lock (this)
         {
-            // このロックに入る前にPostされた可能性があるため、再度確認する
+            // Shutdown() may have set _running to false between the check above and
+            // acquiring this lock. Bail out so we do not assign a fresh _waitToken that
+            // nothing will cancel and then block on WaitOne() forever.
+            if (!_running)
+                return;
+
+            // An operation may have been posted before we took the lock; re-check.
             if (_operationQueue.Any(DispatchPriority.Low))
             {
                 return;
@@ -87,10 +96,18 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
 
             if (_timerQueue.Next is { } next)
             {
-                // 期限が既に過ぎている場合 next - now は負になり、CancelAfter は
-                // ArgumentOutOfRangeException を投げる。Zero にクランプして即時起床させる。
                 TimeSpan delay = next - timeProvider.GetUtcNow();
-                cts.CancelAfter(delay < TimeSpan.Zero ? TimeSpan.Zero : delay);
+                if (delay <= TimeSpan.Zero)
+                {
+                    // The deadline has already passed; wake immediately without arming a timer.
+                    cts.Cancel();
+                }
+                else
+                {
+                    // CancelAfter throws for delays longer than int.MaxValue ms, so clamp
+                    // far-future timers; the wait is re-armed each cycle until the real deadline.
+                    cts.CancelAfter(delay < s_maxCancelAfter ? delay : s_maxCancelAfter);
+                }
             }
         }
 
@@ -101,7 +118,7 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
             _waitToken = null;
         }
 
-        // _waitToken を null にした後に破棄する。他スレッドは null を見て Cancel しないため競合しない。
+        // Dispose after clearing _waitToken: other threads see null and won't cancel it.
         cts.Dispose();
     }
 

--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -73,28 +73,36 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
         if (!_running)
             return;
 
+        CancellationTokenSource cts;
         lock (this)
         {
             // このロックに入る前にPostされた可能性があるため、再度確認する
             if (_operationQueue.Any(DispatchPriority.Low))
             {
-                _waitToken?.Cancel();
-                _waitToken = null;
                 return;
             }
 
-            _waitToken = new CancellationTokenSource();
+            cts = new CancellationTokenSource();
+            _waitToken = cts;
 
             if (_timerQueue.Next is { } next)
-                _waitToken.CancelAfter(next - timeProvider.GetUtcNow());
+            {
+                // 期限が既に過ぎている場合 next - now は負になり、CancelAfter は
+                // ArgumentOutOfRangeException を投げる。Zero にクランプして即時起床させる。
+                TimeSpan delay = next - timeProvider.GetUtcNow();
+                cts.CancelAfter(delay < TimeSpan.Zero ? TimeSpan.Zero : delay);
+            }
         }
 
-        _waitToken.Token.WaitHandle.WaitOne();
+        cts.Token.WaitHandle.WaitOne();
 
         lock (this)
         {
             _waitToken = null;
         }
+
+        // _waitToken を null にした後に破棄する。他スレッドは null を見て Cancel しないため競合しない。
+        cts.Dispose();
     }
 
     public override void Send(SendOrPostCallback d, object? state)

--- a/tests/Beutl.Benchmarks/DispatcherBenchmark.cs
+++ b/tests/Beutl.Benchmarks/DispatcherBenchmark.cs
@@ -1,0 +1,59 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+using Beutl.Threading;
+
+namespace Beutl.Benchmarks;
+
+// Measures the dispatcher message loop across three axes: per-operation wake-up latency,
+// single-producer Post throughput, and multi-producer (contended) Post throughput, plus
+// allocations. Useful when evaluating changes to OperationQueue / the idle-wait machinery.
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 5)]
+public class DispatcherBenchmark
+{
+    private Dispatcher _dispatcher = null!;
+
+    [Params(1000)]
+    public int OperationCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _dispatcher = Dispatcher.Spawn();
+
+    [GlobalCleanup]
+    public void Cleanup() => _dispatcher.Shutdown();
+
+    // Cross-thread Invoke in a tight loop: each call leaves the dispatcher idle and must
+    // wake it again, so this measures the per-operation wake-up latency.
+    [Benchmark]
+    public void InvokeSequential()
+    {
+        for (int i = 0; i < OperationCount; i++)
+        {
+            _dispatcher.Invoke(static () => { });
+        }
+    }
+
+    // Fire-and-forget posts from a single producer, then a Low-priority barrier that only
+    // runs once every Medium operation has drained. Measures Post throughput.
+    [Benchmark]
+    public void DispatchThenDrain()
+    {
+        for (int i = 0; i < OperationCount; i++)
+        {
+            _dispatcher.Dispatch(static () => { });
+        }
+
+        _dispatcher.Invoke(static () => { }, DispatchPriority.Low);
+    }
+
+    // Many producer threads posting concurrently. This is where removing the per-Post
+    // lock + CancellationTokenSource churn should show up most.
+    [Benchmark]
+    public void ConcurrentDispatch()
+    {
+        Dispatcher dispatcher = _dispatcher;
+        Parallel.For(0, OperationCount, _ => dispatcher.Dispatch(static () => { }));
+        dispatcher.Invoke(static () => { }, DispatchPriority.Low);
+    }
+}

--- a/tests/Beutl.Benchmarks/Program.cs
+++ b/tests/Beutl.Benchmarks/Program.cs
@@ -1,3 +1,7 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System.Reflection;
 
-BenchmarkRunner.Run<MatrixEqualityCompareBench>();
+using BenchmarkDotNet.Running;
+
+// Select a benchmark with `-- --filter <pattern>`, e.g. `--filter *DispatcherBenchmark*`.
+// With no arguments, BenchmarkDotNet shows an interactive picker.
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -503,4 +503,43 @@ public class DispatcherTests
 
         dispatcher.Shutdown();
     }
+
+    // Regression test: WaitForPendingOperations passed `next - now` to CancellationTokenSource
+    // .CancelAfter without guarding against a negative value. With a monotonically advancing
+    // clock the next timer slips from "future" at FlushTimerQueue to "past" at the wait
+    // computation, which used to throw ArgumentOutOfRangeException and kill the dispatcher thread.
+    [Test]
+    public void Schedule_WhenTimerElapsesBetweenFlushAndWait_DoesNotCrashDispatcher()
+    {
+        // step (10ms) < delay (15ms) < 2*step (20ms): after the flush read (now = +10, timer
+        // still future) the wait read (now = +20) makes the delay negative by construction.
+        var timeProvider = new AdvancingTimeProvider(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10));
+        var dispatcher = Dispatcher.Spawn(timeProvider);
+        var tcs = new TaskCompletionSource();
+
+        dispatcher.Schedule(TimeSpan.FromMilliseconds(15), () => tcs.SetResult());
+
+        Assert.That(tcs.Task.Wait(TimeSpan.FromSeconds(5)), Is.True,
+            "Scheduled operation did not run; the dispatcher likely crashed on CancelAfter with a negative delay.");
+
+        dispatcher.Shutdown();
+    }
+
+    // Advances by a fixed step on every GetUtcNow() call, so a scheduled timer deterministically
+    // slips from "future" to "past" across the dispatcher's flush and wait reads of the clock.
+    private sealed class AdvancingTimeProvider(DateTimeOffset start, TimeSpan step) : TimeProvider
+    {
+        private readonly object _lock = new();
+        private DateTimeOffset _now = start;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_lock)
+            {
+                DateTimeOffset now = _now;
+                _now += step;
+                return now;
+            }
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
+++ b/tests/Beutl.UnitTests/Threading/OperationQueueTests.cs
@@ -80,6 +80,38 @@ public class OperationQueueTests
         Assert.That(dequeued2, Is.SameAs(second));
     }
 
+    [Test]
+    public void TryDequeue_OrdersByPriorityThenFifoWhenInterleaved()
+    {
+        var queue = new OperationQueue();
+
+        var medium1 = NewOperation("medium1", DispatchPriority.Medium);
+        var high1 = NewOperation("high1", DispatchPriority.High);
+        var low1 = NewOperation("low1", DispatchPriority.Low);
+        var medium2 = NewOperation("medium2", DispatchPriority.Medium);
+        var high2 = NewOperation("high2", DispatchPriority.High);
+
+        queue.Enqueue(medium1);
+        queue.Enqueue(high1);
+        queue.Enqueue(low1);
+        queue.Enqueue(medium2);
+        queue.Enqueue(high2);
+
+        // High (FIFO) -> Medium (FIFO) -> Low
+        Assert.That(Drain(queue), Is.EqualTo(new[] { high1, high2, medium1, medium2, low1 }));
+    }
+
+    private static DispatcherOperation[] Drain(OperationQueue queue)
+    {
+        var result = new List<DispatcherOperation>();
+        while (queue.TryDequeue(out var operation))
+        {
+            result.Add(operation);
+        }
+
+        return [.. result];
+    }
+
     private static DispatcherOperation NewOperation(string label, DispatchPriority priority)
     {
         return new DispatcherOperation(() => { _ = label; }, priority, CancellationToken.None);


### PR DESCRIPTION
## Description
- Fix three latent bugs in the `Beutl.Threading` dispatcher: a negative-delay `CancelAfter` that throws `ArgumentOutOfRangeException` and kills the dispatcher thread, an undisposed per-cycle `CancellationTokenSource` (leaked an internal timer), and a captured `ExecutionContext` that was not released when an operation throws.
- Evaluate replacing the dispatcher's priority queue and idle-wait with `Channel.CreateUnboundedPrioritized`. Benchmarked before/after and **reverted**: for the 3-level `DispatchPriority` enum the bucketed `Queue[]` (O(1)) is faster than the Channel's internal `PriorityQueue` (O(log n) + comparer). Documented under `docs/notes/` so the idea is not re-attempted blindly.
- Refresh the AI workflow surface (`AGENTS.md` module map, hooks table, skill list) to match the current repo.
- Carries pre-existing dependency bumps already committed on this branch (Refit, ReactiveUI/Avalonia/Dock).

## Affected areas
<!-- Beutl.Threading is not in the list below; noting the real surface here. -->
- [x] Build / CI / docs only

> Also touches **`Beutl.Threading`** (core dispatcher — production fix), `tests/Beutl.UnitTests/Threading/`, and `tests/Beutl.Benchmarks/`. None of the labelled modules above map to `Beutl.Threading`.

## Breaking changes
None.

## Test plan
- New / existing NUnit tests under `tests/Beutl.UnitTests/Threading/`:
  - `DispatcherTests.Schedule_WhenTimerElapsesBetweenFlushAndWait_DoesNotCrashDispatcher` — regression for the negative `CancelAfter` delay, using a monotonically advancing `TimeProvider`. Verified it crashes the test host **without** the fix (`ArgumentOutOfRangeException (Parameter 'delay')`) and is green **with** it.
  - `OperationQueueTests.TryDequeue_OrdersByPriorityThenFifoWhenInterleaved` — priority + same-priority FIFO ordering.
- All `Beutl.UnitTests.Threading` tests green (50), run 3× for stability.
- `dotnet format` clean for `Beutl.Threading` and the edited test/benchmark files.
- Benchmark `tests/Beutl.Benchmarks/DispatcherBenchmark.cs` measured before/after the Channel migration; results recorded in `docs/notes/dispatcher-priority-queue-benchmark.md`.

## Fixed issues / References
None.