### PR TITLE
docs: document follow-up task capture in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ Conventional Commits, following the existing history:
 - `refactor: ...` — behavior-preserving refactor
 - `docs: ...` — documentation
 
+## Follow-up tasks
+
+When work surfaces a follow-up — a deferred edge case, a known TODO, a refactor you scoped out, a test you could not add yet — **do not let it evaporate.** Capture it in one of two places:
+
+1. **If a PR is open (or you are about to open one), append it to the PR description.** Use the `## Fixed issues / References` section (or a dedicated `## Follow-ups` list) so reviewers see it. This is the default for anything tightly coupled to the PR under review.
+2. **Otherwise, add it as a Draft item to GitHub Projects v2 — [b-editor/projects/9](https://github.com/orgs/b-editor/projects/9).** This is the default for cross-cutting or longer-horizon work that outlives the current PR. Give the draft a clear title and a one-line body describing the context; reference the originating PR/commit when one exists.
+
+Pick whichever fits; when unsure, prefer the PR description for PR-local items and the project board for everything else. Do not silently drop a follow-up just because it is out of scope for the current change.
+
 ## Spec-Driven Development for large features
 
 For large features (a new filter category, an IPC protocol change, a new editor pane), use the Spec-Kit flow: `/speckit-specify → /speckit-plan → /speckit-tasks → /speckit-implement`. Details: `docs/ai-workflow/spec-driven-development.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Conventional Commits, following the existing history:
 
 When work surfaces a follow-up — a deferred edge case, a known TODO, a refactor you scoped out, a test you could not add yet — **do not let it evaporate.** Capture it in one of two places:
 
-1. **If a PR is open (or you are about to open one), append it to the PR description.** Use the `## Fixed issues / References` section (or a dedicated `## Follow-ups` list) so reviewers see it. This is the default for anything tightly coupled to the PR under review.
+1. **If a PR is open (or you are about to open one), append it to the PR description.** Add a dedicated `## Follow-ups` list so reviewers see it; fall back to `## Fixed issues / References` only when noting a linked issue/PR (that section is for closed/referenced issues, not for "fixed" follow-ups). This is the default for anything tightly coupled to the PR under review.
 2. **Otherwise, add it as a Draft item to GitHub Projects v2 — [b-editor/projects/9](https://github.com/orgs/b-editor/projects/9).** This is the default for cross-cutting or longer-horizon work that outlives the current PR. Give the draft a clear title and a one-line body describing the context; reference the originating PR/commit when one exists.
 
 Pick whichever fits; when unsure, prefer the PR description for PR-local items and the project board for everything else. Do not silently drop a follow-up just because it is out of scope for the current change.


### PR DESCRIPTION
## Description
- Add a `Follow-up tasks` section to AGENTS.md so deferred work isn't silently dropped
- Direct PR-local follow-ups to the PR description, and cross-cutting/longer-horizon items to GitHub Projects v2 (b-editor/projects/9), matching the existing PR-template convention

## Affected areas
- [x] Build / CI / docs only

## Breaking changes
None

## Test plan
Documentation-only change; no code or tests affected.

## Fixed issues / References
None