### PR TITLE
perf(engine): pool per-sample speed buffer in SpeedNode.ProcessAnimatedSpeed

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Animation;
+﻿using System.Buffers;
+using Beutl.Animation;
 using Beutl.Engine;
 using Beutl.Media;
 using NAudio.Dsp;
@@ -94,27 +95,39 @@ public sealed class SpeedNode : AudioNode
         }
 
         // per-sample速度収集（オーディオ固有のロジック）
+        // この配列はアニメーション速度クリップのレンダーごとに最大 SampleRate 要素になりホットパスで
+        // GC 圧力を生むため、ArrayPool から借用して再利用する。ProcessBufferWithVariableSpeed は
+        // ReadOnlySpan<double> を同期的に消費するだけで保持しないため、呼び出し後に安全に返却できる。
         var startInSamples = (int)(context.TimeRange.Start.TotalSeconds * context.SampleRate);
-        Span<double> speeds = new double[expectedOutputSampleCount];
-        double sum = 0;
-        for (int i = 0; i < expectedOutputSampleCount; i++)
+        double[] speedsArray = ArrayPool<double>.Shared.Rent(expectedOutputSampleCount);
+        try
         {
-            var value = animation.GetAnimatedValue(
-                ownerStart + TimeSpan.FromSeconds((startInSamples + i) / (double)context.SampleRate)) / 100.0;
-            speeds[i] = value;
-            sum += value;
+            // 借用配列は要求長より大きいことがあるため必ずスライスして渡す。
+            Span<double> speeds = speedsArray.AsSpan(0, expectedOutputSampleCount);
+            double sum = 0;
+            for (int i = 0; i < expectedOutputSampleCount; i++)
+            {
+                var value = animation.GetAnimatedValue(
+                    ownerStart + TimeSpan.FromSeconds((startInSamples + i) / (double)context.SampleRate)) / 100.0;
+                speeds[i] = value;
+                sum += value;
+            }
+
+            var sourceEndTime = sourceStartTime + TimeSpan.FromSeconds(sum / context.SampleRate);
+            var sourceTimeRange = TimeRange.FromRange(sourceStartTime, sourceEndTime);
+
+            var inputContext = new AudioProcessContext(
+                sourceTimeRange,
+                context.SampleRate,
+                context.AnimationSampler,
+                context.OriginalTimeRange);
+
+            return _processor!.ProcessBufferWithVariableSpeed(inputContext, speeds, expectedOutputSampleCount);
         }
-
-        var sourceEndTime = sourceStartTime + TimeSpan.FromSeconds(sum / context.SampleRate);
-        var sourceTimeRange = TimeRange.FromRange(sourceStartTime, sourceEndTime);
-
-        var inputContext = new AudioProcessContext(
-            sourceTimeRange,
-            context.SampleRate,
-            context.AnimationSampler,
-            context.OriginalTimeRange);
-
-        return _processor!.ProcessBufferWithVariableSpeed(inputContext, speeds, expectedOutputSampleCount);
+        finally
+        {
+            ArrayPool<double>.Shared.Return(speedsArray);
+        }
     }
 
     private TimeRange CalculateSourceTimeRange(TimeRange outputTimeRange, float speed)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -94,15 +94,17 @@ public sealed class SpeedNode : AudioNode
             sourceStartTime = _integrator.Integrate(context.TimeRange.Start, keyFrameAnimation);
         }
 
-        // per-sample速度収集（オーディオ固有のロジック）
-        // この配列はアニメーション速度クリップのレンダーごとに最大 SampleRate 要素になりホットパスで
-        // GC 圧力を生むため、ArrayPool から借用して再利用する。ProcessBufferWithVariableSpeed は
-        // ReadOnlySpan<double> を同期的に消費するだけで保持しないため、呼び出し後に安全に返却できる。
+        // Per-sample speed collection (audio-specific logic).
+        // This buffer is sized to expectedOutputSampleCount (ceil(render-duration * SampleRate)),
+        // which can be large, and it is allocated on every render of an animated-speed audio clip,
+        // so it adds GC pressure on the hot path. Rent it from ArrayPool and reuse instead.
+        // ProcessBufferWithVariableSpeed consumes the ReadOnlySpan<double> synchronously and does
+        // not retain it, so the array can be safely returned after the call.
         var startInSamples = (int)(context.TimeRange.Start.TotalSeconds * context.SampleRate);
         double[] speedsArray = ArrayPool<double>.Shared.Rent(expectedOutputSampleCount);
         try
         {
-            // 借用配列は要求長より大きいことがあるため必ずスライスして渡す。
+            // The rented array can be larger than requested, so always slice before passing it.
             Span<double> speeds = speedsArray.AsSpan(0, expectedOutputSampleCount);
             double sum = 0;
             for (int i = 0; i < expectedOutputSampleCount; i++)

--- a/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
@@ -1,0 +1,128 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class SpeedNodeTests
+{
+    private const int SampleRate = 100;
+
+    // Deterministic stereo source: a ramp keyed off the requested global sample index so that
+    // any change in how SpeedNode requests source ranges shows up as a different output.
+    private sealed class RampInputNode : AudioNode
+    {
+        private readonly int _sampleRate;
+
+        public RampInputNode(int sampleRate) => _sampleRate = sampleRate;
+
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            int count = context.GetSampleCount();
+            var buffer = new AudioBuffer(_sampleRate, 2, count);
+            Span<float> left = buffer.GetChannelData(0);
+            Span<float> right = buffer.GetChannelData(1);
+            int startIndex = (int)(context.TimeRange.Start.TotalSeconds * _sampleRate);
+            for (int i = 0; i < count; i++)
+            {
+                float v = (startIndex + i) * 0.01f;
+                left[i] = v;
+                right[i] = -v;
+            }
+
+            return buffer;
+        }
+    }
+
+    private static IProperty<float> AnimatedSpeed(float fromPercent, float toPercent, double durationSeconds)
+    {
+        var property = Property.CreateAnimatable(fromPercent);
+        property.SetAttributes("Speed", []);
+
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = fromPercent,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromSeconds(durationSeconds),
+            Value = toPercent,
+            Easing = new LinearEasing()
+        });
+        property.Animation = animation;
+        return property;
+    }
+
+    private static SpeedNode CreateAnimatedSpeedNode()
+    {
+        var node = new SpeedNode { Speed = AnimatedSpeed(50f, 200f, 1.0) };
+        node.AddInput(new RampInputNode(SampleRate));
+        return node;
+    }
+
+    private static AudioProcessContext CreateContext()
+    {
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        return new AudioProcessContext(range, SampleRate, new AnimationSampler(), null);
+    }
+
+    [Test]
+    public void ProcessAnimatedSpeed_ProducesExpectedLengthAndFiniteSamples()
+    {
+        using var node = CreateAnimatedSpeedNode();
+        var context = CreateContext();
+
+        using AudioBuffer result = node.Process(context);
+
+        Assert.That(result.SampleCount, Is.EqualTo(context.GetSampleCount()));
+        Assert.That(result.ChannelCount, Is.EqualTo(2));
+
+        for (int ch = 0; ch < result.ChannelCount; ch++)
+        {
+            Span<float> data = result.GetChannelData(ch);
+            for (int i = 0; i < data.Length; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"channel {ch} sample {i} was not finite ({data[i]}).");
+            }
+        }
+    }
+
+    // Guards the ArrayPool usage in ProcessAnimatedSpeed: two independent fresh nodes fed identical
+    // input must yield identical output. A pooled speed buffer that leaked stale data or was not fully
+    // overwritten would make the second instance (which gets a dirtier rented array) diverge.
+    // Note: a single node is stateful across renders (its WdlResampler carries filter state), so each
+    // comparison must use a freshly constructed node.
+    [Test]
+    public void ProcessAnimatedSpeed_IsDeterministicAcrossFreshInstances()
+    {
+        float[][] RenderFresh()
+        {
+            using var node = CreateAnimatedSpeedNode();
+            var context = CreateContext();
+            using AudioBuffer buffer = node.Process(context);
+            return
+            [
+                buffer.GetChannelData(0).ToArray(),
+                buffer.GetChannelData(1).ToArray(),
+            ];
+        }
+
+        float[][] first = RenderFresh();
+        float[][] second = RenderFresh();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second[0], Is.EqualTo(first[0]).AsCollection);
+            Assert.That(second[1], Is.EqualTo(first[1]).AsCollection);
+        });
+    }
+}


### PR DESCRIPTION
## Description
- `SpeedNode.ProcessAnimatedSpeed` allocated a fresh `double[]` (up to `SampleRate` elements, ~353 KB at 44.1 kHz) on **every render** of an animated-speed audio clip, adding GC pressure on the audio render hot path.
- Rent the speed-curve buffer from `ArrayPool<double>.Shared` and return it in a `finally` block.
  - `ProcessBufferWithVariableSpeed` consumes the `ReadOnlySpan<double>` synchronously and does not retain it, so returning the array after the call is safe.
  - The rented array can be larger than requested, so it is sliced to the exact length (`AsSpan(0, expectedOutputSampleCount)`) before use; the loop overwrites every used element, so no pooled stale data is read.
- Behavior-preserving optimization. Aligns with `Beutl.Engine/CLAUDE.md` rule #5 ("avoid allocations on the render hot path; prefer pooled arrays").

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Behavior-preserving.

## Test plan
- Added `tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs` covering the animated-speed path:
  - `ProcessAnimatedSpeed_ProducesExpectedLengthAndFiniteSamples` — output sample count matches the context and all samples are finite.
  - `ProcessAnimatedSpeed_IsDeterministicAcrossFreshInstances` — two independent fresh nodes fed identical input produce identical output (a leaked/partially-overwritten pooled buffer would diverge). Note: a single node is stateful across renders (its `WdlResampler` carries filter state), so the comparison uses freshly constructed nodes.
- Verified the new tests pass on the **unmodified** code first (characterization baseline), then ran `SpeedNodeTests` + `Audio` + `SpeedIntegrator` filters after the change: **59/59 passing**.
- `dotnet format --verify-no-changes` clean on the changed files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-17][diff][medium] SpeedNode.ProcessAnimatedSpeed allocates new double[] per audio render -- use ArrayPool")