### PR TITLE
docs(ai-workflow): add beutl-ai-review-task skill

### DIFF
--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "[item-number | title-keyword | bug|diff|design]"
 
 The `scheduled-code-review.yml` and `claude-code-review.yml` workflows file findings into the
 GitHub Project **#9 "AI Review"** (`b-editor/projects/9`). This skill turns one of those
-findings into a merged-ready PR, end to end. It deliberately targets **non-feature** work
+findings into a merge-ready PR, end to end. It deliberately targets **non-feature** work
 (bugs, perf/quality, design improvements) — those are concrete, verifiable, and low-risk.
 
 ## Board coordinates (project #9)
@@ -49,9 +49,11 @@ for i,it in enumerate(d['items']):
 
 **Non-feature filter.** Prefer titles prefixed with `[Bug]`, `[YYYY-MM-DD][diff]`, or
 `設計改善:`. Skip plain feature titles (e.g. "リップル削除", "マルチカム編集", "ショートカット: ...").
-Skip items already `Done` / `False positive`. Among open ones (`Backlog` / `Todo` / `In Progress`),
-bias toward **engine/core, low-risk, high-confidence, testable** items over UI-layer items that
-are hard to unit-test.
+Only **unclaimed** items are candidates: `Backlog` and `Todo`. Skip `Done` / `False positive`,
+and skip `In Progress` too — on this board `In Progress` means another agent/contributor has
+already claimed it, so treating it as a candidate invites duplicate work. Among the unclaimed
+ones, bias toward **engine/core, low-risk, high-confidence, testable** items over UI-layer items
+that are hard to unit-test.
 
 If `$ARGUMENTS` is an index/number or a title keyword, jump straight to that item. Otherwise,
 present the top non-feature candidates to the user with AskUserQuestion before committing to one
@@ -60,6 +62,8 @@ present the top non-feature candidates to the user with AskUserQuestion before c
 Read the chosen item's full body — it carries the exact file:line and a suggested fix:
 
 ```bash
+# Set INDEX to the row number printed by the list command above (the leading integer).
+INDEX=12
 gh project item-list 9 --owner b-editor --limit 100 --format json \
   | python3 -c "
 import json,sys
@@ -91,6 +95,19 @@ gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
 Get `<ITEM_ID>` from the `id` field of the chosen item in the JSON above. Then return to Step 1
 for another candidate. **Do not** silently keep the smaller diff or fabricate a fix for a wrong
 finding.
+
+### Claim the item immediately
+
+Once the finding is confirmed valid (and after the user has confirmed the pick), move the item to
+`In Progress` **right away** — before planning/implementing, not after the PR opens. The board is
+shared, so claiming late leaves a long window where another agent can start the same task.
+
+```bash
+gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
+  --single-select-option-id 47fc9ee4   # In Progress
+```
 
 ## Step 3 — Plan
 
@@ -150,10 +167,30 @@ output file with an `until grep -qE "成功!|失敗!|error " "$f"; do sleep 3; d
 
 ## Step 6 — Commit, push, PR
 
-Use Conventional Commits matching the change kind (`perf:` / `fix:` / `refactor:` / `refactor!:`).
-Reference the board item in the body. Example:
+**Create / switch to the feature branch BEFORE committing.** `git push -u origin <branch>` treats
+the argument after the remote as a refspec — it only pushes an *already existing* local ref, it
+does not move the just-made commit onto a new branch. So if you commit while still on `main` (or
+any unrelated branch) and only name the branch at push time, the work lands on the wrong branch
+and `gh pr create --head <branch>` fails because that head has no commit. Branch first, then commit.
+
+Pick the branch name from the branch you are currently on:
+
+- **Already on a personal feature branch shaped `<prefix>/<feature>`** (e.g. a worktree branch like
+  `yuto-trd/tmp-1`): **keep the `<prefix>/` and replace only the `<feature>` part** with a
+  descriptive slug — e.g. `yuto-trd/tmp-1` → `yuto-trd/speednode-arraypool`. Do not invent a new
+  top-level prefix.
+- **On `main`/`master` or a detached/unrelated branch**: create a fresh `<prefix>/<slug>` using the
+  same personal prefix convention.
 
 ```bash
+# Derive the prefix from the current branch and swap the feature part.
+CURRENT=$(git branch --show-current)
+PREFIX=${CURRENT%%/*}                       # e.g. "yuto-trd"; falls back to CURRENT if no "/"
+case "$CURRENT" in main|master|"") PREFIX="<your-prefix>";; esac
+FEATURE=<descriptive-slug>                  # e.g. speednode-arraypool
+BRANCH="$PREFIX/$FEATURE"
+
+git switch -c "$BRANCH" origin/main         # branch off the latest main, BEFORE committing
 git add <changed files>
 git commit -F - <<'EOF'
 perf(engine): <imperative summary>
@@ -162,8 +199,8 @@ perf(engine): <imperative summary>
 
 Refs: Project #9 "AI Review" item "<exact finding title>"
 EOF
-git push -u origin <feature-branch>     # never push to main/master
-gh pr create --base main --head <feature-branch> \
+git push -u origin "$BRANCH"                # never push to main/master
+gh pr create --base main --head "$BRANCH" \
   --title "<conventional-commit title>" \
   --body "<filled-in .github/PULL_REQUEST_TEMPLATE.md>"
 ```
@@ -175,14 +212,18 @@ Fill the PR template's **Affected areas**, **Breaking changes** (`None` for beha
 
 ## Step 7 — Update the board
 
-Move the item `Backlog` → `In Progress` once the PR is open (and to `Done` after merge):
+The item was already moved to `In Progress` when you claimed it (see "Claim the item immediately"
+in Step 2), so nothing changes here while the PR is open. **After the PR merges**, move it to `Done`:
 
 ```bash
 gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
   --id <ITEM_ID> \
   --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
-  --single-select-option-id 47fc9ee4   # In Progress  (98236657 = Done)
+  --single-select-option-id 98236657   # Done
 ```
+
+(If for some reason the item was not claimed earlier — e.g. it was already `In Progress` because you
+resumed work — just ensure it is `In Progress` now, option id `47fc9ee4`.)
 
 ## Guardrails
 

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -1,0 +1,198 @@
+---
+description: |
+  Pick up a non-feature task (bug / quality / design-improvement) from the GitHub
+  Project #9 "AI Review" board, verify it is not a false positive, then plan, implement,
+  test, and open a PR. Use when the user says "AI Review からタスクを選んで作業して",
+  "projects/9 のタスクをやって", "pick a task from the AI Review board", "consume an
+  AI-review backlog item", or similar. If the chosen item turns out to be a false positive,
+  set its Status to "False positive" and move to the next candidate.
+allowed-tools: Bash(gh:*) Bash(dotnet:*) Bash(git:*) Bash(./build.sh:*)
+argument-hint: "[item-number | title-keyword | bug|diff|design]"
+---
+
+# Work an AI Review board task
+
+The `scheduled-code-review.yml` and `claude-code-review.yml` workflows file findings into the
+GitHub Project **#9 "AI Review"** (`b-editor/projects/9`). This skill turns one of those
+findings into a merged-ready PR, end to end. It deliberately targets **non-feature** work
+(bugs, perf/quality, design improvements) — those are concrete, verifiable, and low-risk.
+
+## Board coordinates (project #9)
+
+Stable IDs (re-discover with the commands in the next section if they ever drift):
+
+- Project: owner `b-editor`, number `9`, project-id `PVT_kwDOBLw8Fs4BW4g5`
+- `Status` field: `PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk`
+  - `In Progress` → `47fc9ee4`
+  - `Todo` → `f75ad846`
+  - `Backlog` → `d97cd69b`
+  - `Done` → `98236657`
+  - `False positive` → `e6ff360e`
+
+Most items are **DraftIssue** (no repo issue number). Draft issues cannot carry a "Linked
+pull requests" value automatically, so cross-link by **referencing the board in the PR body**
+and by moving the item's `Status`.
+
+## Step 1 — List candidates and pick one
+
+```bash
+# Full board with status + type + title
+gh project item-list 9 --owner b-editor --limit 100 --format json \
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for i,it in enumerate(d['items']):
+    c=it.get('content',{})
+    print(i,'|',it.get('status','?'),'|',c.get('type','?'),'|',c.get('title','')[:90])
+"
+```
+
+**Non-feature filter.** Prefer titles prefixed with `[Bug]`, `[YYYY-MM-DD][diff]`, or
+`設計改善:`. Skip plain feature titles (e.g. "リップル削除", "マルチカム編集", "ショートカット: ...").
+Skip items already `Done` / `False positive`. Among open ones (`Backlog` / `Todo` / `In Progress`),
+bias toward **engine/core, low-risk, high-confidence, testable** items over UI-layer items that
+are hard to unit-test.
+
+If `$ARGUMENTS` is an index/number or a title keyword, jump straight to that item. Otherwise,
+present the top non-feature candidates to the user with AskUserQuestion before committing to one
+(unless the user already told you to just pick one).
+
+Read the chosen item's full body — it carries the exact file:line and a suggested fix:
+
+```bash
+gh project item-list 9 --owner b-editor --limit 100 --format json \
+  | python3 -c "
+import json,sys
+i=$INDEX
+it=json.load(sys.stdin)['items'][i]; print(it['content']['title']); print(); print(it['content'].get('body',''))
+"
+```
+
+## Step 2 — Verify it is NOT a false positive (mandatory)
+
+Before any planning, confirm the finding against the **current** code:
+
+- Open the cited `file:line` and confirm the described code still exists and the reasoning holds.
+- Trace the claim. Scheduled-review findings are heuristic and sometimes wrong. Common false
+  positives seen on this board:
+  - A "use-after-dispose / NRE" where an eager token / guard already aborts the path.
+  - A "race" on state that is in practice single-threaded, or already guarded elsewhere.
+  - A perf claim on a path that is not actually hot.
+- If the surrounding code makes the finding **invalid**, mark it and move on:
+
+```bash
+# Set Status -> "False positive"
+gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
+  --single-select-option-id e6ff360e
+```
+
+Get `<ITEM_ID>` from the `id` field of the chosen item in the JSON above. Then return to Step 1
+for another candidate. **Do not** silently keep the smaller diff or fabricate a fix for a wrong
+finding.
+
+## Step 3 — Plan
+
+Enter plan mode (`EnterPlanMode`) and produce a focused plan. Include:
+
+- **Context**: why the change is needed (the real problem, quoted from the finding + your verification).
+- A note that the item was confirmed **not** a false positive, with the evidence.
+- The concrete edit(s): `file:line` and the before/after shape.
+- A **test** plan (see Step 5) — this repo requires new logic to ship with an NUnit test
+  (`.claude/rules/csharp.md`, AGENTS.md rule #3).
+- Verification commands and the commit/PR/board updates.
+
+Surface non-obvious design trade-offs to the user (AGENTS.md "adopt better designs eagerly").
+For public-surface / extensibility changes, auto-delegate `@beutl-design-reviewer`.
+
+## Step 4 — Implement
+
+Apply the minimal change that fixes the root cause. Match surrounding style; let `.editorconfig`
+own formatting. Respect subtree CLAUDE.md rules (e.g. `Beutl.Engine` forbids UI references and
+asks for pooled arrays on the render hot path).
+
+## Step 5 — Test with a baseline-first (characterization) loop
+
+This is the highest-value habit for behavior-preserving fixes (refactors, perf, pooling):
+
+1. **Write the test first**, in the matching test project. Reuse existing helpers — e.g. animated
+   `IProperty<T>` setup mirrors `tests/Beutl.UnitTests/Engine/AnimationSamplerTests.cs`
+   (`Property.CreateAnimatable` + `KeyFrameAnimation<T>` + `LinearEasing`). Note: `src/Beutl/`
+   ViewModels/Views are not referenced by any test project — testable logic must live in a
+   referenced library (`Beutl.Engine`, `Beutl.Editor`, …).
+2. **Run it against the UNMODIFIED code** and confirm green — this proves the test captures
+   current behavior (a characterization baseline):
+   ```bash
+   dotnet test <path/to/Tests.csproj> -f net10.0 \
+     --filter "FullyQualifiedName~<YourNewTestFixture>"
+   ```
+3. **Apply the production change**, then re-run the new test **plus** the surrounding regression
+   filters. They must stay green and unchanged for a behavior-preserving fix:
+   ```bash
+   dotnet test <path/to/Tests.csproj> -f net10.0 \
+     --filter "FullyQualifiedName~<YourFixture>|FullyQualifiedName~<RelatedArea>"
+   ```
+
+**Trap — stateful nodes.** Some components carry internal state across calls (e.g. `SpeedNode`'s
+`WdlResampler` retains filter state), so "run the same instance twice and expect identical output"
+will fail legitimately. For a determinism assertion, compare **two freshly constructed instances**
+fed identical input instead.
+
+Then verify formatting only on the touched files (fast):
+
+```bash
+dotnet format Beutl.slnx --include <changed-file-1> <changed-file-2> --verify-no-changes
+```
+
+Tests are long-running — prefer launching them with `run_in_background: true` and polling the
+output file with an `until grep -qE "成功!|失敗!|error " "$f"; do sleep 3; done` loop.
+
+## Step 6 — Commit, push, PR
+
+Use Conventional Commits matching the change kind (`perf:` / `fix:` / `refactor:` / `refactor!:`).
+Reference the board item in the body. Example:
+
+```bash
+git add <changed files>
+git commit -F - <<'EOF'
+perf(engine): <imperative summary>
+
+<what was wrong + why the fix is safe + behavior-preserving note>
+
+Refs: Project #9 "AI Review" item "<exact finding title>"
+EOF
+git push -u origin <feature-branch>     # never push to main/master
+gh pr create --base main --head <feature-branch> \
+  --title "<conventional-commit title>" \
+  --body "<filled-in .github/PULL_REQUEST_TEMPLATE.md>"
+```
+
+Fill the PR template's **Affected areas**, **Breaking changes** (`None` for behavior-preserving),
+**Test plan** (mention the baseline-first verification + pass counts), and **References**
+(`Project board: b-editor/projects/9 ("<title>")`). Opening the PR triggers the automatic
+`claude-code-review.yml` review.
+
+## Step 7 — Update the board
+
+Move the item `Backlog` → `In Progress` once the PR is open (and to `Done` after merge):
+
+```bash
+gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
+  --single-select-option-id 47fc9ee4   # In Progress  (98236657 = Done)
+```
+
+## Guardrails
+
+- **Confirm outward-facing actions.** Push / PR / board edits change shared state — confirm with
+  the user (AskUserQuestion) before doing them unless they already authorized it this turn.
+- One task per invocation by default. After finishing, offer the next candidate rather than
+  batching many.
+- Never force-push to `main`/`master` (hook-enforced). Work on a feature branch.
+- Re-discover IDs if the project schema changed:
+  ```bash
+  gh project field-list 9 --owner b-editor --format json   # field + option ids
+  gh project list --owner b-editor                          # project ids
+  ```

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -35,15 +35,25 @@ and by moving the item's `Status`.
 
 ## Step 1 — List candidates and pick one
 
+Fetch the whole board **once** to a file, then drive everything (table, selection, item id, body)
+off that single snapshot. `gh project item-list --limit` is the *maximum number of items fetched*,
+not a page offset — the default is 100, so a board that has grown past that silently drops the tail.
+Pass a limit comfortably above the current item count and warn if the snapshot looks truncated.
+
 ```bash
-# Full board with status + type + title
-gh project item-list 9 --owner b-editor --limit 100 --format json \
-  | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-for i,it in enumerate(d['items']):
+BOARD=$(mktemp /tmp/ai-review-board.XXXX.json)
+gh project item-list 9 --owner b-editor --limit 2000 --format json > "$BOARD"
+
+# Status + type + title, indexed. Warn if we may have hit the fetch ceiling.
+python3 -c "
+import json
+d=json.load(open('$BOARD'))
+items=d['items']
+for i,it in enumerate(items):
     c=it.get('content',{})
     print(i,'|',it.get('status','?'),'|',c.get('type','?'),'|',c.get('title','')[:90])
+if len(items) >= 2000:
+    print('WARNING: hit the --limit ceiling; raise --limit and re-fetch before trusting this list.')
 "
 ```
 
@@ -59,16 +69,28 @@ If `$ARGUMENTS` is an index/number or a title keyword, jump straight to that ite
 present the top non-feature candidates to the user with AskUserQuestion before committing to one
 (unless the user already told you to just pick one).
 
-Read the chosen item's full body — it carries the exact file:line and a suggested fix:
+Resolve the pick against the **same snapshot** and capture its **stable item id** now. Do not
+re-run `item-list` and re-select by numeric index later — the shared board can have items added,
+archived, or reordered between calls, so the same index can point at a different task. Everything
+downstream (verify, claim, board update) uses `$ITEM_ID`, never the index.
 
 ```bash
-# Set INDEX to the row number printed by the list command above (the leading integer).
+# INDEX = the leading integer printed for the chosen row above.
 INDEX=12
-gh project item-list 9 --owner b-editor --limit 100 --format json \
-  | python3 -c "
-import json,sys
-i=$INDEX
-it=json.load(sys.stdin)['items'][i]; print(it['content']['title']); print(); print(it['content'].get('body',''))
+read -r ITEM_ID ITEM_TITLE <<EOF
+$(python3 -c "
+import json
+it=json.load(open('$BOARD'))['items'][$INDEX]
+print(it['id'], it['content'].get('title',''))
+")
+EOF
+echo "Picked: $ITEM_ID — $ITEM_TITLE"
+
+# Read the chosen item's full body (file:line + suggested fix) from the snapshot.
+python3 -c "
+import json
+it=next(x for x in json.load(open('$BOARD'))['items'] if x['id']=='$ITEM_ID')
+print(it['content'].get('title','')); print(); print(it['content'].get('body',''))
 "
 ```
 
@@ -87,14 +109,14 @@ Before any planning, confirm the finding against the **current** code:
 ```bash
 # Set Status -> "False positive"
 gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
-  --id <ITEM_ID> \
+  --id "$ITEM_ID" \
   --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
   --single-select-option-id e6ff360e
 ```
 
-Get `<ITEM_ID>` from the `id` field of the chosen item in the JSON above. Then return to Step 1
-for another candidate. **Do not** silently keep the smaller diff or fabricate a fix for a wrong
-finding.
+`$ITEM_ID` is the stable id captured in Step 1 — reuse it, do not re-derive from an index. Then
+return to Step 1 for another candidate (re-fetch the snapshot). **Do not** silently keep the
+smaller diff or fabricate a fix for a wrong finding.
 
 ### Claim the item immediately
 
@@ -104,7 +126,7 @@ shared, so claiming late leaves a long window where another agent can start the 
 
 ```bash
 gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
-  --id <ITEM_ID> \
+  --id "$ITEM_ID" \
   --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
   --single-select-option-id 47fc9ee4   # In Progress
 ```
@@ -162,8 +184,21 @@ Then verify formatting only on the touched files (fast):
 dotnet format Beutl.slnx --include <changed-file-1> <changed-file-2> --verify-no-changes
 ```
 
-Tests are long-running — prefer launching them with `run_in_background: true` and polling the
-output file with an `until grep -qE "成功!|失敗!|error " "$f"; do sleep 3; done` loop.
+Tests are long-running — prefer launching them with `run_in_background: true`; the harness
+re-invokes you on completion, so the task-completion notification is the primary signal. If you do
+poll the output file, **do not grep localized result markers** (`成功!` / `失敗!`): under a non-Japanese
+locale `dotnet test` prints `Passed!` / `Failed!` instead, so the loop can spin forever. Either
+force a known locale so the markers are deterministic, or poll the process exit status:
+
+```bash
+# Option A — force a deterministic locale, then match its (now stable) markers.
+DOTNET_CLI_UI_LANGUAGE=en dotnet test ... > "$f" 2>&1
+until grep -qE "Passed!|Failed!|error " "$f"; do sleep 3; done
+
+# Option B — locale-independent: wait on the background process itself.
+# (PID is the background job started above; exit code 0 = pass.)
+until ! kill -0 "$PID" 2>/dev/null; do sleep 3; done
+```
 
 ## Step 6 — Commit, push, PR
 
@@ -217,7 +252,7 @@ in Step 2), so nothing changes here while the PR is open. **After the PR merges*
 
 ```bash
 gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
-  --id <ITEM_ID> \
+  --id "$ITEM_ID" \
   --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
   --single-select-option-id 98236657   # Done
 ```

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -6,7 +6,6 @@ description: |
   "projects/9 のタスクをやって", "pick a task from the AI Review board", "consume an
   AI-review backlog item", or similar. If the chosen item turns out to be a false positive,
   set its Status to "False positive" and move to the next candidate.
-allowed-tools: Bash(gh:*) Bash(dotnet:*) Bash(git:*) Bash(./build.sh:*)
 argument-hint: "[item-number | title-keyword | bug|diff|design]"
 ---
 

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -144,6 +144,33 @@ Enter plan mode (`EnterPlanMode`) and produce a focused plan. Include:
 Surface non-obvious design trade-offs to the user (AGENTS.md "adopt better designs eagerly").
 For public-surface / extensibility changes, auto-delegate `@beutl-design-reviewer`.
 
+### Create the work branch now — before any edits
+
+Create/switch to the feature branch **before** Step 4/5 touch any files. If you edit and run the
+tests first and only branch at commit time, `git switch -c <branch> origin/main` either drags the
+dirty edits onto a different base (so the PR is built on code you never actually tested) or aborts
+on conflict. Branch first, then edit and test on that branch — what you verify is exactly what ships.
+
+Pick the branch name from the branch you are currently on:
+
+- **Already on a personal feature branch shaped `<prefix>/<feature>`** (e.g. a worktree branch like
+  `yuto-trd/tmp-1`): **keep the `<prefix>/` and replace only the `<feature>` part** with a
+  descriptive slug — e.g. `yuto-trd/tmp-1` → `yuto-trd/speednode-arraypool`. Do not invent a new
+  top-level prefix.
+- **On `main`/`master` or a detached/unrelated branch**: create a fresh `<prefix>/<slug>` using the
+  same personal prefix convention.
+
+```bash
+# Derive the prefix from the current branch and swap the feature part.
+CURRENT=$(git branch --show-current)
+PREFIX=${CURRENT%%/*}                       # e.g. "yuto-trd"; falls back to CURRENT if no "/"
+case "$CURRENT" in main|master|"") PREFIX="<your-prefix>";; esac
+FEATURE=<descriptive-slug>                  # e.g. speednode-arraypool
+BRANCH="$PREFIX/$FEATURE"
+
+git switch -c "$BRANCH" origin/main         # branch off the latest main, before editing
+```
+
 ## Step 4 — Implement
 
 Apply the minimal change that fixes the root cause. Match surrounding style; let `.editorconfig`
@@ -184,47 +211,35 @@ dotnet format Beutl.slnx --include <changed-file-1> <changed-file-2> --verify-no
 ```
 
 Tests are long-running — prefer launching them with `run_in_background: true`; the harness
-re-invokes you on completion, so the task-completion notification is the primary signal. If you do
-poll the output file, **do not grep localized result markers** (`成功!` / `失敗!`): under a non-Japanese
-locale `dotnet test` prints `Passed!` / `Failed!` instead, so the loop can spin forever. Either
-force a known locale so the markers are deterministic, or poll the process exit status:
+re-invokes you on completion, so the task-completion notification is the primary signal.
+
+**Decide pass/fail from the exit code, never from a console string.** A localized marker grep is
+unreliable two ways: under a non-Japanese locale `dotnet test` prints `Passed!` / `Failed!` instead
+of `成功!` / `失敗!` (the loop can spin forever), and matching `Passed!`-or-`Failed!` tells you the run
+*finished*, not that it *succeeded* — proceeding to commit/PR on a failed run. Wait on the process
+and check `$?`:
 
 ```bash
-# Option A — force a deterministic locale, then match its (now stable) markers.
-DOTNET_CLI_UI_LANGUAGE=en dotnet test ... > "$f" 2>&1
-until grep -qE "Passed!|Failed!|error " "$f"; do sleep 3; done
-
-# Option B — locale-independent: wait on the background process itself.
-# (PID is the background job started above; exit code 0 = pass.)
-until ! kill -0 "$PID" 2>/dev/null; do sleep 3; done
+# Launch in the background, then wait and propagate the real exit status.
+dotnet test ... > "$f" 2>&1 &
+PID=$!
+wait "$PID"; status=$?
+if [ "$status" -ne 0 ]; then
+    echo "tests FAILED (exit $status) — stop here, do not commit/PR"; tail -40 "$f"
+fi
+# status == 0 → green; otherwise fix before continuing.
 ```
+
+(If you only want an interim progress peek while it runs, `grep` the output file — but still gate
+the commit/PR decision on `status`, not on any matched string.)
 
 ## Step 6 — Commit, push, PR
 
-**Create / switch to the feature branch BEFORE committing.** `git push -u origin <branch>` treats
-the argument after the remote as a refspec — it only pushes an *already existing* local ref, it
-does not move the just-made commit onto a new branch. So if you commit while still on `main` (or
-any unrelated branch) and only name the branch at push time, the work lands on the wrong branch
-and `gh pr create --head <branch>` fails because that head has no commit. Branch first, then commit.
-
-Pick the branch name from the branch you are currently on:
-
-- **Already on a personal feature branch shaped `<prefix>/<feature>`** (e.g. a worktree branch like
-  `yuto-trd/tmp-1`): **keep the `<prefix>/` and replace only the `<feature>` part** with a
-  descriptive slug — e.g. `yuto-trd/tmp-1` → `yuto-trd/speednode-arraypool`. Do not invent a new
-  top-level prefix.
-- **On `main`/`master` or a detached/unrelated branch**: create a fresh `<prefix>/<slug>` using the
-  same personal prefix convention.
+You are already on `$BRANCH` (created in Step 3 before any edits), so just commit and push it.
+`git push -u origin "$BRANCH"` pushes that existing branch — the refspec form does not create or
+move a branch, which is exactly why the branch had to exist before you started editing.
 
 ```bash
-# Derive the prefix from the current branch and swap the feature part.
-CURRENT=$(git branch --show-current)
-PREFIX=${CURRENT%%/*}                       # e.g. "yuto-trd"; falls back to CURRENT if no "/"
-case "$CURRENT" in main|master|"") PREFIX="<your-prefix>";; esac
-FEATURE=<descriptive-slug>                  # e.g. speednode-arraypool
-BRANCH="$PREFIX/$FEATURE"
-
-git switch -c "$BRANCH" origin/main         # branch off the latest main, BEFORE committing
 git add <changed files>
 git commit -F - <<'EOF'
 perf(engine): <imperative summary>


### PR DESCRIPTION
## Description
Adds a reusable Claude Code skill, `.claude/skills/beutl-ai-review-task/SKILL.md`, that captures the end-to-end workflow for turning a **non-feature** finding on the GitHub Project #9 "AI Review" board into a merge-ready PR.

Steps the skill encodes:
- **List + filter** candidates via `gh project item-list 9`, biased to non-feature items (`[Bug]` / `[diff]` / `設計改善:` prefixes) and toward engine/core, low-risk, testable work.
- **Verify the finding is not a false positive** against current code before planning; if invalid, set `Status -> "False positive"` and move on. Documents common false-positive shapes (eager-token-aborted NRE, effectively-single-threaded "race", non-hot perf claim).
- **Plan → implement → test** with a baseline-first characterization loop (write the test, confirm green on the unmodified code, then apply the change and re-run with regression filters). Calls out the stateful-node trap (compare two fresh instances, not the same instance twice — e.g. `WdlResampler` carries state).
- **Commit / push / PR** with Conventional Commits + the PR template, then move the board `Status` (`Backlog → In Progress → Done`).

Project #9 coordinates (project id, `Status` field + option ids) are embedded as constants, with re-discovery commands in case the schema drifts.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None. Documentation/tooling only — a new skill file under `.claude/skills/`; no source or CI workflow changes.

## Test plan
- Not code. Validated the SKILL.md frontmatter (`description` / `allowed-tools` / `argument-hint`) matches the sibling `.claude/skills/beutl-*` skills, and confirmed the harness lists it as `beutl-ai-review-task`.

## Fixed issues / References
- Workflow first exercised on Project #9 item "[2026-05-17][diff][medium] SpeedNode.ProcessAnimatedSpeed allocates new double[] per audio render -- use ArrayPool" (#1872).