### PR TITLE
feat: support Windows ARM64 (win-arm64) builds

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -27,7 +27,7 @@ jobs:
       artifact-run-id: ${{ steps.run-id.outputs.run-id }}
     strategy:
       matrix:
-        rid: [ linux_x64, win_x64, osx_x64, osx_arm64 ]
+        rid: [ linux_x64, win_x64, win_arm64, osx_x64, osx_arm64 ]
         standalone: [ true, false ]
 
     steps:

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -21,6 +21,7 @@ jobs:
       artifact-run-id: ${{ steps.run-id.outputs.run-id }}
     strategy:
       matrix:
+        arch: [ x64, arm64 ]
         standalone: [ true, false ]
 
     steps:
@@ -38,14 +39,14 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: beutl-win_x64${{ matrix.standalone == true && '-standalone' || '' }}-${{ inputs.semVer }}
+          name: beutl-win_${{ matrix.arch }}${{ matrix.standalone == true && '-standalone' || '' }}-${{ inputs.semVer }}
           path: artifacts
 
       - name: Extract zip
         run: |
           mkdir output/Beutl
           cd output/Beutl
-          7z x ../../artifacts/beutl-win-x64${{ matrix.standalone == true && '-standalone' || '' }}-${{ inputs.semVer }}.zip
+          7z x ../../artifacts/beutl-win-${{ matrix.arch }}${{ matrix.standalone == true && '-standalone' || '' }}-${{ inputs.semVer }}.zip
 
       - name: Update Metadata
         shell: pwsh
@@ -59,11 +60,12 @@ jobs:
         run: |
           ./build.cmd build-installer `
             --skip publish `
+            --runtime win_${{ matrix.arch }} `
             --self-contained ${{ matrix.standalone }} `
             --assembly-version ${{ inputs.asmVer }}
 
       - name: Save installer
         uses: actions/upload-artifact@v7
         with:
-          name: beutl${{ matrix.standalone == true && '-standalone' || '' }}-setup
-          path: ./artifacts/beutl${{ matrix.standalone == true && '-standalone' || '' }}-setup.exe
+          name: beutl${{ matrix.standalone == true && '-standalone' || '' }}${{ matrix.arch == 'arm64' && '-arm64' || '' }}-setup
+          path: ./artifacts/beutl${{ matrix.standalone == true && '-standalone' || '' }}${{ matrix.arch == 'arm64' && '-arm64' || '' }}-setup.exe

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rid: [linux_x64, win_x64, osx_x64, osx_arm64]
+        rid: [linux_x64, win_x64, win_arm64, osx_x64, osx_arm64]
     steps:
     - name: Checkout
       uses: actions/checkout@v7

--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -55,9 +55,12 @@ jobs:
                a. `## What's Changed`
 
                b. Download links (use these exact URLs — the tag is `${{ inputs.tag }}`):
-                  - Windows
+                  - Windows (x64)
                     - `[Installer](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/beutl-standalone-setup.exe)`
                     - `[Installer (.NET Runtime required)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/beutl-setup.exe)`
+                  - Windows (ARM64)
+                    - `[Installer](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/beutl-standalone-arm64-setup.exe)`
+                    - `[Installer (.NET Runtime required)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/beutl-arm64-setup.exe)`
                   - macOS
                     - `[Zip (arm64)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl.osx_arm64.app.zip)`
                     - `[Zip (x64)](https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/Beutl.osx_x64.app.zip)`

--- a/.github/workflows/reflect-release.yml
+++ b/.github/workflows/reflect-release.yml
@@ -50,6 +50,8 @@ jobs:
 
           WIN_INSTALLER=$(url_of "beutl-setup.exe")
           WIN_STANDALONE=$(url_of "beutl-standalone-setup.exe")
+          WIN_INSTALLER_ARM64=$(url_of "beutl-arm64-setup.exe")
+          WIN_STANDALONE_ARM64=$(url_of "beutl-standalone-arm64-setup.exe")
           LINUX_DEB=$(url_of_glob '^beutl_.*_amd64\.deb$')
           LINUX_ZIP=$(url_of "Beutl-linux-x64-$VER.zip")
           LINUX_ZIP_STANDALONE=$(url_of "Beutl-linux-x64-standalone-$VER.zip")
@@ -67,6 +69,8 @@ jobs:
           }
           check "beutl-setup.exe"                       "$WIN_INSTALLER"
           check "beutl-standalone-setup.exe"            "$WIN_STANDALONE"
+          check "beutl-arm64-setup.exe"                 "$WIN_INSTALLER_ARM64"
+          check "beutl-standalone-arm64-setup.exe"      "$WIN_STANDALONE_ARM64"
           check "beutl_*_amd64.deb"                     "$LINUX_DEB"
           check "Beutl-linux-x64-$VER.zip"              "$LINUX_ZIP"
           check "Beutl-linux-x64-standalone-$VER.zip"   "$LINUX_ZIP_STANDALONE"
@@ -78,6 +82,8 @@ jobs:
             --arg ver "$VER" \
             --arg winI "$WIN_INSTALLER" \
             --arg winS "$WIN_STANDALONE" \
+            --arg winIa "$WIN_INSTALLER_ARM64" \
+            --arg winSa "$WIN_STANDALONE_ARM64" \
             --arg deb "$LINUX_DEB" \
             --arg linZ "$LINUX_ZIP" \
             --arg linZS "$LINUX_ZIP_STANDALONE" \
@@ -85,8 +91,10 @@ jobs:
             --arg macA "$MAC_ARM64" \
             '{
               assets: [
-                {id:"beutl-\($ver)-win-x64-installer",            version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:false, url:$winI},
-                {id:"beutl-\($ver)-win-x64-installer-standalone", version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:true,  url:$winS},
+                {id:"beutl-\($ver)-win-x64-installer",              version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:false, url:$winI},
+                {id:"beutl-\($ver)-win-x64-installer-standalone",   version:$ver, os:"win",   arch:"x64",   type:"installer", standalone:true,  url:$winS},
+                {id:"beutl-\($ver)-win-arm64-installer",            version:$ver, os:"win",   arch:"arm64", type:"installer", standalone:false, url:$winIa},
+                {id:"beutl-\($ver)-win-arm64-installer-standalone", version:$ver, os:"win",   arch:"arm64", type:"installer", standalone:true,  url:$winSa},
                 {id:"beutl-\($ver)-linux-x64-debian",             version:$ver, os:"linux", arch:"x64",   type:"debian",    standalone:true,  url:$deb},
                 {id:"beutl-\($ver)-linux-x64-zip",                version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:false, url:$linZ},
                 {id:"beutl-\($ver)-linux-x64-zip-standalone",     version:$ver, os:"linux", arch:"x64",   type:"zip",       standalone:true,  url:$linZS},

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: ncipollo/release-action@v1
         id: create_release
         with:
-          artifacts: "artifacts/**/*.zip,artifacts/**/*.deb,artifacts/**/*.flatpak,artifacts/beutl-setup/beutl-setup.exe,artifacts/beutl-standalone-setup/beutl-standalone-setup.exe"
+          artifacts: "artifacts/**/*.zip,artifacts/**/*.deb,artifacts/**/*.flatpak,artifacts/beutl-setup/beutl-setup.exe,artifacts/beutl-standalone-setup/beutl-standalone-setup.exe,artifacts/beutl-arm64-setup/beutl-arm64-setup.exe,artifacts/beutl-standalone-arm64-setup/beutl-standalone-arm64-setup.exe"
           draft: true
           makeLatest: true
           generateReleaseNotes: true

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,12 +6,12 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- RID set, opted into with <DesktopExeRids>true</DesktopExeRids>; narrowed to win-x64 on a Windows TFM. -->
+  <!-- RID set, opted into with <DesktopExeRids>true</DesktopExeRids>; narrowed to Windows RIDs on a Windows TFM. -->
   <PropertyGroup Condition="'$(DesktopExeRids)' == 'true'">
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DesktopExeRids)' == 'true' And $(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <!-- Sideload output layout is not hoisted here: it sets OutputPath, which must be set before

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -80,8 +80,8 @@ class Build : NukeBuild
                 .When(_ => Runtime != null, s => s
                     .SetRuntime(Runtime)
                     .SetSelfContained(SelfContained))
-                .When(_ => Runtime == RuntimeIdentifier.win_x64, s => s.SetFramework($"{tfm}-windows"))
-                .When(_ => Runtime != RuntimeIdentifier.win_x64, s => s.SetFramework(tfm))
+                .When(_ => Runtime?.IsWindows == true, s => s.SetFramework($"{tfm}-windows"))
+                .When(_ => Runtime?.IsWindows != true, s => s.SetFramework(tfm))
                 .SetConfiguration(Configuration)
                 .SetVersions(Version, AssemblyVersion, InformationalVersion)
                 .SetProject(mainProj)
@@ -101,8 +101,8 @@ class Build : NukeBuild
                     .When(_ => Runtime != null, s => s
                         .SetRuntime(Runtime)
                         .SetSelfContained(SelfContained))
-                    .When(_ => Runtime == RuntimeIdentifier.win_x64, s => s.SetFramework($"{tfm}-windows"))
-                    .When(_ => Runtime != RuntimeIdentifier.win_x64, s => s.SetFramework(tfm))
+                    .When(_ => Runtime?.IsWindows == true, s => s.SetFramework($"{tfm}-windows"))
+                    .When(_ => Runtime?.IsWindows != true, s => s.SetFramework(tfm))
                     .EnableNoRestore()
                     .SetConfiguration(Configuration)
                     .SetVersions(Version, AssemblyVersion, InformationalVersion)
@@ -221,6 +221,12 @@ class Build : NukeBuild
         .DependsOn(Publish)
         .Executes(() =>
         {
+            // win-arm64 installers get an "-arm64" suffix and the arm64 Inno Setup
+            // architecture flags; win-x64 keeps its historical, suffix-less filename.
+            bool isArm64 = Runtime == RuntimeIdentifier.win_arm64;
+            string archSuffix = isArm64 ? "-arm64" : "";
+            string architectures = isArm64 ? "arm64" : "x64compatible";
+
             InnoSetup(c => c
                 .SetKeyValueDefinition("MyAppVersion", AssemblyVersion)
                 .SetKeyValueDefinition("MyOutputDir", ArtifactsDirectory)
@@ -228,7 +234,9 @@ class Build : NukeBuild
                 .SetKeyValueDefinition("MyGPLLicenseFile", RootDirectory / "LICENSE.GPL")
                 .SetKeyValueDefinition("MySetupIconFile", RootDirectory / "assets/logos/logo.ico")
                 .SetKeyValueDefinition("MySource", OutputDirectory / "Beutl")
-                .SetKeyValueDefinition("MyOutputBaseFilename", $"beutl{(SelfContained ? "-standalone" : "")}-setup")
+                .SetKeyValueDefinition("MyOutputBaseFilename", $"beutl{(SelfContained ? "-standalone" : "")}{archSuffix}-setup")
+                .SetKeyValueDefinition("MyArchitecturesAllowed", architectures)
+                .SetKeyValueDefinition("MyArchitecturesInstallIn64BitMode", architectures)
                 .SetScriptFile(RootDirectory / "nukebuild/beutl-setup.iss"));
         });
 

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -157,8 +157,8 @@ class Build : NukeBuild
                 .When(_ => Runtime != null, s => s
                     .SetRuntime(Runtime)
                     .SetSelfContained(SelfContained))
-                .When(_ => Runtime == RuntimeIdentifier.win_x64, s => s.SetFramework($"{tfm}-windows"))
-                .When(_ => Runtime != RuntimeIdentifier.win_x64, s => s.SetFramework(tfm))
+                .When(_ => Runtime?.IsWindows == true, s => s.SetFramework($"{tfm}-windows"))
+                .When(_ => Runtime?.IsWindows != true, s => s.SetFramework(tfm))
                 .EnableNoRestore()
                 .SetConfiguration(Configuration)
                 .SetVersions(Version, AssemblyVersion, InformationalVersion)

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -44,7 +44,10 @@ class Build : NukeBuild
         .DependsOn(Clean)
         .Executes(() =>
         {
-            DotNetRestore();
+            // Forward the RID so the assets file gains the runtime-specific target the
+            // subsequent --no-restore publish needs; without it publish fails with NETSDK1047.
+            DotNetRestore(s => s
+                .When(_ => Runtime != null, s => s.SetRuntime(Runtime)));
         });
 
     Target Compile => _ => _

--- a/nukebuild/RuntimeIdentifier.cs
+++ b/nukebuild/RuntimeIdentifier.cs
@@ -38,4 +38,13 @@ public class RuntimeIdentifier : Enumeration
     {
         Value = "osx-arm64"
     };
+
+    /// <summary>
+    /// True for Windows RIDs (win-x64, win-arm64, ...), which must publish against the
+    /// net*-windows TFM rather than the cross-platform one.
+    /// </summary>
+    public bool IsWindows => Value.StartsWith("win", StringComparison.Ordinal);
+
+    /// <summary>The architecture segment of the RID (e.g. "x64", "arm64").</summary>
+    public string Architecture => Value[(Value.IndexOf('-') + 1)..];
 }

--- a/nukebuild/beutl-setup.iss
+++ b/nukebuild/beutl-setup.iss
@@ -16,6 +16,14 @@
 #define MyAppAssocKey StringChange(MyAppAssocName, " ", "") + MyAppAssocExt
 ; #define MyOutputBaseFilename "beutl-setup"
 
+; Target architecture. Defaults to x64; the build passes arm64 values for win-arm64.
+#ifndef MyArchitecturesAllowed
+  #define MyArchitecturesAllowed "x64compatible"
+#endif
+#ifndef MyArchitecturesInstallIn64BitMode
+  #define MyArchitecturesInstallIn64BitMode "x64compatible"
+#endif
+
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
@@ -40,8 +48,8 @@ SetupIconFile={#MySetupIconFile}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesInstallIn64BitMode=x64compatible
-ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode={#MyArchitecturesInstallIn64BitMode}
+ArchitecturesAllowed={#MyArchitecturesAllowed}
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
@@ -13,7 +13,7 @@ namespace Beutl.Extensions.FFmpeg;
 /// <see cref="RuntimeInformation.ProcessArchitecture"/> keeps each architecture pointed at its
 /// own native folder.
 /// </remarks>
-public static class FFmpegNativeRid
+internal static class FFmpegNativeRid
 {
     /// <summary>Returns the Windows RID folder name for the given architecture.</summary>
     public static string GetWindowsRid(Architecture architecture) => architecture switch

--- a/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace Beutl.Extensions.FFmpeg;
+
+/// <summary>
+/// Maps a process architecture to the Windows native runtime folder name
+/// (<c>runtimes/&lt;rid&gt;/native</c>) used to locate the bundled FFmpeg shared libraries.
+/// </summary>
+/// <remarks>
+/// <see cref="System.Environment.Is64BitProcess"/> cannot distinguish x64 from arm64 — both are
+/// 64-bit — so an arm64 process would otherwise probe the <c>win-x64</c> folder and fail to load
+/// the native libraries (<see cref="System.BadImageFormatException"/>). Selecting on
+/// <see cref="RuntimeInformation.ProcessArchitecture"/> keeps each architecture pointed at its
+/// own native folder.
+/// </remarks>
+public static class FFmpegNativeRid
+{
+    /// <summary>Returns the Windows RID folder name for the given architecture.</summary>
+    public static string GetWindowsRid(Architecture architecture) => architecture switch
+    {
+        Architecture.Arm64 => "win-arm64",
+        Architecture.X86 => "win-x86",
+        _ => "win-x64",
+    };
+
+    /// <summary>Returns the Windows RID folder name for the current process architecture.</summary>
+    public static string GetWindowsRid() => GetWindowsRid(RuntimeInformation.ProcessArchitecture);
+}

--- a/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegNativeRid.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Beutl.Extensions.FFmpeg;
 

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -10,7 +10,7 @@
     <!-- This extension relies on Direct3D9 / DXVA2 (IDirect3DDeviceManager9), which the
          Win32 metadata marks x86/x64-only, so it cannot be built for win-arm64. Callers
          exclude it from arm64 builds; here we keep the historical x64 target. -->
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformTarget)' == '' And ($([MSBuild]::IsOSPlatform('Windows')) Or $(RuntimeIdentifier.StartsWith('win')))">x64</PlatformTarget>
     <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -7,7 +7,10 @@
     <MFBuildIn Condition="'$(MFBuildIn)' == ''">True</MFBuildIn>
     <DefineConstants>$(DefineConstants);DESKTOP_APP</DefineConstants>
     <DefineConstants Condition="'$(MFBuildIn)'=='True'">$(DefineConstants);MF_BUILD_IN</DefineConstants>
-    <PlatformTarget Condition="'$(PlatformTarget)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">x64</PlatformTarget>
+    <!-- This extension relies on Direct3D9 / DXVA2 (IDirect3DDeviceManager9), which the
+         Win32 metadata marks x86/x64-only, so it cannot be built for win-arm64. Callers
+         exclude it from arm64 builds; here we keep the historical x64 target. -->
+    <PlatformTarget>x64</PlatformTarget>
     <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -34,6 +34,7 @@
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegDecodingSettings.cs" Link="Linked\FFmpegDecodingSettings.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegFrameValidation.cs" Link="Linked\FFmpegFrameValidation.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegSeekDecision.cs" Link="Linked\FFmpegSeekDecision.cs" />
+    <Compile Include="..\Beutl.Extensions.FFmpeg\FFmpegNativeRid.cs" Link="Linked\FFmpegNativeRid.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -60,10 +60,11 @@ internal static class FFmpegLoaderWorker
 
         if (OperatingSystem.IsWindows())
         {
+            string rid = Beutl.Extensions.FFmpeg.FFmpegNativeRid.GetWindowsRid();
             paths.Add(Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location)!.FullName,
-                "runtimes", Environment.Is64BitProcess ? "win-x64" : "win-x86", "native"));
+                "runtimes", rid, "native"));
             paths.Add(Path.Combine(AppContext.BaseDirectory,
-                "runtimes", Environment.Is64BitProcess ? "win-x64" : "win-x86", "native"));
+                "runtimes", rid, "native"));
         }
         else if (OperatingSystem.IsLinux())
         {

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -6,7 +6,15 @@
     <OutputType>WinExe</OutputType>
     <DesktopExeRids>true</DesktopExeRids>
     <FFmpegBuildIn Condition="'$(FFmpegBuildIn)' == ''">True</FFmpegBuildIn>
-    <MFBuildIn Condition="'$(MFBuildIn)' == '' And $(TargetFramework.Contains('windows'))">True</MFBuildIn>
+    <!-- True when this build effectively targets ARM64: an explicit arm64 RID, or a
+         RID-less dev/debug run (e.g. `dotnet run`) on an ARM64 host. Mirrors the host
+         detection in Beutl.Engine.csproj (_ShadercNativeRid). -->
+    <_BeutlTargetsArm64 Condition="$(RuntimeIdentifier.Contains('arm64'))">true</_BeutlTargetsArm64>
+    <_BeutlTargetsArm64 Condition="'$(_BeutlTargetsArm64)' == '' And '$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">true</_BeutlTargetsArm64>
+    <!-- Exclude MediaFoundation on ARM64: it depends on Direct3D9/DXVA2 (x86/x64-only).
+         ARM64 falls back to FFmpeg decoding. Covers both arm64 publishes and RID-less
+         arm64 host runs. -->
+    <MFBuildIn Condition="'$(MFBuildIn)' == '' And $(TargetFramework.Contains('windows')) And '$(_BeutlTargetsArm64)' != 'true'">True</MFBuildIn>
     <!-- AVFoundationはmacOS専用。osx-* RID向けpublish時、または非Windows TFMの開発ビルド
          (RID未指定) のときに含める。Linux/Windows向けpublishでは除外する。 -->
     <AVFBuildIn Condition="'$(AVFBuildIn)' == '' And !$(TargetFramework.Contains('windows')) And ('$(RuntimeIdentifier)' == '' Or $(RuntimeIdentifier.StartsWith('osx')))">True</AVFBuildIn>

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -10,7 +10,7 @@
          RID-less dev/debug run (e.g. `dotnet run`) on an ARM64 host. Mirrors the host
          detection in Beutl.Engine.csproj (_ShadercNativeRid). -->
     <_BeutlTargetsArm64 Condition="$(RuntimeIdentifier.Contains('arm64'))">true</_BeutlTargetsArm64>
-    <_BeutlTargetsArm64 Condition="'$(_BeutlTargetsArm64)' == '' And '$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">true</_BeutlTargetsArm64>
+    <_BeutlTargetsArm64 Condition="'$(_BeutlTargetsArm64)' == '' And '$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">true</_BeutlTargetsArm64>
     <!-- Exclude MediaFoundation on ARM64: it depends on Direct3D9/DXVA2 (x86/x64-only).
          ARM64 falls back to FFmpeg decoding. Covers both arm64 publishes and RID-less
          arm64 host runs. -->
@@ -113,6 +113,13 @@
 
   <ItemGroup Condition="'$(FFmpegBuildIn)'=='True'">
     <ProjectReference Include="..\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
+  </ItemGroup>
+
+  <!-- FFmpegBinaryLocator (WindowCapture, always compiled) needs the shared arch->win-rid mapping.
+       The helper is internal to Beutl.Extensions.FFmpeg, so link the source rather than reference it
+       (same pattern as the FFmpeg worker/benchmark/tests). -->
+  <ItemGroup>
+    <Compile Include="..\Beutl.Extensions.FFmpeg\FFmpegNativeRid.cs" Link="Linked\FFmpegNativeRid.cs" />
   </ItemGroup>
 
   <!-- Dev-only build of the GPL worker. ReferenceOutputAssembly=false keeps the GPL assembly

--- a/src/Beutl/Services/WindowCapture/FFmpegBinaryLocator.cs
+++ b/src/Beutl/Services/WindowCapture/FFmpegBinaryLocator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
+
+using Beutl.Extensions.FFmpeg;
 
 namespace Beutl.Services.WindowCapture;
 
@@ -39,18 +40,11 @@ internal static class FFmpegBinaryLocator
             yield return Path.Combine(
                 AppContext.BaseDirectory,
                 "runtimes",
-                GetWindowsRuntimeIdentifier(),
+                FFmpegNativeRid.GetWindowsRid(),
                 "native",
                 "ffmpeg.exe");
         }
     }
-
-    private static string GetWindowsRuntimeIdentifier() => RuntimeInformation.ProcessArchitecture switch
-    {
-        Architecture.Arm64 => "win-arm64",
-        Architecture.X86 => "win-x86",
-        _ => "win-x64",
-    };
 
     private static bool CanLaunch(string path)
     {

--- a/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
+++ b/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
@@ -40,6 +40,9 @@
   <ItemGroup>
     <Compile Include="..\..\src\Beutl.FFmpegWorker\FFmpegLoaderWorker.cs" Link="Linked\FFmpegLoaderWorker.cs" />
     <Compile Include="..\..\src\Beutl.FFmpegWorker\WorkerLog.cs" Link="Linked\WorkerLog.cs" />
+    <!-- FFmpegLoaderWorker references FFmpegNativeRid; link it here too since this
+         project links the worker source instead of referencing Beutl.Extensions.FFmpeg. -->
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\FFmpegNativeRid.cs" Link="Linked\FFmpegNativeRid.cs" />
   </ItemGroup>
 
   <!-- IPC テスト用: ビルド済みワーカーとその依存DLLを出力ディレクトリにコピー -->

--- a/tests/Beutl.FFmpegWorker.Tests/Beutl.FFmpegWorker.Tests.csproj
+++ b/tests/Beutl.FFmpegWorker.Tests/Beutl.FFmpegWorker.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\..\src\Beutl.FFmpegWorker\ColorSpaceHelper.cs" Link="Linked\ColorSpaceHelper.cs" />
     <Compile Include="..\..\src\Beutl.FFmpegWorker\FFmpegLoaderWorker.cs" Link="Linked\FFmpegLoaderWorker.cs" />
     <Compile Include="..\..\src\Beutl.FFmpegWorker\WorkerLog.cs" Link="Linked\WorkerLog.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\FFmpegNativeRid.cs" Link="Linked\FFmpegNativeRid.cs" />
   </ItemGroup>
 
   <!-- Settings/record types shared with the MIT extension (compiled here under BEUTL_FFMPEG_WORKER). -->

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 using Beutl.Extensions.FFmpeg;
 

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
@@ -15,11 +15,12 @@ public class FFmpegNativeRidTests
         Assert.That(FFmpegNativeRid.GetWindowsRid(architecture), Is.EqualTo(expected));
     }
 
-    [Test]
-    public void GetWindowsRid_UnknownArchitecture_FallsBackToX64()
+    [TestCase(Architecture.Wasm)]
+    [TestCase(Architecture.Arm)] // 32-bit ARM; win-arm is not a supported target
+    public void GetWindowsRid_UnknownArchitecture_FallsBackToX64(Architecture architecture)
     {
         // Anything that is neither arm64 nor x86 must resolve to win-x64 so a 64-bit
         // x64 process never probes the win-x86 folder.
-        Assert.That(FFmpegNativeRid.GetWindowsRid(Architecture.Wasm), Is.EqualTo("win-x64"));
+        Assert.That(FFmpegNativeRid.GetWindowsRid(architecture), Is.EqualTo("win-x64"));
     }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+
+using Beutl.Extensions.FFmpeg;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegNativeRidTests
+{
+    [TestCase(Architecture.Arm64, "win-arm64")]
+    [TestCase(Architecture.X86, "win-x86")]
+    [TestCase(Architecture.X64, "win-x64")]
+    public void GetWindowsRid_MapsArchitectureToRuntimeFolder(Architecture architecture, string expected)
+    {
+        Assert.That(FFmpegNativeRid.GetWindowsRid(architecture), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetWindowsRid_UnknownArchitecture_FallsBackToX64()
+    {
+        // Anything that is neither arm64 nor x86 must resolve to win-x64 so a 64-bit
+        // x64 process never probes the win-x86 folder.
+        Assert.That(FFmpegNativeRid.GetWindowsRid(Architecture.Wasm), Is.EqualTo("win-x64"));
+    }
+}


### PR DESCRIPTION
## Description
- Add native `win-arm64` as a build/distribution target across project files, the Nuke build, FFmpeg native-library resolution, the installer, and CI — so Windows on ARM devices get a native build instead of x64 emulation.
- Fix Windows FFmpeg native-folder resolution: select by `RuntimeInformation.ProcessArchitecture` instead of `Environment.Is64BitProcess`, which returned `win-x64` for arm64 and would throw `BadImageFormatException`. The pure mapping is extracted into `FFmpegNativeRid` and reused from the GPL worker via linked source (GPL/MIT boundary preserved).
- Exclude the MediaFoundation embedding from arm64: it depends on Direct3D9/DXVA2 (`IDirect3DDeviceManager9`), which the Win32 metadata marks x86/x64-only, so CsWin32 cannot generate it for arm64. arm64 falls back to FFmpeg decoding, exactly as Linux/macOS already do.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None

## Test plan
- New: `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegNativeRidTests.cs` — verifies the architecture-to-RID mapping (Arm64 → `win-arm64`, X86 → `win-x86`, others → `win-x64`). All FFmpeg unit tests green (8/8).
- Verified `dotnet publish -r win-arm64` (cross-publish): all native binaries are AArch64 — `libSkiaSharp` / `libHarfBuzzSharp` / `shaderc_shared` / `vk_swiftshader` / `vulkan-1` / `Beutl.dll`. MediaFoundation correctly absent.
- Verified `win-x64` non-regression: still publishes with MediaFoundation included.

## Fixed issues / References

### Follow-ups
- Restore hardware-accelerated MediaFoundation on win-arm64 (replace the Direct3D9/DXVA2 path with a D3D11/alternative route). arm64 currently decodes via FFmpeg only.
- Make the Linux FFmpeg native-path branch (`FFmpegPath.cs` / `FFmpegLoaderWorker.cs`) arm64-aware (`linux-arm64`); this PR targets Windows ARM64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows ARM64 builds to daily builds and published releases, with architecture-specific standalone and installer executables.
  * Release/download notes now present separate Windows x64 vs ARM64 download sections.
* **Bug Fixes**
  * Improved bundled FFmpeg native library loading by selecting the correct Windows runtime folder per architecture.
  * MediaFoundation is disabled when targeting Windows ARM64 to use the appropriate fallback path.
* **Tests**
  * Added unit tests validating architecture-to-Windows runtime-folder mapping (including ARM64).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->