### PR TITLE
feat: migrate player settings to a Preview Settings tool tab

### DIFF
--- a/.claude/skills/beutl-tooltab-extension/SKILL.md
+++ b/.claude/skills/beutl-tooltab-extension/SKILL.md
@@ -34,16 +34,13 @@ Extension (base)
 
 ```csharp
 using System.Diagnostics.CodeAnalysis;
-using System.ComponentModel.DataAnnotations;
 using Avalonia.Controls;
 using Beutl.Extensibility;
 using Beutl.Language;
-using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Services.PrimitiveImpls;
 
 [PrimitiveImpl]
-[Display(Name = nameof(Strings.MyToolTab), ResourceType = typeof(Strings))]
 public sealed class MyToolTabExtension : ToolTabExtension
 {
     public static readonly MyToolTabExtension Instance = new();
@@ -51,15 +48,24 @@ public sealed class MyToolTabExtension : ToolTabExtension
     // Whether multiple instances are allowed
     public override bool CanMultiple => false;
 
+    // Stable identifier (not localized)
+    public override string Name => "My tool tab";
+
+    // Localized display name (shown in the "add tool tab" menu)
+    public override string DisplayName => Strings.MyToolTab;
+
     // Tab header (returning null hides it from the menu).
     // Use null when the tab should only be opened from code.
     public override string? Header => Strings.MyToolTab;
 
-    // Tab icon
-    public override IconSource GetIcon()
-    {
-        return new SymbolIconSource { Symbol = Symbol.Settings };
-    }
+    // Default docking position: None / Left / Right / Bottom / Player
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
+
+    // Sort order among tabs sharing the same anchor (lower = earlier)
+    public override int DefaultOrder => 0;
+
+    // Open automatically when a new editor opens
+    public override bool OpenByDefault => false;
 
     // Create the view (the UI control)
     public override bool TryCreateContent(
@@ -108,13 +114,6 @@ public sealed class MyToolTabViewModel : IToolContext
 
     public string Header => Strings.MyToolTab;
 
-    public IReactiveProperty<ToolTabExtension.TabPlacement> Placement { get; } =
-        new ReactivePropertySlim<ToolTabExtension.TabPlacement>(
-            ToolTabExtension.TabPlacement.RightUpperBottom);
-
-    public IReactiveProperty<ToolTabExtension.TabDisplayMode> DisplayMode { get; } =
-        new ReactivePropertySlim<ToolTabExtension.TabDisplayMode>();
-
     public void Dispose() => _disposables.Dispose();
 
     public void ReadFromJson(JsonObject json) { }
@@ -124,6 +123,11 @@ public sealed class MyToolTabViewModel : IToolContext
         => _editorContext.GetService(serviceType);
 }
 ```
+
+> `IToolContext` itself only requires `Extension`, `IsSelected`, and `Header`
+> (plus `IDisposable` / `IJsonSerializable` / `IServiceProvider`). Docking
+> placement is declared on the **Extension** via `DefaultAnchor` /
+> `DefaultOrder` / `OpenByDefault`, not on the ViewModel.
 
 ### Step 3: Register with `PrimitiveExtensions`
 
@@ -157,11 +161,10 @@ public static readonly Extension[] PrimitiveExtensions =
 ### Step 1: Subclass `ToolTabExtension`
 
 ```csharp
-using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Beutl.Extensibility;
-using FluentAvalonia.UI.Controls;
 
 namespace MyExtension;
 
@@ -175,10 +178,8 @@ public sealed class MyToolTabExtension : ToolTabExtension
 
     public override string? Header => Strings.MyToolTab;
 
-    public override IconSource GetIcon()
-    {
-        return new SymbolIconSource { Symbol = Symbol.Settings };
-    }
+    // Default docking position: None / Left / Right / Bottom / Player
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
 
     public override bool TryCreateContent(
         IEditorContext editorContext,
@@ -227,13 +228,6 @@ public sealed class MyToolTabViewModel : IToolContext
 
     public string Header => Strings.MyToolTab;
 
-    public IReactiveProperty<ToolTabExtension.TabPlacement> Placement { get; } =
-        new ReactivePropertySlim<ToolTabExtension.TabPlacement>(
-            ToolTabExtension.TabPlacement.RightUpperBottom);
-
-    public IReactiveProperty<ToolTabExtension.TabDisplayMode> DisplayMode { get; } =
-        new ReactivePropertySlim<ToolTabExtension.TabDisplayMode>();
-
     public void Dispose() => _disposables.Dispose();
 
     public void ReadFromJson(JsonObject json) { }
@@ -263,18 +257,19 @@ Add `Strings.resx` and `Strings.ja.resx` inside the extension project, generated
 </UserControl>
 ```
 
-## TabPlacement options
+## DockAnchor options
+
+`ToolTabExtension.DefaultAnchor` returns a `DockAnchor` (see
+`src/Beutl.Extensibility/DockAnchor.cs`). It is the default docking position
+when the tab is first opened; the user can re-dock afterwards.
 
 | Value | Meaning |
 |---|---|
-| LeftUpperTop | Left sidebar, upper area, top |
-| LeftUpperBottom | Left sidebar, upper area, bottom |
-| LeftLowerTop | Left sidebar, lower area, top |
-| LeftLowerBottom | Left sidebar, lower area, bottom |
-| RightUpperTop | Right sidebar, upper area, top |
-| RightUpperBottom | Right sidebar, upper area, bottom |
-| RightLowerTop | Right sidebar, lower area, top |
-| RightLowerBottom | Right sidebar, lower area, bottom |
+| None | No fixed anchor — falls back to the first available tool dock |
+| Left | Left sidebar |
+| Right | Right sidebar |
+| Bottom | Bottom panel |
+| Player | The player's own dock area (reserved; don't use for ordinary tabs) |
 
 ## Services available from `IEditorContext`
 

--- a/.claude/skills/beutl-tooltab-extension/references/implementation-patterns.md
+++ b/.claude/skills/beutl-tooltab-extension/references/implementation-patterns.md
@@ -24,8 +24,7 @@ public sealed class SimpleTabExtension : ToolTabExtension
 
     public override string? Header => Strings.SimpleTab;
 
-    public override IconSource GetIcon()
-        => new SymbolIconSource { Symbol = Symbol.Info };
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
 
     public override bool TryCreateContent(IEditorContext editorContext, out Control? control)
     {
@@ -51,10 +50,6 @@ public sealed class SimpleContext : IToolContext
     public ToolTabExtension Extension { get; }
     public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
     public string Header => Strings.SimpleTab;
-    public IReactiveProperty<TabPlacement> Placement { get; } =
-        new ReactivePropertySlim<TabPlacement>(TabPlacement.RightUpperBottom);
-    public IReactiveProperty<TabDisplayMode> DisplayMode { get; } =
-        new ReactivePropertySlim<TabDisplayMode>();
 
     public void Dispose() { }
     public object? GetService(Type t) => null;
@@ -248,9 +243,6 @@ public sealed class HiddenTabExtension : ToolTabExtension
 
     // Returning null for Header hides the entry from the menu
     public override string? Header => null;
-
-    public override IconSource GetIcon()
-        => new SymbolIconSource { Symbol = Symbol.Code };
 
     // ... rest of the implementation ...
 }

--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -1,9 +1,11 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Management;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Beutl.Collections;
+using Beutl.Language;
 using Beutl.Serialization;
 
 namespace Beutl.Configuration;
@@ -90,6 +92,7 @@ public sealed partial class EditorConfig : ConfigurationBase
 
         IsFrameCacheEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsFrameCacheEnabled))
             .DefaultValue(false)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.EnableFrameCache), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         ulong memSize = OperatingSystem.IsWindows() ? GetWindowsMemoryCapacity()
@@ -101,26 +104,32 @@ public sealed partial class EditorConfig : ConfigurationBase
         // デフォルトはメモリ容量の半分にする
         FrameCacheMaxSizeProperty = ConfigureProperty<double, EditorConfig>(nameof(FrameCacheMaxSize))
             .DefaultValue(memSizeInMG / 2)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheMaxSize), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         FrameCacheScaleProperty = ConfigureProperty<FrameCacheConfigScale, EditorConfig>(nameof(FrameCacheScale))
             .DefaultValue(FrameCacheConfigScale.FitToPreviewer)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheScale), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         FrameCacheColorTypeProperty = ConfigureProperty<FrameCacheConfigColorType, EditorConfig>(nameof(FrameCacheColorType))
             .DefaultValue(FrameCacheConfigColorType.RGBA)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheColorType), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         IsNodeCacheEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsNodeCacheEnabled))
             .DefaultValue(false)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.EnableNodeCache), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         NodeCacheMaxPixelsProperty = ConfigureProperty<int, EditorConfig>(nameof(NodeCacheMaxPixels))
             .DefaultValue(1000 * 1000)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.NodeCacheMaxPixels), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         NodeCacheMinPixelsProperty = ConfigureProperty<int, EditorConfig>(nameof(NodeCacheMinPixels))
             .DefaultValue(1)
+            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.NodeCacheMinPixels), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         SwapTimelineScrollDirectionProperty = ConfigureProperty<bool, EditorConfig>(nameof(SwapTimelineScrollDirection))
@@ -153,22 +162,27 @@ public sealed partial class EditorConfig : ConfigurationBase
 
         IsOnionSkinEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsOnionSkinEnabled))
             .DefaultValue(false)
+            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkin), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinPrevCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinPrevCount))
             .DefaultValue(1)
+            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinPrevCount), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinNextCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinNextCount))
             .DefaultValue(0)
+            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinNextCount), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinPrevOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinPrevOpacity))
             .DefaultValue(0.35f)
+            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinPrevOpacity), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinNextOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinNextOpacity))
             .DefaultValue(0.35f)
+            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinNextOpacity), ResourceType = typeof(Strings) })
             .Register();
     }
 

--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -204,6 +204,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(IsFrameCacheEnabledProperty, value);
     }
 
+    [Range(0.0, double.MaxValue)]
     [Display(Name = nameof(SettingsStrings.FrameCacheMaxSize), ResourceType = typeof(SettingsStrings))]
     public double FrameCacheMaxSize
     {
@@ -232,6 +233,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(IsNodeCacheEnabledProperty, value);
     }
 
+    [Range(1, int.MaxValue)]
     [Display(Name = nameof(SettingsStrings.NodeCacheMaxPixels), ResourceType = typeof(SettingsStrings))]
     public int NodeCacheMaxPixels
     {
@@ -239,6 +241,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(NodeCacheMaxPixelsProperty, value);
     }
 
+    [Range(1, int.MaxValue)]
     [Display(Name = nameof(SettingsStrings.NodeCacheMinPixels), ResourceType = typeof(SettingsStrings))]
     public int NodeCacheMinPixels
     {
@@ -295,6 +298,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(IsOnionSkinEnabledProperty, value);
     }
 
+    [Range(0, 10)]
     [Display(Name = nameof(Strings.OnionSkinPrevCount), ResourceType = typeof(Strings))]
     public int OnionSkinPrevCount
     {
@@ -302,6 +306,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(OnionSkinPrevCountProperty, value);
     }
 
+    [Range(0, 10)]
     [Display(Name = nameof(Strings.OnionSkinNextCount), ResourceType = typeof(Strings))]
     public int OnionSkinNextCount
     {
@@ -309,6 +314,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(OnionSkinNextCountProperty, value);
     }
 
+    [Range(0.0, 1.0)]
     [Display(Name = nameof(Strings.OnionSkinPrevOpacity), ResourceType = typeof(Strings))]
     public float OnionSkinPrevOpacity
     {
@@ -316,6 +322,7 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(OnionSkinPrevOpacityProperty, value);
     }
 
+    [Range(0.0, 1.0)]
     [Display(Name = nameof(Strings.OnionSkinNextOpacity), ResourceType = typeof(Strings))]
     public float OnionSkinNextOpacity
     {

--- a/src/Beutl.Configuration/EditorConfig.cs
+++ b/src/Beutl.Configuration/EditorConfig.cs
@@ -92,7 +92,6 @@ public sealed partial class EditorConfig : ConfigurationBase
 
         IsFrameCacheEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsFrameCacheEnabled))
             .DefaultValue(false)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.EnableFrameCache), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         ulong memSize = OperatingSystem.IsWindows() ? GetWindowsMemoryCapacity()
@@ -104,32 +103,26 @@ public sealed partial class EditorConfig : ConfigurationBase
         // デフォルトはメモリ容量の半分にする
         FrameCacheMaxSizeProperty = ConfigureProperty<double, EditorConfig>(nameof(FrameCacheMaxSize))
             .DefaultValue(memSizeInMG / 2)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheMaxSize), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         FrameCacheScaleProperty = ConfigureProperty<FrameCacheConfigScale, EditorConfig>(nameof(FrameCacheScale))
             .DefaultValue(FrameCacheConfigScale.FitToPreviewer)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheScale), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         FrameCacheColorTypeProperty = ConfigureProperty<FrameCacheConfigColorType, EditorConfig>(nameof(FrameCacheColorType))
             .DefaultValue(FrameCacheConfigColorType.RGBA)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.FrameCacheColorType), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         IsNodeCacheEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsNodeCacheEnabled))
             .DefaultValue(false)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.EnableNodeCache), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         NodeCacheMaxPixelsProperty = ConfigureProperty<int, EditorConfig>(nameof(NodeCacheMaxPixels))
             .DefaultValue(1000 * 1000)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.NodeCacheMaxPixels), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         NodeCacheMinPixelsProperty = ConfigureProperty<int, EditorConfig>(nameof(NodeCacheMinPixels))
             .DefaultValue(1)
-            .SetAttribute(new DisplayAttribute { Name = nameof(SettingsStrings.NodeCacheMinPixels), ResourceType = typeof(SettingsStrings) })
             .Register();
 
         SwapTimelineScrollDirectionProperty = ConfigureProperty<bool, EditorConfig>(nameof(SwapTimelineScrollDirection))
@@ -162,27 +155,22 @@ public sealed partial class EditorConfig : ConfigurationBase
 
         IsOnionSkinEnabledProperty = ConfigureProperty<bool, EditorConfig>(nameof(IsOnionSkinEnabled))
             .DefaultValue(false)
-            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkin), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinPrevCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinPrevCount))
             .DefaultValue(1)
-            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinPrevCount), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinNextCountProperty = ConfigureProperty<int, EditorConfig>(nameof(OnionSkinNextCount))
             .DefaultValue(0)
-            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinNextCount), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinPrevOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinPrevOpacity))
             .DefaultValue(0.35f)
-            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinPrevOpacity), ResourceType = typeof(Strings) })
             .Register();
 
         OnionSkinNextOpacityProperty = ConfigureProperty<float, EditorConfig>(nameof(OnionSkinNextOpacity))
             .DefaultValue(0.35f)
-            .SetAttribute(new DisplayAttribute { Name = nameof(Strings.OnionSkinNextOpacity), ResourceType = typeof(Strings) })
             .Register();
     }
 
@@ -209,42 +197,49 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(IsAutoSaveEnabledProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.EnableFrameCache), ResourceType = typeof(SettingsStrings))]
     public bool IsFrameCacheEnabled
     {
         get => GetValue(IsFrameCacheEnabledProperty);
         set => SetValue(IsFrameCacheEnabledProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.FrameCacheMaxSize), ResourceType = typeof(SettingsStrings))]
     public double FrameCacheMaxSize
     {
         get => GetValue(FrameCacheMaxSizeProperty);
         set => SetValue(FrameCacheMaxSizeProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.FrameCacheScale), ResourceType = typeof(SettingsStrings))]
     public FrameCacheConfigScale FrameCacheScale
     {
         get => GetValue(FrameCacheScaleProperty);
         set => SetValue(FrameCacheScaleProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.FrameCacheColorType), ResourceType = typeof(SettingsStrings))]
     public FrameCacheConfigColorType FrameCacheColorType
     {
         get => GetValue(FrameCacheColorTypeProperty);
         set => SetValue(FrameCacheColorTypeProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.EnableNodeCache), ResourceType = typeof(SettingsStrings))]
     public bool IsNodeCacheEnabled
     {
         get => GetValue(IsNodeCacheEnabledProperty);
         set => SetValue(IsNodeCacheEnabledProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.NodeCacheMaxPixels), ResourceType = typeof(SettingsStrings))]
     public int NodeCacheMaxPixels
     {
         get => GetValue(NodeCacheMaxPixelsProperty);
         set => SetValue(NodeCacheMaxPixelsProperty, value);
     }
 
+    [Display(Name = nameof(SettingsStrings.NodeCacheMinPixels), ResourceType = typeof(SettingsStrings))]
     public int NodeCacheMinPixels
     {
         get => GetValue(NodeCacheMinPixelsProperty);
@@ -293,30 +288,35 @@ public sealed partial class EditorConfig : ConfigurationBase
         set => SetValue(UseHdrPreviewProperty, value);
     }
 
+    [Display(Name = nameof(Strings.OnionSkin), ResourceType = typeof(Strings))]
     public bool IsOnionSkinEnabled
     {
         get => GetValue(IsOnionSkinEnabledProperty);
         set => SetValue(IsOnionSkinEnabledProperty, value);
     }
 
+    [Display(Name = nameof(Strings.OnionSkinPrevCount), ResourceType = typeof(Strings))]
     public int OnionSkinPrevCount
     {
         get => GetValue(OnionSkinPrevCountProperty);
         set => SetValue(OnionSkinPrevCountProperty, value);
     }
 
+    [Display(Name = nameof(Strings.OnionSkinNextCount), ResourceType = typeof(Strings))]
     public int OnionSkinNextCount
     {
         get => GetValue(OnionSkinNextCountProperty);
         set => SetValue(OnionSkinNextCountProperty, value);
     }
 
+    [Display(Name = nameof(Strings.OnionSkinPrevOpacity), ResourceType = typeof(Strings))]
     public float OnionSkinPrevOpacity
     {
         get => GetValue(OnionSkinPrevOpacityProperty);
         set => SetValue(OnionSkinPrevOpacityProperty, value);
     }
 
+    [Display(Name = nameof(Strings.OnionSkinNextOpacity), ResourceType = typeof(Strings))]
     public float OnionSkinNextOpacity
     {
         get => GetValue(OnionSkinNextOpacityProperty);

--- a/src/Beutl.Controls/Converters/PropertyEditorContextToViewConverter.cs
+++ b/src/Beutl.Controls/Converters/PropertyEditorContextToViewConverter.cs
@@ -1,19 +1,19 @@
 ﻿#nullable enable
 
 using System.Globalization;
-
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
-
+using Beutl.Controls.PropertyEditors;
 using Beutl.Extensibility;
 
 namespace Beutl.Controls.Converters;
 
-public sealed class PropertyEditorContextToViewConverter : IValueConverter
+public sealed class PropertyEditorContextToViewConverter(bool hideMenu) : IValueConverter
 {
-    public static readonly PropertyEditorContextToViewConverter Instance = new();
+    public static readonly PropertyEditorContextToViewConverter Instance = new(false);
+    public static readonly PropertyEditorContextToViewConverter HideMenu = new(true);
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
@@ -21,15 +21,18 @@ public sealed class PropertyEditorContextToViewConverter : IValueConverter
         {
             if (viewModel.Extension.TryCreateControl(viewModel, out var control))
             {
+                if (hideMenu && control is PropertyEditor pe)
+                {
+                    pe.MenuContent = null;
+                }
+
                 return control;
             }
             else
             {
                 return new Label
                 {
-                    Height = 24,
-                    Margin = new Thickness(0, 4),
-                    Content = viewModel.Extension.DisplayName
+                    Height = 24, Margin = new Thickness(0, 4), Content = viewModel.Extension.DisplayName
                 };
             }
         }

--- a/src/Beutl.Controls/Converters/PropertyEditorContextToViewConverter.cs
+++ b/src/Beutl.Controls/Converters/PropertyEditorContextToViewConverter.cs
@@ -32,7 +32,9 @@ public sealed class PropertyEditorContextToViewConverter(bool hideMenu) : IValue
             {
                 return new Label
                 {
-                    Height = 24, Margin = new Thickness(0, 4), Content = viewModel.Extension.DisplayName
+                    Height = 24,
+                    Margin = new Thickness(0, 4),
+                    Content = viewModel.Extension.DisplayName
                 };
             }
         }

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/PreviewSettingsTabExtension.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/PreviewSettingsTabExtension.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Avalonia.Controls;
+
+using Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
+using Beutl.Editor.Components.PreviewSettingsTab.Views;
+
+namespace Beutl.Editor.Components.PreviewSettingsTab;
+
+[PrimitiveImpl]
+public sealed class PreviewSettingsTabExtension : ToolTabExtension
+{
+    public static readonly PreviewSettingsTabExtension Instance = new();
+
+    public override bool CanMultiple => false;
+
+    public override string Name => "Preview settings";
+
+    public override string DisplayName => Strings.PreviewSettings;
+
+    public override string Header => Strings.PreviewSettings;
+
+    public override DockAnchor DefaultAnchor => DockAnchor.Right;
+
+    public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
+    {
+        control = new PreviewSettingsTabView();
+        return true;
+    }
+
+    public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
+    {
+        context = new PreviewSettingsTabViewModel(editorContext);
+        return true;
+    }
+}

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -21,65 +21,56 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         var factory = editorContext.GetRequiredService<IPropertyEditorFactory>();
         EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
 
-        // Build the editors through the property-editor mechanism so each row reuses the
-        // standard editor for its CoreProperty type (toggle / number / enum). The settings
-        // themselves stay on EditorConfig, which the rest of the app already reacts to.
-        // The "enabled" toggle stays interactive while its dependent rows are disabled
-        // (IsEnabled bound to the flag) whenever the group is turned off.
-        IsOnionSkinEnabled = config.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposables);
-        OnionSkinEnabledEditor = factory.CreateEditor(
-            new CorePropertyAdapter<bool>(EditorConfig.IsOnionSkinEnabledProperty, config));
+        // Each group's "enabled" flag is shown as a ToggleSwitch next to the section header
+        // (bound two-way below), and also drives the IsEnabled of the dependent rows.
+        // The dependent rows themselves go through the property-editor mechanism so they reuse
+        // the standard editor for their CoreProperty type (number / enum). EditorConfig stays
+        // the single source of truth, which the rest of the app already reacts to.
+        IsOnionSkinEnabled = BindToggle(config, EditorConfig.IsOnionSkinEnabledProperty, v => config.IsOnionSkinEnabled = v);
         AddEditors(factory, OnionSkinProperties,
             new CorePropertyAdapter<int>(EditorConfig.OnionSkinPrevCountProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.OnionSkinNextCountProperty, config),
             new CorePropertyAdapter<float>(EditorConfig.OnionSkinPrevOpacityProperty, config),
             new CorePropertyAdapter<float>(EditorConfig.OnionSkinNextOpacityProperty, config));
 
-        IsFrameCacheEnabled = config.GetObservable(EditorConfig.IsFrameCacheEnabledProperty)
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposables);
-        FrameCacheEnabledEditor = factory.CreateEditor(
-            new CorePropertyAdapter<bool>(EditorConfig.IsFrameCacheEnabledProperty, config));
+        IsFrameCacheEnabled = BindToggle(config, EditorConfig.IsFrameCacheEnabledProperty, v => config.IsFrameCacheEnabled = v);
         AddEditors(factory, FrameCacheProperties,
             new CorePropertyAdapter<double>(EditorConfig.FrameCacheMaxSizeProperty, config),
             new CorePropertyAdapter<FrameCacheConfigScale>(EditorConfig.FrameCacheScaleProperty, config),
             new CorePropertyAdapter<FrameCacheConfigColorType>(EditorConfig.FrameCacheColorTypeProperty, config));
 
-        IsNodeCacheEnabled = config.GetObservable(EditorConfig.IsNodeCacheEnabledProperty)
-            .ToReadOnlyReactivePropertySlim()
-            .DisposeWith(_disposables);
-        NodeCacheEnabledEditor = factory.CreateEditor(
-            new CorePropertyAdapter<bool>(EditorConfig.IsNodeCacheEnabledProperty, config));
+        IsNodeCacheEnabled = BindToggle(config, EditorConfig.IsNodeCacheEnabledProperty, v => config.IsNodeCacheEnabled = v);
         AddEditors(factory, NodeCacheProperties,
             new CorePropertyAdapter<int>(EditorConfig.NodeCacheMaxPixelsProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.NodeCacheMinPixelsProperty, config));
     }
 
-    public IPropertyEditorContext? OnionSkinEnabledEditor { get; }
+    public ReactiveProperty<bool> IsOnionSkinEnabled { get; }
 
     public CoreList<IPropertyEditorContext?> OnionSkinProperties { get; } = [];
 
-    public ReadOnlyReactivePropertySlim<bool> IsOnionSkinEnabled { get; }
-
-    public IPropertyEditorContext? FrameCacheEnabledEditor { get; }
+    public ReactiveProperty<bool> IsFrameCacheEnabled { get; }
 
     public CoreList<IPropertyEditorContext?> FrameCacheProperties { get; } = [];
 
-    public ReadOnlyReactivePropertySlim<bool> IsFrameCacheEnabled { get; }
-
-    public IPropertyEditorContext? NodeCacheEnabledEditor { get; }
+    public ReactiveProperty<bool> IsNodeCacheEnabled { get; }
 
     public CoreList<IPropertyEditorContext?> NodeCacheProperties { get; } = [];
-
-    public ReadOnlyReactivePropertySlim<bool> IsNodeCacheEnabled { get; }
 
     public ToolTabExtension Extension => PreviewSettingsTabExtension.Instance;
 
     public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
 
     public string Header => Strings.PreviewSettings;
+
+    private ReactiveProperty<bool> BindToggle(EditorConfig config, CoreProperty<bool> property, Action<bool> setter)
+    {
+        ReactiveProperty<bool> reactive = config.GetObservable(property)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        reactive.Subscribe(setter).DisposeWith(_disposables);
+        return reactive;
+    }
 
     private static void AddEditors(
         IPropertyEditorFactory factory, CoreList<IPropertyEditorContext?> destination,
@@ -93,10 +84,7 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
 
     public void Dispose()
     {
-        IPropertyEditorContext?[] enabledEditors =
-            [OnionSkinEnabledEditor, FrameCacheEnabledEditor, NodeCacheEnabledEditor];
-        foreach (IPropertyEditorContext? context in enabledEditors
-                     .Concat(OnionSkinProperties)
+        foreach (IPropertyEditorContext? context in OnionSkinProperties
                      .Concat(FrameCacheProperties)
                      .Concat(NodeCacheProperties))
         {

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -1,6 +1,11 @@
 ﻿using System.Text.Json.Nodes;
 
+using Beutl.Collections;
 using Beutl.Configuration;
+using Beutl.Editor.Services;
+using Beutl.PropertyAdapters;
+
+using Microsoft.Extensions.DependencyInjection;
 
 using Reactive.Bindings;
 
@@ -8,110 +13,41 @@ namespace Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
 
 public sealed class PreviewSettingsTabViewModel : IToolContext
 {
-    private readonly CompositeDisposable _disposables = [];
     private IEditorContext _editorContext;
 
     public PreviewSettingsTabViewModel(IEditorContext editorContext)
     {
         _editorContext = editorContext;
-        EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+        var factory = editorContext.GetRequiredService<IPropertyEditorFactory>();
+        EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
 
-        // Onion skin (migrated from PlayerViewModel's settings popup).
-        IsOnionSkinEnabled = editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        IsOnionSkinEnabled.Subscribe(v => editorConfig.IsOnionSkinEnabled = v).DisposeWith(_disposables);
+        // Build the editors through the property-editor mechanism so each row reuses the
+        // standard editor for its CoreProperty type (toggle / number / enum). The settings
+        // themselves stay on EditorConfig, which the rest of the app already reacts to.
+        AddEditors(factory, OnionSkinProperties,
+            new CorePropertyAdapter<bool>(EditorConfig.IsOnionSkinEnabledProperty, config),
+            new CorePropertyAdapter<int>(EditorConfig.OnionSkinPrevCountProperty, config),
+            new CorePropertyAdapter<int>(EditorConfig.OnionSkinNextCountProperty, config),
+            new CorePropertyAdapter<float>(EditorConfig.OnionSkinPrevOpacityProperty, config),
+            new CorePropertyAdapter<float>(EditorConfig.OnionSkinNextOpacityProperty, config));
 
-        // NumericUpDown / Slider expose decimal? and double, so the UI-bound ReactiveProperty
-        // types are widened here and cast back to int / float at the EditorConfig boundary.
-        OnionSkinPrevCount = editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty)
-            .Select(v => (decimal)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinPrevCount.Subscribe(v => editorConfig.OnionSkinPrevCount = (int)v).DisposeWith(_disposables);
+        AddEditors(factory, FrameCacheProperties,
+            new CorePropertyAdapter<bool>(EditorConfig.IsFrameCacheEnabledProperty, config),
+            new CorePropertyAdapter<double>(EditorConfig.FrameCacheMaxSizeProperty, config),
+            new CorePropertyAdapter<FrameCacheConfigScale>(EditorConfig.FrameCacheScaleProperty, config),
+            new CorePropertyAdapter<FrameCacheConfigColorType>(EditorConfig.FrameCacheColorTypeProperty, config));
 
-        OnionSkinNextCount = editorConfig.GetObservable(EditorConfig.OnionSkinNextCountProperty)
-            .Select(v => (decimal)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinNextCount.Subscribe(v => editorConfig.OnionSkinNextCount = (int)v).DisposeWith(_disposables);
-
-        OnionSkinPrevOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinPrevOpacityProperty)
-            .Select(v => (double)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinPrevOpacity.Subscribe(v => editorConfig.OnionSkinPrevOpacity = (float)v).DisposeWith(_disposables);
-
-        OnionSkinNextOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinNextOpacityProperty)
-            .Select(v => (double)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinNextOpacity.Subscribe(v => editorConfig.OnionSkinNextOpacity = (float)v).DisposeWith(_disposables);
-
-        // Frame cache (mirrors EditorSettingsPageViewModel; the source of truth stays EditorConfig,
-        // and EditViewModel reacts to these changes to refresh FrameCacheManager / Renderer.CacheOptions).
-        IsFrameCacheEnabled = editorConfig.GetObservable(EditorConfig.IsFrameCacheEnabledProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        IsFrameCacheEnabled.Subscribe(v => editorConfig.IsFrameCacheEnabled = v).DisposeWith(_disposables);
-
-        FrameCacheMaxSize = editorConfig.GetObservable(EditorConfig.FrameCacheMaxSizeProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        FrameCacheMaxSize.Subscribe(v => editorConfig.FrameCacheMaxSize = v).DisposeWith(_disposables);
-
-        FrameCacheScale = editorConfig.GetObservable(EditorConfig.FrameCacheScaleProperty)
-            .Select(v => (int)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        FrameCacheScale.Subscribe(v => editorConfig.FrameCacheScale = (FrameCacheConfigScale)v).DisposeWith(_disposables);
-
-        FrameCacheColorType = editorConfig.GetObservable(EditorConfig.FrameCacheColorTypeProperty)
-            .Select(v => (int)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        FrameCacheColorType.Subscribe(v => editorConfig.FrameCacheColorType = (FrameCacheConfigColorType)v).DisposeWith(_disposables);
-
-        // Node (render) cache.
-        IsNodeCacheEnabled = editorConfig.GetObservable(EditorConfig.IsNodeCacheEnabledProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        IsNodeCacheEnabled.Subscribe(v => editorConfig.IsNodeCacheEnabled = v).DisposeWith(_disposables);
-
-        NodeCacheMaxPixels = editorConfig.GetObservable(EditorConfig.NodeCacheMaxPixelsProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        NodeCacheMaxPixels.Subscribe(v => editorConfig.NodeCacheMaxPixels = v).DisposeWith(_disposables);
-
-        NodeCacheMinPixels = editorConfig.GetObservable(EditorConfig.NodeCacheMinPixelsProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        NodeCacheMinPixels.Subscribe(v => editorConfig.NodeCacheMinPixels = v).DisposeWith(_disposables);
+        AddEditors(factory, NodeCacheProperties,
+            new CorePropertyAdapter<bool>(EditorConfig.IsNodeCacheEnabledProperty, config),
+            new CorePropertyAdapter<int>(EditorConfig.NodeCacheMaxPixelsProperty, config),
+            new CorePropertyAdapter<int>(EditorConfig.NodeCacheMinPixelsProperty, config));
     }
 
-    public ReactiveProperty<bool> IsOnionSkinEnabled { get; }
+    public CoreList<IPropertyEditorContext?> OnionSkinProperties { get; } = [];
 
-    public ReactiveProperty<decimal> OnionSkinPrevCount { get; }
+    public CoreList<IPropertyEditorContext?> FrameCacheProperties { get; } = [];
 
-    public ReactiveProperty<decimal> OnionSkinNextCount { get; }
-
-    public ReactiveProperty<double> OnionSkinPrevOpacity { get; }
-
-    public ReactiveProperty<double> OnionSkinNextOpacity { get; }
-
-    public ReactiveProperty<bool> IsFrameCacheEnabled { get; }
-
-    public ReactiveProperty<double> FrameCacheMaxSize { get; }
-
-    public ReactiveProperty<int> FrameCacheScale { get; }
-
-    public ReactiveProperty<int> FrameCacheColorType { get; }
-
-    public ReactiveProperty<bool> IsNodeCacheEnabled { get; }
-
-    public ReactiveProperty<int> NodeCacheMaxPixels { get; }
-
-    public ReactiveProperty<int> NodeCacheMinPixels { get; }
+    public CoreList<IPropertyEditorContext?> NodeCacheProperties { get; } = [];
 
     public ToolTabExtension Extension => PreviewSettingsTabExtension.Instance;
 
@@ -119,9 +55,28 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
 
     public string Header => Strings.PreviewSettings;
 
+    private static void AddEditors(
+        IPropertyEditorFactory factory, CoreList<IPropertyEditorContext?> destination,
+        params IPropertyAdapter[] adapters)
+    {
+        foreach (IPropertyAdapter adapter in adapters)
+        {
+            destination.Add(factory.CreateEditor(adapter));
+        }
+    }
+
     public void Dispose()
     {
-        _disposables.Dispose();
+        foreach (IPropertyEditorContext? context in OnionSkinProperties
+                     .Concat(FrameCacheProperties)
+                     .Concat(NodeCacheProperties))
+        {
+            context?.Dispose();
+        }
+
+        OnionSkinProperties.Clear();
+        FrameCacheProperties.Clear();
+        NodeCacheProperties.Clear();
         _editorContext = null!;
     }
 
@@ -135,6 +90,6 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
 
     public object? GetService(Type serviceType)
     {
-        return null;
+        return _editorContext.GetService(serviceType);
     }
 }

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -1,0 +1,140 @@
+﻿using System.Text.Json.Nodes;
+
+using Beutl.Configuration;
+
+using Reactive.Bindings;
+
+namespace Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
+
+public sealed class PreviewSettingsTabViewModel : IToolContext
+{
+    private readonly CompositeDisposable _disposables = [];
+    private IEditorContext _editorContext;
+
+    public PreviewSettingsTabViewModel(IEditorContext editorContext)
+    {
+        _editorContext = editorContext;
+        EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+
+        // Onion skin (migrated from PlayerViewModel's settings popup).
+        IsOnionSkinEnabled = editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        IsOnionSkinEnabled.Subscribe(v => editorConfig.IsOnionSkinEnabled = v).DisposeWith(_disposables);
+
+        // NumericUpDown / Slider expose decimal? and double, so the UI-bound ReactiveProperty
+        // types are widened here and cast back to int / float at the EditorConfig boundary.
+        OnionSkinPrevCount = editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty)
+            .Select(v => (decimal)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinPrevCount.Subscribe(v => editorConfig.OnionSkinPrevCount = (int)v).DisposeWith(_disposables);
+
+        OnionSkinNextCount = editorConfig.GetObservable(EditorConfig.OnionSkinNextCountProperty)
+            .Select(v => (decimal)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinNextCount.Subscribe(v => editorConfig.OnionSkinNextCount = (int)v).DisposeWith(_disposables);
+
+        OnionSkinPrevOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinPrevOpacityProperty)
+            .Select(v => (double)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinPrevOpacity.Subscribe(v => editorConfig.OnionSkinPrevOpacity = (float)v).DisposeWith(_disposables);
+
+        OnionSkinNextOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinNextOpacityProperty)
+            .Select(v => (double)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        OnionSkinNextOpacity.Subscribe(v => editorConfig.OnionSkinNextOpacity = (float)v).DisposeWith(_disposables);
+
+        // Frame cache (mirrors EditorSettingsPageViewModel; the source of truth stays EditorConfig,
+        // and EditViewModel reacts to these changes to refresh FrameCacheManager / Renderer.CacheOptions).
+        IsFrameCacheEnabled = editorConfig.GetObservable(EditorConfig.IsFrameCacheEnabledProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        IsFrameCacheEnabled.Subscribe(v => editorConfig.IsFrameCacheEnabled = v).DisposeWith(_disposables);
+
+        FrameCacheMaxSize = editorConfig.GetObservable(EditorConfig.FrameCacheMaxSizeProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        FrameCacheMaxSize.Subscribe(v => editorConfig.FrameCacheMaxSize = v).DisposeWith(_disposables);
+
+        FrameCacheScale = editorConfig.GetObservable(EditorConfig.FrameCacheScaleProperty)
+            .Select(v => (int)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        FrameCacheScale.Subscribe(v => editorConfig.FrameCacheScale = (FrameCacheConfigScale)v).DisposeWith(_disposables);
+
+        FrameCacheColorType = editorConfig.GetObservable(EditorConfig.FrameCacheColorTypeProperty)
+            .Select(v => (int)v)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        FrameCacheColorType.Subscribe(v => editorConfig.FrameCacheColorType = (FrameCacheConfigColorType)v).DisposeWith(_disposables);
+
+        // Node (render) cache.
+        IsNodeCacheEnabled = editorConfig.GetObservable(EditorConfig.IsNodeCacheEnabledProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        IsNodeCacheEnabled.Subscribe(v => editorConfig.IsNodeCacheEnabled = v).DisposeWith(_disposables);
+
+        NodeCacheMaxPixels = editorConfig.GetObservable(EditorConfig.NodeCacheMaxPixelsProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        NodeCacheMaxPixels.Subscribe(v => editorConfig.NodeCacheMaxPixels = v).DisposeWith(_disposables);
+
+        NodeCacheMinPixels = editorConfig.GetObservable(EditorConfig.NodeCacheMinPixelsProperty)
+            .ToReactiveProperty()
+            .DisposeWith(_disposables);
+        NodeCacheMinPixels.Subscribe(v => editorConfig.NodeCacheMinPixels = v).DisposeWith(_disposables);
+    }
+
+    public ReactiveProperty<bool> IsOnionSkinEnabled { get; }
+
+    public ReactiveProperty<decimal> OnionSkinPrevCount { get; }
+
+    public ReactiveProperty<decimal> OnionSkinNextCount { get; }
+
+    public ReactiveProperty<double> OnionSkinPrevOpacity { get; }
+
+    public ReactiveProperty<double> OnionSkinNextOpacity { get; }
+
+    public ReactiveProperty<bool> IsFrameCacheEnabled { get; }
+
+    public ReactiveProperty<double> FrameCacheMaxSize { get; }
+
+    public ReactiveProperty<int> FrameCacheScale { get; }
+
+    public ReactiveProperty<int> FrameCacheColorType { get; }
+
+    public ReactiveProperty<bool> IsNodeCacheEnabled { get; }
+
+    public ReactiveProperty<int> NodeCacheMaxPixels { get; }
+
+    public ReactiveProperty<int> NodeCacheMinPixels { get; }
+
+    public ToolTabExtension Extension => PreviewSettingsTabExtension.Instance;
+
+    public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+
+    public string Header => Strings.PreviewSettings;
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+        _editorContext = null!;
+    }
+
+    public void WriteToJson(JsonObject json)
+    {
+    }
+
+    public void ReadFromJson(JsonObject json)
+    {
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        return null;
+    }
+}

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json.Nodes;
 
-using Beutl.Collections;
 using Beutl.Configuration;
 using Beutl.Editor.Services;
 using Beutl.PropertyAdapters;
@@ -13,6 +12,7 @@ namespace Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
 
 public sealed class PreviewSettingsTabViewModel : IToolContext
 {
+    private readonly CompositeDisposable _disposables = [];
     private IEditorContext _editorContext;
 
     public PreviewSettingsTabViewModel(IEditorContext editorContext)
@@ -24,30 +24,56 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         // Build the editors through the property-editor mechanism so each row reuses the
         // standard editor for its CoreProperty type (toggle / number / enum). The settings
         // themselves stay on EditorConfig, which the rest of the app already reacts to.
+        // The "enabled" toggle stays interactive while its dependent rows are disabled
+        // (IsEnabled bound to the flag) whenever the group is turned off.
+        IsOnionSkinEnabled = config.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        OnionSkinEnabledEditor = factory.CreateEditor(
+            new CorePropertyAdapter<bool>(EditorConfig.IsOnionSkinEnabledProperty, config));
         AddEditors(factory, OnionSkinProperties,
-            new CorePropertyAdapter<bool>(EditorConfig.IsOnionSkinEnabledProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.OnionSkinPrevCountProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.OnionSkinNextCountProperty, config),
             new CorePropertyAdapter<float>(EditorConfig.OnionSkinPrevOpacityProperty, config),
             new CorePropertyAdapter<float>(EditorConfig.OnionSkinNextOpacityProperty, config));
 
+        IsFrameCacheEnabled = config.GetObservable(EditorConfig.IsFrameCacheEnabledProperty)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        FrameCacheEnabledEditor = factory.CreateEditor(
+            new CorePropertyAdapter<bool>(EditorConfig.IsFrameCacheEnabledProperty, config));
         AddEditors(factory, FrameCacheProperties,
-            new CorePropertyAdapter<bool>(EditorConfig.IsFrameCacheEnabledProperty, config),
             new CorePropertyAdapter<double>(EditorConfig.FrameCacheMaxSizeProperty, config),
             new CorePropertyAdapter<FrameCacheConfigScale>(EditorConfig.FrameCacheScaleProperty, config),
             new CorePropertyAdapter<FrameCacheConfigColorType>(EditorConfig.FrameCacheColorTypeProperty, config));
 
+        IsNodeCacheEnabled = config.GetObservable(EditorConfig.IsNodeCacheEnabledProperty)
+            .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+        NodeCacheEnabledEditor = factory.CreateEditor(
+            new CorePropertyAdapter<bool>(EditorConfig.IsNodeCacheEnabledProperty, config));
         AddEditors(factory, NodeCacheProperties,
-            new CorePropertyAdapter<bool>(EditorConfig.IsNodeCacheEnabledProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.NodeCacheMaxPixelsProperty, config),
             new CorePropertyAdapter<int>(EditorConfig.NodeCacheMinPixelsProperty, config));
     }
 
+    public IPropertyEditorContext? OnionSkinEnabledEditor { get; }
+
     public CoreList<IPropertyEditorContext?> OnionSkinProperties { get; } = [];
+
+    public ReadOnlyReactivePropertySlim<bool> IsOnionSkinEnabled { get; }
+
+    public IPropertyEditorContext? FrameCacheEnabledEditor { get; }
 
     public CoreList<IPropertyEditorContext?> FrameCacheProperties { get; } = [];
 
+    public ReadOnlyReactivePropertySlim<bool> IsFrameCacheEnabled { get; }
+
+    public IPropertyEditorContext? NodeCacheEnabledEditor { get; }
+
     public CoreList<IPropertyEditorContext?> NodeCacheProperties { get; } = [];
+
+    public ReadOnlyReactivePropertySlim<bool> IsNodeCacheEnabled { get; }
 
     public ToolTabExtension Extension => PreviewSettingsTabExtension.Instance;
 
@@ -67,7 +93,10 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
 
     public void Dispose()
     {
-        foreach (IPropertyEditorContext? context in OnionSkinProperties
+        IPropertyEditorContext?[] enabledEditors =
+            [OnionSkinEnabledEditor, FrameCacheEnabledEditor, NodeCacheEnabledEditor];
+        foreach (IPropertyEditorContext? context in enabledEditors
+                     .Concat(OnionSkinProperties)
                      .Concat(FrameCacheProperties)
                      .Concat(NodeCacheProperties))
         {
@@ -77,6 +106,7 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         OnionSkinProperties.Clear();
         FrameCacheProperties.Clear();
         NodeCacheProperties.Clear();
+        _disposables.Dispose();
         _editorContext = null!;
     }
 

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Nodes;
 
 using Beutl.Configuration;
+using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.PropertyAdapters;
 
@@ -10,9 +11,10 @@ using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
 
-public sealed class PreviewSettingsTabViewModel : IToolContext
+public sealed class PreviewSettingsTabViewModel : IToolContext, IPropertyEditorContextVisitor
 {
     private readonly CompositeDisposable _disposables = [];
+    private readonly HistoryManager _history;
     private IEditorContext _editorContext;
 
     public PreviewSettingsTabViewModel(IEditorContext editorContext)
@@ -20,6 +22,11 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         _editorContext = editorContext;
         var factory = editorContext.GetRequiredService<IPropertyEditorFactory>();
         EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
+
+        // These editors edit the global EditorConfig, not the scene, so route their Commit()
+        // through a dedicated HistoryManager rooted at EditorConfig instead of the editor's
+        // scene history (same approach as the Output / encoder-settings property editors).
+        _history = new HistoryManager(config, new OperationSequenceGenerator());
 
         // Each group's "enabled" flag is shown as a ToggleSwitch next to the section header
         // (bound two-way below), and also drives the IsEnabled of the dependent rows.
@@ -72,14 +79,21 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         return reactive;
     }
 
-    private static void AddEditors(
+    private void AddEditors(
         IPropertyEditorFactory factory, CoreList<IPropertyEditorContext?> destination,
         params IPropertyAdapter[] adapters)
     {
         foreach (IPropertyAdapter adapter in adapters)
         {
-            destination.Add(factory.CreateEditor(adapter));
+            IPropertyEditorContext? context = factory.CreateEditor(adapter);
+            // Wire the editor's service provider so Commit() resolves our HistoryManager.
+            context?.Accept(this);
+            destination.Add(context);
         }
+    }
+
+    public void Visit(IPropertyEditorContext context)
+    {
     }
 
     public void Dispose()
@@ -95,6 +109,7 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
         FrameCacheProperties.Clear();
         NodeCacheProperties.Clear();
         _disposables.Dispose();
+        _history.Dispose();
         _editorContext = null!;
     }
 
@@ -108,6 +123,13 @@ public sealed class PreviewSettingsTabViewModel : IToolContext
 
     public object? GetService(Type serviceType)
     {
+        // Isolate the settings history: editors Commit() into our EditorConfig-rooted
+        // HistoryManager, never the scene's editor history. Everything else falls through.
+        if (serviceType == typeof(HistoryManager))
+        {
+            return _history;
+        }
+
         return _editorContext.GetService(serviceType);
     }
 }

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -1,0 +1,158 @@
+<UserControl x:Class="Beutl.Editor.Components.PreviewSettingsTab.Views.PreviewSettingsTabView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrls="using:Beutl.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModel="using:Beutl.Editor.Components.PreviewSettingsTab.ViewModels"
+             d:DesignHeight="600"
+             d:DesignWidth="400"
+             x:CompileBindings="True"
+             x:DataType="viewModel:PreviewSettingsTabViewModel"
+             mc:Ignorable="d">
+    <ScrollViewer>
+        <StackPanel Margin="10,12"
+                    Orientation="Vertical"
+                    Spacing="4">
+
+            <TextBlock Text="{x:Static lang:Strings.OnionSkin}" Theme="{StaticResource BodyStrongTextBlockStyle}" />
+
+            <ctrls:OptionsDisplayItem Description="{x:Static lang:Strings.OnionSkin_Description}" Header="{x:Static lang:Strings.OnionSkin}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <ToggleSwitch Classes="left"
+                                  IsChecked="{CompiledBinding IsOnionSkinEnabled.Value}"
+                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinPrevCount}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <NumericUpDown MinWidth="150"
+                                   Increment="1"
+                                   Maximum="10"
+                                   Minimum="0"
+                                   Value="{CompiledBinding OnionSkinPrevCount.Value}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinNextCount}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <NumericUpDown MinWidth="150"
+                                   Increment="1"
+                                   Maximum="10"
+                                   Minimum="0"
+                                   Value="{CompiledBinding OnionSkinNextCount.Value}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinPrevOpacity}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Slider MinWidth="150"
+                                Maximum="1"
+                                Minimum="0"
+                                TickFrequency="0.05"
+                                Value="{CompiledBinding OnionSkinPrevOpacity.Value}" />
+                        <TextBlock Width="40"
+                                   VerticalAlignment="Center"
+                                   Text="{CompiledBinding OnionSkinPrevOpacity.Value, StringFormat={}{0:F2}}" />
+                    </StackPanel>
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinNextOpacity}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Slider MinWidth="150"
+                                Maximum="1"
+                                Minimum="0"
+                                TickFrequency="0.05"
+                                Value="{CompiledBinding OnionSkinNextOpacity.Value}" />
+                        <TextBlock Width="40"
+                                   VerticalAlignment="Center"
+                                   Text="{CompiledBinding OnionSkinNextOpacity.Value, StringFormat={}{0:F2}}" />
+                    </StackPanel>
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <TextBlock Margin="0,16,0,0"
+                       Text="{x:Static lang:Strings.FrameCache}"
+                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.EnableFrameCache}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <ToggleSwitch Classes="left"
+                                  IsChecked="{CompiledBinding IsFrameCacheEnabled.Value}"
+                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Description="{x:Static lang:SettingsStrings.FrameCacheMaxSize_Description}"
+                                      Header="{x:Static lang:SettingsStrings.FrameCacheMaxSize}"
+                                      IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <TextBox MinWidth="150" Text="{CompiledBinding FrameCacheMaxSize.Value}">
+                        <TextBox.InnerRightContent>
+                            <TextBlock Margin="8,0"
+                                       VerticalAlignment="Center"
+                                       Text="MB" />
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.FrameCacheScale}" IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <ComboBox MinWidth="150" SelectedIndex="{CompiledBinding FrameCacheScale.Value}">
+                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Original}" />
+                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_FitToPreviewer}" />
+                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Half}" />
+                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Quarter}" />
+                    </ComboBox>
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.FrameCacheColorType}" IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <ComboBox MinWidth="150" SelectedIndex="{CompiledBinding FrameCacheColorType.Value}">
+                        <ComboBoxItem Content="RGBA" />
+                        <ComboBoxItem Content="YUV" />
+                    </ComboBox>
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <TextBlock Margin="0,16,0,0"
+                       Text="{x:Static lang:SettingsStrings.NodeCache}"
+                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.EnableNodeCache}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <ToggleSwitch Classes="left"
+                                  IsChecked="{CompiledBinding IsNodeCacheEnabled.Value}"
+                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.NodeCacheMaxPixels}" IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <NumericUpDown MinWidth="150"
+                                   FormatString="F0"
+                                   Minimum="{CompiledBinding NodeCacheMinPixels.Value}"
+                                   Value="{CompiledBinding NodeCacheMaxPixels.Value}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.NodeCacheMinPixels}" IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}">
+                <ctrls:OptionsDisplayItem.ActionButton>
+                    <NumericUpDown MinWidth="150"
+                                   FormatString="F0"
+                                   Maximum="{CompiledBinding NodeCacheMaxPixels.Value}"
+                                   Minimum="1"
+                                   Value="{CompiledBinding NodeCacheMinPixels.Value}" />
+                </ctrls:OptionsDisplayItem.ActionButton>
+            </ctrls:OptionsDisplayItem>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -11,11 +11,11 @@
              x:DataType="viewModel:PreviewSettingsTabViewModel"
              mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel Grid.IsSharedSizeScope="True"
-                    Margin="4,8"
+        <StackPanel Margin="0,0,4,0"
+                    Grid.IsSharedSizeScope="True"
                     Orientation="Vertical">
 
-            <Grid Margin="8,8,8,4" ColumnDefinitions="*,Auto">
+            <Grid Margin="8,8,8,0" ColumnDefinitions="*,Auto">
                 <TextBlock VerticalAlignment="Center"
                            Text="{x:Static lang:Strings.OnionSkin}"
                            Theme="{StaticResource BodyStrongTextBlockStyle}" />
@@ -33,7 +33,7 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <Grid Margin="8,16,8,4" ColumnDefinitions="*,Auto">
+            <Grid Margin="8,16,8,0" ColumnDefinitions="*,Auto">
                 <TextBlock VerticalAlignment="Center"
                            Text="{x:Static lang:Strings.FrameCache}"
                            Theme="{StaticResource BodyStrongTextBlockStyle}" />
@@ -51,7 +51,7 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <Grid Margin="8,16,8,4" ColumnDefinitions="*,Auto">
+            <Grid Margin="8,16,8,0" ColumnDefinitions="*,Auto">
                 <TextBlock VerticalAlignment="Center"
                            Text="{x:Static lang:SettingsStrings.NodeCache}"
                            Theme="{StaticResource BodyStrongTextBlockStyle}" />

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -1,7 +1,6 @@
 <UserControl x:Class="Beutl.Editor.Components.PreviewSettingsTab.Views.PreviewSettingsTabView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,146 +11,43 @@
              x:DataType="viewModel:PreviewSettingsTabViewModel"
              mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel Margin="10,12"
-                    Orientation="Vertical"
-                    Spacing="4">
+        <StackPanel Margin="4,8" Orientation="Vertical">
 
-            <TextBlock Text="{x:Static lang:Strings.OnionSkin}" Theme="{StaticResource BodyStrongTextBlockStyle}" />
+            <TextBlock Margin="8,8,8,4"
+                       Text="{x:Static lang:Strings.OnionSkin}"
+                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ctrls:OptionsDisplayItem Description="{x:Static lang:Strings.OnionSkin_Description}" Header="{x:Static lang:Strings.OnionSkin}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <ToggleSwitch Classes="left"
-                                  IsChecked="{CompiledBinding IsOnionSkinEnabled.Value}"
-                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
+            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding OnionSkinProperties}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
 
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinPrevCount}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <NumericUpDown MinWidth="150"
-                                   Increment="1"
-                                   Maximum="10"
-                                   Minimum="0"
-                                   Value="{CompiledBinding OnionSkinPrevCount.Value}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinNextCount}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <NumericUpDown MinWidth="150"
-                                   Increment="1"
-                                   Maximum="10"
-                                   Minimum="0"
-                                   Value="{CompiledBinding OnionSkinNextCount.Value}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinPrevOpacity}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <Slider MinWidth="150"
-                                Maximum="1"
-                                Minimum="0"
-                                TickFrequency="0.05"
-                                Value="{CompiledBinding OnionSkinPrevOpacity.Value}" />
-                        <TextBlock Width="40"
-                                   VerticalAlignment="Center"
-                                   Text="{CompiledBinding OnionSkinPrevOpacity.Value, StringFormat={}{0:F2}}" />
-                    </StackPanel>
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:Strings.OnionSkinNextOpacity}" IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <Slider MinWidth="150"
-                                Maximum="1"
-                                Minimum="0"
-                                TickFrequency="0.05"
-                                Value="{CompiledBinding OnionSkinNextOpacity.Value}" />
-                        <TextBlock Width="40"
-                                   VerticalAlignment="Center"
-                                   Text="{CompiledBinding OnionSkinNextOpacity.Value, StringFormat={}{0:F2}}" />
-                    </StackPanel>
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <TextBlock Margin="0,16,0,0"
+            <TextBlock Margin="8,16,8,4"
                        Text="{x:Static lang:Strings.FrameCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.EnableFrameCache}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <ToggleSwitch Classes="left"
-                                  IsChecked="{CompiledBinding IsFrameCacheEnabled.Value}"
-                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
+            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding FrameCacheProperties}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
 
-            <ctrls:OptionsDisplayItem Description="{x:Static lang:SettingsStrings.FrameCacheMaxSize_Description}"
-                                      Header="{x:Static lang:SettingsStrings.FrameCacheMaxSize}"
-                                      IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <TextBox MinWidth="150" Text="{CompiledBinding FrameCacheMaxSize.Value}">
-                        <TextBox.InnerRightContent>
-                            <TextBlock Margin="8,0"
-                                       VerticalAlignment="Center"
-                                       Text="MB" />
-                        </TextBox.InnerRightContent>
-                    </TextBox>
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.FrameCacheScale}" IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <ComboBox MinWidth="150" SelectedIndex="{CompiledBinding FrameCacheScale.Value}">
-                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Original}" />
-                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_FitToPreviewer}" />
-                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Half}" />
-                        <ComboBoxItem Content="{x:Static lang:SettingsStrings.FrameCacheScale_Quarter}" />
-                    </ComboBox>
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.FrameCacheColorType}" IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <ComboBox MinWidth="150" SelectedIndex="{CompiledBinding FrameCacheColorType.Value}">
-                        <ComboBoxItem Content="RGBA" />
-                        <ComboBoxItem Content="YUV" />
-                    </ComboBox>
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <TextBlock Margin="0,16,0,0"
+            <TextBlock Margin="8,16,8,4"
                        Text="{x:Static lang:SettingsStrings.NodeCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.EnableNodeCache}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <ToggleSwitch Classes="left"
-                                  IsChecked="{CompiledBinding IsNodeCacheEnabled.Value}"
-                                  Theme="{StaticResource CompactToggleSwitchStyle}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.NodeCacheMaxPixels}" IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <NumericUpDown MinWidth="150"
-                                   FormatString="F0"
-                                   Minimum="{CompiledBinding NodeCacheMinPixels.Value}"
-                                   Value="{CompiledBinding NodeCacheMaxPixels.Value}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
-
-            <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.NodeCacheMinPixels}" IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}">
-                <ctrls:OptionsDisplayItem.ActionButton>
-                    <NumericUpDown MinWidth="150"
-                                   FormatString="F0"
-                                   Maximum="{CompiledBinding NodeCacheMaxPixels.Value}"
-                                   Minimum="1"
-                                   Value="{CompiledBinding NodeCacheMinPixels.Value}" />
-                </ctrls:OptionsDisplayItem.ActionButton>
-            </ctrls:OptionsDisplayItem>
+            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding NodeCacheProperties}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
 
         </StackPanel>
     </ScrollViewer>

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -15,11 +15,15 @@
                     Margin="4,8"
                     Orientation="Vertical">
 
-            <TextBlock Margin="8,8,8,4"
-                       Text="{x:Static lang:Strings.OnionSkin}"
-                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
-
-            <ContentControl Content="{CompiledBinding OnionSkinEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+            <Grid Margin="8,8,8,4" ColumnDefinitions="*,Auto">
+                <TextBlock VerticalAlignment="Center"
+                           Text="{x:Static lang:Strings.OnionSkin}"
+                           Theme="{StaticResource BodyStrongTextBlockStyle}" />
+                <ToggleSwitch Grid.Column="1"
+                              Classes="left"
+                              IsChecked="{CompiledBinding IsOnionSkinEnabled.Value}"
+                              Theme="{StaticResource CompactToggleSwitchStyle}" />
+            </Grid>
 
             <ItemsControl IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}" ItemsSource="{CompiledBinding OnionSkinProperties}">
                 <ItemsControl.ItemTemplate>
@@ -29,11 +33,15 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,8,4"
-                       Text="{x:Static lang:Strings.FrameCache}"
-                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
-
-            <ContentControl Content="{CompiledBinding FrameCacheEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+            <Grid Margin="8,16,8,4" ColumnDefinitions="*,Auto">
+                <TextBlock VerticalAlignment="Center"
+                           Text="{x:Static lang:Strings.FrameCache}"
+                           Theme="{StaticResource BodyStrongTextBlockStyle}" />
+                <ToggleSwitch Grid.Column="1"
+                              Classes="left"
+                              IsChecked="{CompiledBinding IsFrameCacheEnabled.Value}"
+                              Theme="{StaticResource CompactToggleSwitchStyle}" />
+            </Grid>
 
             <ItemsControl IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}" ItemsSource="{CompiledBinding FrameCacheProperties}">
                 <ItemsControl.ItemTemplate>
@@ -43,11 +51,15 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,8,4"
-                       Text="{x:Static lang:SettingsStrings.NodeCache}"
-                       Theme="{StaticResource BodyStrongTextBlockStyle}" />
-
-            <ContentControl Content="{CompiledBinding NodeCacheEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+            <Grid Margin="8,16,8,4" ColumnDefinitions="*,Auto">
+                <TextBlock VerticalAlignment="Center"
+                           Text="{x:Static lang:SettingsStrings.NodeCache}"
+                           Theme="{StaticResource BodyStrongTextBlockStyle}" />
+                <ToggleSwitch Grid.Column="1"
+                              Classes="left"
+                              IsChecked="{CompiledBinding IsNodeCacheEnabled.Value}"
+                              Theme="{StaticResource CompactToggleSwitchStyle}" />
+            </Grid>
 
             <ItemsControl IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}" ItemsSource="{CompiledBinding NodeCacheProperties}">
                 <ItemsControl.ItemTemplate>

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -11,13 +11,17 @@
              x:DataType="viewModel:PreviewSettingsTabViewModel"
              mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel Orientation="Vertical">
+        <StackPanel Grid.IsSharedSizeScope="True"
+                    Margin="4,8"
+                    Orientation="Vertical">
 
-            <TextBlock Margin="8,8,0,0"
+            <TextBlock Margin="8,8,8,4"
                        Text="{x:Static lang:Strings.OnionSkin}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding OnionSkinProperties}">
+            <ContentControl Content="{CompiledBinding OnionSkinEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+
+            <ItemsControl IsEnabled="{CompiledBinding IsOnionSkinEnabled.Value}" ItemsSource="{CompiledBinding OnionSkinProperties}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />
@@ -25,11 +29,13 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,0,0"
+            <TextBlock Margin="8,16,8,4"
                        Text="{x:Static lang:Strings.FrameCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding FrameCacheProperties}">
+            <ContentControl Content="{CompiledBinding FrameCacheEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+
+            <ItemsControl IsEnabled="{CompiledBinding IsFrameCacheEnabled.Value}" ItemsSource="{CompiledBinding FrameCacheProperties}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />
@@ -37,11 +43,13 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,0,0"
+            <TextBlock Margin="8,16,8,4"
                        Text="{x:Static lang:SettingsStrings.NodeCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
-            <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{CompiledBinding NodeCacheProperties}">
+            <ContentControl Content="{CompiledBinding NodeCacheEnabledEditor, Converter={StaticResource ViewModelToViewConverter}}" />
+
+            <ItemsControl IsEnabled="{CompiledBinding IsNodeCacheEnabled.Value}" ItemsSource="{CompiledBinding NodeCacheProperties}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <ContentControl Content="{Binding Converter={StaticResource ViewModelToViewConverter}}" />

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -11,9 +11,9 @@
              x:DataType="viewModel:PreviewSettingsTabViewModel"
              mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel Margin="4,8" Orientation="Vertical">
+        <StackPanel Orientation="Vertical">
 
-            <TextBlock Margin="8,8,8,4"
+            <TextBlock Margin="8,8,0,0"
                        Text="{x:Static lang:Strings.OnionSkin}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
@@ -25,7 +25,7 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,8,4"
+            <TextBlock Margin="8,16,0,0"
                        Text="{x:Static lang:Strings.FrameCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 
@@ -37,7 +37,7 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <TextBlock Margin="8,16,8,4"
+            <TextBlock Margin="8,16,0,0"
                        Text="{x:Static lang:SettingsStrings.NodeCache}"
                        Theme="{StaticResource BodyStrongTextBlockStyle}" />
 

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Beutl.Editor.Components.PreviewSettingsTab.Views;
+
+public partial class PreviewSettingsTabView : UserControl
+{
+    public PreviewSettingsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia.Controls;
 
+using Beutl.Controls.Converters;
+
 namespace Beutl.Editor.Components.PreviewSettingsTab.Views;
 
 public partial class PreviewSettingsTabView : UserControl
@@ -7,5 +9,6 @@ public partial class PreviewSettingsTabView : UserControl
     public PreviewSettingsTabView()
     {
         InitializeComponent();
+        Resources["ViewModelToViewConverter"] = PropertyEditorContextToViewConverter.Instance;
     }
 }

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-
 using Beutl.Controls.Converters;
 
 namespace Beutl.Editor.Components.PreviewSettingsTab.Views;
@@ -8,7 +7,7 @@ public partial class PreviewSettingsTabView : UserControl
 {
     public PreviewSettingsTabView()
     {
+        Resources["ViewModelToViewConverter"] = PropertyEditorContextToViewConverter.HideMenu;
         InitializeComponent();
-        Resources["ViewModelToViewConverter"] = PropertyEditorContextToViewConverter.Instance;
     }
 }

--- a/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheHelper.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheHelper.cs
@@ -126,13 +126,23 @@ public record RenderCacheOptions(bool IsEnabled, RenderCacheRules Rules)
         EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
         return new RenderCacheOptions(
             config.IsNodeCacheEnabled,
-            new RenderCacheRules(config.NodeCacheMaxPixels, config.NodeCacheMinPixels));
+            RenderCacheRules.Create(config.NodeCacheMaxPixels, config.NodeCacheMinPixels));
     }
 }
 
 public readonly record struct RenderCacheRules(int MaxPixels, int MinPixels)
 {
     public static readonly RenderCacheRules Default = new(1000 * 1000, 1);
+
+    // The settings UI exposes Min/Max through independent number editors that cannot express the
+    // cross-field constraint, so normalize here: MinPixels >= 1 and MaxPixels >= MinPixels. Without
+    // this, MinPixels > MaxPixels would make Match() always false and silently disable all caching.
+    public static RenderCacheRules Create(int maxPixels, int minPixels)
+    {
+        int min = Math.Max(1, minPixels);
+        int max = Math.Max(min, maxPixels);
+        return new RenderCacheRules(max, min);
+    }
 
     public bool Match(PixelSize size)
     {

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1153,6 +1153,9 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="Preview" xml:space="preserve">
     <value>プレビュー</value>
   </data>
+  <data name="PreviewSettings" xml:space="preserve">
+    <value>プレビュー設定</value>
+  </data>
   <data name="Templates" xml:space="preserve">
     <value>テンプレート</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1159,6 +1159,9 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="Preview" xml:space="preserve">
     <value>Preview</value>
   </data>
+  <data name="PreviewSettings" xml:space="preserve">
+    <value>Preview Settings</value>
+  </data>
   <data name="Templates" xml:space="preserve">
     <value>Templates</value>
   </data>

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -12,6 +12,7 @@ using Beutl.Editor.Components.LibraryTab;
 using Beutl.Editor.Components.NodeGraphTab;
 using Beutl.Editor.Components.ObjectPropertyTab;
 using Beutl.Editor.Components.PathEditorTab;
+using Beutl.Editor.Components.PreviewSettingsTab;
 using Beutl.Editor.Components.SceneSettingsTab;
 using Beutl.Logging;
 using Beutl.Services.PrimitiveImpls;
@@ -38,6 +39,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         NodeGraphTabExtension.Instance,
         GraphEditorTabExtension.Instance,
         SceneSettingsTabExtension.Instance,
+        PreviewSettingsTabExtension.Instance,
         WaveReaderExtension.Instance,
         PathEditorTabExtension.Instance,
         LibraryTabExtension.Instance,

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reactive.Subjects;
 using Avalonia.Controls;
 using Beutl.Animation;
+using Beutl.Configuration;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
 using Beutl.Engine;
@@ -157,8 +158,11 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
                 SeekToAdjacentKeyFrame(forward: false);
                 break;
             case "ToggleOnionSkin" when !isFromTextBox:
-                Player.IsOnionSkinEnabled.Value = !Player.IsOnionSkinEnabled.Value;
-                break;
+                {
+                    EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
+                    editorConfig.IsOnionSkinEnabled = !editorConfig.IsOnionSkinEnabled;
+                    break;
+                }
             default:
                 if (execution.KeyEventArgs != null)
                     execution.KeyEventArgs.Handled = false;

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -7,6 +7,7 @@ using Beutl.Composition;
 using Beutl.Configuration;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.PathEditorTab.ViewModels;
+using Beutl.Editor.Components.PreviewSettingsTab.ViewModels;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Models;
 using Beutl.Graphics;
@@ -192,45 +193,34 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
 
-        IsOnionSkinEnabled = editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        IsOnionSkinEnabled.Subscribe(v => editorConfig.IsOnionSkinEnabled = v).DisposeWith(_disposables);
-
-        // NumericUpDown / Slider expose decimal? and double, so the UI-bound ReactiveProperty
-        // types are widened here and cast back to int / float at the EditorConfig boundary.
-        OnionSkinPrevCount = editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty)
-            .Select(v => (decimal)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinPrevCount.Subscribe(v => editorConfig.OnionSkinPrevCount = (int)v).DisposeWith(_disposables);
-
-        OnionSkinNextCount = editorConfig.GetObservable(EditorConfig.OnionSkinNextCountProperty)
-            .Select(v => (decimal)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinNextCount.Subscribe(v => editorConfig.OnionSkinNextCount = (int)v).DisposeWith(_disposables);
-
-        OnionSkinPrevOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinPrevOpacityProperty)
-            .Select(v => (double)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinPrevOpacity.Subscribe(v => editorConfig.OnionSkinPrevOpacity = (float)v).DisposeWith(_disposables);
-
-        OnionSkinNextOpacity = editorConfig.GetObservable(EditorConfig.OnionSkinNextOpacityProperty)
-            .Select(v => (double)v)
-            .ToReactiveProperty()
-            .DisposeWith(_disposables);
-        OnionSkinNextOpacity.Subscribe(v => editorConfig.OnionSkinNextOpacity = (float)v).DisposeWith(_disposables);
-
-        // Re-render preview whenever any onion-skin setting changes.
-        IsOnionSkinEnabled.CombineLatest(OnionSkinPrevCount, OnionSkinNextCount, OnionSkinPrevOpacity, OnionSkinNextOpacity)
+        // The onion-skin settings UI lives in PreviewSettingsTab and writes directly to EditorConfig.
+        // Observe EditorConfig here so the preview re-renders whenever any onion-skin setting changes.
+        editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
+            .CombineLatest(
+                editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty),
+                editorConfig.GetObservable(EditorConfig.OnionSkinNextCountProperty),
+                editorConfig.GetObservable(EditorConfig.OnionSkinPrevOpacityProperty),
+                editorConfig.GetObservable(EditorConfig.OnionSkinNextOpacityProperty))
             .Skip(1)
             .Subscribe(_ =>
             {
                 if (!IsPlaying.Value)
                 {
                     QueueRender();
+                }
+            })
+            .DisposeWith(_disposables);
+
+        OpenPreviewSettings = new ReactiveCommand()
+            .WithSubscribe(() =>
+            {
+                if (_editViewModel.FindToolTab<PreviewSettingsTabViewModel>() is { } tab)
+                {
+                    tab.IsSelected.Value = true;
+                }
+                else
+                {
+                    _editViewModel.OpenToolTab(new PreviewSettingsTabViewModel(_editViewModel));
                 }
             })
             .DisposeWith(_disposables);
@@ -407,15 +397,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactiveProperty<float> ToneMappingExposure { get; }
 
-    public ReactiveProperty<bool> IsOnionSkinEnabled { get; }
-
-    public ReactiveProperty<decimal> OnionSkinPrevCount { get; }
-
-    public ReactiveProperty<decimal> OnionSkinNextCount { get; }
-
-    public ReactiveProperty<double> OnionSkinPrevOpacity { get; }
-
-    public ReactiveProperty<double> OnionSkinNextOpacity { get; }
+    public ReactiveCommand OpenPreviewSettings { get; }
 
     public event EventHandler? PreviewInvalidated;
 

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -124,72 +124,10 @@
         <Player.InnerRightContent>
             <Button Padding="7,6,5,6"
                     VerticalAlignment="Top"
+                    Command="{Binding OpenPreviewSettings}"
                     Theme="{StaticResource TransparentButton}"
-                    ToolTip.Tip="{x:Static lang:Strings.OnionSkin}">
+                    ToolTip.Tip="{x:Static lang:Strings.PreviewSettings}">
                 <icons:SymbolIcon FontSize="16" Symbol="Settings" />
-                    <Button.Flyout>
-                        <Flyout Placement="Left">
-                            <StackPanel MinWidth="240" Spacing="8">
-                                <TextBlock Classes="Body"
-                                           Text="{x:Static lang:Strings.OnionSkin}" />
-                                <TextBlock Classes="Caption"
-                                           Text="{x:Static lang:Strings.OnionSkin_Description}"
-                                           TextWrapping="Wrap" />
-                                <ToggleSwitch IsChecked="{Binding IsOnionSkinEnabled.Value, Mode=TwoWay}"
-                                              OffContent="{x:Static lang:Strings.OnionSkin}"
-                                              OnContent="{x:Static lang:Strings.OnionSkin}" />
-                                <Grid ColumnDefinitions="*,Auto"
-                                      IsEnabled="{Binding IsOnionSkinEnabled.Value}"
-                                      RowDefinitions="Auto,Auto,Auto,Auto"
-                                      RowSpacing="4">
-                                    <TextBlock Grid.Row="0"
-                                               Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Static lang:Strings.OnionSkinPrevCount}" />
-                                    <NumericUpDown Grid.Row="0"
-                                                   Grid.Column="1"
-                                                   MinWidth="100"
-                                                   Increment="1"
-                                                   Maximum="10"
-                                                   Minimum="0"
-                                                   Value="{Binding OnionSkinPrevCount.Value, Mode=TwoWay}" />
-                                    <TextBlock Grid.Row="1"
-                                               Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Static lang:Strings.OnionSkinNextCount}" />
-                                    <NumericUpDown Grid.Row="1"
-                                                   Grid.Column="1"
-                                                   MinWidth="100"
-                                                   Increment="1"
-                                                   Maximum="10"
-                                                   Minimum="0"
-                                                   Value="{Binding OnionSkinNextCount.Value, Mode=TwoWay}" />
-                                    <TextBlock Grid.Row="2"
-                                               Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Static lang:Strings.OnionSkinPrevOpacity}" />
-                                    <Slider Grid.Row="2"
-                                            Grid.Column="1"
-                                            MinWidth="120"
-                                            Maximum="1"
-                                            Minimum="0"
-                                            TickFrequency="0.05"
-                                            Value="{Binding OnionSkinPrevOpacity.Value, Mode=TwoWay}" />
-                                    <TextBlock Grid.Row="3"
-                                               Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Static lang:Strings.OnionSkinNextOpacity}" />
-                                    <Slider Grid.Row="3"
-                                            Grid.Column="1"
-                                            MinWidth="120"
-                                            Maximum="1"
-                                            Minimum="0"
-                                            TickFrequency="0.05"
-                                            Value="{Binding OnionSkinNextOpacity.Value, Mode=TwoWay}" />
-                                </Grid>
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
             </Button>
         </Player.InnerRightContent>
         <Player.Content>

--- a/src/Beutl/Views/Tools/OutputPropertiesEditor.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputPropertiesEditor.axaml.cs
@@ -1,8 +1,5 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Data;
-using Avalonia.Data.Converters;
-using Beutl.Controls.PropertyEditors;
+﻿using Avalonia.Controls;
+using Beutl.Controls.Converters;
 
 namespace Beutl.Views.Tools;
 
@@ -10,46 +7,7 @@ public partial class OutputPropertiesEditor : UserControl
 {
     public OutputPropertiesEditor()
     {
-        Resources["ViewModelToViewConverter"] = ViewModelToViewConverter.Instance;
+        Resources["ViewModelToViewConverter"] = PropertyEditorContextToViewConverter.HideMenu;
         InitializeComponent();
-    }
-
-    public sealed class ViewModelToViewConverter : IValueConverter
-    {
-        public static readonly ViewModelToViewConverter Instance = new();
-
-        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        {
-            if (value is IPropertyEditorContext viewModel)
-            {
-                if (viewModel.Extension.TryCreateControl(viewModel, out var control))
-                {
-                    if (control is PropertyEditor pe)
-                    {
-                        pe.MenuContent = null;
-                    }
-
-                    return control;
-                }
-                else
-                {
-                    return new Label
-                    {
-                        Height = 24,
-                        Margin = new Thickness(0, 4),
-                        Content = viewModel.Extension.DisplayName
-                    };
-                }
-            }
-            else
-            {
-                return BindingNotification.Null;
-            }
-        }
-
-        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        {
-            return BindingNotification.Null;
-        }
     }
 }

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -386,4 +386,45 @@ public class OnionSkinTests
         Assert.That(samples[0].IsPrev, Is.True);
         Assert.That(samples[0].Time, Is.EqualTo(TimeSpan.Zero));
     }
+
+    [Test]
+    public void EditorConfig_ClampsOnionSkinCounts_ViaRangeAttribute()
+    {
+        // The settings tab uses a generic number editor, so the 0..10 bound the old flyout
+        // enforced now lives as a [Range] on the property and is coerced on assignment.
+        var config = new EditorConfig
+        {
+            OnionSkinPrevCount = 1_000_000,
+            OnionSkinNextCount = -5,
+        };
+
+        Assert.That(config.OnionSkinPrevCount, Is.EqualTo(10));
+        Assert.That(config.OnionSkinNextCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void EditorConfig_ClampsOnionSkinOpacity_ViaRangeAttribute()
+    {
+        var config = new EditorConfig
+        {
+            OnionSkinPrevOpacity = 5f,
+            OnionSkinNextOpacity = -1f,
+        };
+
+        Assert.That(config.OnionSkinPrevOpacity, Is.EqualTo(1f).Within(0.0001f));
+        Assert.That(config.OnionSkinNextOpacity, Is.EqualTo(0f).Within(0.0001f));
+    }
+
+    [Test]
+    public void EditorConfig_ClampsNodeCachePixels_ViaRangeAttribute()
+    {
+        var config = new EditorConfig
+        {
+            NodeCacheMaxPixels = 0,
+            NodeCacheMinPixels = -10,
+        };
+
+        Assert.That(config.NodeCacheMaxPixels, Is.EqualTo(1));
+        Assert.That(config.NodeCacheMinPixels, Is.EqualTo(1));
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheRulesTest.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Cache/RenderCacheRulesTest.cs
@@ -89,4 +89,33 @@ public class RenderCacheRulesTest
         // Assert
         Assert.That(result, Is.False);
     }
+
+    [Test]
+    public void Create_ShouldClampMinToOne_WhenBelowOne()
+    {
+        var rules = RenderCacheRules.Create(maxPixels: 10000, minPixels: 0);
+
+        Assert.That(rules.MinPixels, Is.EqualTo(1));
+        Assert.That(rules.MaxPixels, Is.EqualTo(10000));
+    }
+
+    [Test]
+    public void Create_ShouldRaiseMaxToMin_WhenMinExceedsMax()
+    {
+        // A mis-ordered configuration (min > max) must not produce a range that matches nothing.
+        var rules = RenderCacheRules.Create(maxPixels: 100, minPixels: 5000);
+
+        Assert.That(rules.MinPixels, Is.EqualTo(5000));
+        Assert.That(rules.MaxPixels, Is.EqualTo(5000));
+        Assert.That(rules.Match(5000), Is.True);
+    }
+
+    [Test]
+    public void Create_ShouldPreserveValidRange()
+    {
+        var rules = RenderCacheRules.Create(maxPixels: 10000, minPixels: 100);
+
+        Assert.That(rules.MinPixels, Is.EqualTo(100));
+        Assert.That(rules.MaxPixels, Is.EqualTo(10000));
+    }
 }


### PR DESCRIPTION
## Description
- Replace PlayerView's onion-skin settings flyout with a dockable **Preview Settings** tool tab, and add frame-cache and node (render) cache settings to the same tab so they are reachable while editing (previously only under Settings > Editor).
- Build the tab's rows through the standard property-editor mechanism (`IPropertyEditorFactory` + `CorePropertyAdapter`), like `ElementPropertyTab`, instead of hand-written controls. `EditorConfig` stays the single source of truth, so values stay in sync with Settings > Editor and the existing re-render / cache machinery keeps reacting.
- The gear button in the player toolbar now opens/focuses the tab instead of a flyout; the `ToggleOnionSkin` keybinding toggles `EditorConfig` directly.
- Also fixes the `beutl-tooltab-extension` skill, which documented a stale `ToolTabExtension` API (non-existent `Placement` / `DisplayMode` / `GetIcon`) that no longer compiles.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

Also touches `Beutl.Configuration`: additive `DisplayAttribute` metadata on the `EditorConfig` onion-skin / cache properties (so the property editors resolve localized labels).

## Breaking changes
None. The onion-skin `ReactiveProperty` members removed from `PlayerViewModel` were internal app state (`src/Beutl`), not a published API consumed by plugins, and the new `EditorConfig` `DisplayAttribute`s are additive.

## Test plan
- No automated tests added: the new `PreviewSettingsTabViewModel` is reactive plumbing over `EditorConfig` (mirrors the untested `EditorSettingsPageViewModel` / `SceneSettingsTabViewModel`), and `Beutl.Editor.Components` is not referenced by any test project.
- Manual: open a scene → click the gear in the player → the **Preview Settings** tab opens/focuses; toggling onion-skin or changing values re-renders the preview; values stay in sync with Settings > Editor; the `ToggleOnionSkin` keybinding still toggles and the tab reflects it; enabling frame/node cache is reflected by the renderer (`EditViewModel.OnEditorConfigPropertyChanged`).
- `dotnet build Beutl.slnx` passes; `dotnet format` applied.

## Follow-ups
- Add test coverage for the Preview Settings / cache-settings plumbing (e.g. add a test project reference for `Beutl.Editor.Components` or extract a testable helper).

## Fixed issues / References
None.