### PR TITLE
refactor(engine): consolidate Delay parameter constants into DelayParameters

### DIFF
--- a/src/Beutl.Engine/Audio/Effects/DelayEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/DelayEffect.cs
@@ -3,38 +3,37 @@ using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 using Beutl.Language;
+using static Beutl.Audio.Effects.DelayParameters;
 
 namespace Beutl.Audio.Effects;
 
 [Display(Name = nameof(AudioStrings.DelayEffect), ResourceType = typeof(AudioStrings))]
 public sealed partial class DelayEffect : AudioEffect
 {
-    private const float MaxDelayTime = 5000f; // 5 seconds in milliseconds
-
     public DelayEffect()
     {
         ScanProperties<DelayEffect>();
     }
 
-    [Range(0, MaxDelayTime)]
+    [Range(DelayTimeMin, DelayTimeMax)]
     [Display(Name = nameof(AudioStrings.DelayEffect_DelayTime), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> DelayTime { get; } = Property.CreateAnimatable(200f);
+    public IProperty<float> DelayTime { get; } = Property.CreateAnimatable(DelayTimeDefault);
 
-    [Range(0, 100)]
+    [Range(FeedbackMin, FeedbackMax)]
     [Display(Name = nameof(AudioStrings.DelayEffect_Feedback), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> Feedback { get; } = Property.CreateAnimatable(50f);
+    public IProperty<float> Feedback { get; } = Property.CreateAnimatable(FeedbackDefault);
 
-    [Range(0, 100)]
+    [Range(DryMixMin, DryMixMax)]
     [Display(Name = nameof(AudioStrings.DelayEffect_DryMix), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> DryMix { get; } = Property.CreateAnimatable(60f);
+    public IProperty<float> DryMix { get; } = Property.CreateAnimatable(DryMixDefault);
 
-    [Range(0, 100)]
+    [Range(WetMixMin, WetMixMax)]
     [Display(Name = nameof(AudioStrings.DelayEffect_WetMix), ResourceType = typeof(AudioStrings))]
     [SuppressResourceClassGeneration]
-    public IProperty<float> WetMix { get; } = Property.CreateAnimatable(40f);
+    public IProperty<float> WetMix { get; } = Property.CreateAnimatable(WetMixDefault);
 
     public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
     {

--- a/src/Beutl.Engine/Audio/Effects/DelayParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/DelayParameters.cs
@@ -1,0 +1,39 @@
+﻿namespace Beutl.Audio.Effects;
+
+/// <summary>
+/// Single source of truth for the <see cref="DelayEffect"/> / <see cref="Beutl.Audio.Graph.Nodes.DelayNode"/>
+/// parameter ranges and defaults.
+/// </summary>
+/// <remarks>
+/// The same constants drive the <c>[Range]</c> attributes on <see cref="DelayEffect"/> and the per-sample
+/// processing in <c>DelayNode</c> (default fallbacks and the delay-line buffer sizing). Keeping them here
+/// prevents the two declarations from drifting apart. Deliberately avoids <c>[ModuleInitializer]</c> so the
+/// values stay plain compile-time constants usable inside attribute arguments.
+///
+/// The boundary constants intentionally keep their original literal types so the
+/// <see cref="System.ComponentModel.DataAnnotations.RangeAttribute"/> overload resolution — and therefore the
+/// resulting <c>OperandType</c> — is unchanged: the delay-time bounds were authored as <c>float</c>
+/// (double operand) and the percentage bounds as <c>int</c> (int operand).
+/// </remarks>
+internal static class DelayParameters
+{
+    // Delay time, in milliseconds. (double-operand range)
+    public const float DelayTimeMin = 0f;
+    public const float DelayTimeDefault = 200f;
+    public const float DelayTimeMax = 5000f; // 5 seconds in milliseconds
+
+    // Feedback amount, as a percentage (0-100). (int-operand range)
+    public const int FeedbackMin = 0;
+    public const float FeedbackDefault = 50f;
+    public const int FeedbackMax = 100;
+
+    // Dry-signal mix, as a percentage (0-100). (int-operand range)
+    public const int DryMixMin = 0;
+    public const float DryMixDefault = 60f;
+    public const int DryMixMax = 100;
+
+    // Wet-signal mix, as a percentage (0-100). (int-operand range)
+    public const int WetMixMin = 0;
+    public const float WetMixDefault = 40f;
+    public const int WetMixMax = 100;
+}

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -1,13 +1,12 @@
 ﻿using Beutl.Audio.Effects;
 using Beutl.Engine;
 using Beutl.Media;
+using static Beutl.Audio.Effects.DelayParameters;
 
 namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class DelayNode : AudioNode
 {
-    private const float MaxDelayTime = 5000f; // 5 seconds in milliseconds
-
     private CircularBuffer<float>[]? _delayLines;
     private int _maxDelaySamples;
     private int _lastSampleRate;
@@ -66,7 +65,7 @@ public sealed class DelayNode : AudioNode
             }
         }
 
-        _maxDelaySamples = (int)(MaxDelayTime / 1000f * sampleRate);
+        _maxDelaySamples = (int)(DelayTimeMax / 1000f * sampleRate);
         _delayLines = new CircularBuffer<float>[channelCount];
         for (int i = 0; i < _delayLines.Length; i++)
         {
@@ -76,10 +75,10 @@ public sealed class DelayNode : AudioNode
 
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
-        float delayTime = DelayTime?.CurrentValue ?? 200f;
-        float feedback = (Feedback?.CurrentValue ?? 50f) / 100f;
-        float dryMix = (DryMix?.CurrentValue ?? 60f) / 100f;
-        float wetMix = (WetMix?.CurrentValue ?? 40f) / 100f;
+        float delayTime = DelayTime?.CurrentValue ?? DelayTimeDefault;
+        float feedback = (Feedback?.CurrentValue ?? FeedbackDefault) / 100f;
+        float dryMix = (DryMix?.CurrentValue ?? DryMixDefault) / 100f;
+        float wetMix = (WetMix?.CurrentValue ?? WetMixDefault) / 100f;
 
         int delaySamples = (int)(delayTime / 1000f * context.SampleRate);
         delaySamples = System.Math.Clamp(delaySamples, 0, _maxDelaySamples - 1);

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayParametersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayParametersTests.cs
@@ -1,0 +1,49 @@
+﻿using Beutl.Audio.Effects;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class DelayParametersTests
+{
+    // (name, min, default, max) for every DelayEffect/DelayNode parameter.
+    private static readonly object[] s_parameterCases =
+    [
+        new object[] { "DelayTime", (float)DelayParameters.DelayTimeMin, DelayParameters.DelayTimeDefault, (float)DelayParameters.DelayTimeMax },
+        new object[] { "Feedback", (float)DelayParameters.FeedbackMin, DelayParameters.FeedbackDefault, (float)DelayParameters.FeedbackMax },
+        new object[] { "DryMix", (float)DelayParameters.DryMixMin, DelayParameters.DryMixDefault, (float)DelayParameters.DryMixMax },
+        new object[] { "WetMix", (float)DelayParameters.WetMixMin, DelayParameters.WetMixDefault, (float)DelayParameters.WetMixMax },
+    ];
+
+    [TestCaseSource(nameof(s_parameterCases))]
+    public void Default_is_within_min_and_max(string name, float min, float @default, float max)
+    {
+        Assert.That(min, Is.LessThanOrEqualTo(@default), $"{name}: Min must be <= Default");
+        Assert.That(@default, Is.LessThanOrEqualTo(max), $"{name}: Default must be <= Max");
+        Assert.That(min, Is.LessThan(max), $"{name}: Min must be < Max");
+    }
+
+    // Characterization: lock the consolidated constants to the literals that DelayEffect/DelayNode
+    // previously declared independently, so the single-source refactor stays behavior-preserving.
+    [Test]
+    public void Constants_match_the_original_literals()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(DelayParameters.DelayTimeMin, Is.EqualTo(0f));
+            Assert.That(DelayParameters.DelayTimeDefault, Is.EqualTo(200f));
+            Assert.That(DelayParameters.DelayTimeMax, Is.EqualTo(5000f));
+
+            Assert.That(DelayParameters.FeedbackMin, Is.EqualTo(0));
+            Assert.That(DelayParameters.FeedbackDefault, Is.EqualTo(50f));
+            Assert.That(DelayParameters.FeedbackMax, Is.EqualTo(100));
+
+            Assert.That(DelayParameters.DryMixMin, Is.EqualTo(0));
+            Assert.That(DelayParameters.DryMixDefault, Is.EqualTo(60f));
+            Assert.That(DelayParameters.DryMixMax, Is.EqualTo(100));
+
+            Assert.That(DelayParameters.WetMixMin, Is.EqualTo(0));
+            Assert.That(DelayParameters.WetMixDefault, Is.EqualTo(40f));
+            Assert.That(DelayParameters.WetMixMax, Is.EqualTo(100));
+        });
+    }
+}


### PR DESCRIPTION
## Description
`DelayEffect.cs` and `DelayNode.cs` each declared their own `private const float MaxDelayTime = 5000f`, and the per-parameter defaults (200 / 50 / 60 / 40) and percentage ranges were duplicated between the effect's property declarations and the node's static fallbacks. The two `MaxDelayTime` copies could drift apart silently.

- Add internal static `DelayParameters` as the single source of truth for the Min/Default/Max of every Delay parameter.
- Reference it from `DelayEffect` (`[Range]` + `Property.CreateAnimatable`) and `DelayNode` (buffer sizing + static fallbacks) via `using static`.
- No `[ModuleInitializer]` — values stay plain compile-time constants usable inside `[Range]` attribute arguments.
- Boundary constants keep their original literal types (delay-time bounds `float`, percentage bounds `int`) so `RangeAttribute` overload resolution — and therefore the `OperandType` consumed by the property validators — is unchanged.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Pure internal refactor — the consolidated constants are bit-for-bit identical to the previous literals, and `RangeAttribute` operand types are preserved, so behavior is unchanged. `DelayParameters` is `internal`; no public API change.

## Test plan
- Added `tests/Beutl.UnitTests/Engine/Audio/DelayParametersTests.cs`:
  - `[TestCaseSource]` invariant: `Min <= Default <= Max` (and `Min < Max`) for every parameter.
  - Characterization: each constant equals the original literal (`200/50/60/40`, `5000`, `0/100`) so the single-source refactor cannot silently change values.
- Verification (local, `net10.0`):
  - New tests: **5 passed**.
  - Regression `FullyQualifiedName~UnitTests.Engine.Audio`: **27 passed**.
  - `dotnet format --verify-no-changes` on the touched files: clean.

## Fixed issues / References
- Project board: b-editor/projects/9 ("DelayEffect/DelayNode の定数を DelayParameters に集約（単一ソース化）")