### PR TITLE
refactor(engine): unify DelayNode/GainNode animation guard to Animation != null

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -41,11 +41,13 @@ public sealed class DelayNode : AudioNode
             _lastTimeRangeStart = context.TimeRange.Start;
         }
 
-        // If no animations, use static processing
-        bool hasAnimation = DelayTime?.IsAnimatable == true ||
-                            Feedback?.IsAnimatable == true ||
-                            DryMix?.IsAnimatable == true ||
-                            WetMix?.IsAnimatable == true;
+        // If no animations are assigned, use static processing. Guard on Animation (an actual
+        // keyframe animation) rather than IsAnimatable (a capability flag that is always true for
+        // an animatable property), so an unkeyed property skips the per-sample animated path.
+        bool hasAnimation = DelayTime.Animation != null ||
+                            Feedback.Animation != null ||
+                            DryMix.Animation != null ||
+                            WetMix.Animation != null;
 
         if (!hasAnimation)
         {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -44,10 +44,12 @@ public sealed class DelayNode : AudioNode
         // If no animations are assigned, use static processing. Guard on Animation (an actual
         // keyframe animation) rather than IsAnimatable (a capability flag that is always true for
         // an animatable property), so an unkeyed property skips the per-sample animated path.
-        bool hasAnimation = DelayTime.Animation != null ||
-                            Feedback.Animation != null ||
-                            DryMix.Animation != null ||
-                            WetMix.Animation != null;
+        // The null-conditional keeps a misconfigured (null) property degrading to static defaults
+        // (see ProcessStatic) instead of throwing, matching GainNode.
+        bool hasAnimation = DelayTime?.Animation != null ||
+                            Feedback?.Animation != null ||
+                            DryMix?.Animation != null ||
+                            WetMix?.Animation != null;
 
         if (!hasAnimation)
         {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -13,8 +13,10 @@ public sealed class GainNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
-        // If no animation, use static gain
-        if (Gain?.IsAnimatable != true)
+        // If no animation is assigned, use static gain. Guard on Animation (an actual keyframe
+        // animation) rather than IsAnimatable (a capability flag that is always true for an
+        // animatable property), so an unkeyed Gain skips the per-sample animated path.
+        if (Gain?.Animation is null)
         {
             return ProcessStaticGain(input);
         }

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
@@ -1,0 +1,81 @@
+﻿using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class DelayNodeTests
+{
+    private const int SampleRate = 100;
+
+    // Deterministic stereo source: a ramp keyed off the requested global sample index.
+    private sealed class RampInputNode(int sampleRate) : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            int count = context.GetSampleCount();
+            var buffer = new AudioBuffer(sampleRate, 2, count);
+            Span<float> left = buffer.GetChannelData(0);
+            Span<float> right = buffer.GetChannelData(1);
+            int startIndex = (int)(context.TimeRange.Start.TotalSeconds * sampleRate);
+            for (int i = 0; i < count; i++)
+            {
+                float v = (startIndex + i) * 0.01f;
+                left[i] = v;
+                right[i] = -v;
+            }
+
+            return buffer;
+        }
+    }
+
+    private static AudioProcessContext CreateContext() =>
+        new(new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), SampleRate, new AnimationSampler(), null);
+
+    private static float[][] Render(Func<float, IProperty<float>> makeProperty)
+    {
+        using var node = new DelayNode
+        {
+            DelayTime = makeProperty(200f),
+            Feedback = makeProperty(50f),
+            DryMix = makeProperty(60f),
+            WetMix = makeProperty(40f),
+        };
+        node.AddInput(new RampInputNode(SampleRate));
+
+        using AudioBuffer buffer = node.Process(CreateContext());
+        return
+        [
+            buffer.GetChannelData(0).ToArray(),
+            buffer.GetChannelData(1).ToArray(),
+        ];
+    }
+
+    private static IProperty<float> Animatable(float value)
+    {
+        var property = Property.CreateAnimatable(value);
+        property.SetAttributes("P", []);
+        return property;
+    }
+
+    // An animatable property with NO animation assigned must behave exactly like a genuinely
+    // non-animatable (static) property: both feed CurrentValue every sample. This is the core
+    // guarantee of routing on Animation != null instead of the IsAnimatable capability flag.
+    // The CircularBuffer state is stateful across renders, so each render uses a fresh node.
+    [Test]
+    public void Process_AnimatableParamsWithoutAnimation_MatchesNonAnimatableStatic()
+    {
+        float[][] animatable = Render(Animatable);
+        float[][] simple = Render(v => Property.Create(v));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(animatable[0], Is.EqualTo(simple[0]).AsCollection);
+            Assert.That(animatable[1], Is.EqualTo(simple[1]).AsCollection);
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
@@ -1,0 +1,99 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class GainNodeTests
+{
+    private const int SampleRate = 100;
+
+    private sealed class ConstInputNode(int sampleRate, int channels, int count, float value) : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            var buffer = new AudioBuffer(sampleRate, channels, count);
+            for (int ch = 0; ch < channels; ch++)
+            {
+                buffer.GetChannelData(ch).Fill(value);
+            }
+
+            return buffer;
+        }
+    }
+
+    private static IProperty<float> AnimatedGain(float fromPercent, float toPercent, double durationSeconds)
+    {
+        var property = Property.CreateAnimatable(fromPercent);
+        property.SetAttributes("Gain", []);
+
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = fromPercent,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromSeconds(durationSeconds),
+            Value = toPercent,
+            Easing = new LinearEasing()
+        });
+        property.Animation = animation;
+        return property;
+    }
+
+    private static AudioProcessContext CreateContext() =>
+        new(new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), SampleRate, new AnimationSampler(), null);
+
+    // Gain is animatable (capability) but has no animation assigned. The node must use the static
+    // value (CurrentValue), not the per-sample animated path. Output values are identical either way,
+    // so this also characterizes the behavior-preserving IsAnimatable -> Animation != null change.
+    [Test]
+    public void Process_AnimatableGainWithoutAnimation_AppliesCurrentValue()
+    {
+        var gain = Property.CreateAnimatable(50f); // 50% -> factor 0.5
+        gain.SetAttributes("Gain", []);
+        using var node = new GainNode { Gain = gain };
+        node.AddInput(new ConstInputNode(SampleRate, 2, SampleRate, 1.0f));
+
+        using AudioBuffer result = node.Process(CreateContext());
+
+        Assert.That(result.SampleCount, Is.EqualTo(SampleRate));
+        Assert.That(result.ChannelCount, Is.EqualTo(2));
+        for (int ch = 0; ch < result.ChannelCount; ch++)
+        {
+            Span<float> data = result.GetChannelData(ch);
+            for (int i = 0; i < data.Length; i++)
+            {
+                Assert.That(data[i], Is.EqualTo(0.5f).Within(1e-6f),
+                    $"channel {ch} sample {i}");
+            }
+        }
+    }
+
+    // A real keyframe animation must still drive the per-sample animated path. Output ramps with the
+    // animated gain, so the last sample is strictly louder than the first.
+    [Test]
+    public void Process_GainWithAnimation_AppliesAnimatedValues()
+    {
+        using var node = new GainNode { Gain = AnimatedGain(0f, 100f, 1.0) };
+        node.AddInput(new ConstInputNode(SampleRate, 1, SampleRate, 1.0f));
+
+        using AudioBuffer result = node.Process(CreateContext());
+
+        Span<float> data = result.GetChannelData(0);
+        Assert.That(data[0], Is.EqualTo(0f).Within(1e-3f));
+        Assert.That(data[^1], Is.GreaterThan(data[0]));
+        foreach (float sample in data)
+        {
+            Assert.That(float.IsFinite(sample), Is.True);
+        }
+    }
+}


### PR DESCRIPTION
## Description
`DelayNode` and `GainNode` gated their per-sample *animated* path on `IProperty.IsAnimatable`, which is a **capability flag** (always `true` for an animatable property), not "an animation is assigned".

- Effect of the bug: an unkeyed (no animation assigned) property always took the animated path and ran `AnimationSampler.SampleBuffer` per sample, which merely fills `CurrentValue` when no `KeyFrameAnimation` is present — wasted per-sample work plus an extra output buffer allocation.
- Fix: guard on `Animation != null` (the actual assignment), matching the idiom already used in `EngineObject` (`{ IsAnimatable: true, Animation: not null }`) and `CompressorNode`.
- This is **behavior-preserving**: with no animation, the animated path's `SampleBuffer` falls back to `output.Fill(CurrentValue)` (`AnimationSampler.cs`), identical to the static path. Only the redundant per-sample sampling and allocation are removed.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. No public API change; output is unchanged.

## Test plan
Baseline-first (characterization) verification:
- New `tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs`
  - `Process_AnimatableGainWithoutAnimation_AppliesCurrentValue` — animatable-but-unkeyed `Gain` applies the static `CurrentValue`.
  - `Process_GainWithAnimation_AppliesAnimatedValues` — a real keyframe animation still drives the per-sample path.
- New `tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs`
  - `Process_AnimatableParamsWithoutAnimation_MatchesNonAnimatableStatic` — animatable-but-unkeyed params produce byte-identical output to a genuinely non-animatable (`SimpleProperty`) static configuration. (Fresh node per render — `CircularBuffer` is stateful.)

Results:
- Baseline against **unmodified** production code: `exit 0`, 3 passed.
- After the production change (new tests + `SpeedNodeTests` regression): `exit 0`, 5 passed.
- `dotnet format --verify-no-changes` on the 4 changed files: `exit 0`.

## Fixed issues / References
- Project board: b-editor/projects/9 ("DelayNode/GainNode のアニメーション判定を Animation != null に統一")