### PR TITLE
docs: shorten recently added code comments

### DIFF
--- a/src/Beutl.Editor.Components/BeutlDataFormats.cs
+++ b/src/Beutl.Editor.Components/BeutlDataFormats.cs
@@ -6,8 +6,8 @@ namespace Beutl.Editor.Components;
 
 public static class BeutlDataFormats
 {
-    // Format strings come from BeutlClipboardFormats so the Avalonia-free
-    // layer and this Avalonia-typed layer can never drift apart.
+    // Reuse BeutlClipboardFormats' strings so the Avalonia-free and Avalonia-typed
+    // layers can't drift apart.
     public static readonly DataFormat<string> Element = DataFormat.CreateStringApplicationFormat(BeutlClipboardFormats.Element);
     public static readonly DataFormat<string> Elements = DataFormat.CreateStringApplicationFormat(BeutlClipboardFormats.Elements);
     public static readonly DataFormat<string> KeyFrame = DataFormat.CreateStringApplicationFormat(nameof(Animation.KeyFrame));

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorViewModel.cs
@@ -420,9 +420,8 @@ public abstract class GraphEditorViewModel : IDisposable
                 NotificationService.ShowWarning(Strings.GraphEditor, MessageStrings.KeyframeExistsAtPastePosition);
                 break;
             case KeyFramePasteOutcome.GenericTypeMismatch when result.EasingForFallback is { } easing:
-                // Type does not match — fall back to creating a new keyframe at
-                // pointerPosition using the View's typed insert path, applying
-                // only the easing the clipboard carried.
+                // Type mismatch: insert a fresh keyframe via the View's typed path,
+                // carrying over only the clipboard's easing.
                 InsertKeyFrame(easing, pointerPosition);
                 NotificationService.ShowWarning(Strings.GraphEditor, MessageStrings.KeyframePropertyTypeMismatch_EasingApplied);
                 break;

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -23,16 +23,12 @@ public sealed class PreviewSettingsTabViewModel : IToolContext, IPropertyEditorC
         var factory = editorContext.GetRequiredService<IPropertyEditorFactory>();
         EditorConfig config = GlobalConfiguration.Instance.EditorConfig;
 
-        // These editors edit the global EditorConfig, not the scene, so route their Commit()
-        // through a dedicated HistoryManager rooted at EditorConfig instead of the editor's
-        // scene history (same approach as the Output / encoder-settings property editors).
+        // Editors target global EditorConfig, not the scene, so commit into a dedicated
+        // EditorConfig-rooted HistoryManager (same as the Output / encoder-settings editors).
         _history = new HistoryManager(config, new OperationSequenceGenerator());
 
-        // Each group's "enabled" flag is shown as a ToggleSwitch next to the section header
-        // (bound two-way below), and also drives the IsEnabled of the dependent rows.
-        // The dependent rows themselves go through the property-editor mechanism so they reuse
-        // the standard editor for their CoreProperty type (number / enum). EditorConfig stays
-        // the single source of truth, which the rest of the app already reacts to.
+        // Each group's "enabled" ToggleSwitch (bound two-way below) gates its dependent rows,
+        // which reuse the standard property editors. EditorConfig stays the single source of truth.
         IsOnionSkinEnabled = BindToggle(config, EditorConfig.IsOnionSkinEnabledProperty, v => config.IsOnionSkinEnabled = v);
         AddEditors(factory, OnionSkinProperties,
             new CorePropertyAdapter<int>(EditorConfig.OnionSkinPrevCountProperty, config),
@@ -123,8 +119,7 @@ public sealed class PreviewSettingsTabViewModel : IToolContext, IPropertyEditorC
 
     public object? GetService(Type serviceType)
     {
-        // Isolate the settings history: editors Commit() into our EditorConfig-rooted
-        // HistoryManager, never the scene's editor history. Everything else falls through.
+        // Route editor Commit() into our EditorConfig-rooted history, not the scene's.
         if (serviceType == typeof(HistoryManager))
         {
             return _history;

--- a/src/Beutl.Editor.Components/Services/AvaloniaClipboardGateway.cs
+++ b/src/Beutl.Editor.Components/Services/AvaloniaClipboardGateway.cs
@@ -7,11 +7,9 @@ using Beutl.Editor.Services;
 namespace Beutl.Editor.Components.Services;
 
 /// <summary>
-/// Avalonia-backed implementation of <see cref="IClipboardGateway"/>. Lives in
-/// <c>Beutl.Editor.Components</c> so <c>Beutl.Editor</c> can stay Avalonia-free.
-/// Maps Avalonia clipboard formats (<see cref="DataFormat.File"/>, <see cref="DataFormat.Bitmap"/>,
-/// and the Beutl element JSON formats) onto the plain string identifiers in
-/// <see cref="BeutlClipboardFormats"/>.
+/// Avalonia-backed <see cref="IClipboardGateway"/>, kept here so <c>Beutl.Editor</c>
+/// stays Avalonia-free. Maps Avalonia clipboard formats onto the plain string
+/// identifiers in <see cref="BeutlClipboardFormats"/>.
 /// </summary>
 public sealed class AvaloniaClipboardGateway : IClipboardGateway
 {
@@ -88,8 +86,7 @@ public sealed class AvaloniaClipboardGateway : IClipboardGateway
 
             if (entry.Format == BeutlClipboardFormats.Text)
             {
-                // Route plain-text payloads through the platform's native
-                // text slot so other apps see them on a normal "Paste".
+                // Use the native text slot so other apps see it on a normal "Paste".
                 data.Add(DataTransferItem.CreateText(entry.Text));
                 continue;
             }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/LayerHeaderViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/LayerHeaderViewModel.cs
@@ -144,13 +144,10 @@ public sealed class LayerHeaderViewModel : IDisposable
 
     public void UpdateZIndex(int layerNum)
     {
-        // When a TimelineLayer backs this header, LayerMoveService writes its
-        // recorded ZIndex inside the committed MoveLayer transaction and the
-        // reactive Number binding already reflects layerNum. Writing the model
-        // again here would (a) re-touch a recorded property outside that
-        // transaction — leaking it into the next history entry — and (b)
-        // double-apply the shift for shifted headers. Only a model-less header
-        // needs its Number pushed manually.
+        // For model-backed headers, LayerMoveService already wrote ZIndex (in its
+        // committed transaction) and Number reflects it; re-touching the model here
+        // would leak into the next history entry and double-apply the shift. Only a
+        // model-less header needs its Number pushed manually.
         if (_model.Value is null)
         {
             Number.Value = layerNum;
@@ -221,9 +218,8 @@ public sealed class LayerHeaderViewModel : IDisposable
         Timeline.EditorContext.GetRequiredService<ILayerAttributeService>()
             .SetColor(Timeline.Scene, Number.Value, color.ToBtlColor(), Name.Value);
 
-        // Sync the local TimelineLayer reference back from the scene so future
-        // bindings (Name, Color observables) track the same model the service
-        // either created or updated.
+        // Re-sync the local TimelineLayer from the scene so Name/Color bindings track
+        // the model the service just created or updated.
         _model.Value = Timeline.Scene.Layers.FirstOrDefault(l => l.ZIndex == Number.Value);
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -213,8 +213,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
 
-        // ElementNudgeService is the owner of the Undo/Redo flush hook; it
-        // is wired to HistoryManager.BeforeMutation by the editor context.
+        // The Undo/Redo flush hook now lives in ElementNudgeService, wired to
+        // HistoryManager.BeforeMutation by the editor context.
 
         _logger.LogInformation("TimelineTabViewModel initialized successfully.");
     }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -741,11 +741,8 @@ public sealed partial class ElementView : UserControl
                     NotificationService.ShowWarning(Strings.Duplicate_Failed, Strings.Duplicate_FallbackToMove);
                     break;
                 case ElementMoveOutcome.None:
-                    // Sub-frame drag round to zero delta: the model is
-                    // unchanged but Margin/BorderMargin were already
-                    // mutated during OnPointerMoved. Snap visuals back so
-                    // the clips do not stay visibly offset until a later
-                    // model/scale change rebinds them.
+                    // Zero net delta (sub-frame drag), but OnPointerMoved already shifted
+                    // Margin/BorderMargin; snap visuals back so clips aren't left offset.
                     ForceRestoreVisualToModel(animations.Select(a => a.ViewModel));
                     return;
             }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml.cs
@@ -89,10 +89,8 @@ public sealed partial class LayerHeader : UserControl
 
     private void Border_PointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        // Border_PointerPressed sets _pressed = true only on a left-button drag start.
-        // Right-click and single-click left-release reach this handler with
-        // _pressed = false and _newLayer = 0 (its initial value), so guarding here
-        // prevents an accidental MoveLayer to ZIndex 0.
+        // _pressed is only set on a left-button drag start; guard against right-click /
+        // single-click reaching here and triggering an accidental MoveLayer to ZIndex 0.
         if (!_pressed) return;
 
         _pressed = false;
@@ -109,9 +107,8 @@ public sealed partial class LayerHeader : UserControl
             return;
         }
 
-        // Snapshot the affected LayerHeaderViewModels (between old and new layer
-        // inclusive of newLayer) against the pre-move state, so the View can update
-        // their Number.Value after the service has rewritten Element.ZIndex.
+        // Snapshot the headers shifted by the move (against pre-move state) so we can
+        // update their Number.Value after the service rewrites Element.ZIndex.
         List<LayerHeaderViewModel> shiftedHeaders = [];
         foreach (LayerHeaderViewModel item in vm.Timeline.LayerHeaders.GetMarshal().Value)
         {
@@ -131,9 +128,8 @@ public sealed partial class LayerHeader : UserControl
             newLayerNum,
             directElements.Select(x => x.Model).ToArray());
 
-        // The service already wrote Element.ZIndex on every model in the plan
-        // and committed history. Now update VM-side state (Number.Value, layer
-        // header collection order) and animate the affected element views.
+        // Service already wrote Element.ZIndex and committed history; now sync VM-side
+        // state (Number.Value, header order) and animate the affected element views.
         int headerShift = oldLayerNum < newLayerNum ? -1 : 1;
         vm.UpdateZIndex(newLayerNum);
         foreach (LayerHeaderViewModel item in CollectionsMarshal.AsSpan(shiftedHeaders))
@@ -143,8 +139,7 @@ public sealed partial class LayerHeader : UserControl
 
         vm.Timeline.LayerHeaders.Move(oldLayerNum, newLayerNum);
 
-        // affectModel: false — Element.ZIndex was already written by the
-        // service; the animation hook just needs to drive the visual.
+        // affectModel: false — ZIndex already written by the service; just drive the visual.
         foreach (ElementViewModel item in directElements)
         {
             item.AnimationRequest(newLayerNum, affectModel: false);

--- a/src/Beutl.Editor/EditorConstants.cs
+++ b/src/Beutl.Editor/EditorConstants.cs
@@ -1,10 +1,8 @@
 ﻿namespace Beutl.Editor;
 
 /// <summary>
-/// File-extension and folder-name constants used across the editor
-/// projects (<c>Beutl.Editor</c>, <c>Beutl.Editor.Components</c>, and the
-/// app). Single source of truth — call sites in every layer reach for
-/// this type, no duplicated literals.
+/// File-extension and folder-name constants shared across the editor projects.
+/// Single source of truth so no layer duplicates the literals.
 /// </summary>
 public static class EditorConstants
 {

--- a/src/Beutl.Editor/Services/BeutlClipboardFormats.cs
+++ b/src/Beutl.Editor/Services/BeutlClipboardFormats.cs
@@ -1,10 +1,10 @@
 ﻿namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Format identifiers used on the platform clipboard for Beutl-specific
-/// payloads. Mirrored from <c>Beutl.Editor.Components.BeutlDataFormats</c>
-/// without the Avalonia <c>DataFormat&lt;T&gt;</c> wrapper, so services in
-/// <c>Beutl.Editor</c> can dispatch on them without taking a UI dependency.
+/// Clipboard format identifiers for Beutl payloads. Mirrors
+/// <c>Beutl.Editor.Components.BeutlDataFormats</c> without the Avalonia
+/// <c>DataFormat&lt;T&gt;</c> wrapper, so <c>Beutl.Editor</c> services stay
+/// UI-free.
 /// </summary>
 public static class BeutlClipboardFormats
 {
@@ -17,10 +17,8 @@ public static class BeutlClipboardFormats
     public const string Bitmap = "Bitmap";
 
     /// <summary>
-    /// MIME identifier for a plain-text payload. Mapped to the platform's
-    /// native text clipboard slot (<c>DataTransferItem.CreateText</c> on
-    /// Avalonia) so a Copy that exposes a JSON payload also leaves a
-    /// human-pasteable string for other applications.
+    /// Plain-text payload, mapped to the platform's native text slot so a Copy
+    /// that exposes JSON also leaves a human-pasteable string for other apps.
     /// </summary>
     public const string Text = "text/plain";
 }

--- a/src/Beutl.Editor/Services/ClipboardJson.cs
+++ b/src/Beutl.Editor/Services/ClipboardJson.cs
@@ -4,11 +4,9 @@ using System.Text.Json.Nodes;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Parsing helpers for clipboard payloads. <see cref="JsonNode.Parse(string, System.Text.Json.Nodes.JsonNodeOptions?, JsonDocumentOptions)"/>
-/// throws <see cref="JsonException"/> on malformed input, but clipboard text is
-/// untrusted, so this returns <see langword="null"/> on failure to let callers
-/// map it onto their own "invalid JSON" outcome instead of propagating the
-/// exception out of a paste command.
+/// Parsing helpers for clipboard payloads. Returns <see langword="null"/> on
+/// malformed input (clipboard text is untrusted) so callers map it to their own
+/// "invalid JSON" outcome instead of an exception escaping the paste command.
 /// </summary>
 internal static class ClipboardJson
 {

--- a/src/Beutl.Editor/Services/ElementClipboardService.cs
+++ b/src/Beutl.Editor/Services/ElementClipboardService.cs
@@ -22,10 +22,9 @@ public sealed class ElementClipboardService : IElementClipboardService
     private readonly IElementAdder? _elementAdder;
     private readonly Func<Color> _imageAccentColorFactory;
 
-    /// <param name="imageAccentColorFactory">Supplies the accent color for an
-    /// element created from a clipboard bitmap paste. The production wiring
-    /// passes <c>ColorGenerator.GenerateColor</c> so the deterministic color
-    /// matches the rest of the application; tests can pass a fixed color.</param>
+    /// <param name="imageAccentColorFactory">Accent color for an element created
+    /// from a bitmap paste. Production passes <c>ColorGenerator.GenerateColor</c>;
+    /// tests can pass a fixed color.</param>
     public ElementClipboardService(
         HistoryManager historyManager,
         IClipboardGateway clipboard,
@@ -68,10 +67,8 @@ public sealed class ElementClipboardService : IElementClipboardService
         ArgumentNullException.ThrowIfNull(elements);
         if (elements.Count == 0) return false;
 
-        // Abort the destructive half when the clipboard write failed —
-        // otherwise the user loses the elements with no way to paste them
-        // back (the platform clipboard is unavailable, e.g. no top-level
-        // window).
+        // Abort the delete half if the clipboard write failed, else the user
+        // loses the elements with no way to paste them back.
         if (!await CopyAsync(elements))
         {
             s_logger.LogWarning(
@@ -140,9 +137,8 @@ public sealed class ElementClipboardService : IElementClipboardService
 
         if (!outcome.Success)
         {
-            // Match the diagnostic surface of the single-element / bitmap
-            // paths so the user can see why a multi-element paste did
-            // nothing (e.g. unsaved scene, I/O failure staging duplicates).
+            // Log like the single-element / bitmap paths so a no-op
+            // multi-element paste is diagnosable (unsaved scene, staging I/O).
             s_logger.LogWarning(
                 "PasteElementsAsync skipped: DuplicateAtClickedPosition failed for {Count} element(s) at ({Frame}, layer {Layer}).",
                 oldElements.Length, clickedFrame, clickedLayer);

--- a/src/Beutl.Editor/Services/ElementDuplicateService.cs
+++ b/src/Beutl.Editor/Services/ElementDuplicateService.cs
@@ -38,9 +38,8 @@ public sealed class ElementDuplicateService : IElementDuplicateService
         int anchorZIndex;
         try
         {
-            // Regeneration can throw on a corrupt / unknown-plugin element, so it
-            // belongs inside the guarded region alongside placement (matching
-            // DuplicateAtPosition) instead of escaping the paste command.
+            // Regeneration can throw on a corrupt / unknown-plugin element, so
+            // keep it inside the guarded region (like DuplicateAtPosition).
             ObjectRegenerator.Regenerate(sourceArray, out regenerated);
             (seedRange, minZIndex, maxZIndex) = DuplicateHelper.ComputePlacementRange(regenerated);
             (anchorStart, anchorZIndex) =
@@ -91,9 +90,8 @@ public sealed class ElementDuplicateService : IElementDuplicateService
     }
 
     /// <summary>
-    /// Spiral search around the clicked position for a non-overlapping slot.
-    /// Bounded by <see cref="MaxSearchSteps"/> so a densely-packed timeline
-    /// can never hang the caller.
+    /// Spiral search around the clicked position for a non-overlapping slot,
+    /// bounded by <see cref="MaxSearchSteps"/> so a packed timeline can't hang.
     /// </summary>
     private static (TimeSpan Start, int ZIndex) CorrectPosition(
         Scene scene,

--- a/src/Beutl.Editor/Services/ElementNudgeService.cs
+++ b/src/Beutl.Editor/Services/ElementNudgeService.cs
@@ -7,9 +7,8 @@ namespace Beutl.Editor.Services;
 
 public sealed class ElementNudgeService : IElementNudgeService
 {
-    // Empirical: long enough to bridge typical key-repeat intervals (~30-50ms)
-    // but short enough to keep two intentional taps from collapsing into one
-    // history entry.
+    // Empirical: bridges key-repeat (~30-50ms) without collapsing two
+    // intentional taps into one history entry.
     private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(300);
 
     private static readonly ILogger s_logger = Log.CreateLogger<ElementNudgeService>();
@@ -19,17 +18,16 @@ public sealed class ElementNudgeService : IElementNudgeService
     private readonly Timer _timer;
     private readonly object _gate = new();
     private bool _pending;
-    // volatile so a Nudge() racing with Dispose() on another thread sees the
-    // flag immediately. The lock-protected re-check inside Schedule() is the
-    // primary guard against ObjectDisposedException on _timer.Change.
+    // volatile for a quick cross-thread read; the lock-protected re-check in
+    // Schedule() is the real guard against ObjectDisposedException on _timer.
     private volatile bool _disposed;
 
     /// <param name="postToUi">
-    /// Posts the deferred commit onto the UI thread. The debounce timer fires on
-    /// a thread-pool thread, but <see cref="HistoryManager.Commit"/> and its
-    /// reactive fan-out must run where every other editing service commits.
-    /// Pass <see langword="null"/> (the default) to commit inline on the timer
-    /// thread — tests rely on this and drive <see cref="Flush"/> synchronously.
+    /// Posts the deferred commit onto the UI thread, since the debounce timer
+    /// fires on a thread-pool thread but <see cref="HistoryManager.Commit"/>
+    /// must run on the UI thread. Pass <see langword="null"/> (default) to
+    /// commit inline on the timer thread — tests drive <see cref="Flush"/>
+    /// synchronously this way.
     /// </param>
     public ElementNudgeService(HistoryManager historyManager, Action<Action>? postToUi = null)
     {
@@ -46,8 +44,8 @@ public sealed class ElementNudgeService : IElementNudgeService
 
         int rate = SceneTimeRangeService.GetFrameRate(scene);
 
-        // Anchor on the leftmost element so the resulting delta lands on the
-        // frame grid even when callers have off-grid starts.
+        // Anchor on the leftmost element so the delta lands on the frame grid
+        // even when callers have off-grid starts.
         Element anchor = targets
             .OrderBy(e => e.Start)
             .ThenBy(e => e.ZIndex)
@@ -79,9 +77,8 @@ public sealed class ElementNudgeService : IElementNudgeService
 
     public void Dispose()
     {
-        // _disposed is volatile, but the lock pairs Flush()/Schedule() against
-        // Dispose() so a concurrent Schedule cannot reach _timer.Change after
-        // _timer.Dispose has run.
+        // Lock pairs Flush()/Schedule() against Dispose() so a concurrent
+        // Schedule cannot reach _timer.Change after _timer.Dispose.
         lock (_gate)
         {
             if (_disposed) return;
@@ -96,9 +93,8 @@ public sealed class ElementNudgeService : IElementNudgeService
     {
         lock (_gate)
         {
-            // Recheck under the lock: Dispose may have flipped _disposed between
-            // the unlocked guard in Nudge() and reaching this line. Without this
-            // recheck _timer.Change throws ObjectDisposedException.
+            // Recheck under the lock: Dispose may have flipped _disposed since
+            // the unlocked guard in Nudge(), else _timer.Change would throw.
             if (_disposed) return;
 
             _pending = true;
@@ -108,10 +104,9 @@ public sealed class ElementNudgeService : IElementNudgeService
 
     private void OnTimerTick(object? state)
     {
-        // Runs on a thread-pool thread. Marshal the drain to the UI thread when a
-        // post is available so the commit's reactive fan-out is serialized with
-        // every other UI-thread editing operation; the _gate re-check inside
-        // DrainPending keeps it correct against a concurrent Flush / Dispose.
+        // Runs on a thread-pool thread; marshal the drain to the UI thread when
+        // a post is available so the commit serializes with other UI edits. The
+        // _gate re-check in DrainPending guards against a concurrent Flush/Dispose.
         if (_postToUi is { } post)
         {
             post(DrainPending);

--- a/src/Beutl.Editor/Services/ElementStructureService.cs
+++ b/src/Beutl.Editor/Services/ElementStructureService.cs
@@ -76,8 +76,7 @@ public sealed class ElementStructureService : IElementStructureService
 
             newElements.Add(backward);
 
-            // Track group membership so the resulting back-clips stay in the
-            // same group as their source.
+            // Track group membership so back-clips stay in their source's group.
             int groupIndex = -1;
             for (int i = 0; i < scene.Groups.Count; i++)
             {
@@ -121,9 +120,8 @@ public sealed class ElementStructureService : IElementStructureService
         ArgumentNullException.ThrowIfNull(ids);
         if (ids.Count == 0) return GroupOutcome.NotCreated;
 
-        // Always remove the ids from existing groups first — when only one id is
-        // passed this is effectively an "ungroup this element from its set",
-        // which matches the previous in-VM behavior.
+        // Remove ids from existing groups first — with a single id this acts as
+        // "ungroup this element", matching the previous in-VM behavior.
         bool removed = RemoveIdsFromGroups(scene, ids);
 
         bool created = false;
@@ -137,10 +135,8 @@ public sealed class ElementStructureService : IElementStructureService
             }
         }
 
-        // Commit only when the call actually mutated something. An
-        // unconditional Commit would close the current transaction and pull
-        // in any unrelated pending operations (e.g. a Scene.Children.Add
-        // staged just before this call), creating a phantom undo entry.
+        // Commit only when something changed; an unconditional Commit would
+        // sweep unrelated pending operations into a phantom undo entry.
         if (removed || created)
         {
             _historyManager.Commit(CommandNames.GroupElements);

--- a/src/Beutl.Editor/Services/IClipboardGateway.cs
+++ b/src/Beutl.Editor/Services/IClipboardGateway.cs
@@ -1,11 +1,10 @@
 ﻿namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Avalonia-free abstraction over the platform clipboard. The concrete
-/// implementation lives in <c>Beutl.Editor.Components</c> and is wired in via
-/// <c>IEditorContext.GetService</c>. Services in <c>Beutl.Editor</c> depend on
-/// this interface instead of <c>Avalonia.Input.Platform.IClipboard</c> so that
-/// they remain unit-testable without an Avalonia application.
+/// Avalonia-free abstraction over the platform clipboard (concrete impl in
+/// <c>Beutl.Editor.Components</c>, wired via <c>IEditorContext.GetService</c>).
+/// Services depend on this rather than <c>Avalonia.Input.Platform.IClipboard</c>
+/// so they stay unit-testable without an Avalonia application.
 /// </summary>
 public interface IClipboardGateway
 {
@@ -18,13 +17,11 @@ public interface IClipboardGateway
     Task<ReadOnlyMemory<byte>?> TryGetBitmapPngAsync();
 
     /// <summary>
-    /// Publishes <paramref name="entries"/> to the platform clipboard.
-    /// Returns <see langword="true"/> when the entries were committed,
-    /// <see langword="false"/> when the platform clipboard is unavailable
-    /// (e.g. no top-level <c>Avalonia</c> window). Destructive callers
-    /// (Cut / Move-to-clipboard) MUST check the return and abort the
-    /// destructive half when this is <see langword="false"/>, otherwise
-    /// the user loses data they cannot paste back.
+    /// Publishes <paramref name="entries"/> to the platform clipboard. Returns
+    /// <see langword="false"/> when the clipboard is unavailable (e.g. no top-level
+    /// window). Destructive callers (Cut / Move-to-clipboard) MUST abort their
+    /// destructive half on <see langword="false"/>, or the user loses data they
+    /// cannot paste back.
     /// </summary>
     Task<bool> SetAsync(IReadOnlyList<ClipboardEntry> entries);
 

--- a/src/Beutl.Editor/Services/IElementAttributeService.cs
+++ b/src/Beutl.Editor/Services/IElementAttributeService.cs
@@ -5,10 +5,9 @@ namespace Beutl.Editor.Services;
 
 /// <summary>
 /// Single-element attribute writes (boolean flags, accent color, etc.).
-/// Distinct from <see cref="IElementStructureService"/>: these operations
-/// only mutate a single property on a single <see cref="Element"/> and
-/// touch nothing else — no file IO, no scene-graph traversal. A plugin
-/// that adds a new attribute belongs here, not on the structure service.
+/// Distinct from <see cref="IElementStructureService"/>: one property on one
+/// <see cref="Element"/>, no file IO or scene-graph traversal. New attributes
+/// belong here, not on the structure service.
 /// </summary>
 public interface IElementAttributeService
 {

--- a/src/Beutl.Editor/Services/IElementClipboardService.cs
+++ b/src/Beutl.Editor/Services/IElementClipboardService.cs
@@ -4,19 +4,17 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Cut / Copy / Paste pipeline for <see cref="Element"/>s. The service
-/// consumes <see cref="IClipboardGateway"/> so it can be exercised in unit
-/// tests without an Avalonia clipboard. <see cref="PasteAsync"/> dispatches
-/// internally over the four supported payloads (element list JSON, single
-/// element JSON, files, bitmap) and commits a single history entry.
+/// Cut / Copy / Paste pipeline for <see cref="Element"/>s. Consumes
+/// <see cref="IClipboardGateway"/> so it stays unit-testable without an Avalonia
+/// clipboard. <see cref="PasteAsync"/> dispatches over the four supported payloads
+/// (element-list JSON, single-element JSON, files, bitmap) and commits one entry.
 /// </summary>
 public interface IElementClipboardService
 {
     /// <summary>
-    /// Publishes <paramref name="elements"/> to the platform clipboard.
-    /// Returns <see langword="false"/> when the platform clipboard is
-    /// unavailable; callers that destroy the source after a successful
-    /// copy (e.g. Cut) MUST check the return value.
+    /// Publishes <paramref name="elements"/> to the platform clipboard. Returns
+    /// <see langword="false"/> when the clipboard is unavailable; callers that
+    /// destroy the source on a successful copy (e.g. Cut) MUST check it.
     /// </summary>
     Task<bool> CopyAsync(IReadOnlyList<Element> elements);
 

--- a/src/Beutl.Editor/Services/IElementDuplicateService.cs
+++ b/src/Beutl.Editor/Services/IElementDuplicateService.cs
@@ -4,10 +4,9 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Selection-based duplicate and Alt+drag duplicate. Internally delegates to
-/// the stateless <see cref="DuplicateHelper"/> for the actual file staging
-/// and group remap, then commits a history entry. Centralizing the commit
-/// here removes the duplicate "Regenerate -&gt; PlaceDuplicates -&gt; Commit"
+/// Selection-based and Alt+drag duplicate. Delegates file staging and group
+/// remap to the stateless <see cref="DuplicateHelper"/>, then commits a history
+/// entry — centralizing the "Regenerate -&gt; PlaceDuplicates -&gt; Commit"
 /// boilerplate that used to live on <c>TimelineTabViewModel</c>.
 /// </summary>
 public interface IElementDuplicateService

--- a/src/Beutl.Editor/Services/IElementMoveService.cs
+++ b/src/Beutl.Editor/Services/IElementMoveService.cs
@@ -3,11 +3,10 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Moves one or more <see cref="Element"/>s on a <see cref="Scene"/>. The
-/// service owns the history commit; the View calls <see cref="Move"/> or
-/// <see cref="DuplicateOrMove"/> once on drag release and inspects the
-/// returned <see cref="ElementMoveOutcome"/> to drive notifications and
-/// visual rollback.
+/// Moves one or more <see cref="Element"/>s on a <see cref="Scene"/>, owning the
+/// history commit. The View calls <see cref="Move"/> / <see cref="DuplicateOrMove"/>
+/// once on drag release and inspects the <see cref="ElementMoveOutcome"/> to drive
+/// notifications and visual rollback.
 /// </summary>
 public interface IElementMoveService
 {
@@ -20,10 +19,9 @@ public interface IElementMoveService
         TimeSpan deltaStart,
         int deltaZIndex);
 
-    /// <summary>Places duplicates of <paramref name="elements"/> at
-    /// (origin + delta). Falls back to a plain move when the duplicate cannot
-    /// be staged (e.g., project has no Uri yet). Returns one of
-    /// <see cref="ElementMoveOutcome.Duplicated"/>,
+    /// <summary>Places duplicates of <paramref name="elements"/> at (origin + delta),
+    /// falling back to a plain move when the duplicate cannot be staged (e.g. project
+    /// has no Uri yet). Returns <see cref="ElementMoveOutcome.Duplicated"/>,
     /// <see cref="ElementMoveOutcome.DuplicateOverlapsSource"/>, or
     /// <see cref="ElementMoveOutcome.FellBackToMove"/>.</summary>
     ElementMoveOutcome DuplicateOrMove(

--- a/src/Beutl.Editor/Services/IElementObjectService.cs
+++ b/src/Beutl.Editor/Services/IElementObjectService.cs
@@ -4,13 +4,10 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Mutations on the <c>EngineObject</c> list that an <see cref="Element"/>
-/// owns — Add / Insert / Move / Remove / PasteOver / SetEnabled. These
-/// operations were scattered across <c>ElementPropertyTabView</c>,
-/// <c>EngineObjectPropertyView</c>, and <c>EngineObjectPropertyViewModel</c>
-/// with no shared invariant guard. Centralizing them allows a single set
-/// of unit tests to lock in the index-validation, idempotency, and
-/// paste-failure contracts.
+/// Mutations on the <c>EngineObject</c> list an <see cref="Element"/> owns —
+/// Add / Insert / Move / Remove / PasteOver / SetEnabled. Centralizes what was
+/// scattered across the property ViewModels so the index-validation, idempotency,
+/// and paste-failure contracts can be unit-tested in one place.
 /// </summary>
 public interface IElementObjectService
 {
@@ -18,29 +15,23 @@ public interface IElementObjectService
     /// <paramref name="element"/>.<c>Objects</c>. Commits <c>AddObject</c>.</summary>
     void Add(Element element, EngineObject obj);
 
-    /// <summary>Inserts <paramref name="obj"/> at <paramref name="index"/>.
-    /// Clamps the index to the valid <c>[0, Count]</c> range. Commits
-    /// <c>AddObject</c>.</summary>
+    /// <summary>Inserts <paramref name="obj"/> at <paramref name="index"/>, clamped
+    /// to <c>[0, Count]</c>. Commits <c>AddObject</c>.</summary>
     void InsertAt(Element element, int index, EngineObject obj);
 
-    /// <summary>Removes <paramref name="obj"/> from
-    /// <paramref name="element"/>.<c>Objects</c>. Returns false and commits
-    /// nothing when the object is not in the list.</summary>
+    /// <summary>Removes <paramref name="obj"/>. Returns false and commits nothing
+    /// when it is not in the list.</summary>
     bool Remove(Element element, EngineObject obj);
 
-    /// <summary>Reorders the object at <paramref name="oldIndex"/> to
-    /// <paramref name="newIndex"/>. No-ops and returns false when the
-    /// indices are equal. Commits <c>MoveObject</c> on success.</summary>
+    /// <summary>Reorders <paramref name="oldIndex"/> to <paramref name="newIndex"/>.
+    /// Returns false (no-op) when they are equal; commits <c>MoveObject</c> otherwise.</summary>
     bool Move(Element element, int oldIndex, int newIndex);
 
-    /// <summary>Replaces <paramref name="element"/>.<c>Objects[index]</c>
-    /// with an object materialized from the clipboard JSON. Returns
-    /// <see cref="ObjectPasteOutcome.Pasted"/> on success;
-    /// <see cref="ObjectPasteOutcome.InvalidJson"/> when the payload does
-    /// not parse; <see cref="ObjectPasteOutcome.MissingType"/> when the
+    /// <summary>Replaces <c>Objects[index]</c> with an object materialized from the
+    /// clipboard JSON. Returns <see cref="ObjectPasteOutcome.InvalidJson"/> when the
+    /// payload does not parse, <see cref="ObjectPasteOutcome.MissingType"/> when the
     /// $type discriminator is absent or does not resolve to an
-    /// <see cref="EngineObject"/>. Commits <c>PasteObject</c> only on
-    /// success.</summary>
+    /// <see cref="EngineObject"/>. Commits <c>PasteObject</c> only on success.</summary>
     ObjectPasteOutcome PasteOver(Element element, int index, string json);
 
     /// <summary>Idempotent boolean write: skips the commit when

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -3,10 +3,10 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Applies resize requests to one or more <see cref="Element"/>s and commits
-/// a single MoveElement history entry. The View handles the per-pointer-frame
-/// preview by writing the VM reactive properties; the service is invoked once
-/// on drag release with the final (start, length, zIndex) per element.
+/// Applies resize requests to one or more <see cref="Element"/>s and commits one
+/// MoveElement entry. The View handles per-pointer-frame preview via VM reactive
+/// properties; the service runs once on drag release with the final
+/// (start, length, zIndex) per element.
 /// </summary>
 public interface IElementResizeService
 {

--- a/src/Beutl.Editor/Services/IElementStructureService.cs
+++ b/src/Beutl.Editor/Services/IElementStructureService.cs
@@ -3,11 +3,10 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Structural commands that mutate the scene graph (`Scene.Children` and
-/// `Scene.Groups`). Distinct from <see cref="IElementAttributeService"/>:
-/// these operations frequently touch the file-system (regenerate, store
-/// to URI) and produce different history command names per call. Each
-/// method commits exactly one history entry.
+/// Structural commands that mutate the scene graph (<c>Scene.Children</c> /
+/// <c>Scene.Groups</c>). Distinct from <see cref="IElementAttributeService"/>:
+/// these often touch the file-system (regenerate, store to URI) and use a
+/// per-call history command name. Each method commits exactly one entry.
 /// </summary>
 public interface IElementStructureService
 {

--- a/src/Beutl.Editor/Services/IKeyFrameClipboardService.cs
+++ b/src/Beutl.Editor/Services/IKeyFrameClipboardService.cs
@@ -4,11 +4,10 @@ using Beutl.Animation.Easings;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Parses clipboard JSON payloads for <see cref="KeyFrameAnimation"/> and
-/// <see cref="KeyFrame"/> and applies them to a target animation. The
-/// type-discriminator validation, generic-mismatch fallback, and
-/// existing-key collision logic was previously duplicated between
-/// <c>GraphEditorViewModel</c> and <c>InlineAnimationLayerViewModel</c>.
+/// Parses clipboard JSON for <see cref="KeyFrameAnimation"/> / <see cref="KeyFrame"/>
+/// and applies it to a target animation. Centralizes the type-discriminator
+/// validation, generic-mismatch fallback, and existing-key collision logic that
+/// was duplicated between the graph and inline-animation ViewModels.
 /// </summary>
 public interface IKeyFrameClipboardService
 {
@@ -18,13 +17,10 @@ public interface IKeyFrameClipboardService
     KeyFrameAnimationPasteOutcome PasteAnimation(KeyFrameAnimation target, string json);
 
     /// <summary>Parses <paramref name="json"/> as a single <see cref="KeyFrame"/>
-    /// and inserts (or replaces) it on <paramref name="target"/> at
-    /// <paramref name="keyTime"/>. On success commits one <c>PasteKeyFrame</c>
-    /// entry. When the pasted key's generic type does not match
-    /// <paramref name="target"/>, returns
-    /// <see cref="KeyFramePasteOutcome.GenericTypeMismatch"/> with the parsed
-    /// easing — the caller is expected to fall back to its own
-    /// <c>InsertKeyFrame</c> path using that easing.</summary>
+    /// and inserts/replaces it at <paramref name="keyTime"/>, committing one
+    /// <c>PasteKeyFrame</c>. On generic-type mismatch returns
+    /// <see cref="KeyFramePasteOutcome.GenericTypeMismatch"/> with the parsed easing,
+    /// so the caller can fall back to its own <c>InsertKeyFrame</c> using it.</summary>
     KeyFramePasteResult PasteKeyFrame(KeyFrameAnimation target, string json, TimeSpan keyTime);
 }
 

--- a/src/Beutl.Editor/Services/ILayerAttributeService.cs
+++ b/src/Beutl.Editor/Services/ILayerAttributeService.cs
@@ -4,25 +4,21 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Layer-level attribute writes (toggle every element at a zIndex,
-/// recolor a <see cref="TimelineLayer"/>). The lazy-create of
-/// <see cref="TimelineLayer"/> when none exists yet is the main piece
-/// of logic worth testing in isolation — without it the existing color
-/// picker on an unrecorded layer would silently fail.
+/// Layer-level attribute writes (toggle every element at a zIndex, recolor a
+/// <see cref="TimelineLayer"/>). Lazy-creates the <see cref="TimelineLayer"/>
+/// when none exists yet — otherwise recoloring an unrecorded layer silently fails.
 /// </summary>
 public interface ILayerAttributeService
 {
-    /// <summary>Sets <see cref="Element.IsEnabled"/> = <paramref name="newEnabled"/> on
-    /// every element at <paramref name="zIndex"/> whose current state differs.
-    /// Returns true and commits <c>ChangeLayerEnabled</c> when at least one element
-    /// was mutated; returns false and commits nothing when every element already
-    /// matched.</summary>
+    /// <summary>Sets <see cref="Element.IsEnabled"/> = <paramref name="newEnabled"/>
+    /// on every differing element at <paramref name="zIndex"/>. Returns true and
+    /// commits <c>ChangeLayerEnabled</c> when at least one was mutated; otherwise
+    /// false and no commit.</summary>
     bool SetEnabled(Scene scene, int zIndex, bool newEnabled);
 
-    /// <summary>Sets the <see cref="TimelineLayer.Color"/> for the layer at
-    /// <paramref name="zIndex"/>, creating the model on demand if none exists yet.
-    /// Returns true and commits <c>ChangeLayerColor</c> when the model was created
-    /// or its color was changed; returns false and commits nothing when the existing
-    /// model already had the target color.</summary>
+    /// <summary>Sets <see cref="TimelineLayer.Color"/> for the layer at
+    /// <paramref name="zIndex"/>, creating the model on demand. Returns true and
+    /// commits <c>ChangeLayerColor</c> when the model was created or recolored;
+    /// otherwise false and no commit.</summary>
     bool SetColor(Scene scene, int zIndex, Color color, string defaultName);
 }

--- a/src/Beutl.Editor/Services/ILayerMoveService.cs
+++ b/src/Beutl.Editor/Services/ILayerMoveService.cs
@@ -3,12 +3,11 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Reorders layers: the elements at <c>oldLayer</c> move to <c>newLayer</c>
-/// and every layer between them shifts by one. <see cref="ApplyMove"/>
-/// owns the model writes (<see cref="Element.ZIndex"/> on the direct and
-/// shifted sets) and commits a single <c>MoveLayer</c> history entry.
-/// The returned <see cref="LayerMovePlan"/> lists the affected elements so
-/// the View can drive matching animations after the call.
+/// Reorders layers: elements at <c>oldLayer</c> move to <c>newLayer</c> and the
+/// layers between shift by one. <see cref="ApplyMove"/> owns the
+/// <see cref="Element.ZIndex"/> writes (direct + shifted sets) and commits one
+/// <c>MoveLayer</c> entry, returning a <see cref="LayerMovePlan"/> of affected
+/// elements so the View can drive matching animations afterward.
 /// </summary>
 public interface ILayerMoveService
 {

--- a/src/Beutl.Editor/Services/INodeGraphMutationService.cs
+++ b/src/Beutl.Editor/Services/INodeGraphMutationService.cs
@@ -4,44 +4,37 @@ namespace Beutl.Editor.Services;
 
 /// <summary>
 /// Mutation operations on a <see cref="GraphModel"/>: add/remove/move/rename
-/// nodes, connect/disconnect ports, and the dynamic-port add/remove flow that
-/// is unique to <see cref="GroupInput"/> / <see cref="GroupOutput"/>. The
-/// validation branches (GroupInput uniqueness, port-direction sorting, cascade
-/// disconnects when a node or dynamic port is removed) were previously scattered
-/// across <c>NodeGraphViewModel</c>, <c>GraphNodeViewModel</c>, and
-/// <c>NodePortViewModel</c> with ~11 distinct <c>HistoryManager.Commit</c>
-/// sites and no shared test surface.
+/// nodes, connect/disconnect ports, and the dynamic-port flow unique to
+/// <see cref="GroupInput"/> / <see cref="GroupOutput"/>. Centralizes the
+/// validation branches (GroupInput uniqueness, cascade disconnects) and the
+/// many commit sites that were scattered across the node-graph ViewModels.
 /// </summary>
 public interface INodeGraphMutationService
 {
-    /// <summary>Adds <paramref name="node"/> to <paramref name="graph"/> at the
-    /// given position. Rejects (returns false, no commit) when a duplicate
-    /// <see cref="GroupInput"/> / <see cref="GroupOutput"/> would be added to a
-    /// <see cref="GraphGroup"/>. Commits <c>AddNode</c> on success.</summary>
+    /// <summary>Adds <paramref name="node"/> at the given position. Returns false
+    /// (no commit) for a duplicate <see cref="GroupInput"/> / <see cref="GroupOutput"/>
+    /// in a <see cref="GraphGroup"/>; commits <c>AddNode</c> on success.</summary>
     bool AddNode(GraphModel graph, GraphNode node, double x, double y);
 
     /// <summary>Cascade-disconnects every connection touching
-    /// <paramref name="node"/>, removes the node from
-    /// <paramref name="graph"/>, and commits one <c>RemoveNode</c> entry.</summary>
+    /// <paramref name="node"/>, removes it, and commits one <c>RemoveNode</c>.</summary>
     void RemoveNode(GraphModel graph, GraphNode node);
 
-    /// <summary>Bulk-writes <see cref="GraphNode.Position"/> for each pair,
-    /// then commits one <c>MoveNode</c> entry.</summary>
+    /// <summary>Bulk-writes <see cref="GraphNode.Position"/> for each pair, then
+    /// commits one <c>MoveNode</c>.</summary>
     void MoveNodes(IReadOnlyList<(GraphNode Node, double X, double Y)> moves);
 
     /// <summary>Idempotent rename. Returns false and commits nothing when
     /// <paramref name="newName"/> already matches the current name.</summary>
     bool RenameNode(GraphNode node, string newName);
 
-    /// <summary>Removes a dynamic port from <paramref name="owner"/>,
-    /// cascade-disconnecting every connection on the port first. Returns
-    /// false when <paramref name="port"/> is not an
-    /// <see cref="IDynamicPort"/>. Commits <c>RemovePort</c> on success.</summary>
+    /// <summary>Cascade-disconnects then removes a dynamic port. Returns false
+    /// when <paramref name="port"/> is not an <see cref="IDynamicPort"/>; commits
+    /// <c>RemovePort</c> on success.</summary>
     bool RemovePort(GraphNode owner, INodePort port);
 
-    /// <summary>Reorders a slot inside an <see cref="IListPort"/>. Returns
-    /// false when the port is not list-typed. Commits
-    /// <c>MoveConnection</c> on success.</summary>
+    /// <summary>Reorders a slot inside an <see cref="IListPort"/>. Returns false
+    /// when the port is not list-typed; commits <c>MoveConnection</c> on success.</summary>
     bool MoveConnectionSlot(INodePort port, int oldIndex, int newIndex);
 
     /// <summary>Idempotent port rename.</summary>
@@ -60,15 +53,13 @@ public interface INodeGraphMutationService
         GraphNode node1, INodePort? port1,
         GraphNode node2, INodePort? port2);
 
-    /// <summary>Disconnects a specific connection. The hint takes precedence
-    /// when supplied; otherwise the service looks up the connection by
-    /// matching the two port ids. Commits <c>DisconnectPort</c> on success.</summary>
+    /// <summary>Disconnects a specific connection — <paramref name="hint"/> wins
+    /// when supplied, otherwise it is looked up by matching the two port ids.
+    /// Commits <c>DisconnectPort</c> on success.</summary>
     bool TryDisconnect(GraphModel graph, INodePort port1, INodePort port2, Connection? hint = null);
 
-    /// <summary>Disconnects every connection on the port (walks
-    /// <see cref="IOutputPort"/>, <see cref="IListPort"/>, and
-    /// <see cref="IInputPort"/> variants). Commits <c>DisconnectPort</c>
-    /// when at least one connection was severed.</summary>
+    /// <summary>Disconnects every connection on the port (output / list / input
+    /// variants). Commits <c>DisconnectPort</c> when at least one was severed.</summary>
     bool DisconnectAll(GraphModel graph, INodePort port);
 
     /// <summary>Disconnects a specific known <see cref="Connection"/>.

--- a/src/Beutl.Editor/Services/ISceneSettingsService.cs
+++ b/src/Beutl.Editor/Services/ISceneSettingsService.cs
@@ -4,18 +4,15 @@ using Beutl.ProjectSystem;
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// One-shot apply of the Scene-level metadata edited in the Scene Settings
-/// tab (frame size, start, duration). The testable parts are: change
-/// detection (skip commit when nothing differs) and atomicity (three
-/// field writes collapse into one history entry).
+/// One-shot apply of the Scene-level metadata from the Scene Settings tab
+/// (frame size, start, duration). Key behavior: change detection (skip commit
+/// when nothing differs) and atomicity (three writes collapse into one entry).
 /// </summary>
 public interface ISceneSettingsService
 {
     /// <summary>Applies <paramref name="frameSize"/>, <paramref name="start"/>,
-    /// and <paramref name="duration"/> to <paramref name="scene"/>. Returns
-    /// <see langword="true"/> and commits one <c>ChangeSceneSettings</c>
-    /// entry when at least one field differs from the current state; returns
-    /// <see langword="false"/> and commits nothing when all three already
-    /// match.</summary>
+    /// and <paramref name="duration"/> to <paramref name="scene"/>. Returns true and
+    /// commits one <c>ChangeSceneSettings</c> when at least one field differs;
+    /// otherwise false and no commit.</summary>
     bool Apply(Scene scene, PixelSize frameSize, TimeSpan start, TimeSpan duration);
 }

--- a/src/Beutl.Editor/Services/ISceneTimeRangeService.cs
+++ b/src/Beutl.Editor/Services/ISceneTimeRangeService.cs
@@ -3,15 +3,14 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Edits the <see cref="Scene.Start"/> and <see cref="Scene.Duration"/> range.
+/// Edits the <see cref="Scene.Start"/> / <see cref="Scene.Duration"/> range.
 /// <para>
-/// <see cref="SetStart"/> / <see cref="SetEnd"/> are one-shot mutate+commit
-/// methods for keyboard / menu callers. <see cref="UpdateStartDrag"/> and
-/// <see cref="UpdateEndDrag"/> mutate the scene without committing — call them
-/// per pointer frame during a drag, then finalize the history entry with
-/// <see cref="CommitStartChange"/> / <see cref="CommitEndChange"/>. Callers
-/// that abandon a drag (pointer-exit, ESC) re-call the matching UpdateXxxDrag
-/// with the initial values to restore state instead of committing.
+/// <see cref="SetStart"/> / <see cref="SetEnd"/> are one-shot mutate+commit for
+/// keyboard / menu callers. <see cref="UpdateStartDrag"/> / <see cref="UpdateEndDrag"/>
+/// mutate per pointer frame without committing; finalize with
+/// <see cref="CommitStartChange"/> / <see cref="CommitEndChange"/>. To abandon a
+/// drag (pointer-exit, ESC), re-call UpdateXxxDrag with the initial values rather
+/// than committing.
 /// </para>
 /// </summary>
 public interface ISceneTimeRangeService

--- a/src/Beutl.Editor/Services/KeyFrameClipboardService.cs
+++ b/src/Beutl.Editor/Services/KeyFrameClipboardService.cs
@@ -46,10 +46,8 @@ public sealed class KeyFrameClipboardService : IKeyFrameClipboardService
 
         try
         {
-            // Preserve the target's identity (Id) so observers tracking the
-            // animation by id keep their subscriptions valid across paste.
-            // New ids are minted for the keyframes so the pasted set does not
-            // alias the source.
+            // Keep the target's Id so id-based observers stay subscribed across
+            // paste; mint fresh ids for the keyframes so they don't alias the source.
             Guid id = target.Id;
             CoreSerializer.PopulateFromJsonObject(target, newJson);
             target.Id = id;
@@ -103,9 +101,8 @@ public sealed class KeyFrameClipboardService : IKeyFrameClipboardService
         if (discriminator.GenericTypeArguments.Length == 0
             || discriminator.GenericTypeArguments[0] != target.ValueType)
         {
-            // Caller handles the fallback "insert with this easing at keyTime"
-            // because creating a new key requires the View's property-value
-            // accessor — the service does not know the typed value.
+            // Caller handles the "insert with this easing at keyTime" fallback;
+            // the service lacks the View's property-value accessor for the typed value.
             return new KeyFramePasteResult(
                 KeyFramePasteOutcome.GenericTypeMismatch,
                 EasingForFallback: newKeyFrame.Easing);

--- a/src/Beutl.Editor/Services/LayerAttributeService.cs
+++ b/src/Beutl.Editor/Services/LayerAttributeService.cs
@@ -48,9 +48,8 @@ public sealed class LayerAttributeService : ILayerAttributeService
 
         if (existing is null)
         {
-            // No TimelineLayer for this zIndex yet — lazily materialize one so the
-            // color is persisted. Without this branch the picker silently no-ops
-            // on a fresh layer.
+            // No TimelineLayer for this zIndex yet — materialize one to persist
+            // the color, else the picker no-ops on a fresh layer.
             var created = new TimelineLayer
             {
                 Name = defaultName,

--- a/src/Beutl.Editor/Services/LayerMoveService.cs
+++ b/src/Beutl.Editor/Services/LayerMoveService.cs
@@ -22,8 +22,7 @@ public sealed class LayerMoveService : ILayerMoveService
         ArgumentNullException.ThrowIfNull(directElements);
         if (oldLayer == newLayer) return LayerMovePlan.Noop;
 
-        // Enumerate the shift-range before mutating, so the range is
-        // captured against the pre-write state.
+        // Snapshot the shift-range before mutating, against the pre-write state.
         var shifted = new List<Element>();
         foreach (Element child in scene.Children)
         {
@@ -34,12 +33,9 @@ public sealed class LayerMoveService : ILayerMoveService
             }
         }
 
-        // TimelineLayer carries the layer's persisted color / name and its own
-        // recorded ZIndex. Its writes must land in the SAME transaction as the
-        // Element.ZIndex writes; otherwise an Undo of MoveLayer reverts the
-        // elements but leaves the header model desynced, and the stray writes
-        // leak into the next history entry. Snapshot before mutating, like the
-        // Element pass above.
+        // TimelineLayer's ZIndex writes must land in the SAME transaction as the
+        // Element writes, or Undo desyncs the header model and the stray writes
+        // leak into the next history entry. Snapshot first, like the pass above.
         var directLayers = new List<TimelineLayer>();
         var shiftedLayers = new List<TimelineLayer>();
         foreach (TimelineLayer layer in scene.Layers)
@@ -77,8 +73,8 @@ public sealed class LayerMoveService : ILayerMoveService
         return new LayerMovePlan(oldLayer, newLayer, directElements, shifted);
     }
 
-    // A ZIndex is shifted when it sits strictly between the old layer and the
-    // new layer, inclusive of the new layer (the slot the moved layer vacates).
+    // A ZIndex shifts when it lies between old and new layer, inclusive of the
+    // new layer (the slot the moved layer vacates).
     private static bool InShiftRange(int zIndex, int oldLayer, int newLayer)
         => oldLayer < newLayer
             ? zIndex > oldLayer && zIndex <= newLayer

--- a/src/Beutl.Editor/Services/NodeGraphMutationService.cs
+++ b/src/Beutl.Editor/Services/NodeGraphMutationService.cs
@@ -21,9 +21,8 @@ public sealed class NodeGraphMutationService : INodeGraphMutationService
 
         if (graph is GraphGroup group)
         {
-            // Only one GroupInput and one GroupOutput is allowed per GraphGroup
-            // — silently reject duplicates so callers do not have to repeat the
-            // type-check at every call site.
+            // At most one GroupInput / GroupOutput per GraphGroup; silently
+            // reject duplicates so callers need not repeat the type-check.
             if ((node is GroupInput && group.Nodes.Any(x => x is GroupInput))
                 || (node is GroupOutput && group.Nodes.Any(x => x is GroupOutput)))
             {
@@ -42,8 +41,8 @@ public sealed class NodeGraphMutationService : INodeGraphMutationService
         ArgumentNullException.ThrowIfNull(graph);
         ArgumentNullException.ThrowIfNull(node);
 
-        // Collect every connection touching the node before mutating so
-        // the iteration is not invalidated by the disconnect calls.
+        // Snapshot touching connections first so disconnect calls don't
+        // invalidate the iteration.
         Connection[] touching = node.Items
             .SelectMany(i => i switch
             {
@@ -145,8 +144,8 @@ public sealed class NodeGraphMutationService : INodeGraphMutationService
         ArgumentNullException.ThrowIfNull(node1);
         ArgumentNullException.ThrowIfNull(node2);
 
-        // Case 1: one port is unset and the opposite side is a dynamic-port
-        // node — materialize a new port on the dynamic-port node.
+        // Case 1: one side unset, the other a dynamic-port node — materialize
+        // a new port on that node.
         if (port1 is null ^ port2 is null)
         {
             IDynamicPortNode? dynamicNode = null;

--- a/src/Beutl.Editor/Services/SceneSettingsService.cs
+++ b/src/Beutl.Editor/Services/SceneSettingsService.cs
@@ -24,8 +24,8 @@ public sealed class SceneSettingsService : ISceneSettingsService
             return false;
         }
 
-        // Order matters less than atomicity — all three writes batch into the
-        // current transaction and collapse into one history entry on Commit.
+        // All three writes batch into one transaction, collapsing to a single
+        // history entry on Commit.
         scene.FrameSize = frameSize;
         scene.Start = start;
         scene.Duration = duration;

--- a/src/Beutl.Editor/Services/SceneTimeRangeService.cs
+++ b/src/Beutl.Editor/Services/SceneTimeRangeService.cs
@@ -59,11 +59,9 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
     }
 
     /// <summary>
-    /// One-shot start update. Used by the keyboard / menu path. When the
-    /// caller asks to set start past the current end, the scene end is
-    /// shifted forward by one frame and the start snaps to the old end —
-    /// this preserves the historical "set start to pointer position"
-    /// menu behavior.
+    /// One-shot start update (keyboard / menu path). Setting start past the
+    /// current end shifts the end forward one frame and snaps start to the old
+    /// end, preserving the legacy "set start to pointer position" behavior.
     /// </summary>
     private static void ApplyStart(Scene scene, TimeSpan newStart, TimeSpan referenceStart, TimeSpan referenceDuration)
     {
@@ -73,8 +71,7 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
 
         if (newStart > sceneEnd)
         {
-            // Moving the start past the current end: shift the scene end forward
-            // by one frame and snap start to the old end.
+            // Start past end: shift end forward one frame, snap start to old end.
             TimeSpan shift = newStart - sceneEnd + frame;
             scene.Duration = shift;
             scene.Start = sceneEnd;
@@ -96,10 +93,9 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
     }
 
     /// <summary>
-    /// One-shot end update. Used by the keyboard / menu path. When the
-    /// caller asks for an end before the current start, both start and
-    /// duration shift backward — this preserves the historical "set end
-    /// to pointer position" menu behavior.
+    /// One-shot end update (keyboard / menu path). An end before the current
+    /// start shifts both start and duration backward, preserving the legacy
+    /// "set end to pointer position" behavior.
     /// </summary>
     private static void ApplyEnd(Scene scene, TimeSpan newEnd)
     {
@@ -108,7 +104,7 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
 
         if (newEnd < scene.Start)
         {
-            // Pulling the end past the current start: shift both back by one frame.
+            // End past start: shift both back one frame.
             TimeSpan shifted = newEnd - frame;
             if (shifted < TimeSpan.Zero) shifted = TimeSpan.Zero;
             scene.Duration = scene.Start - shifted;
@@ -122,13 +118,10 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
     }
 
     /// <summary>
-    /// Drag-phase start update. Clamps the new start to
-    /// <c>[0, initialEnd - 1 frame]</c> against the initial end captured
-    /// at drag-press time, so the absolute end of the scene stays pinned
-    /// while the user drags the start marker. Unlike <see cref="ApplyStart"/>
-    /// this never shifts the end forward — dragging the start marker past
-    /// the end is treated as "right up against the end", matching the
-    /// pre-refactor drag-loop behavior.
+    /// Drag-phase start update. Clamps start to <c>[0, initialEnd - 1 frame]</c>
+    /// against the end captured at drag-press, pinning the scene end. Unlike
+    /// <see cref="ApplyStart"/> it never shifts the end forward (drag past end
+    /// clamps to the end), matching the pre-refactor drag loop.
     /// </summary>
     private static void ApplyStartDrag(Scene scene, TimeSpan newStart, TimeSpan initialStart, TimeSpan initialDuration)
     {
@@ -144,11 +137,9 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
     }
 
     /// <summary>
-    /// Drag-phase end update. Clamps duration to <c>>= 1 frame</c> but
-    /// never touches <see cref="Scene.Start"/>. Pulling the pointer left
-    /// of <see cref="Scene.Start"/> during a drag must not jerk the
-    /// scene's absolute time range backward — that was a regression vs.
-    /// the pre-refactor drag-loop, which only adjusted duration.
+    /// Drag-phase end update. Clamps duration to <c>>= 1 frame</c> and never
+    /// touches <see cref="Scene.Start"/>; dragging left of Start must only
+    /// shrink duration, not move the scene backward (a pre-refactor regression).
     /// </summary>
     private static void ApplyEndDrag(Scene scene, TimeSpan pointerTime)
     {

--- a/src/Beutl.Editor/Services/SceneTimeRangeService.cs
+++ b/src/Beutl.Editor/Services/SceneTimeRangeService.cs
@@ -104,7 +104,7 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
 
         if (newEnd < scene.Start)
         {
-            // End past start: shift both back one frame.
+            // End dragged before the start: shift both back one frame.
             TimeSpan shifted = newEnd - frame;
             if (shifted < TimeSpan.Zero) shifted = TimeSpan.Zero;
             scene.Duration = scene.Start - shifted;
@@ -139,7 +139,8 @@ public sealed class SceneTimeRangeService : ISceneTimeRangeService
     /// <summary>
     /// Drag-phase end update. Clamps duration to <c>>= 1 frame</c> and never
     /// touches <see cref="Scene.Start"/>; dragging left of Start must only
-    /// shrink duration, not move the scene backward (a pre-refactor regression).
+    /// shrink duration, not move the scene backward — a regression vs. the
+    /// pre-refactor drag loop.
     /// </summary>
     private static void ApplyEndDrag(Scene scene, TimeSpan pointerTime)
     {

--- a/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/CompressorParameters.cs
@@ -1,22 +1,16 @@
 ﻿namespace Beutl.Audio.Effects;
 
-// Single source of truth for the compressor's parameter ranges and defaults. CompressorEffect
-// references these in its [Range] / Property.CreateAnimatable declarations and CompressorNode
-// references the same values when clamping per-sample animated inputs, so the two cannot drift.
-//
-// The Min/Default/Max consistency of every entry below is asserted by
-// CompressorEffectTests.CompressorParameters_RangeIsConsistent — a plain unit test, not a runtime
-// hook — so a future edit that puts a default outside its range fails CI with a named test rather
-// than a load-time Debug.Assert.
+// Single source of truth for the compressor's ranges and defaults, shared by CompressorEffect's
+// [Range] declarations and CompressorNode's per-sample clamps so the two cannot drift.
+// CompressorEffectTests.CompressorParameters_RangeIsConsistent asserts each entry's consistency.
 internal static class CompressorParameters
 {
     public const float MinThresholdDb = -60f;
     public const float MaxThresholdDb = 0f;
     public const float DefaultThresholdDb = -20f;
 
-    // MinRatio must stay >= 1f. The slope formula `1 - 1/Ratio` becomes negative below 1, which
-    // would amplify above-threshold signals instead of compressing them; CompressorNode.Sanitize
-    // relies on this invariant to make the slope safe without an additional guard.
+    // MinRatio must stay >= 1f: below 1 the slope `1 - 1/Ratio` goes negative and amplifies instead
+    // of compresses. CompressorNode.Sanitize relies on this to keep the slope safe without a guard.
     public const float MinRatio = 1f;
     public const float MaxRatio = 20f;
     public const float DefaultRatio = 4f;

--- a/src/Beutl.Engine/Audio/Effects/DelayParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/DelayParameters.cs
@@ -5,15 +5,11 @@
 /// parameter ranges and defaults.
 /// </summary>
 /// <remarks>
-/// The same constants drive the <c>[Range]</c> attributes on <see cref="DelayEffect"/> and the per-sample
-/// processing in <c>DelayNode</c> (default fallbacks and the delay-line buffer sizing). Keeping them here
-/// prevents the two declarations from drifting apart. Deliberately avoids <c>[ModuleInitializer]</c> so the
-/// values stay plain compile-time constants usable inside attribute arguments.
-///
-/// The boundary constants intentionally keep their original literal types so the
-/// <see cref="System.ComponentModel.DataAnnotations.RangeAttribute"/> overload resolution — and therefore the
-/// resulting <c>OperandType</c> — is unchanged: the delay-time bounds were authored as <c>float</c>
-/// (double operand) and the percentage bounds as <c>int</c> (int operand).
+/// Shared by the <c>[Range]</c> attributes on <see cref="DelayEffect"/> and the per-sample processing in
+/// <c>DelayNode</c> so the two cannot drift. Plain constants (not <c>[ModuleInitializer]</c>) so they stay
+/// usable in attribute arguments. The boundary constants keep their original literal types (delay-time as
+/// <c>float</c>, percentages as <c>int</c>) so the
+/// <see cref="System.ComponentModel.DataAnnotations.RangeAttribute"/> overload and <c>OperandType</c> are unchanged.
 /// </remarks>
 internal static class DelayParameters
 {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -18,30 +18,23 @@ public sealed class CompressorNode : AudioNode
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
 
-    // Per-channel handles into the current input/output buffers, cached so the per-sample hot loops
-    // avoid GetChannelData's disposed/bounds checks and re-slicing on every access. Span<float>[]
-    // cannot be used (Span is a ref struct), so we hold Memory<float> and materialize the span per
-    // channel. The backing arrays are reused across Process() calls and only reallocated when the
-    // channel count changes, mirroring EqualizerNode's channel-keyed filter cache.
+    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing.
+    // Memory<float> (not Span, a ref struct); arrays reused across Process(), reallocated only on
+    // channel-count change.
     private Memory<float>[]? _inputChannelCache;
     private Memory<float>[]? _outputChannelCache;
 
-    // Latched per node instance so the warning only fires once per non-finite event class, even
-    // when the corruption persists across thousands of samples.
+    // Latched per node instance so each non-finite warning fires only once, not per sample.
     private bool _loggedNonFiniteEnvelope;
     private bool _loggedNonFiniteSample;
-    // Per-parameter so a non-finite sample on one parameter (e.g. Attack) does not silently
-    // suppress diagnostics for an unrelated parameter (e.g. Threshold) later in the stream.
+    // Per-parameter so a non-finite value on one parameter does not suppress diagnostics for another.
     private readonly HashSet<string> _loggedNonFiniteParameters = new();
-    // Same once-per-parameter latch for the distinct "finite but out-of-[Range]" case (e.g. an
-    // animation drives Attack to 1e9 ms). Kept separate from _loggedNonFiniteParameters so a
-    // non-finite warning and a clamp warning for the same parameter are not conflated.
+    // Separate once-per-parameter latch for the "finite but out-of-[Range]" case, so clamp and
+    // non-finite warnings for the same parameter are not conflated.
     private readonly HashSet<string> _loggedClampedParameters = new();
 
-    // Test-only counters (observed via InternalsVisibleTo) recording how many warnings were
-    // actually emitted — the only externally visible consequence of the one-shot latches. They let
-    // the latch re-arm semantics (preserved across a seek, re-armed on a sample-rate change or
-    // Reset) be asserted without wiring a logger sink to the static logger.
+    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted, letting the latch
+    // re-arm semantics be asserted without a logger sink.
     internal int NonFiniteSampleWarnings;
     internal int ClampWarnings;
 
@@ -65,23 +58,20 @@ public sealed class CompressorNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
-        // A sample-rate change is a genuine reconfiguration (coefficients must be recomputed for
-        // the new rate), so treat it as a full session boundary: reset both the envelope and the
-        // one-shot diagnostic latches.
+        // A sample-rate change needs new coefficients, so treat it as a full session boundary:
+        // reset both the envelope and the one-shot diagnostic latches.
         if (_lastSampleRate != context.SampleRate)
         {
             Reset();
             _lastSampleRate = context.SampleRate;
         }
 
-        // Reset the envelope on the very first call (no prior end recorded) and whenever the new
-        // chunk does not start exactly where the previous one ended. The node instance is cached
-        // across Compose() calls, so without this guard stale envelope state would bleed into the
-        // first samples after a seek or stop/restart. Only the DSP state is reset here, NOT the
-        // diagnostic latches: a stuttering scrubber produces many discontinuities within a single
-        // session, and re-arming the one-shot warnings on every one of them would let a persistent
-        // non-finite condition re-log once per Process call. Diagnostics re-arm only on a
-        // sample-rate change or an explicit Reset() (e.g. a deliberate re-render).
+        // Reset the envelope on the first call or whenever this chunk does not continue from the
+        // previous one. The node is cached across Compose() calls, so without this guard stale
+        // envelope state would bleed in after a seek/restart. Only DSP state resets here, NOT the
+        // diagnostic latches — re-arming them on every scrub discontinuity would let a persistent
+        // non-finite condition re-log per Process call. Diagnostics re-arm only on a sample-rate
+        // change or an explicit Reset().
         if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
         {
             ResetEnvelope();
@@ -93,14 +83,10 @@ public sealed class CompressorNode : AudioNode
             return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
         }
 
-        // Expression-backed properties are intentionally not checked here: AnimationSampler does
-        // not currently evaluate expressions per-sample, so treating HasExpression as live would
-        // route to ProcessAnimated and read the same CurrentValue every iteration — strictly
-        // worse than ProcessStatic, which reads it once. The same root cause is documented at
-        // EqualizerEffect.IsNeutral (build-time band elision), where the FIXME notes that once
-        // AnimationSampler evaluates expressions per-sample, both that guard and this one must
-        // be updated to treat HasExpression as live; otherwise expression-backed parameters
-        // will be silently frozen at their graph-build-time value.
+        // Expression-backed properties are deliberately not checked: AnimationSampler does not yet
+        // evaluate expressions per-sample, so routing them to ProcessAnimated would just re-read the
+        // same CurrentValue every iteration. FIXME: once it does (see EqualizerEffect.IsNeutral),
+        // treat HasExpression as live here too, or such parameters stay frozen at build-time value.
         bool hasAnimation = Threshold.Animation != null ||
                             Ratio.Animation != null ||
                             Attack.Animation != null ||
@@ -130,11 +116,9 @@ public sealed class CompressorNode : AudioNode
         int sampleCount = input.SampleCount;
         var (inputChannels, outputChannels) = MapChannels(input, output);
 
-        // The cached Memory handles are loop-invariant for the whole call, so materialize the
-        // channel spans ONCE for the dominant mono/stereo case and index those — this removes the
-        // per-sample Memory<float>.Span getter (called 3x/sample/channel) that the >2-channel
-        // fallback still pays. Span<float>[] is impossible (Span is a ref struct), hence the
-        // explicit locals.
+        // Materialize the channel spans ONCE for the mono/stereo fast path to avoid the per-sample
+        // Memory.Span getter the >2-channel fallback still pays. Span<float>[] is impossible (ref
+        // struct), hence the explicit locals.
         if (channels <= 2)
         {
             Span<float> in0 = inputChannels[0].Span;
@@ -200,19 +184,16 @@ public sealed class CompressorNode : AudioNode
         Span<float> knees = stackalloc float[bufferSize];
         Span<float> makeups = stackalloc float[bufferSize];
 
-        // Final fallbacks used when an animated parameter samples to NaN/Infinity (e.g. malformed
-        // KeyFrame). Without this guard, a single non-finite animated value would propagate into
-        // the gain calculation and cause the output sanitizer to silently zero out every sample.
+        // Fallbacks for when an animated parameter samples to NaN/Infinity (e.g. malformed
+        // KeyFrame); otherwise one non-finite value would zero out every output sample.
         EffectiveParameters fallback = ReadStaticParameters();
 
         int channels = input.ChannelCount;
         int sampleCount = input.SampleCount;
         var (inputChannels, outputChannels) = MapChannels(input, output);
 
-        // Materialize the channel spans once for the whole call (the cached Memory handles are
-        // stable across the chunk loop), matching ProcessStatic so the per-sample Memory.Span
-        // getter is removed for the dominant mono/stereo case. The >2-channel path keeps the
-        // Memory indexing, where the getter cost is negligible beside the per-sample sampling.
+        // Materialize the channel spans once (matching ProcessStatic) for the mono/stereo fast path;
+        // the >2-channel path keeps Memory indexing where the getter cost is negligible.
         Span<float> in0 = channels <= 2 ? inputChannels[0].Span : default;
         Span<float> out0 = channels <= 2 ? outputChannels[0].Span : default;
         Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
@@ -220,9 +201,8 @@ public sealed class CompressorNode : AudioNode
 
         int processed = 0;
 
-        // lastAttackMs/lastReleaseMs are seeded with NaN so the first comparison is always
-        // unequal and the coefficients get computed on the very first sample. After that, Exp
-        // is only called when the animated ms value actually changes.
+        // Seed with NaN so the first comparison is always unequal and coefficients compute on
+        // sample 0; afterwards Exp runs only when the animated ms value changes.
         float lastAttackMs = float.NaN;
         float lastReleaseMs = float.NaN;
         float attackCoeff = 0f;
@@ -307,9 +287,8 @@ public sealed class CompressorNode : AudioNode
         return output;
     }
 
-    // Caches per-channel Memory handles for the current input/output buffers, reusing the backing
-    // arrays across calls (only reallocated on a channel-count change). The hot loops then index
-    // the cached handles instead of calling GetChannelData per sample. See the field comment.
+    // Caches per-channel Memory handles, reusing the backing arrays across calls (reallocated only
+    // on a channel-count change) so the hot loops avoid per-sample GetChannelData. See field comment.
     private (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
     {
         int channels = input.ChannelCount;
@@ -356,20 +335,16 @@ public sealed class CompressorNode : AudioNode
         };
     }
 
-    // Substitute fallback for NaN/Infinity, then clamp to the parameter's declared [Range].
-    // The clamp is what guards against an animated value silently bypassing the [Range] declaration
-    // on CompressorEffect — without it, e.g. an animated Attack of 1e9 ms would freeze the
-    // envelope. A finite-but-out-of-range value is a real authoring error (a malformed keyframe, a
-    // units mistake, an easing overshoot) distinct from the non-finite case SafeParameter handles,
-    // so it gets its own once-per-parameter warning: the clamp keeps the DSP safe, but without this
-    // breadcrumb the misconfiguration would be indistinguishable from correct in-range automation.
+    // Substitute fallback for NaN/Infinity, then clamp to the parameter's [Range]. The clamp stops
+    // an animated value (e.g. Attack of 1e9 ms) from bypassing the declared range and freezing the
+    // envelope. A finite-but-out-of-range value is a real authoring error distinct from the
+    // non-finite case, so it gets its own once-per-parameter warning as a breadcrumb.
     private float Sanitize(float value, float fallback, float min, float max, string paramName)
     {
         float safe = SafeParameter(value, fallback, paramName);
         float clamped = Math.Clamp(safe, min, max);
-        // Only finite values reach here as `safe != clamped` (a non-finite input was already
-        // replaced with the in-range fallback, so it clamps to itself). Latch once per parameter to
-        // keep the audio thread quiet; re-armed only by ResetDiagnostics (sample-rate change / Reset).
+        // Only finite values reach here as `safe != clamped` (non-finite was already replaced by the
+        // in-range fallback). Latch once per parameter; re-armed only by ResetDiagnostics.
         if (clamped != safe && _loggedClampedParameters.Add(paramName))
         {
             ClampWarnings++;
@@ -380,9 +355,8 @@ public sealed class CompressorNode : AudioNode
         return clamped;
     }
 
-    // Without this guard, a single non-finite envelope sample would permanently poison the state
-    // until the next Reset(). The first occurrence is logged; subsequent ones are suppressed so
-    // the audio thread is not spammed.
+    // Without this, one non-finite envelope sample would poison the state until the next Reset().
+    // First occurrence is logged, the rest suppressed.
     private void RecoverEnvelopeIfNonFinite()
     {
         if (float.IsFinite(_envelopeDb)) return;
@@ -412,10 +386,9 @@ public sealed class CompressorNode : AudioNode
         if (!_loggedNonFiniteSample)
         {
             NonFiniteSampleWarnings++;
-            // With every parameter clamped and the envelope independently recovered, the computed
-            // gain cannot itself overflow — so a non-finite sample here almost always means an
-            // upstream node emitted NaN/Infinity. We zero it to protect downstream nodes and point
-            // the breadcrumb at the likely culprit rather than implying the compressor produced it.
+            // Parameters are clamped and the envelope recovered, so the gain cannot overflow — a
+            // non-finite sample here almost always came from upstream. Zero it to protect downstream
+            // nodes and point the breadcrumb at the likely culprit.
             s_logger.LogWarning(
                 "Compressor encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.");
             _loggedNonFiniteSample = true;
@@ -423,16 +396,12 @@ public sealed class CompressorNode : AudioNode
         return 0f;
     }
 
-    // Advances the envelope follower by one sample's peak and returns the linear gain to apply.
-    // Shared by ProcessStatic and ProcessAnimated so the envelope/gain math cannot drift between
-    // the two paths: they already shared ComputeGainReductionDb/ComputeGainLinear, and this also
-    // unifies the inputDb derivation and the one-pole envelope update that were previously
-    // duplicated inline in both loops.
+    // Advances the envelope follower by one sample's peak and returns the linear gain. Shared by
+    // ProcessStatic and ProcessAnimated so the envelope/gain math cannot drift between the paths.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, float slope)
     {
-        // peak == 0 (digital silence) collapses inputDb to MinDb. The caller's abs/max keeps `peak`
-        // finite (MathF.Abs(NaN) > 0 is false, so a stray NaN never raises peak); any non-finite
-        // envelope state arriving from elsewhere is recovered by RecoverEnvelopeIfNonFinite below.
+        // peak == 0 (silence) collapses inputDb to MinDb. The caller's abs/max keeps peak finite
+        // (a stray NaN never raises it); other non-finite envelope state is recovered below.
         float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
         float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
         _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);
@@ -442,31 +411,23 @@ public sealed class CompressorNode : AudioNode
         return ComputeGainLinear(gainReductionDb, p.MakeupGain);
     }
 
-    // Combined linear gain factor: the dB-domain reduction is subtracted and the makeup gain is
-    // added before a single dB→linear conversion. Both ProcessStatic and ProcessAnimated share
-    // this helper so the static and animated paths cannot drift out of agreement (they used to
-    // apply makeup as a pre-computed `makeupLinear` multiplier vs. an in-formula addition, which
-    // is mathematically equivalent but a future refactor of one branch could silently break the
-    // other).
+    // Combined linear gain: subtract the dB reduction, add makeup, then a single dB→linear
+    // conversion. Shared by both paths so the static and animated math cannot drift apart.
     private static float ComputeGainLinear(float gainReductionDb, float makeupDb)
     {
         return AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
     }
 
-    // Standard one-pole IIR smoothing coefficient for a 1/e settling time of `timeMs` at the
-    // given sample rate: y[n] = x[n] + coeff * (y[n-1] - x[n]) reaches (1 - 1/e) ≈ 63% of a step
-    // change after exactly `timeMs` milliseconds. Operates in dB-domain on `_envelopeDb` because
-    // dB-domain peak smoothing better matches how the human ear perceives compression action.
+    // One-pole IIR smoothing coefficient for a 1/e settling time of `timeMs`: the envelope reaches
+    // ~63% of a step change after `timeMs`. dB-domain because that better matches perceived loudness.
     private static float ComputeCoeff(float timeMs, int sampleRate)
     {
         return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
     }
 
-    // Soft-knee gain computer (Reece/Giannoulis formulation): when `kneeDb > 0`, the gain
-    // reduction curve transitions smoothly from "no compression" to the full `slope * diff`
-    // line over a `kneeDb`-wide region centred on the threshold, via a quadratic that is
-    // C¹-continuous at both knee boundaries. With `kneeDb == 0` this collapses to the standard
-    // hard-knee formula.
+    // Soft-knee gain computer (Reece/Giannoulis): when kneeDb > 0, a C¹-continuous quadratic blends
+    // from no compression to the full `slope * diff` line over a kneeDb-wide region around the
+    // threshold. kneeDb == 0 collapses to the hard-knee formula.
     private static float ComputeGainReductionDb(float envelopeDb, float thresholdDb, float kneeDb, float slope)
     {
         if (kneeDb > 0f)
@@ -479,9 +440,8 @@ public sealed class CompressorNode : AudioNode
             }
             if (diff < halfKnee)
             {
-                // Quadratic interpolation across the knee: at diff = -halfKnee returns 0, at
-                // diff = +halfKnee returns slope * halfKnee, with matching derivatives at both
-                // ends (= 0 below, = slope above) so the overall curve is smooth.
+                // Quadratic across the knee: 0 at -halfKnee, slope * halfKnee at +halfKnee, with
+                // matching derivatives at both ends so the curve stays smooth.
                 float x = diff + halfKnee;
                 return slope * x * x / (2f * kneeDb);
             }
@@ -496,12 +456,10 @@ public sealed class CompressorNode : AudioNode
     /// and re-arms the one-shot non-finite diagnostic warnings.
     /// </summary>
     /// <remarks>
-    /// Do not call this mid-buffer during continuous playback — zeroing the envelope there produces
-    /// an audible click. <see cref="Reset"/> is for genuine session boundaries (a deliberate
-    /// re-render, or an explicit stop/seek driven by an orchestrator). <see cref="Process"/> already
-    /// resets the envelope automatically on a sample-rate change or a time-range discontinuity, so
-    /// routine seeking does not require an external call. Public to match the sibling stateful nodes
-    /// <c>EqualizerNode</c> and <c>DelayNode</c>, which expose <c>Reset()</c> for the same purpose.
+    /// Do not call mid-buffer during playback — zeroing the envelope there clicks. This is for
+    /// genuine session boundaries (a deliberate re-render or an orchestrator-driven stop/seek);
+    /// <see cref="Process"/> already resets the envelope on a sample-rate change or time-range
+    /// discontinuity. Public to match the sibling stateful nodes <c>EqualizerNode</c> / <c>DelayNode</c>.
     /// </remarks>
     public void Reset()
     {
@@ -526,8 +484,8 @@ public sealed class CompressorNode : AudioNode
     {
         if (disposing)
         {
-            // Drop the cached handles so we do not keep the last processed buffers' pooled memory
-            // referenced after disposal. They are re-filled at the start of the next Process() call.
+            // Drop the cached handles so we do not pin the last buffers' pooled memory after
+            // disposal; they are re-filled on the next Process() call.
             _inputChannelCache = null;
             _outputChannelCache = null;
         }
@@ -535,8 +493,8 @@ public sealed class CompressorNode : AudioNode
         base.Dispose(disposing);
     }
 
-    // readonly + init-only: every instance is built via object initializer and thereafter only read
-    // (it is even passed `in` to NextGain/SanitizeAnimated), so immutability is the real intent.
+    // readonly + init-only: built once via object initializer, then only read (passed `in`), so
+    // immutability is intentional.
     private readonly struct EffectiveParameters
     {
         public float Threshold { get; init; }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -40,11 +40,9 @@ public sealed class DelayNode : AudioNode
             _lastTimeRangeStart = context.TimeRange.Start;
         }
 
-        // If no animations are assigned, use static processing. Guard on Animation (an actual
-        // keyframe animation) rather than IsAnimatable (a capability flag that is always true for
-        // an animatable property), so an unkeyed property skips the per-sample animated path.
-        // The null-conditional keeps a misconfigured (null) property degrading to static defaults
-        // (see ProcessStatic) instead of throwing, matching GainNode.
+        // Guard on Animation (an actual keyframe), not IsAnimatable (always true for animatable
+        // properties), so an unkeyed property skips the per-sample path. The null-conditional lets a
+        // null property fall back to static defaults instead of throwing, matching GainNode.
         bool hasAnimation = DelayTime?.Animation != null ||
                             Feedback?.Animation != null ||
                             DryMix?.Animation != null ||

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -13,9 +13,8 @@ public sealed class GainNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
-        // If no animation is assigned, use static gain. Guard on Animation (an actual keyframe
-        // animation) rather than IsAnimatable (a capability flag that is always true for an
-        // animatable property), so an unkeyed Gain skips the per-sample animated path.
+        // Guard on Animation (an actual keyframe), not IsAnimatable (always true for animatable
+        // properties), so an unkeyed Gain skips the per-sample animated path.
         if (Gain?.Animation is null)
         {
             return ProcessStaticGain(input);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -94,12 +94,9 @@ public sealed class SpeedNode : AudioNode
             sourceStartTime = _integrator.Integrate(context.TimeRange.Start, keyFrameAnimation);
         }
 
-        // Per-sample speed collection (audio-specific logic).
-        // This buffer is sized to expectedOutputSampleCount (ceil(render-duration * SampleRate)),
-        // which can be large, and it is allocated on every render of an animated-speed audio clip,
-        // so it adds GC pressure on the hot path. Rent it from ArrayPool and reuse instead.
-        // ProcessBufferWithVariableSpeed consumes the ReadOnlySpan<double> synchronously and does
-        // not retain it, so the array can be safely returned after the call.
+        // Per-sample speed buffer, sized to expectedOutputSampleCount and allocated every render —
+        // rent from ArrayPool to avoid hot-path GC pressure. ProcessBufferWithVariableSpeed consumes
+        // the span synchronously without retaining it, so the array is safe to return afterwards.
         var startInSamples = (int)(context.TimeRange.Start.TotalSeconds * context.SampleRate);
         double[] speedsArray = ArrayPool<double>.Shared.Rent(expectedOutputSampleCount);
         try

--- a/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheHelper.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCacheHelper.cs
@@ -134,9 +134,8 @@ public readonly record struct RenderCacheRules(int MaxPixels, int MinPixels)
 {
     public static readonly RenderCacheRules Default = new(1000 * 1000, 1);
 
-    // The settings UI exposes Min/Max through independent number editors that cannot express the
-    // cross-field constraint, so normalize here: MinPixels >= 1 and MaxPixels >= MinPixels. Without
-    // this, MinPixels > MaxPixels would make Match() always false and silently disable all caching.
+    // The settings UI edits Min/Max independently, so normalize the cross-field constraint here
+    // (Min >= 1, Max >= Min); otherwise Min > Max makes Match() always false and disables caching.
     public static RenderCacheRules Create(int maxPixels, int minPixels)
     {
         int min = Math.Max(1, minPixels);

--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -79,9 +79,8 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
         CancellationTokenSource cts;
         lock (this)
         {
-            // Shutdown() may have set _running to false between the check above and
-            // acquiring this lock. Bail out so we do not assign a fresh _waitToken that
-            // nothing will cancel and then block on WaitOne() forever.
+            // Shutdown() may have cleared _running since the check above; bail out so we
+            // don't arm a _waitToken nothing cancels and block on WaitOne() forever.
             if (!_running)
                 return;
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -743,11 +743,11 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     private ElementNudgeService CreateNudgeService()
     {
-        // The nudge debounce timer fires on a thread-pool thread; post its commit
-        // back to the UI thread so it serializes with every other editing op.
+        // The debounce timer fires off the UI thread; post the commit back so it serializes
+        // with other editing ops.
         var nudge = new ElementNudgeService(HistoryManager, action => Dispatcher.UIThread.Post(action));
-        // BeforeMutation fires just before Undo / Redo / JumpTo: drain pending
-        // nudges so they don't merge into the next history transaction.
+        // Drain pending nudges before Undo / Redo / JumpTo so they don't merge into the next
+        // history transaction.
         HistoryManager.BeforeMutation
             .Subscribe(_ => nudge.Flush())
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -193,8 +193,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
 
-        // The onion-skin settings UI lives in PreviewSettingsTab and writes directly to EditorConfig.
-        // Observe EditorConfig here so the preview re-renders whenever any onion-skin setting changes.
+        // The settings UI now lives in PreviewSettingsTab; observe EditorConfig directly so the
+        // preview re-renders on any onion-skin setting change.
         editorConfig.GetObservable(EditorConfig.IsOnionSkinEnabledProperty)
             .CombineLatest(
                 editorConfig.GetObservable(EditorConfig.OnionSkinPrevCountProperty),

--- a/tests/Beutl.Benchmarks/DispatcherBenchmark.cs
+++ b/tests/Beutl.Benchmarks/DispatcherBenchmark.cs
@@ -5,9 +5,8 @@ using Beutl.Threading;
 
 namespace Beutl.Benchmarks;
 
-// Measures the dispatcher message loop across three axes: per-operation wake-up latency,
-// single-producer Post throughput, and multi-producer (contended) Post throughput, plus
-// allocations. Useful when evaluating changes to OperationQueue / the idle-wait machinery.
+// Dispatcher message-loop benchmarks: wake-up latency, single- and multi-producer Post
+// throughput, plus allocations. Use when changing OperationQueue / the idle-wait machinery.
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 5)]
 public class DispatcherBenchmark
@@ -23,8 +22,7 @@ public class DispatcherBenchmark
     [GlobalCleanup]
     public void Cleanup() => _dispatcher.Shutdown();
 
-    // Cross-thread Invoke in a tight loop: each call leaves the dispatcher idle and must
-    // wake it again, so this measures the per-operation wake-up latency.
+    // Each Invoke leaves the dispatcher idle and re-wakes it: measures per-operation wake-up latency.
     [Benchmark]
     public void InvokeSequential()
     {
@@ -34,8 +32,7 @@ public class DispatcherBenchmark
         }
     }
 
-    // Fire-and-forget posts from a single producer, then a Low-priority barrier that only
-    // runs once every Medium operation has drained. Measures Post throughput.
+    // Single-producer posts, then a Low-priority barrier that drains them. Measures Post throughput.
     [Benchmark]
     public void DispatchThenDrain()
     {
@@ -47,8 +44,7 @@ public class DispatcherBenchmark
         _dispatcher.Invoke(static () => { }, DispatchPriority.Low);
     }
 
-    // Many producer threads posting concurrently. This is where removing the per-Post
-    // lock + CancellationTokenSource churn should show up most.
+    // Many producers posting concurrently: where removing per-Post lock + CTS churn shows up most.
     [Benchmark]
     public void ConcurrentDispatch()
     {

--- a/tests/Beutl.Benchmarks/Program.cs
+++ b/tests/Beutl.Benchmarks/Program.cs
@@ -2,6 +2,5 @@
 
 using BenchmarkDotNet.Running;
 
-// Select a benchmark with `-- --filter <pattern>`, e.g. `--filter *DispatcherBenchmark*`.
-// With no arguments, BenchmarkDotNet shows an interactive picker.
+// Select a benchmark via `-- --filter <pattern>`; no args shows an interactive picker.
 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -390,8 +390,7 @@ public class OnionSkinTests
     [Test]
     public void EditorConfig_ClampsOnionSkinCounts_ViaRangeAttribute()
     {
-        // The settings tab uses a generic number editor, so the 0..10 bound the old flyout
-        // enforced now lives as a [Range] on the property and is coerced on assignment.
+        // The old flyout's 0..10 bound now lives as a [Range] coerced on assignment.
         var config = new EditorConfig
         {
             OnionSkinPrevCount = 1_000_000,

--- a/tests/Beutl.UnitTests/Editor/Services/ElementClipboardServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementClipboardServiceTests.cs
@@ -156,9 +156,7 @@ public class ElementClipboardServiceTests
 
         bool result = await _service.CutAsync(_scene, [element]);
 
-        // Without this guard, Cut would remove the element and commit a
-        // history entry even though the clipboard write silently failed —
-        // user-visible data loss.
+        // Guard against data loss: a failed clipboard write must not let Cut remove + commit.
         Assert.Multiple(() =>
         {
             Assert.That(result, Is.False);
@@ -183,11 +181,8 @@ public class ElementClipboardServiceTests
 
         ElementPasteOutcome outcome = await _service.PasteAsync(_scene, clicked, clickedLayer);
 
-        // The spiral search anchors at (clickedFrame, clickedLayer); with an
-        // empty timeline area around (20s, layer 3) the duplicates land
-        // exactly there. Previously this test would have placed copies at
-        // (0s, layer 0) regardless of the click — the regression Copilot
-        // flagged.
+        // Spiral search anchors at (clickedFrame, clickedLayer); empty area means duplicates land
+        // exactly there. Regression: copies used to land at (0s, layer 0) regardless of the click.
         Assert.Multiple(() =>
         {
             Assert.That(outcome.Pasted, Is.True);
@@ -203,8 +198,7 @@ public class ElementClipboardServiceTests
 
         await _service.CopyAsync([element]);
 
-        // Both the JSON format and the platform text slot must carry the
-        // payload — the gateway used to drop "text/plain" silently.
+        // Both JSON and the platform text slot must carry the payload; "text/plain" used to be dropped.
         IReadOnlyList<string> formats = await _clipboard.GetFormatsAsync();
         Assert.Multiple(() =>
         {
@@ -220,9 +214,7 @@ public class ElementClipboardServiceTests
         private byte[]? _bitmapPng;
 
         /// <summary>
-        /// Simulates an unavailable platform clipboard (e.g. no top-level
-        /// window). When true, <see cref="SetAsync"/> returns false and
-        /// drops the entries.
+        /// Simulates an unavailable platform clipboard: <see cref="SetAsync"/> returns false and drops entries.
         /// </summary>
         public bool SimulateUnavailable { get; set; }
 

--- a/tests/Beutl.UnitTests/Editor/Services/ElementNudgeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementNudgeServiceTests.cs
@@ -111,8 +111,7 @@ public class ElementNudgeServiceTests
     [Test]
     public void Nudge_PullsAnchorOntoGrid_BeforeShifting()
     {
-        // Element starts off-grid (1.555s); first nudge should round to grid
-        // (1.5333... @ 30fps = 46 frames = 1533ms) plus 1 frame.
+        // Off-grid start (1.555s): first nudge rounds to grid (1533ms @ 30fps) then adds 1 frame.
         Element element = AddElement(TimeSpan.FromMilliseconds(1555), TimeSpan.FromSeconds(2));
         TimeSpan originalStart = element.Start;
 

--- a/tests/Beutl.UnitTests/Editor/Services/ElementObjectServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementObjectServiceTests.cs
@@ -76,9 +76,7 @@ public class ElementObjectServiceTests
         var inserted = new TestEngineObject();
         int before = _history.UndoCount;
 
-        // Index 99 is past Count; service must clamp to Count rather than
-        // throw — the View dropping at the bottom of the list ends up
-        // passing an out-of-range index.
+        // Out-of-range index (drop at list bottom) must clamp to Count, not throw.
         _service.InsertAt(_element, 99, inserted);
 
         Assert.Multiple(() =>

--- a/tests/Beutl.UnitTests/Editor/Services/ElementStructureServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementStructureServiceTests.cs
@@ -106,8 +106,7 @@ public class ElementStructureServiceTests
     [Test]
     public void Split_ShortBothSides_DoesNotCommit()
     {
-        // Total length is 1 frame (~33ms at 30fps); split at midpoint leaves
-        // both halves shorter than minDuration, so the service should bail.
+        // Splitting a ~1-frame element leaves both halves under minDuration, so it must bail.
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(20));
         int before = _history.UndoCount;
 
@@ -170,9 +169,7 @@ public class ElementStructureServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(outcome.Created, Is.False);
-            // No group change and no observable mutation should reach the
-            // history stack — Commit() must silently no-op when the
-            // current transaction has no recorded operations.
+            // Commit() must no-op when the transaction recorded no operations.
             Assert.That(_scene.Groups.Count, Is.EqualTo(beforeGroups));
             Assert.That(_history.UndoCount, Is.EqualTo(beforeUndo));
         });
@@ -201,9 +198,7 @@ public class ElementStructureServiceTests
 
         Assert.Multiple(() =>
         {
-            // Same contract as Group_SingleId: no group touched, no
-            // history entry. An unconditional Commit would close the
-            // pending transaction and pull in unrelated mutations.
+            // Same contract as Group_SingleId: an unconditional Commit would pull in unrelated mutations.
             Assert.That(_scene.Groups.Count, Is.EqualTo(beforeGroups));
             Assert.That(_history.UndoCount, Is.EqualTo(beforeUndo));
         });

--- a/tests/Beutl.UnitTests/Editor/Services/KeyFrameClipboardServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/KeyFrameClipboardServiceTests.cs
@@ -99,9 +99,7 @@ public class KeyFrameClipboardServiceTests
     public void PasteAnimation_Matching_Pasted_AndCommits()
     {
         KeyFrameAnimation<double> animation = MakeDoubleAnimation();
-        // Use a CoreObjectOperationObserver attached to the animation so its
-        // KeyFrames mutations are visible to the HistoryManager (the service
-        // calls PopulateFromJsonObject which mutates KeyFrames).
+        // Observer makes the service's KeyFrames mutations visible to the HistoryManager.
         using var observer = new CoreObjectOperationObserver(null, animation, _sequence);
         _history.Subscribe(observer);
 
@@ -151,8 +149,7 @@ public class KeyFrameClipboardServiceTests
         {
             Assert.That(result.Outcome, Is.EqualTo(KeyFramePasteOutcome.GenericTypeMismatch));
             Assert.That(result.EasingForFallback, Is.Not.Null);
-            // Service does not commit on this branch; the caller's
-            // InsertKeyFrame fallback owns the commit boundary.
+            // No commit here: the caller's InsertKeyFrame fallback owns the commit boundary.
             Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }
@@ -199,7 +196,7 @@ public class KeyFrameClipboardServiceTests
             Easing = new LinearEasing(),
         };
         animation.KeyFrames.Add(existing, out _);
-        _history.Commit("seed"); // seal the seed so the next paste is a fresh entry
+        _history.Commit("seed"); // seal so the next paste is a fresh entry
 
         // Paste a different value at the same time.
         var sourceKey = new KeyFrame<double>
@@ -216,7 +213,7 @@ public class KeyFrameClipboardServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.Outcome, Is.EqualTo(KeyFramePasteOutcome.ReplacedExisting));
-            // No new keyframe added — the existing one was updated in place.
+            // Existing keyframe updated in place, no new one added.
             Assert.That(animation.KeyFrames.Count, Is.EqualTo(1));
             Assert.That(((KeyFrame<double>)animation.KeyFrames[0]).Value, Is.EqualTo(0.5));
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));

--- a/tests/Beutl.UnitTests/Editor/Services/LayerAttributeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/LayerAttributeServiceTests.cs
@@ -73,8 +73,7 @@ public class LayerAttributeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(changed, Is.True);
-            // Only the differing element flipped; the already-false one
-            // and the other-layer one are untouched.
+            // Only the differing element flipped; already-false and other-layer ones untouched.
             Assert.That(a.IsEnabled, Is.False);
             Assert.That(b.IsEnabled, Is.False);
             Assert.That(other.IsEnabled, Is.True);

--- a/tests/Beutl.UnitTests/Editor/Services/LayerMoveServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/LayerMoveServiceTests.cs
@@ -177,9 +177,8 @@ public class LayerMoveServiceTests
     [Test]
     public void ApplyMove_AfterUndo_RestoresTimelineLayerZIndexes()
     {
-        // Regression: TimelineLayer.ZIndex is a recorded property. If its writes
-        // landed outside the committed MoveLayer transaction, this Undo would
-        // revert the Element.ZIndex but leave the header models desynced.
+        // Regression: TimelineLayer.ZIndex writes must join the MoveLayer transaction,
+        // else Undo reverts Element.ZIndex but leaves the header models desynced.
         Element e1 = AddElement(1);
         AddElement(2);
         AddElement(3);

--- a/tests/Beutl.UnitTests/Editor/Services/NodeGraphMutationServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/NodeGraphMutationServiceTests.cs
@@ -61,9 +61,7 @@ public class NodeGraphMutationServiceTests
         int beforeUndo = _history.UndoCount;
         int beforeNodes = _graph.Nodes.Count;
 
-        // GraphGroup allows only one GroupInput. The second add must
-        // silently reject — historically this guard was duplicated at
-        // every call site in NodeGraphViewModel.AddNodePort.
+        // GraphGroup allows only one GroupInput: the second add must reject (guard centralized here).
         bool added = _service.AddNode(_graph, new GroupInput(), 50, 50);
 
         Assert.Multiple(() =>

--- a/tests/Beutl.UnitTests/Editor/Services/SceneSettingsServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/SceneSettingsServiceTests.cs
@@ -92,9 +92,7 @@ public class SceneSettingsServiceTests
             Assert.That(_scene.FrameSize, Is.EqualTo(newSize));
             Assert.That(_scene.Start, Is.EqualTo(newStart));
             Assert.That(_scene.Duration, Is.EqualTo(newDuration));
-            // The three field writes must collapse into one history entry,
-            // not three. Without that guarantee, Undo would have to be
-            // pressed three times to revert a single Apply.
+            // The three field writes must collapse into one entry, so one Undo reverts the Apply.
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }

--- a/tests/Beutl.UnitTests/Editor/Services/SceneTimeRangeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/SceneTimeRangeServiceTests.cs
@@ -140,9 +140,7 @@ public class SceneTimeRangeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(_scene.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
-            // The Start/Duration delta must always cancel back to the original
-            // end — without this guard, each drag frame would compound the
-            // previous frame's mutation.
+            // End must stay pinned: without this, each drag frame compounds the previous one.
             Assert.That(_scene.Start + _scene.Duration, Is.EqualTo(initialEnd));
         });
     }
@@ -155,8 +153,7 @@ public class SceneTimeRangeServiceTests
         int before = _history.UndoCount;
 
         _service.UpdateStartDrag(_scene, TimeSpan.FromSeconds(4), initialStart, initialDuration);
-        // The caller (View) cancels by re-driving UpdateStartDrag with the initial
-        // values — there is no Cancel method.
+        // No Cancel method: the View cancels by re-driving UpdateStartDrag with initial values.
         _service.UpdateStartDrag(_scene, initialStart, initialStart, initialDuration);
 
         Assert.Multiple(() =>
@@ -170,11 +167,8 @@ public class SceneTimeRangeServiceTests
     [Test]
     public void UpdateEndDrag_PointerBeforeStart_KeepsStartPinned()
     {
-        // Dragging the end marker left past Scene.Start must not pull
-        // Start backward — only clamp duration to >= 1 frame. The previous
-        // implementation re-used the one-shot SetEnd logic, which would
-        // jerk the entire scene's absolute time range backward as soon as
-        // the pointer crossed Start (Codex review #r3278970042).
+        // End marker dragged past Start must pin Start and clamp duration to >= 1 frame,
+        // not shift the whole range back like the old one-shot SetEnd did (Codex review #r3278970042).
         TimeSpan initialStart = _scene.Start;
 
         _service.UpdateEndDrag(_scene, TimeSpan.Zero);
@@ -190,11 +184,8 @@ public class SceneTimeRangeServiceTests
     [Test]
     public void UpdateStartDrag_PointerAfterInitialEnd_ClampsToOneFrameBeforeEnd()
     {
-        // Dragging the start marker past the initial end must clamp it
-        // to (initialEnd - 1 frame), NOT shift the end forward. The
-        // one-shot SetStart path does shift the end forward, but the drag
-        // loop should never re-extend the scene's absolute time range
-        // (same family of regression as the end-marker case).
+        // Start marker dragged past initial end must clamp to (initialEnd - 1 frame), not shift
+        // the end forward: the drag loop must never re-extend the range (same regression family).
         TimeSpan initialStart = _scene.Start;
         TimeSpan initialDuration = _scene.Duration;
         TimeSpan initialEnd = initialStart + initialDuration;

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorEffectTests.cs
@@ -22,11 +22,9 @@ public class CompressorEffectTests
     [Test]
     public void CreateNode_WiresEveryPropertyToMatchingNodeSlot()
     {
-        // Each IProperty<float> on the effect must be forwarded by reference to the corresponding
-        // slot on CompressorNode. Reference equality (not just value equality) is critical because
-        // the node reads CurrentValue and Animation through these references at process time —
-        // copying the value would freeze it. A swap of any two properties (Threshold↔Ratio, etc.)
-        // would silently corrupt the compressor without this test.
+        // Each property must be forwarded to its node slot by reference, not copied: the node reads
+        // CurrentValue/Animation through these references at process time, and copying would freeze
+        // the value. Also catches a swap of any two properties (Threshold↔Ratio, etc.).
         var effect = new CompressorEffect();
         using var context = new AudioContext(48000, 2);
         var inputNode = context.AddNode(new StubInputNode());
@@ -47,10 +45,8 @@ public class CompressorEffectTests
     [Test]
     public void CreateNode_ConnectsInputAheadOfCompressor()
     {
-        // The contract is "audio flows input → compressor". Connect must run with arguments in
-        // that order so the compressor's Inputs collection contains the upstream node, not the
-        // other way around (which would route the compressor's own output into the input node
-        // and produce silence at best, an infinite loop at worst).
+        // Audio flows input → compressor, so the compressor's Inputs must hold the upstream node.
+        // The reverse would route the compressor's output into the input (silence or an infinite loop).
         var effect = new CompressorEffect();
         using var context = new AudioContext(48000, 2);
         var inputNode = context.AddNode(new StubInputNode());
@@ -59,18 +55,15 @@ public class CompressorEffectTests
 
         Assert.That(node.Inputs, Has.Count.EqualTo(1));
         Assert.That(node.Inputs[0], Is.SameAs(inputNode));
-        // The returned node is the compressor itself, not the input — downstream effects need to
-        // chain off the compressor.
+        // The returned node is the compressor, not the input, so downstream effects chain off it.
         Assert.That(node, Is.Not.SameAs(inputNode));
     }
 
     [Test]
     public void CreateNode_DefaultPropertyValuesMatchCompressorParameters()
     {
-        // The CompressorEffect's default values are sourced from CompressorParameters. If any
-        // default drifted (e.g. the file was edited but not the [Range]), the effect would still
-        // load but operators would see unexpected starting parameters. This guards against that
-        // drift by asserting each property's CurrentValue is the documented default.
+        // Defaults come from CompressorParameters; assert each CurrentValue matches so a drifted
+        // default (file edited but not the [Range]) is caught.
         var effect = new CompressorEffect();
 
         Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(-20f));
@@ -84,11 +77,9 @@ public class CompressorEffectTests
     [Test]
     public void ScanProperties_RegistersNamesAndRangeValidatorsForEveryProperty()
     {
-        // ScanProperties<CompressorEffect>() runs in the constructor and is expected to (a) name
-        // each IProperty<float> after its CLR member and (b) attach the [Range] validator so
-        // out-of-range assignments are coerced at the engine layer — not just visually constrained
-        // in the UI. A validator-absent property would silently accept any value. We assert the
-        // name and exercise the coercion (clamp) at both bounds for every property.
+        // ScanProperties (run in the constructor) must name each property after its CLR member and
+        // attach the [Range] validator so out-of-range values are clamped at the engine layer, not
+        // just in the UI. Assert the name and exercise the clamp at both bounds.
         var effect = new CompressorEffect();
 
         AssertNameAndRange(effect.Threshold, nameof(effect.Threshold), MinThresholdDb, MaxThresholdDb);
@@ -128,11 +119,8 @@ public class CompressorEffectTests
     [TestCaseSource(nameof(ParameterRanges))]
     public void CompressorParameters_RangeIsConsistent(float min, float def, float max)
     {
-        // CompressorParameters is the single source of truth shared between CompressorEffect's
-        // [Range] declarations and CompressorNode's per-sample clamps. These asserts catch an edit
-        // that puts a default outside its range, or inverts a min/max, at CI time with a named
-        // failing case — the role formerly served by a [ModuleInitializer] + Debug.Assert, which
-        // was invisible in Release builds and ran on every Debug host load for no benefit.
+        // Catches an edit that puts a default outside its range or inverts a min/max, at CI time —
+        // the role formerly served by a [ModuleInitializer] + Debug.Assert (invisible in Release).
         Assert.That(min, Is.LessThan(max), "Min must be strictly less than Max.");
         Assert.That(def, Is.InRange(min, max), "Default must lie within [Min, Max].");
     }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -50,9 +50,8 @@ public class CompressorNodeTests
         return buffer;
     }
 
-    // A normal sine buffer with a single +Infinity head sample on every channel. Feeding it drives
-    // the envelope non-finite (recovered to MinDb) and the product non-finite (zeroed by
-    // SanitizeOutput), emitting the one-shot non-finite-sample warning exactly once per armed period.
+    // Sine buffer with a +Infinity head sample on every channel: drives the envelope and product
+    // non-finite, emitting the one-shot non-finite-sample warning once per armed period.
     private static AudioBuffer MakeInfinityHeadBuffer(int sampleCount, int sampleRate = SampleRate)
     {
         var buffer = CreateSineBuffer(0.9f, 1000f, sampleCount, 2, sampleRate);
@@ -137,15 +136,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_SilenceInput_ProducesExactSilenceOutput()
     {
-        // End-to-end "silence in → silence out" smoke test. Note: this does NOT specifically
-        // isolate the `peak > 0f` guard, because RecoverEnvelopeIfNonFinite would mask the
-        // non-finite envelope state produced when Log10(0) = -Infinity propagates through the
-        // IIR formula `inputDb + coeff * (_envelopeDb - inputDb)` (NaN appears at the
-        // (-∞) + coeff·(+∞) step). The gain calculation against a 0-amplitude sample still
-        // yields exactly 0 either way. Genuinely isolating that guard would require log capture
-        // or exposing internal state. What this test does catch: any future bug that injects DC,
-        // noise, or non-zero offset into a silent stream (e.g., a stray makeup application that
-        // mishandles the additive identity, or a sanitizer that fails open).
+        // End-to-end "silence in → silence out" smoke test. It does NOT isolate the `peak > 0f`
+        // guard (RecoverEnvelopeIfNonFinite masks the Log10(0) = -∞ envelope state, and the gain
+        // calc yields 0 either way), but it catches any future bug injecting DC/noise/offset into
+        // a silent stream (a stray makeup application, a sanitizer that fails open, etc.).
         const int sampleCount = SampleRate / 4;
         using var input = new AudioBuffer(SampleRate, 2, sampleCount);
         // Default-constructed AudioBuffer is zeroed, so no fill needed.
@@ -170,11 +164,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_AttackTimeConstant_EnvelopeReachesAbout63PercentAfterAttackMs()
     {
-        // Step input drives the envelope from MinDb toward inputDb_max. After exactly attackMs
-        // milliseconds, a one-pole IIR with time constant attackMs should have reached
-        // ~(1 - 1/e) ≈ 63% of the way to its target. This is the contract the ComputeCoeff
-        // formula encodes; a regression like dropping the ms→s conversion (timeMs * sampleRate
-        // instead of timeMs * 0.001f * sampleRate) would leave the envelope still near -100 dB.
+        // A one-pole IIR with time constant attackMs should reach ~(1 - 1/e) ≈ 63% of its target
+        // after attackMs. Catches a dropped ms→s conversion in ComputeCoeff, which would leave the
+        // envelope near -100 dB.
         const float attackMs = 50f;
         const int sampleCount = SampleRate; // 1 s
         const int stepAt = SampleRate / 10; // step at 100 ms; envelope sits at MinDb until then
@@ -185,13 +177,10 @@ public class CompressorNodeTests
             data[i] = 1f; // exactly 0 dB peak after the step
         }
 
-        // Threshold = -50 dB is the load-bearing choice. With the bug, envelope stays near
-        // -100 dB (below threshold) → gainReductionDb = 0 → output = input → reconstructed
-        // envelope clamps to thresholdDb = -50 dB. Setting threshold ABOVE the buggy envelope
-        // (at -50, far above -100) makes the buggy reconstruction 13.21 dB away from the target
-        // (-36.79 dB), well outside the ±5 dB tolerance. A threshold of -40 or lower would put
-        // the buggy reconstruction within tolerance and the test would falsely pass.
-        // Knee=0 keeps the gain formula linear so we can back-solve the envelope value.
+        // Threshold = -50 dB is load-bearing: it sits far above the buggy frozen envelope (-100 dB),
+        // so the buggy reconstruction lands ~13 dB from the -36.79 dB target, outside the ±5 dB
+        // tolerance (a threshold of -40 or lower would falsely pass). Knee=0 keeps the formula linear
+        // so the envelope is back-solvable.
         const float thresholdDb = -50f;
         const float ratio = 4f;
         const float slope = 1f - 1f / ratio; // 0.75
@@ -200,26 +189,20 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
         using var output = node.Process(ctx);
 
-        // Sample exactly attackMs after the step. At that point, in dB-domain:
-        //   envelopeDb(t) = inputDb_max - (inputDb_max - inputDb_initial) * exp(-t / attackMs)
-        // With inputDb_max = 0 dB (peak 1.0) and inputDb_initial = MinDb = -100 dB:
-        //   envelopeDb ≈ 0 - 100 * (1/e) ≈ -36.79 dB at t = attackMs.
+        // Sample exactly attackMs after the step: envelopeDb ≈ 0 - 100/e ≈ -36.79 dB there
+        // (inputDb_max = 0 dB, initial = MinDb = -100 dB).
         int probeIdx = stepAt + (int)(attackMs * 0.001f * SampleRate);
-        // Reconstruct envelopeDb from the observed gain reduction:
-        //   gainLinear = 10^(-gainReductionDb / 20), envelope = output / input.
+        // Reconstruct envelopeDb from observed gain: gainLinear = output / input.
         float gainLinear = MathF.Abs(output.GetChannelData(0)[probeIdx] / data[probeIdx]);
         float gainReductionDb = -20f * MathF.Log10(gainLinear);
 
-        // Direct assertion: the expected gain reduction at t = attackMs is
-        //   slope * (-36.79 - thresholdDb) = 0.75 * (-36.79 - (-50)) = 0.75 * 13.21 ≈ 9.91 dB.
-        // Under the ms→s bug, envelope stays below threshold so gainReductionDb is 0 — the
-        // tolerance below excludes that. This is the load-bearing assertion.
+        // Load-bearing assertion: expected reduction ≈ slope * (-36.79 - thresholdDb) ≈ 9.91 dB.
+        // Under the ms→s bug the envelope stays below threshold (reduction 0), which the tolerance excludes.
         Assert.That(gainReductionDb, Is.EqualTo(9.91f).Within(2f),
             $"At t = attackMs ({attackMs} ms), expected ≈9.91 dB reduction but got {gainReductionDb:F2} dB. " +
             $"Near 0 dB indicates ComputeCoeff lost its ms→s conversion.");
 
-        // Secondary back-solve for human readability of the failure mode:
-        //   gainReductionDb = slope * (envelopeDb - thresholdDb) for envelopeDb > thresholdDb.
+        // Secondary back-solve to make the failure mode human-readable.
         float reconstructedEnvelopeDb = thresholdDb + gainReductionDb / slope;
         Assert.That(reconstructedEnvelopeDb, Is.EqualTo(-36.79f).Within(5f),
             $"After attackMs={attackMs} ms, envelope should reach ~63% (≈-36.79 dB) but got {reconstructedEnvelopeDb:F2} dB");
@@ -228,11 +211,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_BelowThreshold_LeavesSignalUnchanged()
     {
-        // Amplitude 0.05 ≈ -26 dB peak, well below the -20 dB threshold, so output should be a
-        // bit-identical pass-through: the envelope never crosses the threshold, gainReductionDb is
-        // always 0, makeup is 0, so gainLinear = 10^0 = 1.0f exactly and output == input bit-for-bit.
-        // We assert exact equality (no tolerance) so any future bug injecting a near-zero residual
-        // gain is caught immediately.
+        // Amplitude 0.05 (≈-26 dB) is below the -20 dB threshold, so output must be a bit-identical
+        // pass-through (gain = 1.0 exactly). Asserted with no tolerance to catch any near-zero
+        // residual gain a future bug might inject.
         const int sampleCount = SampleRate / 2;
         using var input = CreateSineBuffer(0.05f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
@@ -258,12 +239,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_AboveThreshold_AppliesExpectedGainReduction()
     {
-        // Sine well above the threshold. The analytic steady-state for a 0.9 peak (-0.92 dB) at
-        // threshold -20, ratio 4 is -0.92 - 0.75*(-0.92+20) = -15.23 dB, but the per-sample peak
-        // detector dips at every zero crossing so the measured peak sits a little above that, near
-        // -13.5 dB. The band [-16, -11] (center -13.5, ±2.5) intentionally spans BOTH the analytic
-        // ratio value and the ripple-attenuated measurement, so it stays sensitive to a slope sign
-        // flip or a missing makeup while not encoding a peak-detector-specific magic number.
+        // Sine above threshold. Analytic steady-state is -15.23 dB but the per-sample peak detector
+        // dips at zero crossings, so the measured peak sits near -13.5 dB. The ±2.5 band spans both
+        // values: sensitive to a slope sign flip or missing makeup without encoding a detector-specific
+        // magic number.
         const int sampleCount = SampleRate;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
@@ -298,8 +277,8 @@ public class CompressorNodeTests
         float steadyStartSample = SampleRate / 2;
         float outputPeakDb = PeakDb(output, (int)steadyStartSample);
 
-        // Makeup gain should add directly on top of the compressed level. Same ±2.5 band as the
-        // no-makeup case, shifted up by the +6 dB makeup (analytic -9.23 dB, measured near -7.5 dB).
+        // Makeup adds on top of the compressed level: same ±2.5 band shifted up by +6 dB
+        // (measured near -7.5 dB).
         Assert.That(outputPeakDb, Is.EqualTo(-7.5f).Within(2.5f));
     }
 
@@ -352,9 +331,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_LinkedStereo_AppliesSameGainToBothChannels()
     {
-        // L = 0.9 sine drives compression; R = 0.05 sine sits below the threshold and would not
-        // compress on its own. Linked-stereo behaviour applies the L-derived gain reduction to R
-        // as well, so R's output should be R_input_peak attenuated by the same amount as L.
+        // L (0.9 sine) drives compression; R (0.05 sine) is below threshold and wouldn't compress
+        // alone. Linked-stereo applies L's gain reduction to R, so R is attenuated by the same amount.
         const int sampleCount = SampleRate;
         using var input = new AudioBuffer(SampleRate, 2, sampleCount);
         float leftInputPeakDb = 20f * MathF.Log10(0.9f);
@@ -384,9 +362,8 @@ public class CompressorNodeTests
         Assert.That(leftPeakDb, Is.EqualTo(-13.5f).Within(2.5f),
             "Sanity check: this test relies on L being compressed; if this fails the linked-gain expectation below is moot.");
 
-        // The L-channel gain reduction (positive dB number) inferred from the measurement is
-        // applied to the R channel by linked-stereo design, so R should land at the same dB
-        // distance below its input peak.
+        // L's measured gain reduction is applied to R by linked-stereo design, so R lands the same
+        // dB distance below its input peak.
         float leftGainReductionDb = leftInputPeakDb - leftPeakDb;
         float expectedRightDb = rightInputPeakDb - leftGainReductionDb;
         Assert.That(rightPeakDb, Is.EqualTo(expectedRightDb).Within(1.5f));
@@ -395,11 +372,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_EnvelopeStateContinuesAcrossChunks()
     {
-        // A node warmed up by a previous loud chunk must NOT reset its envelope when the next
-        // chunk continues directly in time. We verify this by comparing the first sample of the
-        // second chunk against a fresh node processing the same loud input from scratch:
-        // the warmed-up node is already in compression so its first sample is quieter, while
-        // the fresh node still has to ramp through the attack phase.
+        // A node warmed up by a previous loud chunk must NOT reset its envelope on a time-contiguous
+        // next chunk. The warmed-up node is already in compression, so its first sample is quieter
+        // than a fresh node still ramping through attack.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
@@ -427,8 +402,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_NonContiguousTimeRange_ResetsEnvelope()
     {
-        // First chunk drives compression; the second chunk starts at a non-contiguous time and
-        // must therefore reset the envelope so it begins fresh from MinDb.
+        // Second chunk starts at a non-contiguous time, so the envelope must reset to MinDb.
         const int chunkSamples = SampleRate / 10;
         using var loud = CreateConstantBuffer(0.9f, chunkSamples);
 
@@ -450,8 +424,7 @@ public class CompressorNodeTests
         using var freshOutput = nodeFresh.Process(
             CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate)));
 
-        // After a seek-style discontinuity, the envelope was reset, so the first sample should
-        // match a fresh node's first sample (within float tolerance).
+        // After the seek reset, the first sample should match a fresh node's first sample.
         float seekedFirst = MathF.Abs(seekedOutput.GetChannelData(0)[0]);
         float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
         Assert.That(seekedFirst, Is.EqualTo(freshFirst).Within(1e-4f));
@@ -472,8 +445,7 @@ public class CompressorNodeTests
         const int altSampleRate = 44100;
         using var loud44 = CreateSineBuffer(0.9f, 1000f, altSampleRate / 10, 2, altSampleRate);
         node.AddInput(new StubSourceNode { Buffer = loud44 });
-        // Time continues but sample rate changed → must reset envelope (and recompute coefficients
-        // for the new rate).
+        // Time continues but the sample rate changed → reset envelope and recompute coefficients.
         var ctx44 = new AudioProcessContext(
             new TimeRange(TimeSpan.FromSeconds(chunkSamples / (double)SampleRate), TimeSpan.FromSeconds(0.1)),
             altSampleRate,
@@ -481,8 +453,7 @@ public class CompressorNodeTests
             null);
         using var secondOutput = node.Process(ctx44);
 
-        // After a sample-rate switch the envelope is reset, so the first sample must match a
-        // fresh node running at the new rate.
+        // After the sample-rate reset, the first sample must match a fresh node at the new rate.
         var nodeFresh = CreateNode(release: 1000f);
         using var freshInput = CreateSineBuffer(0.9f, 1000f, altSampleRate / 10, 2, altSampleRate);
         nodeFresh.AddInput(new StubSourceNode { Buffer = freshInput });
@@ -501,10 +472,9 @@ public class CompressorNodeTests
     [Test]
     public void Reset_ClearsEnvelopeState()
     {
-        // Process one chunk to drive the envelope into compression, then Reset() and process the
-        // next chunk at a *contiguous* time. Without Reset(), the time-range check would NOT
-        // trigger an automatic reset, so any difference from a fresh node must come from the
-        // explicit Reset() call.
+        // Drive the envelope into compression, then Reset() and process a *contiguous* next chunk.
+        // Contiguous time means no automatic reset, so any match with a fresh node must come from
+        // the explicit Reset().
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
@@ -534,9 +504,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedThreshold_EngagesAnimatedPath()
     {
-        // Threshold animates from -10 dB (no compression for 0.05 input) at t=0 to -40 dB
-        // (heavy compression for 0.05 input) at t=0.5s. The output should be louder near t=0
-        // and quieter near t=0.5s, proving the animated path is exercised.
+        // Threshold animates from -10 dB (no compression for 0.05 input) to -40 dB (heavy
+        // compression), so the output goes from louder to quieter — proving the animated path runs.
         const int sampleCount = SampleRate / 2;
         using var input = CreateConstantBuffer(0.05f, sampleCount);
         var source = new StubSourceNode { Buffer = input };
@@ -567,8 +536,8 @@ public class CompressorNodeTests
         float earlyPeakDb = PeakDb(output, 0);
         float latePeakDb = PeakDb(output, lastQuarterStart);
 
-        // Early threshold sits above the input (no compression); late threshold sits below it
-        // (compression engages). The late portion must therefore be measurably quieter.
+        // Early threshold is above the input (no compression), late is below it (compression
+        // engages), so the late portion must be measurably quieter.
         Assert.That(latePeakDb, Is.LessThan(earlyPeakDb - 2f),
             $"Animated threshold should attenuate the late portion (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB)");
     }
@@ -576,10 +545,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_InfinityInputSamples_RecoversAndDoesNotLeakNonFiniteOutput()
     {
-        // First few samples on every channel are +Infinity, which (after MathF.Abs and Log10)
-        // produces inputDb = +Infinity, polluting the envelope state. Subsequent samples are a
-        // normal sine wave. The self-recovery clamp must reset the envelope and the output
-        // sanitizer must ensure no NaN/Infinity sample escapes downstream.
+        // The first samples on every channel are +Infinity, polluting the envelope; the rest is a
+        // normal sine. The self-recovery clamp must reset the envelope and the sanitizer must keep
+        // any NaN/Infinity from escaping downstream.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         for (int ch = 0; ch < input.ChannelCount; ch++)
@@ -616,8 +584,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_NaNInputSamples_ProducesFiniteOutput()
     {
-        // A NaN input sample multiplied by any gain stays NaN. The output sanitizer must
-        // replace it with 0 so downstream consumers receive only finite samples.
+        // A NaN input stays NaN through any gain, so the sanitizer must replace it with 0.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         input.GetChannelData(0)[0] = float.NaN;
@@ -646,9 +613,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_SoftKnee_ProducesSmoothTransitionAroundThreshold()
     {
-        // Soft knee starts attenuating before the input crosses the threshold; hard knee does
-        // not. We feed a sine right at the threshold and verify that soft-knee output is lower
-        // than hard-knee output, confirming the quadratic in-knee region engages.
+        // Soft knee attenuates before the input crosses the threshold; hard knee doesn't. Feeding a
+        // sine right at the threshold, soft-knee output should be lower — confirming the quadratic
+        // in-knee region engages.
         const int sampleCount = SampleRate / 2;
         // 0.1 amplitude → exactly -20 dB peak, matching the threshold.
         using var input = CreateSineBuffer(0.1f, 1000f, sampleCount);
@@ -665,8 +632,7 @@ public class CompressorNodeTests
         float hardPeakDb = PeakDb(hardOutput, steadyStart);
         float softPeakDb = PeakDb(softOutput, steadyStart);
 
-        // Soft knee already engages before the input crosses the threshold, so its output peak
-        // should be measurably lower than the hard-knee output.
+        // Soft knee engages before the threshold, so its peak should be measurably lower than hard.
         Assert.That(softPeakDb, Is.LessThan(hardPeakDb - 0.3f),
             $"Soft knee should attenuate near threshold (hard≈{hardPeakDb:F2} dB, soft≈{softPeakDb:F2} dB)");
     }
@@ -674,8 +640,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_MonoBuffer_ProducesExpectedGainReduction()
     {
-        // The implementation iterates over the channel count; a single-channel buffer must work
-        // with no off-by-one and reach the same compression level as the stereo case.
+        // A single-channel buffer must work with no off-by-one and reach the stereo compression level.
         const int sampleCount = SampleRate;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount, channels: 1);
         var source = new StubSourceNode { Buffer = input };
@@ -702,14 +667,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedAttackRelease_ExercisesCoefficientCache()
     {
-        // Animate Attack from 1 ms (fast) to 200 ms (slow) over the buffer. Every new ms value
-        // invalidates the per-sample coefficient cache (`attackMs != lastAttackMs`), so
-        // ComputeCoeff is recomputed repeatedly. To verify the recomputed coefficients actually
-        // affect behaviour, we feed a step input (silence → loud) that arrives late in the
-        // buffer when the slow attack value is in effect. Right after the step the envelope
-        // hasn't clamped yet, so the transient peak must be louder than the eventually-settled
-        // tail. With attack stuck at 1 ms throughout, the transient would clamp instantly and
-        // this difference would not appear.
+        // Animate Attack 1 ms → 200 ms so every sample invalidates the coefficient cache and forces
+        // ComputeCoeff to recompute. A late step input lands while the slow attack is in effect, so
+        // the unclamped transient peak must exceed the settled tail. A stuck 1 ms attack would clamp
+        // instantly and erase that difference.
         const int sampleCount = SampleRate; // 1 s buffer
         int stepAt = SampleRate * 4 / 10;   // 400 ms in: animated attack ≈ 80 ms
         using var input = new AudioBuffer(SampleRate, 2, sampleCount);
@@ -762,16 +723,14 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedPath_SmoothAcrossChunkBoundary()
     {
-        // ProcessAnimated walks the input in fixed-size chunks. We send a buffer that straddles
-        // several chunk boundaries and verify that the envelope state survives them: a steady
-        // input must not show any visible discontinuity at sample indices that align with the
-        // chunk size, which would indicate the envelope was reset at the boundary.
+        // ProcessAnimated walks the input in fixed-size chunks. A buffer straddling several chunk
+        // boundaries must show no discontinuity at boundary indices for steady input — a jump there
+        // would mean the envelope was reset at the boundary.
         const int chunkSize = 1024;
         const int sampleCount = chunkSize * 3 + 137; // straddles several boundaries
         using var input = CreateConstantBuffer(0.9f, sampleCount);
 
-        // Animate threshold trivially so ProcessAnimated is taken; the value stays the same so
-        // the gain reduction itself should be smooth.
+        // Trivial threshold animation (constant value) just to force the ProcessAnimated path.
         var thresholdAnim = new KeyFrameAnimation<float>();
         thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.Zero });
         thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.FromSeconds(sampleCount / (double)SampleRate) });
@@ -792,16 +751,14 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate));
         using var output = node.Process(ctx);
 
-        // Across each chunk boundary, the absolute change between adjacent samples must remain
-        // bounded by the change inside the previous window — i.e. no sudden jump caused by
-        // resetting state at a boundary.
+        // At each boundary the adjacent-sample delta must stay bounded by the prior delta — no jump
+        // from a boundary state reset.
         var data = output.GetChannelData(0);
         for (int boundary = chunkSize; boundary < sampleCount; boundary += chunkSize)
         {
             float prevDelta = MathF.Abs(data[boundary - 1] - data[boundary - 2]);
             float boundaryDelta = MathF.Abs(data[boundary] - data[boundary - 1]);
-            // Tolerance allows for a tiny natural variation in the sine-like product but rejects
-            // an envelope reset (which would create a step of order 0.1 or larger here).
+            // Tolerance absorbs tiny natural variation but rejects an envelope reset (step ≥ ~0.1).
             Assert.That(boundaryDelta, Is.LessThanOrEqualTo(prevDelta + 0.01f),
                 $"Discontinuity at chunk boundary {boundary}: prevDelta={prevDelta:F6}, boundaryDelta={boundaryDelta:F6}");
         }
@@ -817,12 +774,9 @@ public class CompressorNodeTests
     [TestCase(AnimatedParam.MakeupGain)]
     public void Process_AnimatedNonFiniteValue_FallsBackWithoutMutingOutput(AnimatedParam param)
     {
-        // A KeyFrame with NaN or Infinity on any animated parameter must not propagate to the
-        // output sanitizer (which would silently mute the entire chunk). Instead each parameter
-        // must fall back to the value ReadStaticParameters supplies — i.e. the property's static
-        // CurrentValue (which itself only drops to DefaultValue if CurrentValue is non-finite). We
-        // test every animated parameter so the SafeParameter call cannot be silently dropped from
-        // any one of them.
+        // A NaN/Infinity keyframe on any animated parameter must not reach the sanitizer (which
+        // would mute the whole chunk); each must fall back to its static CurrentValue. Every
+        // parameter is tested so a missing SafeParameter call on any one is caught.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -846,7 +800,7 @@ public class CompressorNodeTests
         var anim = new KeyFrameAnimation<float>();
         anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
         anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
-        // IProperty<float> exposes the Animation setter directly; no concrete-type cast needed.
+        // IProperty<float> exposes the Animation setter directly, no concrete cast needed.
         target.Animation = anim;
 
         var node = new CompressorNode
@@ -863,9 +817,8 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25));
         using var output = node.Process(ctx);
 
-        // If the NaN had reached the gain calc the output sanitizer would have zeroed every
-        // sample and the peak would be -100 dB. Anything well above that proves the fallback
-        // engaged for the parameter under test.
+        // If NaN reached the gain calc the sanitizer would zero everything (-100 dB peak); a peak
+        // well above that proves the fallback engaged.
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
         Assert.That(steadyPeakDb, Is.GreaterThan(-25f),
             $"Fallback failed for {param}: output appears to have been zeroed by NaN propagation");
@@ -887,9 +840,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_ZeroLengthInput_Static_ReturnsEmptyBuffer()
     {
-        // A zero-length chunk (silent gap, end-of-stream tail) must not divide by zero, allocate
-        // a stackalloc[0] for animation buffers, or otherwise misbehave. The static path is
-        // exercised because no parameters are animated.
+        // A zero-length chunk must not divide by zero or stackalloc[0]. No animated parameters, so
+        // the static path is exercised.
         using var input = new AudioBuffer(SampleRate, 2, 0);
         var node = CreateNode();
         node.AddInput(new StubSourceNode { Buffer = input });
@@ -905,10 +857,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_ZeroLengthInput_Animated_ReturnsEmptyBuffer()
     {
-        // Same as above, but with an animated parameter. The zero-length early-return in Process()
-        // intercepts BOTH the static and animated paths before ProcessAnimated (and its
-        // stackalloc float[bufferSize]) is ever entered, so this asserts the early-return contract
-        // — not the animated chunk loop itself, which is unreachable for SampleCount == 0.
+        // Same as above but animated. The zero-length early-return in Process() fires before
+        // ProcessAnimated is entered, so this pins the early-return contract — the animated chunk
+        // loop is unreachable at SampleCount == 0.
         using var input = new AudioBuffer(SampleRate, 2, 0);
 
         var thresholdAnim = new KeyFrameAnimation<float>();
@@ -938,10 +889,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedMakeupGain_AppliesPerSampleGain()
     {
-        // Sweep MakeupGain from 0 dB (start) to +12 dB (end) over a steady loud signal. The
-        // tail of the buffer must measure ~12 dB louder than the head — proving that the
-        // animated `makeupDb - gainReductionDb` path actually mixes the per-sample makeup value
-        // into the output (and that the sign is correct).
+        // Sweep MakeupGain 0 → +12 dB over a steady loud signal; the tail must measure ~12 dB louder
+        // than the head, proving the animated per-sample makeup is mixed in with the correct sign.
         const int sampleCount = SampleRate; // 1 s buffer
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -965,15 +914,14 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
         using var output = node.Process(ctx);
 
-        // Compare a steady-state window early in the buffer (makeup ≈ 0 dB) against one near
-        // the end (makeup ≈ +12 dB). Both are after the attack ramp so envelope state is steady.
+        // Compare an early window (makeup ≈ 0 dB) against a late one (≈ +12 dB), both past the attack
+        // ramp so the envelope is steady.
         int probeWidth = SampleRate / 100; // 10 ms
         float earlyPeakDb = PeakDbInWindow(output, SampleRate / 4, probeWidth);
         float latePeakDb = PeakDbInWindow(output, sampleCount - probeWidth, probeWidth);
 
         float observedRise = latePeakDb - earlyPeakDb;
-        // 12 dB nominal; tolerance allows for ~3 dB of drift due to envelope ripple and the
-        // 25%→100% sweep range covering 9 dB rather than the full 12 dB.
+        // 12 dB nominal; wide tolerance because the 25%→100% window covers only ~9 dB plus ripple.
         Assert.That(observedRise, Is.GreaterThan(6f),
             $"Animated MakeupGain should raise output level (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB, rise≈{observedRise:F2} dB)");
         Assert.That(observedRise, Is.LessThan(15f),
@@ -983,9 +931,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedRatio_BelowOne_ClampsToPassthrough()
     {
-        // The animated path's clamp must mirror the static path: an animated ratio of 0.5
-        // would otherwise produce slope = 1 - 1/0.5 = -1 which AMPLIFIES above the threshold.
-        // After clamping to MinRatio=1, slope = 0 → passthrough.
+        // The animated clamp must mirror the static path: ratio 0.5 gives slope -1 (amplifies above
+        // threshold); clamping to MinRatio=1 makes slope 0 → passthrough.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -1021,11 +968,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedAttack_AboveMaxClampsAndKeepsEnvelopeMoving()
     {
-        // An animated Attack of 1e9 ms would collapse the coefficient to exactly 1.0, freezing
-        // the envelope so it never tracks the input — and therefore never crosses the threshold
-        // and never compresses. After clamping to MaxAttackMs the coefficient is < 1.0 so the
-        // envelope advances. We use a deep threshold (-50 dB) so the slow envelope reaches it
-        // within a 1 s buffer; the visible output reduction is then proof the clamp engaged.
+        // An animated Attack of 1e9 ms would collapse the coefficient to 1.0, freezing the envelope
+        // so it never compresses. Clamping to MaxAttackMs keeps coeff < 1.0 so the envelope advances.
+        // A deep -50 dB threshold lets the slow envelope reach it within 1 s; the output reduction
+        // proves the clamp engaged.
         const int sampleCount = SampleRate;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -1049,8 +995,7 @@ public class CompressorNodeTests
         var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0));
         using var output = node.Process(ctx);
 
-        // Probe in the last 50 ms window so the clamped 500 ms attack has had ~2 time constants
-        // to bring the envelope above -50 dB and trigger compression.
+        // Probe the last 50 ms, by when the clamped attack has had ~2 time constants to cross -50 dB.
         int probeWidth = SampleRate / 20;
         float steadyPeakDb = PeakDbInWindow(output, sampleCount - probeWidth, probeWidth);
         // Without clamping: envelope frozen at -100 dB → no compression → output ≈ input (-0.92 dB).
@@ -1062,10 +1007,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_MultipleAnimatedNonFiniteParameters_AllFallBackIndependently()
     {
-        // Two animated parameters simultaneously produce NaN. With a single shared latch, only
-        // one parameter would log and the second's fallback could be skipped if the latch were
-        // also gating the substitution; the per-parameter HashSet ensures both still substitute
-        // their fallbacks. Observable: output is not muted (would be -100 dB if NaN propagated).
+        // Two animated parameters produce NaN at once. A per-parameter HashSet (not a shared latch)
+        // ensures both still substitute their fallbacks. Observable: output is not muted (would be
+        // -100 dB if a NaN propagated).
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 
@@ -1113,13 +1057,11 @@ public class CompressorNodeTests
     [Test]
     public void Process_StaticAndAnimatedPaths_ProduceIdenticalOutputForConstantParameters()
     {
-        // ProcessStatic and ProcessAnimated deliberately share ComputeCoeff / ComputeGainReductionDb
-        // / ComputeGainLinear so the two paths cannot drift. This pins that parity directly: with a
-        // constant-valued (two identical keyframes) Threshold animation, the animated path runs but
-        // every sampled parameter equals what the static path reads, so the outputs must be
-        // sample-for-sample identical. A coefficient-cache off-by-one, a chunk-boundary coefficient
-        // reset, or a slope re-derivation bug that uniformly scaled the animated output would break
-        // this even though Process_AnimatedPath_SmoothAcrossChunkBoundary (smoothness only) passes.
+        // ProcessStatic and ProcessAnimated share the same compute helpers so they cannot drift.
+        // With a constant Threshold animation the animated path runs but reads the same values as
+        // static, so outputs must match sample-for-sample. Catches a coefficient-cache off-by-one,
+        // a boundary coefficient reset, or a slope re-derivation bug that the smoothness-only test
+        // would miss.
         const int sampleCount = SampleRate / 2; // straddles many 1024-sample chunks
         var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
@@ -1129,9 +1071,8 @@ public class CompressorNodeTests
         staticNode.AddInput(new StubSourceNode { Buffer = input });
         using var staticOut = staticNode.Process(CreateContext(TimeSpan.Zero, duration));
 
-        // Animated path forced on via a constant Threshold animation (-20 → -20). The remaining
-        // parameters have no animation, so AnimationSampler fills each with the same CurrentValue
-        // the static path reads.
+        // Animated path forced on via a constant Threshold animation; the other parameters stay
+        // unanimated, so AnimationSampler fills each with the same CurrentValue static reads.
         var thresholdAnim = new KeyFrameAnimation<float>();
         thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.Zero });
         thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = duration });
@@ -1165,12 +1106,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_SoftKnee_InKneeReductionMatchesClosedForm()
     {
-        // Validate the soft-knee quadratic numerically, not just "soft < hard". A DC signal whose
-        // peak level equals the threshold drives the envelope to a known value (= thresholdDb), so
-        // diff = 0, landing in the middle of the knee. The closed form there is
-        //   GR = slope * x^2 / (2*knee)  with x = diff + halfKnee = halfKnee.
-        // The hard-knee formula would give 0 dB at diff == 0, so this point distinctively exercises
-        // the quadratic branch of CompressorNode.ComputeGainReductionDb.
+        // Validate the soft-knee quadratic numerically, not just "soft < hard". A DC signal at the
+        // threshold drives the envelope to thresholdDb (diff = 0, mid-knee), where the closed form
+        // is GR = slope * halfKnee^2 / (2*knee). Hard knee gives 0 dB there, so this point uniquely
+        // exercises the quadratic branch of ComputeGainReductionDb.
         const int sampleCount = SampleRate / 2; // long enough for the envelope to settle to inputDb
         const float thresholdDb = -20f;
         const float ratio = 4f;
@@ -1182,8 +1121,7 @@ public class CompressorNodeTests
         node.AddInput(new StubSourceNode { Buffer = input });
         using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
 
-        // After settling, output[last] = amplitude * 10^(-GR/20). Recover GR and compare to the
-        // closed-form value at diff = 0.
+        // Recover GR from the settled output and compare to the closed form at diff = 0.
         float settled = MathF.Abs(output.GetChannelData(0)[sampleCount - 1]);
         float measuredGrDb = -20f * MathF.Log10(settled / amplitude);
 
@@ -1199,13 +1137,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_ExpressionBackedParameter_RoutesToStaticPathAndIgnoresExpression()
     {
-        // hasAnimation keys solely on Animation != null, so an expression-backed property
-        // (Animation == null, HasExpression == true) routes to ProcessStatic, which reads
-        // CurrentValue and does NOT evaluate the expression per-sample. This pins that documented
-        // contract: the output must equal a fully-static node with the same CurrentValue even
-        // though the expression evaluates to a different number. If a future change flips the gate
-        // to treat HasExpression as live (the FIXME's eventual goal), this test forces a deliberate
-        // update instead of silently changing rendered audio.
+        // hasAnimation keys solely on Animation != null, so an expression-backed property routes to
+        // ProcessStatic and reads CurrentValue without evaluating the expression. Output must equal
+        // a fully-static node with the same CurrentValue. If a future change makes HasExpression
+        // live (the FIXME's goal), this forces a deliberate update instead of silently changing audio.
         const int sampleCount = SampleRate / 2;
         var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
@@ -1248,12 +1183,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_NonFiniteSampleLatch_SurvivesSeekDiscontinuity()
     {
-        // The diagnostic latch must be PRESERVED across a time-range discontinuity (seek). A
-        // stuttering scrubber produces many discontinuities within one session; re-arming the
-        // one-shot warning on each would let a persistent fault re-log once per Process() call.
+        // The diagnostic latch must be PRESERVED across a seek discontinuity: a stuttering scrubber
+        // produces many seeks, and re-arming on each would re-log a persistent fault every Process().
         // The seek path calls ResetEnvelope() only (not ResetDiagnostics), so a second seeked chunk
-        // carrying the same fault must emit NO second warning. This pins the node's most heavily
-        // justified design decision (the 8-line comment at CompressorNode.Process).
+        // with the same fault must emit no second warning.
         var node = CreateNode();
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
@@ -1276,8 +1209,8 @@ public class CompressorNodeTests
     [Test]
     public void Process_NonFiniteSampleLatch_ReArmsOnSampleRateChange()
     {
-        // A sample-rate change is a genuine session boundary: Process() calls the full Reset(),
-        // which DOES re-arm diagnostics. The same fault at the new rate must therefore warn again.
+        // A sample-rate change is a real session boundary: Process() calls full Reset(), which
+        // re-arms diagnostics, so the same fault at the new rate must warn again.
         var node = CreateNode();
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
@@ -1301,9 +1234,8 @@ public class CompressorNodeTests
     [Test]
     public void Reset_ReArmsNonFiniteSampleLatch()
     {
-        // Explicit Reset() (deliberate re-render / orchestrated stop) re-arms diagnostics too. We
-        // keep the second chunk CONTIGUOUS in time so only the explicit Reset() — not a
-        // discontinuity — can be responsible for re-arming the latch.
+        // Explicit Reset() re-arms diagnostics too. The second chunk stays time-contiguous so only
+        // the Reset() — not a discontinuity — can re-arm the latch.
         var node = CreateNode();
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
@@ -1325,12 +1257,10 @@ public class CompressorNodeTests
     [Test]
     public void Process_LinkedSurround_AppliesLoudestChannelGainToAllChannels()
     {
-        // Peak detection links across ALL channels (not just the first two) and MapChannels
-        // reallocates its caches for a >2-channel count, exercising the channel-major fallback loop.
-        // We drive a 4-channel buffer where the loudest channel is channel 2 (NOT channel 0); the
-        // other three sit below threshold. Linked behaviour must attenuate every channel by channel
-        // 2's gain reduction — a peak loop that only scanned channels 0..1, or an off-by-one in the
-        // channel bound, would fail here.
+        // Peak detection links across ALL channels and MapChannels reallocates caches for >2
+        // channels (the channel-major fallback). A 4-channel buffer whose loudest is channel 2
+        // (not 0) must attenuate every channel by channel 2's reduction — a loop scanning only
+        // channels 0..1, or a channel-bound off-by-one, would fail here.
         const int sampleCount = SampleRate;
         const int channels = 4;
         using var input = new AudioBuffer(SampleRate, channels, sampleCount);
@@ -1373,10 +1303,9 @@ public class CompressorNodeTests
     [Test]
     public void Process_AnimatedOutOfRangeParameter_LogsClampWarningOncePerParameter()
     {
-        // A finite but out-of-[Range] animated value (Attack = 1e9 ms) is clamped to keep the DSP
-        // safe, and must emit exactly one clamp warning for that parameter — not zero (a silently
-        // hidden misconfiguration) and not one-per-sample (audio-thread spam). The other five
-        // parameters stay in range, so the count isolates the single offending parameter.
+        // A finite out-of-[Range] animated value (Attack = 1e9 ms) is clamped and must emit exactly
+        // one clamp warning — not zero (hidden misconfiguration), not per-sample (audio-thread spam).
+        // The other five parameters stay in range, isolating the count to the offending one.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
 

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
@@ -62,10 +62,9 @@ public class DelayNodeTests
         return property;
     }
 
-    // An animatable property with NO animation assigned must behave exactly like a genuinely
-    // non-animatable (static) property: both feed CurrentValue every sample. This is the core
-    // guarantee of routing on Animation != null instead of the IsAnimatable capability flag.
-    // The CircularBuffer state is stateful across renders, so each render uses a fresh node.
+    // An animatable property with NO animation must behave exactly like a static one: both feed
+    // CurrentValue every sample. This is the point of routing on Animation != null, not IsAnimatable.
+    // The CircularBuffer is stateful across renders, so each render uses a fresh node.
     [Test]
     public void Process_AnimatableParamsWithoutAnimation_MatchesNonAnimatableStatic()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayParametersTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayParametersTests.cs
@@ -22,8 +22,8 @@ public class DelayParametersTests
         Assert.That(min, Is.LessThan(max), $"{name}: Min must be < Max");
     }
 
-    // Characterization: lock the consolidated constants to the literals that DelayEffect/DelayNode
-    // previously declared independently, so the single-source refactor stays behavior-preserving.
+    // Characterization: lock the consolidated constants to the literals DelayEffect/DelayNode
+    // declared before the single-source refactor, keeping it behavior-preserving.
     [Test]
     public void Constants_match_the_original_literals()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
@@ -52,9 +52,8 @@ public class GainNodeTests
     private static AudioProcessContext CreateContext() =>
         new(new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), SampleRate, new AnimationSampler(), null);
 
-    // Gain is animatable (capability) but has no animation assigned. The node must use the static
-    // value (CurrentValue), not the per-sample animated path. Output values are identical either way,
-    // so this also characterizes the behavior-preserving IsAnimatable -> Animation != null change.
+    // Animatable Gain with no animation assigned must use the static CurrentValue, not the
+    // per-sample path. Characterizes the behavior-preserving IsAnimatable -> Animation != null change.
     [Test]
     public void Process_AnimatableGainWithoutAnimation_AppliesCurrentValue()
     {
@@ -78,8 +77,8 @@ public class GainNodeTests
         }
     }
 
-    // A real keyframe animation must still drive the per-sample animated path. Output ramps with the
-    // animated gain, so the last sample is strictly louder than the first.
+    // A real keyframe animation must drive the per-sample path: output ramps with the gain, so the
+    // last sample is louder than the first.
     [Test]
     public void Process_GainWithAnimation_AppliesAnimatedValues()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
@@ -13,8 +13,8 @@ public class SpeedNodeTests
 {
     private const int SampleRate = 100;
 
-    // Deterministic stereo source: a ramp keyed off the requested global sample index so that
-    // any change in how SpeedNode requests source ranges shows up as a different output.
+    // Deterministic stereo source: a ramp keyed off the global sample index, so any change in how
+    // SpeedNode requests source ranges shows up in the output.
     private sealed class RampInputNode : AudioNode
     {
         private readonly int _sampleRate;
@@ -96,11 +96,9 @@ public class SpeedNodeTests
         }
     }
 
-    // Guards the ArrayPool usage in ProcessAnimatedSpeed: two independent fresh nodes fed identical
-    // input must yield identical output. A pooled speed buffer that leaked stale data or was not fully
-    // overwritten would make the second instance (which gets a dirtier rented array) diverge.
-    // Note: a single node is stateful across renders (its WdlResampler carries filter state), so each
-    // comparison must use a freshly constructed node.
+    // Guards the ArrayPool usage in ProcessAnimatedSpeed: two fresh nodes fed identical input must
+    // produce identical output, so a pooled speed buffer with leftover stale data would diverge.
+    // A node is stateful across renders (WdlResampler filter state), hence a fresh node per render.
     [Test]
     public void ProcessAnimatedSpeed_IsDeterministicAcrossFreshInstances()
     {

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -504,15 +504,12 @@ public class DispatcherTests
         dispatcher.Shutdown();
     }
 
-    // Regression test: WaitForPendingOperations passed `next - now` to CancellationTokenSource
-    // .CancelAfter without guarding against a negative value. With a monotonically advancing
-    // clock the next timer slips from "future" at FlushTimerQueue to "past" at the wait
-    // computation, which used to throw ArgumentOutOfRangeException and kill the dispatcher thread.
+    // Regression: an unguarded negative `next - now` (timer slips past between flush and wait)
+    // used to throw in CancelAfter and kill the dispatcher thread.
     [Test]
     public void Schedule_WhenTimerElapsesBetweenFlushAndWait_DoesNotCrashDispatcher()
     {
-        // step (10ms) < delay (15ms) < 2*step (20ms): after the flush read (now = +10, timer
-        // still future) the wait read (now = +20) makes the delay negative by construction.
+        // step < delay < 2*step: timer is future at the flush read (+10) but past at the wait read (+20).
         var timeProvider = new AdvancingTimeProvider(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(10));
         var dispatcher = Dispatcher.Spawn(timeProvider);
         var tcs = new TaskCompletionSource();
@@ -525,8 +522,8 @@ public class DispatcherTests
         dispatcher.Shutdown();
     }
 
-    // Advances by a fixed step on every GetUtcNow() call, so a scheduled timer deterministically
-    // slips from "future" to "past" across the dispatcher's flush and wait reads of the clock.
+    // Advances a fixed step per GetUtcNow() so a timer deterministically slips past between
+    // the dispatcher's flush and wait clock reads.
     private sealed class AdvancingTimeProvider(DateTimeOffset start, TimeSpan step) : TimeProvider
     {
         private readonly object _lock = new();


### PR DESCRIPTION
## Summary

Compress the verbose `//` and `///` comments added across the last 10 commits down to 1-2 lines, at "medium" strength — removing redundant phrasing and self-evident restatement while preserving the load-bearing "why" (regression guards, pitfalls, invariants, single-source-of-truth rationale).

- 65 `.cs` files, **+496 / -787** (net ~290 comment lines trimmed)
- **Comment text only** — no code, string literals, attributes, signatures, or test logic changed
- XML doc comments (`///`) keep their `<summary>` / `<param>` / `<remarks>` structure; only the prose was tightened
- Already-concise one-line comments left as-is
- The unrelated `MacWindow.axaml.cs` working-tree change is **not** included in this PR

## Examples

- `CompressorNode` envelope reset: 8 → 6 lines (kept "stale state after seek" + "don't re-arm diagnostics")
- `LayerHeaderViewModel` ZIndex double-apply note: 6 → 2 lines (kept "leaks into next history entry + double-applies the shift")
- `SceneTimeRangeService` drag-cancel doc: 8 → 4 lines (kept the pre-refactor regression rationale)

## Affected areas

`Beutl.Engine` (audio nodes/params), `Beutl.Editor` (services + interfaces), `Beutl.Editor.Components`, `Beutl.Threading`, `Beutl` (ViewModels), benchmarks, and unit tests.

## Breaking changes

None — comment-only, behavior-preserving.

## Test plan

No behavior change; comment-only edits. Verified mechanically that no non-comment line changed (the only flagged lines were trailing inline-comment shortenings on otherwise-unchanged code).