### PR TITLE
feat: add 'Add Adjustment Layer' menu (refactor ElementDescription to EngineObjectFactory)

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -170,6 +170,11 @@
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
                         <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
+                        <ui:MenuFlyoutItem Click="AddAdjustmentLayerClick" Text="{x:Static lang:Strings.AddAdjustmentLayer}">
+                            <ui:MenuFlyoutItem.IconSource>
+                                <icons:SymbolIconSource Symbol="Color" />
+                            </ui:MenuFlyoutItem.IconSource>
+                        </ui:MenuFlyoutItem>
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{h:GetCommandGesture Paste}"
                                            Text="{x:Static lang:Strings.Paste}">

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -656,6 +656,25 @@ public sealed partial class TimelineTabView : UserControl
             InitialObject: operatorType));
     }
 
+    private void AddAdjustmentLayerClick(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel == null) return;
+
+        ViewModel.AddElement.Execute(new ElementDescription(
+            ViewModel.ClickedFrame,
+            TimeSpan.FromSeconds(5),
+            ViewModel.CalculateClickedLayer(),
+            Name: Strings.AdjustmentLayer,
+            InitialObject: typeof(Beutl.Graphics.SourceBackdrop),
+            InitialObjectConfigure: obj =>
+            {
+                if (obj is Beutl.Graphics.SourceBackdrop backdrop)
+                {
+                    backdrop.Clear.CurrentValue = true;
+                }
+            }));
+    }
+
     private void PopulateAddFromTemplateSubMenu()
     {
         AddFromTemplateSubMenu.Items.Clear();

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -562,7 +562,7 @@ public sealed partial class TimelineTabView : UserControl
         {
             viewModel.AddElement.Execute(new ElementDescription(
                 viewModel.ClickedFrame, TimeSpan.FromSeconds(5), viewModel.CalculateClickedLayer(),
-                InitialObject: type));
+                EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(type)!));
 
             e.Handled = true;
         }
@@ -653,7 +653,7 @@ public sealed partial class TimelineTabView : UserControl
             ViewModel.ClickedFrame,
             TimeSpan.FromSeconds(5),
             ViewModel.CalculateClickedLayer(),
-            InitialObject: operatorType));
+            EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(operatorType)!));
     }
 
     private void AddAdjustmentLayerClick(object? sender, RoutedEventArgs e)
@@ -665,14 +665,7 @@ public sealed partial class TimelineTabView : UserControl
             TimeSpan.FromSeconds(5),
             ViewModel.CalculateClickedLayer(),
             Name: Strings.AdjustmentLayer,
-            InitialObject: typeof(Beutl.Graphics.SourceBackdrop),
-            InitialObjectConfigure: obj =>
-            {
-                if (obj is Beutl.Graphics.SourceBackdrop backdrop)
-                {
-                    backdrop.Clear.CurrentValue = true;
-                }
-            }));
+            EngineObjectFactory: () => new Beutl.Graphics.SourceBackdrop { Clear = { CurrentValue = true } }));
     }
 
     private void PopulateAddFromTemplateSubMenu()

--- a/src/Beutl.Editor/Models/ElementDescription.cs
+++ b/src/Beutl.Editor/Models/ElementDescription.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Graphics;
+﻿using Beutl.Engine;
+using Beutl.Graphics;
 
 namespace Beutl.Editor.Models;
 
@@ -9,4 +10,5 @@ public record struct ElementDescription(
     string Name = "",
     Type? InitialObject = null,
     string? FileName = null,
-    Point Position = default);
+    Point Position = default,
+    Action<EngineObject>? InitialObjectConfigure = null);

--- a/src/Beutl.Editor/Models/ElementDescription.cs
+++ b/src/Beutl.Editor/Models/ElementDescription.cs
@@ -3,12 +3,28 @@ using Beutl.Graphics;
 
 namespace Beutl.Editor.Models;
 
+/// <summary>
+/// Describes how to create and place a new <c>Element</c> on the timeline.
+/// </summary>
+/// <param name="EngineObjectFactory">
+/// Produces the initial engine object hosted by the element. The factory both constructs and
+/// configures the object, so callers can supply a fully-typed object (e.g. an adjustment layer)
+/// without a separate post-construction configuration step. Mutually exclusive with
+/// <paramref name="FileName"/>; ignored when a file is imported.
+/// </param>
 public record struct ElementDescription(
     TimeSpan Start,
     TimeSpan Length,
     int Layer,
     string Name = "",
-    Type? InitialObject = null,
+    Func<EngineObject>? EngineObjectFactory = null,
     string? FileName = null,
-    Point Position = default,
-    Action<EngineObject>? InitialObjectConfigure = null);
+    Point Position = default)
+{
+    /// <summary>
+    /// Resolves the element name: the explicit <see cref="Name"/> when set, otherwise the
+    /// localized display name of <paramref name="fallbackType"/>.
+    /// </summary>
+    public readonly string ResolveName(Type fallbackType) =>
+        string.IsNullOrEmpty(Name) ? TypeDisplayHelpers.GetLocalizedName(fallbackType) : Name;
+}

--- a/src/Beutl.Editor/Models/ElementDescription.cs
+++ b/src/Beutl.Editor/Models/ElementDescription.cs
@@ -9,8 +9,8 @@ namespace Beutl.Editor.Models;
 /// <param name="EngineObjectFactory">
 /// Produces the initial engine object hosted by the element. The factory both constructs and
 /// configures the object, so callers can supply a fully-typed object (e.g. an adjustment layer)
-/// without a separate post-construction configuration step. Mutually exclusive with
-/// <paramref name="FileName"/>; ignored when a file is imported.
+/// without a separate post-construction configuration step. When <paramref name="FileName"/> is
+/// also set, file import takes precedence and the factory is ignored.
 /// </param>
 public record struct ElementDescription(
     TimeSpan Start,

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -48,6 +48,12 @@
   <data name="AddElement" xml:space="preserve">
     <value>要素を追加</value>
   </data>
+  <data name="AddAdjustmentLayer" xml:space="preserve">
+    <value>アジャストメントレイヤーを追加</value>
+  </data>
+  <data name="AdjustmentLayer" xml:space="preserve">
+    <value>アジャストメントレイヤー</value>
+  </data>
   <data name="Apply" xml:space="preserve">
     <value>適用</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -203,6 +203,12 @@
   <data name="AddElement" xml:space="preserve">
     <value>Add Element</value>
   </data>
+  <data name="AddAdjustmentLayer" xml:space="preserve">
+    <value>Add Adjustment Layer</value>
+  </data>
+  <data name="AdjustmentLayer" xml:space="preserve">
+    <value>Adjustment Layer</value>
+  </data>
   <data name="Location" xml:space="preserve">
     <value>Location</value>
   </data>

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -57,7 +57,7 @@ public static class AnimationEditTutorial
                     Start: TimeSpan.Zero,
                     Length: TimeSpan.FromSeconds(5),
                     Layer: 0,
-                    InitialObject: typeof(EllipseShape)));
+                    EngineObjectFactory: () => new EllipseShape()));
 
                 return true;
             },

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -185,7 +185,7 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
             Element element = CreateElement();
             if (desc.EngineObjectFactory != null)
             {
-                EngineObject engineObject;
+                EngineObject? engineObject;
                 try
                 {
                     engineObject = desc.EngineObjectFactory();
@@ -195,6 +195,14 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
                     // Aborting before any scene mutation keeps the add transactional: nothing is
                     // persisted or committed to history when the factory fails.
                     _logger.LogError(ex, "Failed to create the engine object for the new element; aborting add.");
+                    return;
+                }
+
+                if (engineObject == null)
+                {
+                    // A factory that returns null (rather than throwing) would otherwise NRE below,
+                    // bypassing the guard above. Abort here too, before mutating the scene.
+                    _logger.LogError("EngineObjectFactory returned null for the new element; aborting add.");
                     return;
                 }
 

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -183,16 +183,24 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
         {
             _logger.LogInformation("Adding new element without file.");
             Element element = CreateElement();
-            if (desc.InitialObject != null)
+            if (desc.EngineObjectFactory != null)
             {
-                element.Name = string.IsNullOrEmpty(desc.Name)
-                    ? TypeDisplayHelpers.GetLocalizedName(desc.InitialObject)
-                    : desc.Name;
+                EngineObject engineObject;
+                try
+                {
+                    engineObject = desc.EngineObjectFactory();
+                }
+                catch (Exception ex)
+                {
+                    // Aborting before any scene mutation keeps the add transactional: nothing is
+                    // persisted or committed to history when the factory fails.
+                    _logger.LogError(ex, "Failed to create the engine object for the new element; aborting add.");
+                    return;
+                }
 
-                element.AccentColor =
-                    ColorGenerator.GenerateColor(desc.InitialObject.FullName ?? desc.InitialObject.Name);
-                var engineObject = (EngineObject)Activator.CreateInstance(desc.InitialObject)!;
-                desc.InitialObjectConfigure?.Invoke(engineObject);
+                Type objectType = engineObject.GetType();
+                element.Name = desc.ResolveName(objectType);
+                element.AccentColor = ColorGenerator.GenerateColor(objectType.FullName ?? objectType.Name);
                 element.AddObject(engineObject);
                 if (engineObject is Drawable drawable)
                 {

--- a/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
+++ b/src/Beutl/ViewModels/EditContext/ElementAdderImpl.cs
@@ -185,11 +185,14 @@ internal sealed class ElementAdderImpl(EditViewModel context) : IElementAdder
             Element element = CreateElement();
             if (desc.InitialObject != null)
             {
-                element.Name = TypeDisplayHelpers.GetLocalizedName(desc.InitialObject);
+                element.Name = string.IsNullOrEmpty(desc.Name)
+                    ? TypeDisplayHelpers.GetLocalizedName(desc.InitialObject)
+                    : desc.Name;
 
                 element.AccentColor =
                     ColorGenerator.GenerateColor(desc.InitialObject.FullName ?? desc.InitialObject.Name);
                 var engineObject = (EngineObject)Activator.CreateInstance(desc.InitialObject)!;
+                desc.InitialObjectConfigure?.Invoke(engineObject);
                 element.AddObject(engineObject);
                 if (engineObject is Drawable drawable)
                 {

--- a/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
+++ b/src/Beutl/Views/PlayerView.axaml.DragDrop.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using Beutl.Editor.Models;
+using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Rendering;
@@ -95,7 +96,9 @@ public partial class PlayerView
                 int zindex = CalculateZIndex(scene);
 
                 adder.AddElement(new ElementDescription(
-                    frame, TimeSpan.FromSeconds(5), zindex, InitialObject: type, Position: centeredPosition));
+                    frame, TimeSpan.FromSeconds(5), zindex,
+                    EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(type)!,
+                    Position: centeredPosition));
             }
             else if (e.DataTransfer.TryGetFile()?.TryGetLocalPath() is { } fileName)
             {

--- a/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Editor.Models;
+using Beutl.Engine;
 using Beutl.Graphics;
 
 namespace Beutl.UnitTests.Editor;
@@ -13,7 +14,8 @@ public class ElementDescriptionTests
         Assert.That(desc.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
         Assert.That(desc.Layer, Is.EqualTo(3));
         Assert.That(desc.Name, Is.EqualTo(string.Empty));
-        Assert.That(desc.InitialObject, Is.Null);
+        // Cast to object so NUnit compares the delegate reference instead of invoking it.
+        Assert.That((object?)desc.EngineObjectFactory, Is.Null);
         Assert.That(desc.FileName, Is.Null);
         Assert.That(desc.Position, Is.EqualTo(default(Point)));
     }
@@ -21,19 +23,63 @@ public class ElementDescriptionTests
     [Test]
     public void With_AllProperties()
     {
+        Func<EngineObject> factory = () => new SourceBackdrop();
         var desc = new ElementDescription(
             TimeSpan.FromSeconds(0),
             TimeSpan.FromSeconds(5),
             Layer: 2,
             Name: "title",
-            InitialObject: typeof(string),
+            EngineObjectFactory: factory,
             FileName: "/tmp/x.mp4",
             Position: new Point(10, 20));
 
         Assert.That(desc.Name, Is.EqualTo("title"));
-        Assert.That(desc.InitialObject, Is.EqualTo(typeof(string)));
+        // Cast to object so NUnit compares the delegate reference instead of invoking it.
+        Assert.That((object?)desc.EngineObjectFactory, Is.SameAs(factory));
         Assert.That(desc.FileName, Is.EqualTo("/tmp/x.mp4"));
         Assert.That(desc.Position, Is.EqualTo(new Point(10, 20)));
+    }
+
+    [Test]
+    public void EngineObjectFactory_ProducesConfiguredObject()
+    {
+        // Mirrors the "Add Adjustment Layer" caller: the factory both constructs and configures.
+        var desc = new ElementDescription(
+            TimeSpan.Zero, TimeSpan.FromSeconds(5), 0,
+            EngineObjectFactory: () => new SourceBackdrop { Clear = { CurrentValue = true } });
+
+        EngineObject produced = desc.EngineObjectFactory!();
+
+        Assert.That(produced, Is.TypeOf<SourceBackdrop>());
+        Assert.That(((SourceBackdrop)produced).Clear.CurrentValue, Is.True);
+    }
+
+    [Test]
+    public void ResolveName_ReturnsExplicitName_WhenSet()
+    {
+        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, Name: "Adjustment Layer");
+
+        // The explicit name wins even though the fallback type has a different localized name.
+        Assert.That(desc.ResolveName(typeof(SourceBackdrop)), Is.EqualTo("Adjustment Layer"));
+    }
+
+    [Test]
+    public void ResolveName_FallsBackToLocalizedTypeName_WhenNameEmpty()
+    {
+        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0);
+
+        Assert.That(
+            desc.ResolveName(typeof(SourceBackdrop)),
+            Is.EqualTo(TypeDisplayHelpers.GetLocalizedName(typeof(SourceBackdrop))));
+    }
+
+    [Test]
+    public void ResolveName_TreatsWhitespaceNameAsExplicit()
+    {
+        // Pins IsNullOrEmpty (not IsNullOrWhiteSpace) semantics: a whitespace name is kept verbatim.
+        var desc = new ElementDescription(TimeSpan.Zero, TimeSpan.FromSeconds(1), 0, Name: " ");
+
+        Assert.That(desc.ResolveName(typeof(SourceBackdrop)), Is.EqualTo(" "));
     }
 
     [Test]


### PR DESCRIPTION
## Description
Adds an **"Add Adjustment Layer"** item to the timeline context menu. It creates an element backed by `SourceBackdrop` with `Clear = true`, so layers above it are composited onto the cleared backdrop (the adjustment-layer idiom).

Construction plumbing was refactored during review:
- `ElementDescription` now takes a single `Func<EngineObject>? EngineObjectFactory` instead of the `Type? InitialObject` + `Action<EngineObject>? InitialObjectConfigure` pair. The factory both constructs and configures the object, eliminating the type-laundering (`typeof(...)` → runtime `is`-cast) and the unexpressed XOR/dependency invariants between the old fields.
- `ElementAdderImpl` guards the factory call with try/catch: failures are logged and abort **before** any scene mutation, so a throwing factory no longer crashes to the global unhandled-exception handler or leaves partial state.
- Name resolution extracted into the pure, testable `ElementDescription.ResolveName(Type)`.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
`ElementDescription.InitialObject` and `ElementDescription.InitialObjectConfigure` are removed in favor of `EngineObjectFactory` (public type in `Beutl.Editor`).

Migration:
```csharp
// before
new ElementDescription(start, length, layer, InitialObject: typeof(Foo));
// after
new ElementDescription(start, length, layer,
    EngineObjectFactory: () => (EngineObject)Activator.CreateInstance(typeof(Foo))!);
```
Fold any post-construction configuration into the factory body. All in-tree call sites (`Beutl`, `Beutl.Editor.Components`) are updated in this PR.

## Test plan
- `tests/Beutl.UnitTests/Editor/ElementDescriptionTests.cs` — extended: `EngineObjectFactory` default/assignment/produces-configured-object, and `ResolveName` across its three branches (explicit name wins / localized type-name fallback / whitespace kept verbatim per `IsNullOrEmpty`). 7/7 green.
- `dotnet build Beutl.slnx` — 0 errors.
- Manual: timeline right-click → **Add Adjustment Layer** creates a 5s `SourceBackdrop` element with `Clear` enabled.

## Follow-ups
- Consider promoting the adjustment layer to a first-class engine type (`AdjustmentLayer : SourceBackdrop`) so the concept is legible in the serialized document and enables future features (type-specific icon, "select all adjustment layers"). Deferred per review; the current approach keeps it a UI shortcut.

## Fixed issues / References
- Comprehensive review run via `pr-review-toolkit:review-pr` (code / types / tests / errors / design); findings #1 (silent `is`-cast), #2 (unguarded factory), #3 (missing tests), #4 (invalid-state fields) addressed in commit `dcb509e`.
