### PR TITLE
fix(engine): dispose consumed AudioBuffer in audio graph nodes

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -56,7 +56,8 @@ public sealed class CompressorNode : AudioNode
             throw new InvalidOperationException(
                 $"Compressor node requires exactly one input but got {Inputs.Count}.");
 
-        var input = Inputs[0].Process(context);
+        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
+        using var input = Inputs[0].Process(context);
 
         // A sample-rate change needs new coefficients, so treat it as a full session boundary:
         // reset both the envelope and the one-shot diagnostic latches.

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -25,7 +25,8 @@ public sealed class DelayNode : AudioNode
         if (Inputs.Count != 1)
             throw new InvalidOperationException("Delay node requires exactly one input.");
 
-        var input = Inputs[0].Process(context);
+        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
+        using var input = Inputs[0].Process(context);
 
         // Initialize delay lines if needed or sample rate changed
         if (_delayLines == null || _lastSampleRate != context.SampleRate)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
@@ -26,11 +26,14 @@ public sealed class EqualizerNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
-        // Pass-through if no bands
+        // Pass-through if no bands (caller owns it, don't dispose).
         if (Bands.Count == 0)
         {
             return input;
         }
+
+        // Otherwise every path emits a fresh buffer, so dispose the consumed input.
+        using var owned = input;
 
         // Initialize or reinitialize filters
         if (_filters == null || _lastChannelCount != input.ChannelCount || _lastBandCount != Bands.Count)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -20,75 +20,89 @@ public sealed class GainNode : AudioNode
             return ProcessStaticGain(input);
         }
 
-        // Create output buffer
-        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        // Gain is non-null past the guard; pass it in so the helper need not re-check.
+        return ProcessAnimatedGain(Gain, input, context);
+    }
 
-        // Sample gain values for each sample
-        Span<float> gains = stackalloc float[System.Math.Min(input.SampleCount, 8192)];
-
-        // Process in chunks to avoid stack overflow for large buffers
-        int processed = 0;
-        while (processed < input.SampleCount)
+    // Owns and disposes `input`; emits a fresh buffer.
+    private static AudioBuffer ProcessAnimatedGain(IProperty<float> gain, AudioBuffer input, AudioProcessContext context)
+    {
+        using (input)
         {
-            int chunkSize = System.Math.Min(gains.Length, input.SampleCount - processed);
-            var chunkGains = gains.Slice(0, chunkSize);
+            // Create output buffer
+            var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-            var chunkStart = context.GetTimeForSample(processed);
-            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-            // すでにcontext.TimeRange.StartがGetTimeForSampleで加算されている
-            var chunkRange = new Media.TimeRange(chunkStart, chunkEnd - chunkStart);
+            // Sample gain values for each sample
+            Span<float> gains = stackalloc float[System.Math.Min(input.SampleCount, 8192)];
 
-            // Sample animation values
-            context.AnimationSampler.SampleBuffer(
-                Gain,
-                chunkRange,
-                context.SampleRate,
-                chunkGains);
-
-            // Convert from percentage (0-100) to factor (0-1)
-            for (int i = 0; i < chunkSize; i++)
+            // Process in chunks to avoid stack overflow for large buffers
+            int processed = 0;
+            while (processed < input.SampleCount)
             {
-                chunkGains[i] /= 100f;
-            }
+                int chunkSize = System.Math.Min(gains.Length, input.SampleCount - processed);
+                var chunkGains = gains.Slice(0, chunkSize);
 
-            // Apply gain to each channel
-            for (int ch = 0; ch < input.ChannelCount; ch++)
-            {
-                var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
-                var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                // すでにcontext.TimeRange.StartがGetTimeForSampleで加算されている
+                var chunkRange = new Media.TimeRange(chunkStart, chunkEnd - chunkStart);
 
+                // Sample animation values
+                context.AnimationSampler.SampleBuffer(
+                    gain,
+                    chunkRange,
+                    context.SampleRate,
+                    chunkGains);
+
+                // Convert from percentage (0-100) to factor (0-1)
                 for (int i = 0; i < chunkSize; i++)
                 {
-                    outData[i] = inData[i] * chunkGains[i];
+                    chunkGains[i] /= 100f;
                 }
+
+                // Apply gain to each channel
+                for (int ch = 0; ch < input.ChannelCount; ch++)
+                {
+                    var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
+                    var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+
+                    for (int i = 0; i < chunkSize; i++)
+                    {
+                        outData[i] = inData[i] * chunkGains[i];
+                    }
+                }
+
+                processed += chunkSize;
             }
 
-            processed += chunkSize;
+            return output;
         }
-
-        return output;
     }
 
     private AudioBuffer ProcessStaticGain(AudioBuffer input)
     {
         float gain = (Gain?.CurrentValue ?? 100f) / 100f;
-        // If gain is 1.0, return input as-is
+        // Unity gain: pass the input through (caller owns it, don't dispose).
         if (System.Math.Abs(gain - 1.0f) < float.Epsilon)
             return input;
 
-        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        for (int ch = 0; ch < input.ChannelCount; ch++)
+        // Otherwise we emit a fresh buffer, so dispose the consumed input.
+        using (input)
         {
-            var inData = input.GetChannelData(ch);
-            var outData = output.GetChannelData(ch);
+            var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
 
-            for (int i = 0; i < input.SampleCount; i++)
+            for (int ch = 0; ch < input.ChannelCount; ch++)
             {
-                outData[i] = inData[i] * gain;
-            }
-        }
+                var inData = input.GetChannelData(ch);
+                var outData = output.GetChannelData(ch);
 
-        return output;
+                for (int i = 0; i < input.SampleCount; i++)
+                {
+                    outData[i] = inData[i] * gain;
+                }
+            }
+
+            return output;
+        }
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/MixerNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/MixerNode.cs
@@ -20,48 +20,60 @@ public sealed class MixerNode : AudioNode
 
         // Process all inputs
         var buffers = new AudioBuffer[Inputs.Count];
-        for (int i = 0; i < Inputs.Count; i++)
+        try
         {
-            buffers[i] = Inputs[i].Process(context);
-        }
-
-        // Validate all buffers have the same format
-        var firstBuffer = buffers[0];
-        for (int i = 1; i < buffers.Length; i++)
-        {
-            if (buffers[i].SampleRate != firstBuffer.SampleRate)
-                throw new InvalidOperationException($"All inputs must have the same sample rate. Expected {firstBuffer.SampleRate}, but input {i} has {buffers[i].SampleRate}.");
-            if (buffers[i].ChannelCount != firstBuffer.ChannelCount)
-                throw new InvalidOperationException($"All inputs must have the same channel count. Expected {firstBuffer.ChannelCount}, but input {i} has {buffers[i].ChannelCount}.");
-            if (buffers[i].SampleCount != firstBuffer.SampleCount)
-                throw new InvalidOperationException($"All inputs must have the same sample count. Expected {firstBuffer.SampleCount}, but input {i} has {buffers[i].SampleCount}.");
-        }
-
-        // Create output buffer
-        var output = new AudioBuffer(firstBuffer.SampleRate, firstBuffer.ChannelCount, firstBuffer.SampleCount);
-
-        // Mix all channels
-        for (int ch = 0; ch < output.ChannelCount; ch++)
-        {
-            var outData = output.GetChannelData(ch);
-
-            // Clear output buffer (already cleared in constructor, but being explicit)
-            outData.Clear();
-
-            // Mix each input
-            for (int i = 0; i < buffers.Length; i++)
+            for (int i = 0; i < Inputs.Count; i++)
             {
-                var gain = i < _gains.Length ? _gains[i] : 1.0f;
-                var inData = buffers[i].GetChannelData(ch);
+                buffers[i] = Inputs[i].Process(context);
+            }
 
-                // Add with gain
-                for (int s = 0; s < output.SampleCount; s++)
+            // Validate all buffers have the same format
+            var firstBuffer = buffers[0];
+            for (int i = 1; i < buffers.Length; i++)
+            {
+                if (buffers[i].SampleRate != firstBuffer.SampleRate)
+                    throw new InvalidOperationException($"All inputs must have the same sample rate. Expected {firstBuffer.SampleRate}, but input {i} has {buffers[i].SampleRate}.");
+                if (buffers[i].ChannelCount != firstBuffer.ChannelCount)
+                    throw new InvalidOperationException($"All inputs must have the same channel count. Expected {firstBuffer.ChannelCount}, but input {i} has {buffers[i].ChannelCount}.");
+                if (buffers[i].SampleCount != firstBuffer.SampleCount)
+                    throw new InvalidOperationException($"All inputs must have the same sample count. Expected {firstBuffer.SampleCount}, but input {i} has {buffers[i].SampleCount}.");
+            }
+
+            // Create output buffer
+            var output = new AudioBuffer(firstBuffer.SampleRate, firstBuffer.ChannelCount, firstBuffer.SampleCount);
+
+            // Mix all channels
+            for (int ch = 0; ch < output.ChannelCount; ch++)
+            {
+                var outData = output.GetChannelData(ch);
+
+                // Clear output buffer (already cleared in constructor, but being explicit)
+                outData.Clear();
+
+                // Mix each input
+                for (int i = 0; i < buffers.Length; i++)
                 {
-                    outData[s] += inData[s] * gain;
+                    var gain = i < _gains.Length ? _gains[i] : 1.0f;
+                    var inData = buffers[i].GetChannelData(ch);
+
+                    // Add with gain
+                    for (int s = 0; s < output.SampleCount; s++)
+                    {
+                        outData[s] += inData[s] * gain;
+                    }
                 }
             }
-        }
 
-        return output;
+            return output;
+        }
+        finally
+        {
+            // Dispose every consumed input (also on the validation-throw path, where trailing
+            // slots may still be null).
+            foreach (var buffer in buffers)
+            {
+                buffer?.Dispose();
+            }
+        }
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/ResampleNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/ResampleNode.cs
@@ -32,8 +32,13 @@ public sealed class ResampleNode : AudioNode
         var newContext = new AudioProcessContext(context.TimeRange, SourceSampleRate, context.AnimationSampler, context.OriginalTimeRange);
         var input = Inputs[0].Process(newContext);
 
+        // Same rate: pass the input through (caller owns it, don't dispose).
         if (input.SampleRate == context.SampleRate)
             return input;
+
+        // Otherwise the resampler reads `input` synchronously into a fresh buffer; dispose it after.
+        // (The provider is rebuilt next call, so it never reads this buffer again.)
+        using var owned = input;
 
         if (_resampleProvider == null || _lastSampleRate != context.SampleRate)
         {

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
@@ -1,0 +1,242 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Audio;
+using Beutl.Audio.Effects.Equalizer;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+// Pins the AudioNode buffer-ownership contract: a node that emits a NEW buffer must dispose the
+// input it consumed (an undisposed input leaks its MemoryPool<float>.Shared lease); a pass-through
+// node returns the input untouched, transferring ownership to the caller. Disposal is observed via
+// the public surface — AudioBuffer.GetChannelData throws ObjectDisposedException once disposed.
+[TestFixture]
+public class AudioNodeBufferDisposalTests
+{
+    private const int SampleRate = 100;
+    private const int SampleCount = 100;
+
+    // Records every buffer it hands out so a test can assert its post-Process disposal state.
+    private sealed class CapturingInputNode(int sampleRate, int channels, int count, float value) : AudioNode
+    {
+        public List<AudioBuffer> Produced { get; } = new();
+
+        public AudioBuffer Last => Produced[^1];
+
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            var buffer = new AudioBuffer(sampleRate, channels, count);
+            for (int ch = 0; ch < channels; ch++)
+            {
+                buffer.GetChannelData(ch).Fill(value);
+            }
+
+            Produced.Add(buffer);
+            return buffer;
+        }
+    }
+
+    private static AudioProcessContext CreateContext(int sampleRate = SampleRate) =>
+        new(new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), sampleRate, new AnimationSampler(), null);
+
+    private static bool IsDisposed(AudioBuffer buffer)
+    {
+        try
+        {
+            buffer.GetChannelData(0);
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    private static IProperty<float> Static(float value) => Property.Create(value);
+
+    private static IProperty<float> AnimatedGain(float fromPercent, float toPercent, double durationSeconds)
+    {
+        var property = Property.CreateAnimatable(fromPercent);
+        property.SetAttributes("Gain", []);
+
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float> { KeyTime = TimeSpan.Zero, Value = fromPercent, Easing = new LinearEasing() });
+        animation.KeyFrames.Add(new KeyFrame<float> { KeyTime = TimeSpan.FromSeconds(durationSeconds), Value = toPercent, Easing = new LinearEasing() });
+        property.Animation = animation;
+        return property;
+    }
+
+    [Test]
+    public void CompressorNode_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new CompressorNode
+        {
+            Threshold = Static(-20f),
+            Ratio = Static(4f),
+            Attack = Static(10f),
+            Release = Static(100f),
+            Knee = Static(6f),
+            MakeupGain = Static(0f),
+        };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False, "compressor must emit a new buffer, not the input");
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void GainNode_NonUnityGain_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new GainNode { Gain = Static(50f) };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void GainNode_AnimatedGain_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 1, SampleCount, 1.0f);
+        using var node = new GainNode { Gain = AnimatedGain(0f, 100f, 1.0) };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void GainNode_UnityGain_PassesInputThroughWithoutDisposing()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new GainNode { Gain = Static(100f) };
+        node.AddInput(inputNode);
+
+        AudioBuffer result = node.Process(CreateContext());
+
+        Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "unity gain must pass the input through");
+        Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
+        result.Dispose();
+    }
+
+    [Test]
+    public void EqualizerNode_WithBands_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new EqualizerNode { Bands = [new EqualizerBand()] };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void EqualizerNode_NoBands_PassesInputThroughWithoutDisposing()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new EqualizerNode { Bands = [] };
+        node.AddInput(inputNode);
+
+        AudioBuffer result = node.Process(CreateContext());
+
+        Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "no bands must pass the input through");
+        Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
+        result.Dispose();
+    }
+
+    [Test]
+    public void DelayNode_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new DelayNode
+        {
+            DelayTime = Static(200f),
+            Feedback = Static(50f),
+            DryMix = Static(60f),
+            WetMix = Static(40f),
+        };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void MixerNode_DisposesAllConsumedInputs()
+    {
+        var a = new CapturingInputNode(SampleRate, 2, SampleCount, 0.25f);
+        var b = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new MixerNode { Gains = [1f, 1f] };
+        node.AddInput(a);
+        node.AddInput(b);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, a.Last), Is.False);
+            Assert.That(ReferenceEquals(result, b.Last), Is.False);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(IsDisposed(a.Last), Is.True, "first consumed input must be disposed");
+            Assert.That(IsDisposed(b.Last), Is.True, "second consumed input must be disposed");
+        });
+    }
+
+    [Test]
+    public void ResampleNode_Resampling_DisposesConsumedInput()
+    {
+        // Input produces a 100 Hz buffer; the node is asked to deliver 200 Hz, so it must resample
+        // (allocate a new buffer) and dispose the consumed input.
+        var inputNode = new CapturingInputNode(100, 2, SampleCount, 0.5f);
+        using var node = new ResampleNode { SourceSampleRate = 100 };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext(200)))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void ResampleNode_MatchingRate_PassesInputThroughWithoutDisposing()
+    {
+        // Input already at 200 Hz: the node short-circuits and returns the input as-is.
+        var inputNode = new CapturingInputNode(200, 2, SampleCount, 0.5f);
+        using var node = new ResampleNode { SourceSampleRate = 200 };
+        node.AddInput(inputNode);
+
+        AudioBuffer result = node.Process(CreateContext(200));
+
+        Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "matching rate must pass the input through");
+        Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
+        result.Dispose();
+    }
+}


### PR DESCRIPTION
## Description
Audio graph nodes that pull a buffer from `Inputs[].Process()` and emit a **new** buffer were never disposing the consumed input. `AudioBuffer` holds a `MemoryPool<float>.Shared` (ArrayPool) lease, so each undisposed input leaked a pooled array — over a long editing/playback session this exhausts the pool and drives GC pressure. `ClipNode` already does this correctly (`using var buffer = Inputs[0].Process(...)`).

Fixed nodes:
- **CompressorNode**, **DelayNode** — no pass-through path, so the consumed input is taken with `using var input = Inputs[0].Process(context)`.
- **GainNode** — extracted `ProcessAnimatedGain` (matching the `ProcessStatic` / `ProcessAnimated` split of the sibling nodes); the animated path and the non-unity static path dispose the input, while the **unity-gain** path still passes the input through untouched.
- **EqualizerNode**, **ResampleNode** — dispose the input on the processing path while preserving the **no-bands** / **matching-rate** pass-through.
- **MixerNode** — disposes **all N** input buffers in a `finally` (also on the format-validation throw path); it previously leaked one buffer per input.

The board finding named Compressor/Gain/Equalizer/Delay; **MixerNode** and **ResampleNode** were found to leak via the same root cause during verification and are fixed here too (MixerNode leaked N buffers per call).

Pass-through contract is preserved: a node that returns its input as-is transfers ownership to the caller and must **not** dispose it. Only the ownership/disposal of intermediate buffers changes.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Behavior-preserving resource-leak fix — all existing audio DSP-output tests stay green.

## Test plan
- Added `tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs` (10 tests). Baseline-first: the **7** consume-and-dispose assertions were **red** on the unmodified tree (proving they capture the leak) and **green** after the fix; the **3** pass-through assertions (unity gain / no bands / matching rate) characterize unchanged behavior and were green on both.
- Disposal is observed through the public surface — `AudioBuffer.GetChannelData` throws `ObjectDisposedException` once disposed — so no reflection into private state.
- `dotnet test` on the audio area: **102/102 passed** (exit 0). `dotnet format --verify-no-changes` on the touched files: clean (exit 0).

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-09][diff][medium] AudioBuffer from child Process() not disposed — MemoryPool leak in audio nodes")

## Follow-ups
- During verification, two adjacent AI-Review findings were confirmed **not actionable on `main`** and can be closed/marked on the board: `[2026-06-07] SpeedProcessor.Read offset unit mismatch` (already fixed by the streaming refactor in `964b2b4e8`) and `LimiterNode: make mid-buffer throw recovery deterministic` (the `LimiterNode` code only exists on the unmerged `yuto-trd/audio-limiter` branch).