### PR TITLE
fix(encoding): surface encode cancellation as OperationCanceledException

### DIFF
--- a/src/Beutl.Extensions.AVFoundation/Encoding/AVFEncodingController.cs
+++ b/src/Beutl.Extensions.AVFoundation/Encoding/AVFEncodingController.cs
@@ -81,6 +81,9 @@ public class AVFEncodingController : EncodingController
                 }
             }
 
+            // Report cancellation as OperationCanceledException, not a finalized truncated file.
+            cancellationToken.ThrowIfCancellationRequested();
+
             BeutlAVFException.ThrowIfFailed(BeutlAVFNative.beutl_avf_writer_finish(handle));
         }
     }

--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs
@@ -307,6 +307,9 @@ public class FFmpegEncodingController(string outputFile, FFmpegEncodingSettings 
                     }
                 }
 
+                // Report cancellation as OperationCanceledException, not success or a muxer error.
+                cancellationToken.ThrowIfCancellationRequested();
+
                 encodeCompletedSuccessfully = true;
             }
             finally

--- a/tests/Beutl.Extensions.AVFoundation.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/EncodingCancellationTests.cs
@@ -1,0 +1,79 @@
+﻿using Beutl.Extensibility;
+using Beutl.Extensions.AVFoundation.Encoding;
+using Beutl.Media;
+
+namespace Beutl.Extensions.AVFoundation.Tests;
+
+// A cancelled Encode must throw OperationCanceledException (both callers already catch it). This
+// AVF test pins the shared contract; FFmpegEncodingController has the identical fix but no
+// cross-platform test seam.
+[TestFixture]
+[Platform("MacOSX")]
+public class EncodingCancellationTests
+{
+    private string _workDir = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), "beutl-avf-cancel-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_workDir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Test]
+    public void EncodeSurfacesCancellationAsOperationCanceledException()
+    {
+        string outputPath = Path.Combine(_workDir, "cancelled.mp4");
+        var controller = new AVFEncodingController(outputPath);
+
+        const int width = 64;
+        const int height = 64;
+        const int sampleRate = 44100;
+        const int frameCount = 30;
+        const int frameRateNum = 30;
+        const int frameRateDen = 1;
+
+        controller.VideoSettings.DestinationSize = new PixelSize(width, height);
+        controller.VideoSettings.SourceSize = new PixelSize(width, height);
+        controller.VideoSettings.FrameRate = new Rational(frameRateNum, frameRateDen);
+
+        controller.AudioSettings.SampleRate = sampleRate;
+        controller.AudioSettings.Channels = 2;
+
+        using var cts = new CancellationTokenSource();
+        // Cancel mid-clip (after one frame) so the controller exits its loop on cancellation.
+        var frameProvider = new CancelAfterFirstFrameProvider(
+            cts, frameCount, new Rational(frameRateNum, frameRateDen), width, height);
+        var sampleProvider = new SineSampleProvider(sampleRate, sampleRate);
+
+        Assert.That(
+            async () => await controller.Encode(frameProvider, sampleProvider, cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    // Cancels the token right after the first frame, so the loop's next iteration sees cancellation.
+    private sealed class CancelAfterFirstFrameProvider(
+        CancellationTokenSource cts, long frameCount, Rational frameRate, int width, int height)
+        : IFrameProvider
+    {
+        private readonly GradientFrameProvider _inner = new(frameCount, frameRate, width, height);
+
+        public long FrameCount => _inner.FrameCount;
+
+        public Rational FrameRate => _inner.FrameRate;
+
+        public async ValueTask<Bitmap> RenderFrame(long frame)
+        {
+            Bitmap bitmap = await _inner.RenderFrame(frame);
+            cts.Cancel();
+            return bitmap;
+        }
+    }
+}


### PR DESCRIPTION
## Description

`FFmpegEncodingController` and `AVFEncodingController` exited their encode loop on cancellation but then proceeded as if the encode had finished successfully:

- **FFmpeg**: set `encodeCompletedSuccessfully = true`, so when the `finally` block's muxer finalization (`FlushCodecs` / `WriteTrailer`) failed, that muxer error was surfaced to the caller **instead of** the cancellation. On a clean cancel it returned normally, which the worker reports as a *successful* encode.
- **AVF**: called `beutl_avf_writer_finish` and returned normally, finalizing a truncated file as a successful encode.

Both callers already expect cancellation to arrive as `OperationCanceledException`:
- `src/Beutl/ViewModels/Tools/OutputViewModel.cs` — `catch (OperationCanceledException) { HandleCancellation(); }`
- `src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs` — `catch (OperationCanceledException)` → reports `Success = false, Error = "Cancelled"`

So the controllers were violating the contract their callers assume.

**Fix:** add `cancellationToken.ThrowIfCancellationRequested()` immediately after the encode loop in both controllers. On normal completion it is a no-op (the success path is behavior-preserving); on cancellation it throws `OperationCanceledException`, which both callers already handle. This is the robust fix (the report's "Fix A", `encodeCompletedSuccessfully = !IsCancellationRequested`, would not make the worker report `Cancelled` on a clean cancel).

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] Build / CI / docs only

Files touched: `src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingController.cs` (also compiled into the GPL `Beutl.FFmpegWorker` via `<Compile Include … Link>`) and `src/Beutl.Extensions.AVFoundation/Encoding/AVFEncodingController.cs`. No GPL/MIT boundary change — no new project references were added.

## Breaking changes

None. The success path is unchanged; the cancellation path now throws `OperationCanceledException`, which aligns the controllers with the contract their callers already assume (both already `catch (OperationCanceledException)`). This is a bug fix, not a public API change.

## Test plan

- **Added** `tests/Beutl.Extensions.AVFoundation.Tests/EncodingCancellationTests.cs` (macOS-only) — cancels mid-encode (right after the first frame is ingested) and asserts `Encode` throws `OperationCanceledException`.
  - Baseline-first: **RED** against the unmodified controller (`Expected: OperationCanceledException / But was: no exception thrown`), **GREEN** after the fix.
- Ran the new test + the existing AVF encode/decode round-trip regression: **失敗 0 / 合格 4** (28 s).
- Built `Beutl.Extensions.FFmpeg` and `Beutl.FFmpegWorker` (the FFmpeg controller is shared into the GPL worker via `<Compile Link>`): both succeed, 0 warnings.
- `dotnet format Beutl.slnx --verify-no-changes` on the three touched files: clean.
- The FFmpeg encode path cannot be unit-tested cross-platform (it needs FFmpeg natives plus a muxer-failure injection seam that does not exist), so the shared cancellation contract is pinned via the AVF backend; the FFmpeg controller receives the identical one-line fix.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-22][diff][medium] encodeCompletedSuccessfully=true on cancellation may expose muxer error instead of cancellation")

## Follow-ups
- A FFmpeg-specific cancellation regression test would require refactoring `FFmpegEncodingController` to accept a mockable muxer (a seam to force a `FlushCodecs` / `WriteTrailer` failure under cancellation). Out of scope here; the AVF backend test covers the shared contract in the meantime.
