### PR TITLE
chore: remove unused PackageReferences and dead PackageVersion pins

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,6 @@
     <PackageVersion Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageVersion Include="DynamicData" Version="9.4.31" />
     <PackageVersion Include="FFmpeg.AutoGen.Bindings.DynamicallyLoaded" Version="8.1.0" />
-    <PackageVersion Include="FFmpeg.AutoGen.Abstractions" Version="8.0.0" />
     <PackageVersion Include="FFmpeg4Sharp" Version="7.0.1" />
     <PackageVersion Include="FluentAvaloniaUI" Version="2.5.1" />
     <PackageVersion Include="FluentIcons.FluentAvalonia" Version="1.1.224" />
@@ -61,28 +60,22 @@
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
-    <PackageVersion Include="OpenTK.OpenAL" Version="5.0.0-pre.8" />
     <PackageVersion Include="PanelExtension" Version="1.0.0" />
     <PackageVersion Include="ReactiveProperty" Version="9.8.0" />
     <PackageVersion Include="Dock.Avalonia" Version="11.3.12.1" />
     <PackageVersion Include="Dock.Model.Inpc" Version="11.3.12.1" />
     <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="11.3.12.1" />
-    <PackageVersion Include="Dock.Serializer.SystemTextJson" Version="11.3.12.1" />
     <PackageVersion Include="Refit" Version="10.2.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="1.2.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
     <PackageVersion Include="System.CommandLine" Version="2.0.8" />
     <PackageVersion Include="System.Interactive" Version="7.0.1" />
-    <PackageVersion Include="System.Interactive.Async" Version="7.0.1" />
     <PackageVersion Include="System.Management" Version="10.0.8" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="Vortice.Direct3D9" Version="3.8.3" />

--- a/src/Beutl.Api/Beutl.Api.csproj
+++ b/src/Beutl.Api/Beutl.Api.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Refit" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="System.Interactive" />
-    <PackageReference Include="System.Interactive.Async" />
 
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Protocol" />

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -67,8 +67,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="OpenTelemetry" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
     <PackageReference Include="PanelExtension" />
     <PackageReference Include="ReactiveProperty" />
     <PackageReference Include="Dock.Avalonia" />
@@ -78,9 +76,8 @@
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Debug" />
-    <PackageReference Include="System.Interactive" />
-    <PackageReference Include="System.Interactive.Async" />
     <PackageReference Include="System.Reactive" />
+    <PackageReference Include="System.Interactive" />
     <PackageReference Include="Roslynator.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Removes genuinely-unused package references and orphan central-version pins.

## Changes
- Remove `System.Interactive.Async` and the unused `OpenTelemetry.Exporter.Console` / `.Zipkin` (active exporter is OTLP only)
- Remove 4 orphan `PackageVersion` pins with no `PackageReference`: `Serilog.Sinks.OpenTelemetry`, `Dock.Serializer.SystemTextJson`, `OpenTK.OpenAL`, `FFmpeg.AutoGen.Abstractions`

## Kept (verified still in use)
- **`System.Interactive`** — `EnumerableEx.Do`/`.ForEach` (namespace `System.Linq`) are used transitively via `Beutl.Api` by `Beutl.Editor.Components` and `Beutl.PackageTools.UI`. (Initially mis-flagged as unused; the dependency was caught by an integrated build of all Phase 1 clusters and the removal was reverted.)
- `ReactiveUI.Avalonia` (`AvaloniaScheduler.Instance`, `UseReactiveUI`), `OpenTelemetry` core + OTLP exporter, `Microsoft.Extensions.DependencyInjection` (kept for Phase 5).

## Follow-ups
- `Beutl.WaitingDialog` / `Beutl.PackageTools.UI` may carry unused `ReactiveUI.Avalonia` refs — needs its own build-based check.

---
Part of **Phase 1 — dead code & dead asset sweep** ([`docs/refactoring-plan.md`](docs/refactoring-plan.md)); tracked in [Projects v2 #9 (item 199667878)](https://github.com/orgs/b-editor/projects/9?pane=issue&itemId=199667878). Re-verified against current `main` and adversarially reviewed (repo-wide liveness check). The full 16-cluster Phase 1 set was integrated and built/tested together on net10.0: **Beutl.UnitTests 3045 passed / 0 failed**, **Beutl.FFmpegIpc.Tests 18 passed**.