### PR TITLE
refactor!: remove dead FFmpegIpc protocol surface (QueryDefaultCodec, EncodeProgress, Handshake)

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingControllerProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Encoding/FFmpegEncodingControllerProxy.cs
@@ -158,9 +158,6 @@ public class FFmpegEncodingControllerProxy(string outputFile, FFmpegEncodingSett
                             return;
                         }
 
-                    case MessageType.EncodeProgress:
-                        break;
-
                     case MessageType.Error:
                         throw new FFmpegWorkerException(msg.Error ?? "Unknown error", msg.ErrorStackTrace);
 

--- a/src/Beutl.FFmpegIpc/Protocol/IpcMessage.cs
+++ b/src/Beutl.FFmpegIpc/Protocol/IpcMessage.cs
@@ -75,7 +75,6 @@ public sealed class IpcMessage
 [JsonSerializable(typeof(ProvideFrameMessage))]
 [JsonSerializable(typeof(RequestSampleMessage))]
 [JsonSerializable(typeof(ProvideSampleMessage))]
-[JsonSerializable(typeof(EncodeProgressMessage))]
 [JsonSerializable(typeof(EncodeCompleteMessage))]
 // Codec queries
 [JsonSerializable(typeof(QueryCodecsRequest))]
@@ -86,8 +85,6 @@ public sealed class IpcMessage
 [JsonSerializable(typeof(QuerySampleRatesResponse))]
 [JsonSerializable(typeof(QueryAudioFormatsRequest))]
 [JsonSerializable(typeof(QueryAudioFormatsResponse))]
-[JsonSerializable(typeof(QueryDefaultCodecRequest))]
-[JsonSerializable(typeof(QueryDefaultCodecResponse))]
 // Supporting types
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSourceGenerationOptions(

--- a/src/Beutl.FFmpegIpc/Protocol/MessageType.cs
+++ b/src/Beutl.FFmpegIpc/Protocol/MessageType.cs
@@ -3,7 +3,8 @@
 public enum MessageType
 {
     // ライフサイクル
-    Handshake = 0,
+    // default(MessageType) / 未設定・破損メッセージを表すセンチネル。意味のあるメッセージには使わない
+    Unknown = 0,
     HandshakeAck = 1,
     Shutdown = 3,
 
@@ -26,7 +27,6 @@ public enum MessageType
     ProvideFrame = 33,
     RequestSample = 34,
     ProvideSample = 35,
-    EncodeProgress = 36,
     EncodeComplete = 37,
     CancelEncode = 38,
 
@@ -39,8 +39,6 @@ public enum MessageType
     QuerySampleRatesResult = 45,
     QueryAudioFormats = 46,
     QueryAudioFormatsResult = 47,
-    QueryDefaultCodec = 48,
-    QueryDefaultCodecResult = 49,
 
     // エラー
     Error = 99,

--- a/src/Beutl.FFmpegIpc/Protocol/Messages/CodecQueryMessages.cs
+++ b/src/Beutl.FFmpegIpc/Protocol/Messages/CodecQueryMessages.cs
@@ -55,14 +55,3 @@ public sealed class QueryAudioFormatsResponse
 {
     public int[] Formats { get; set; } = [];
 }
-
-public sealed class QueryDefaultCodecRequest
-{
-    public string OutputFile { get; set; } = "";
-}
-
-public sealed class QueryDefaultCodecResponse
-{
-    public string? VideoCodecName { get; set; }
-    public string? AudioCodecName { get; set; }
-}

--- a/src/Beutl.FFmpegIpc/Protocol/Messages/EncodingMessages.cs
+++ b/src/Beutl.FFmpegIpc/Protocol/Messages/EncodingMessages.cs
@@ -83,12 +83,6 @@ public sealed class ProvideSampleMessage
     public int DataLength { get; set; }
 }
 
-public sealed class EncodeProgressMessage
-{
-    public long VideoFramesDone { get; set; }
-    public long AudioSamplesDone { get; set; }
-}
-
 public sealed class EncodeCompleteMessage
 {
     public bool Success { get; set; }

--- a/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
@@ -102,32 +102,6 @@ internal sealed class CodecQueryHandler
         }
     }
 
-    public IpcMessage HandleQueryDefaultCodec(IpcMessage msg)
-    {
-        var request = msg.GetPayload<QueryDefaultCodecRequest>()
-            ?? throw new InvalidOperationException("Missing payload for QueryDefaultCodec");
-
-        try
-        {
-            var outFormat = OutputFormat.GuessFormat(null, request.OutputFile, null);
-            string? videoCodec = outFormat.VideoCodec != AVCodecID.AV_CODEC_ID_NONE
-                ? MediaCodec.FindEncoder(outFormat.VideoCodec).Name
-                : null;
-            string? audioCodec = outFormat.AudioCodec != AVCodecID.AV_CODEC_ID_NONE
-                ? MediaCodec.FindEncoder(outFormat.AudioCodec).Name
-                : null;
-
-            return IpcMessage.Create(msg.Id, MessageType.QueryDefaultCodecResult,
-                new QueryDefaultCodecResponse { VideoCodecName = videoCodec, AudioCodecName = audioCodec });
-        }
-        catch (Exception ex)
-        {
-            WorkerLog.Warning($"QueryDefaultCodec: query failed: {ex.Message}", ex);
-            return IpcMessage.Create(msg.Id, MessageType.QueryDefaultCodecResult,
-                new QueryDefaultCodecResponse());
-        }
-    }
-
     private static MediaCodec FindVideoEncoder(string? codecName, string? outputFile)
     {
         if (!string.IsNullOrEmpty(codecName) && codecName != "Default")

--- a/src/Beutl.FFmpegWorker/WorkerHost.cs
+++ b/src/Beutl.FFmpegWorker/WorkerHost.cs
@@ -100,7 +100,6 @@ internal sealed class WorkerHost(IpcConnection connection) : IDisposable
             MessageType.QueryPixelFormats => _codecQueryHandler.HandleQueryPixelFormats(message),
             MessageType.QuerySampleRates => _codecQueryHandler.HandleQuerySampleRates(message),
             MessageType.QueryAudioFormats => _codecQueryHandler.HandleQueryAudioFormats(message),
-            MessageType.QueryDefaultCodec => _codecQueryHandler.HandleQueryDefaultCodec(message),
             _ => IpcMessage.CreateError(message.Id, $"Unknown message type: {message.Type}"),
         };
     }
@@ -115,8 +114,7 @@ internal sealed class WorkerHost(IpcConnection connection) : IDisposable
             or MessageType.QueryCodecs
             or MessageType.QueryPixelFormats
             or MessageType.QuerySampleRates
-            or MessageType.QueryAudioFormats
-            or MessageType.QueryDefaultCodec;
+            or MessageType.QueryAudioFormats;
     }
 
     private static IpcMessage HandleShutdown(IpcMessage message)


### PR DESCRIPTION
## Summary
Removes protocol surface that no client sends and no handler meaningfully consumes.

## Changes
- Remove `MessageType` members `Handshake`(=0), `EncodeProgress`, `QueryDefaultCodec`, `QueryDefaultCodecResult`
- Remove the `EncodeProgressMessage`, `QueryDefaultCodecRequest`, `QueryDefaultCodecResponse` message classes (+ their `JsonSerializable` registrations)
- Remove the worker `HandleQueryDefaultCodec` handler + dispatch and the client's no-op `EncodeProgress` case arm

Kept: the live handshake (`HandshakeAck`=1, `HandshakeMessage`, `ProtocolConstants`). GPL/MIT boundary respected.

**BREAKING CHANGE** in the commit footer (`Beutl.FFmpegIpc` protocol).

---
Part of **Phase 1 — dead code & dead asset sweep** ([`docs/refactoring-plan.md`](docs/refactoring-plan.md)); tracked in [Projects v2 #9 (item 199667878)](https://github.com/orgs/b-editor/projects/9?pane=issue&itemId=199667878). Re-verified against current `main` and adversarially reviewed (repo-wide liveness check). The full 16-cluster Phase 1 set was integrated and built/tested together on net10.0: **Beutl.UnitTests 3045 passed / 0 failed**, **Beutl.FFmpegIpc.Tests 18 passed**.