### PR TITLE
fix(threading): make _running volatile and cover the Shutdown/Wait race

### DIFF
--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -8,16 +8,13 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
     private readonly OperationQueue _operationQueue = new();
     private readonly TimerQueue _timerQueue = new(timeProvider);
 
-    // volatile: _running is written by Shutdown() outside the lock and read unsynchronized by
-    // Start()'s loop and ExecuteAvailableOperations(); without it a reader can cache a stale value
-    // on weak-memory architectures (ARM64) and miss a shutdown. The inner-lock check in
-    // WaitForPendingOperations() guards the wait-token race; volatile covers the unlocked reads.
+    // Written by Shutdown() outside the lock, read unlocked elsewhere; volatile stops a stale read
+    // that misses a shutdown on weak-memory architectures.
     private volatile bool _running;
     private CancellationTokenSource? _waitToken;
 
-    // volatile for the same reason as _running: these flags are written on one thread (the dispatcher
-    // thread for HasShutdownFinished, the caller's thread for HasShutdownStarted) and read cross-thread
-    // through the public Dispatcher getters with no lock, so a reader could otherwise stale-read.
+    // Volatile for the same reason as _running: written on one thread, read cross-thread through the
+    // public getters with no lock.
     private volatile bool _hasShutdownFinished;
     private volatile bool _hasShutdownStarted;
 

--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -15,15 +15,21 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
     private volatile bool _running;
     private CancellationTokenSource? _waitToken;
 
+    // volatile for the same reason as _running: these flags are written on one thread (the dispatcher
+    // thread for HasShutdownFinished, the caller's thread for HasShutdownStarted) and read cross-thread
+    // through the public Dispatcher getters with no lock, so a reader could otherwise stale-read.
+    private volatile bool _hasShutdownFinished;
+    private volatile bool _hasShutdownStarted;
+
     public event EventHandler<DispatcherUnhandledExceptionEventArgs>? UnhandledException;
 
     public event EventHandler? ShutdownStarted;
 
     public event EventHandler? ShutdownFinished;
 
-    public bool HasShutdownFinished { get; private set; }
+    public bool HasShutdownFinished { get => _hasShutdownFinished; private set => _hasShutdownFinished = value; }
 
-    public bool HasShutdownStarted { get; private set; }
+    public bool HasShutdownStarted { get => _hasShutdownStarted; private set => _hasShutdownStarted = value; }
 
     internal void Start()
     {

--- a/src/Beutl.Threading/QueueSynchronizationContext.cs
+++ b/src/Beutl.Threading/QueueSynchronizationContext.cs
@@ -8,7 +8,11 @@ internal sealed class QueueSynchronizationContext(Dispatcher dispatcher, TimePro
     private readonly OperationQueue _operationQueue = new();
     private readonly TimerQueue _timerQueue = new(timeProvider);
 
-    private bool _running;
+    // volatile: _running is written by Shutdown() outside the lock and read unsynchronized by
+    // Start()'s loop and ExecuteAvailableOperations(); without it a reader can cache a stale value
+    // on weak-memory architectures (ARM64) and miss a shutdown. The inner-lock check in
+    // WaitForPendingOperations() guards the wait-token race; volatile covers the unlocked reads.
+    private volatile bool _running;
     private CancellationTokenSource? _waitToken;
 
     public event EventHandler<DispatcherUnhandledExceptionEventArgs>? UnhandledException;

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -504,6 +504,31 @@ public class DispatcherTests
         dispatcher.Shutdown();
     }
 
+    // Regression for the deadlock where Shutdown() interleaves between WaitForPendingOperations'
+    // outer unlocked _running check and its lock acquisition: without the inner-lock guard
+    // (if (!_running) return; inside the lock) the dispatcher would arm a _waitToken that nothing
+    // cancels and block on WaitOne() forever, so HasShutdownFinished would never become true. Each
+    // iteration uses a fresh dispatcher because Shutdown is terminal; the loop widens the race
+    // window the same way Post_BeforeWaitTokenCreated does.
+    [Test]
+    public void Shutdown_RacingWithWaitForPendingOperations_DoesNotDeadlock()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            var dispatcher = Dispatcher.Spawn();
+
+            // Drain the queue so the dispatcher transitions ExecuteAvailableOperations (empty) ->
+            // WaitForPendingOperations, then shut down from this thread to race the lock acquisition.
+            dispatcher.Invoke(() => { });
+            dispatcher.Shutdown();
+
+            Assert.That(
+                SpinWait.SpinUntil(() => dispatcher.HasShutdownFinished, TimeSpan.FromSeconds(5)),
+                Is.True,
+                $"Iteration {i}: dispatcher deadlocked in WaitForPendingOperations after Shutdown");
+        }
+    }
+
     // Regression: an unguarded negative `next - now` (timer slips past between flush and wait)
     // used to throw in CancelAfter and kill the dispatcher thread.
     [Test]

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -507,9 +507,9 @@ public class DispatcherTests
     // Regression for the deadlock where Shutdown() interleaves between WaitForPendingOperations'
     // outer unlocked _running check and its lock acquisition: without the inner-lock guard
     // (if (!_running) return; inside the lock) the dispatcher would arm a _waitToken that nothing
-    // cancels and block on WaitOne() forever, so HasShutdownFinished would never become true. Each
-    // iteration uses a fresh dispatcher because Shutdown is terminal; the loop widens the race
-    // window the same way Post_BeforeWaitTokenCreated does.
+    // cancels and block on WaitOne() forever, so its thread would never exit. Each iteration uses a
+    // fresh dispatcher because Shutdown is terminal; the loop widens the race window the same way
+    // Post_BeforeWaitTokenCreated does.
     [Test]
     public void Shutdown_RacingWithWaitForPendingOperations_DoesNotDeadlock()
     {
@@ -517,13 +517,22 @@ public class DispatcherTests
         {
             var dispatcher = Dispatcher.Spawn();
 
+            // If the race regresses, the dispatcher thread deadlocks; mark it background so a leaked
+            // thread cannot keep the test process (and thus the whole run) alive after the assertion
+            // below fails.
+            dispatcher.Thread.IsBackground = true;
+
             // Drain the queue so the dispatcher transitions ExecuteAvailableOperations (empty) ->
             // WaitForPendingOperations, then shut down from this thread to race the lock acquisition.
             dispatcher.Invoke(() => { });
             dispatcher.Shutdown();
 
+            // Join the dispatcher thread directly rather than polling the non-volatile
+            // HasShutdownFinished flag (a cross-thread read of which could itself stale-read on a
+            // weak-memory architecture). The thread terminates only when Start()'s loop exits — i.e.
+            // shutdown was observed and no _waitToken was left armed — so a timeout here means deadlock.
             Assert.That(
-                SpinWait.SpinUntil(() => dispatcher.HasShutdownFinished, TimeSpan.FromSeconds(5)),
+                dispatcher.Thread.Join(TimeSpan.FromSeconds(5)),
                 Is.True,
                 $"Iteration {i}: dispatcher deadlocked in WaitForPendingOperations after Shutdown");
         }

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -504,12 +504,10 @@ public class DispatcherTests
         dispatcher.Shutdown();
     }
 
-    // Regression for the deadlock where Shutdown() interleaves between WaitForPendingOperations'
-    // outer unlocked _running check and its lock acquisition: without the inner-lock guard
-    // (if (!_running) return; inside the lock) the dispatcher would arm a _waitToken that nothing
-    // cancels and block on WaitOne() forever, so its thread would never exit. Each iteration uses a
-    // fresh dispatcher because Shutdown is terminal; the loop widens the race window the same way
-    // Post_BeforeWaitTokenCreated does.
+    // Regression for the deadlock where Shutdown() races WaitForPendingOperations' lock acquisition:
+    // without the inner-lock _running guard the dispatcher arms a _waitToken nothing cancels and
+    // blocks on WaitOne() forever. The loop widens the race window; each iteration needs a fresh
+    // dispatcher because Shutdown is terminal.
     [Test]
     public void Shutdown_RacingWithWaitForPendingOperations_DoesNotDeadlock()
     {
@@ -517,20 +515,17 @@ public class DispatcherTests
         {
             var dispatcher = Dispatcher.Spawn();
 
-            // If the race regresses, the dispatcher thread deadlocks; mark it background so a leaked
-            // thread cannot keep the test process (and thus the whole run) alive after the assertion
-            // below fails.
+            // Mark background so a thread leaked by a regressed race cannot keep the test process
+            // alive after the assertion fails.
             dispatcher.Thread.IsBackground = true;
 
-            // Drain the queue so the dispatcher transitions ExecuteAvailableOperations (empty) ->
-            // WaitForPendingOperations, then shut down from this thread to race the lock acquisition.
+            // Drain the queue so the dispatcher reaches WaitForPendingOperations, then shut down from
+            // this thread to race its lock acquisition.
             dispatcher.Invoke(() => { });
             dispatcher.Shutdown();
 
-            // Join the dispatcher thread directly rather than polling HasShutdownFinished: the thread
-            // terminates only when Start()'s loop actually exits — i.e. shutdown was observed and no
-            // _waitToken was left armed — which is the precise condition under test, whereas the flag
-            // is set just before the loop returns. A timeout here therefore means deadlock.
+            // Join the thread rather than poll HasShutdownFinished: the thread exits only when the
+            // dispatcher loop ends, the exact condition under test. A timeout here means deadlock.
             Assert.That(
                 dispatcher.Thread.Join(TimeSpan.FromSeconds(5)),
                 Is.True,

--- a/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
+++ b/tests/Beutl.UnitTests/Threading/DispatcherTests.cs
@@ -527,10 +527,10 @@ public class DispatcherTests
             dispatcher.Invoke(() => { });
             dispatcher.Shutdown();
 
-            // Join the dispatcher thread directly rather than polling the non-volatile
-            // HasShutdownFinished flag (a cross-thread read of which could itself stale-read on a
-            // weak-memory architecture). The thread terminates only when Start()'s loop exits — i.e.
-            // shutdown was observed and no _waitToken was left armed — so a timeout here means deadlock.
+            // Join the dispatcher thread directly rather than polling HasShutdownFinished: the thread
+            // terminates only when Start()'s loop actually exits — i.e. shutdown was observed and no
+            // _waitToken was left armed — which is the precise condition under test, whereas the flag
+            // is set just before the loop returns. A timeout here therefore means deadlock.
             Assert.That(
                 dispatcher.Thread.Join(TimeSpan.FromSeconds(5)),
                 Is.True,


### PR DESCRIPTION
## Description
Two paired findings against `QueueSynchronizationContext` (the dispatcher's sync context):

- `#120` — `_running` is written by `Shutdown()` *outside* the lock and read unsynchronized by `Start()`'s `while (_running)` loop and `ExecuteAvailableOperations()`. On weak-memory architectures (ARM64) a reader can cache a stale value and miss a shutdown. Fixed by marking the field `volatile` (x86-64 happens to hide this; ARM64 does not).
- `#121` — the inner-lock guard in `WaitForPendingOperations()` (`if (!_running) return;` *inside* the lock, added by #1870) prevents a deadlock where `Shutdown()` interleaves between the outer unlocked `_running` check and the lock acquisition — without it the dispatcher arms a `_waitToken` nothing cancels and blocks on `WaitOne()` forever. That guard had **no regression test**; this PR adds one.

Review of this PR also surfaced that `HasShutdownFinished` / `HasShutdownStarted` share the exact cross-thread pattern that motivated #120: written on one thread (the dispatcher thread / the caller's thread), read cross-thread through the public `Dispatcher` getters with no lock. They are now backed by `volatile` fields too, so a poller cannot stale-read on a weak-memory architecture. The double-checked-locking guard logic itself is unchanged.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track) — via the `Beutl.Threading` library it depends on
- [ ] `Beutl.ProjectSystem`
- [ ] UI
- [ ] `Beutl.Extensibility`
- [ ] `Beutl.NodeGraph`
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker`
- [ ] `Beutl.Api`
- [ ] Build / CI / docs only

(Primary change is in `src/Beutl.Threading/`, an MIT support library.)

## Breaking changes
None. The `volatile` changes are memory-model hardening with identical observable behavior; the regression test characterizes the existing guard.

## Test plan
- Added `Shutdown_RacingWithWaitForPendingOperations_DoesNotDeadlock` to `tests/Beutl.UnitTests/Threading/DispatcherTests.cs`. It spawns a fresh dispatcher per iteration (Shutdown is terminal), drains the queue with `Invoke(() => {})` so the thread reaches `WaitForPendingOperations`, then races `Shutdown()` and joins the dispatcher thread within 5s — 100 iterations widen the race window (same approach as the existing `Post_BeforeWaitTokenCreated_OperationExecutedPromptly`).
- **Meaningfulness verified**: with the inner-lock guard temporarily removed the test deadlocks and fails at iteration 4 (5s timeout); with the guard it stays green. The test is not flaky on correct code — the dispatcher always shuts down well under the timeout.
- The `HasShutdown*` volatile change is memory-model hardening that cannot be meaningfully unit-tested (a non-volatile read passes on x86 anyway), so — like the `_running` volatile change — it ships without a dedicated visibility test; the existing `HasShutdownFinished_Be_True_When_ShutdownFinished` / `HasShutdownStarted_Be_True_When_ShutdownStarted` cover the same-thread semantics.
- `dotnet test --filter DispatcherTests`: **36/36 passed** (exit 0). `dotnet format --verify-no-changes` on both files: clean (exit 0).

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-06][diff][medium] _running field not volatile in QueueSynchronizationContext")
- Project board: b-editor/projects/9 ("[2026-06-06][diff][medium] Missing regression test for concurrent Shutdown race in WaitForPendingOperations")
