### PR TITLE
fix: prevent IpcFrameProvider from returning wrong frame on non-sequential requests

### DIFF
--- a/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
@@ -53,7 +53,11 @@ internal sealed class IpcFrameProvider : IFrameProvider
             {
                 Task<IpcMessage> staleTask = _prefetchTask;
                 _prefetchTask = null;
-                await staleTask;
+                IpcMessage? staleResponse = await staleTask;
+                // 破棄するフレームであっても、先行リクエストの応答がキャンセル通知だった場合は
+                // 操作全体のキャンセルを意味するため、新規リクエストを発行せずそのまま伝播する。
+                if (staleResponse is { Type: MessageType.CancelEncode })
+                    throw new OperationCanceledException();
             }
 
             // 初回フレーム or 非連続要求: 要求フレームを改めて取得

--- a/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
@@ -45,19 +45,14 @@ internal sealed class IpcFrameProvider : IFrameProvider
         }
         else
         {
-            // プリフェッチが進行中だが要求フレームと一致しない場合 (シーク等の非連続要求) は、
-            // 完了を待ってから結果を破棄する。参照を捨てるだけでなく必ず await することで、
-            // 先行リクエストの応答をこのフレームの応答として取り違えたり、ホストへ非順次の
-            // リクエストが流出するのを防ぐ。キャンセルや通信エラーはそのまま上位へ伝播させる。
+            // プリフェッチ中だが要求フレームと一致しない場合 (シーク等の非連続要求)。
+            // 参照を捨てるだけでなく必ず await して完了を待つことで、先行リクエストの応答を
+            // このフレームの応答として取り違えたり、ホストへ非順次のリクエストが流出するのを防ぐ。
             if (_prefetchTask != null)
             {
                 Task<IpcMessage> staleTask = _prefetchTask;
                 _prefetchTask = null;
-                IpcMessage? staleResponse = await staleTask;
-                // 破棄するフレームであっても、先行リクエストの応答がキャンセル通知だった場合は
-                // 操作全体のキャンセルを意味するため、新規リクエストを発行せずそのまま伝播する。
-                if (staleResponse is { Type: MessageType.CancelEncode })
-                    throw new OperationCanceledException();
+                await staleTask;
             }
 
             // 初回フレーム or 非連続要求: 要求フレームを改めて取得

--- a/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
@@ -16,6 +16,7 @@ internal sealed class IpcFrameProvider : IFrameProvider
     // 先行リクエスト: 次フレームのレンダリングを事前に要求
     private Task<IpcMessage>? _prefetchTask;
     private int _prefetchBufferIndex;
+    private long _prefetchFrameIndex;
 
     public IpcFrameProvider(IpcConnection connection, SharedMemoryBuffer[] videoBuffers,
         long frameCount, Rational frameRate)
@@ -35,16 +36,27 @@ internal sealed class IpcFrameProvider : IFrameProvider
         IpcMessage response;
         int readBufferIndex;
 
-        if (_prefetchTask != null)
+        if (_prefetchTask != null && _prefetchFrameIndex == frame)
         {
-            // 先行リクエスト済み: その結果を使う
+            // 先行リクエスト済みかつ要求フレームと一致: その結果を使う
             response = await _prefetchTask;
             readBufferIndex = _prefetchBufferIndex;
             _prefetchTask = null;
         }
         else
         {
-            // 初回フレーム: 通常リクエスト
+            // プリフェッチが進行中だが要求フレームと一致しない場合 (シーク等の非連続要求) は、
+            // 完了を待ってから結果を破棄する。参照を捨てるだけでなく必ず await することで、
+            // 先行リクエストの応答をこのフレームの応答として取り違えたり、ホストへ非順次の
+            // リクエストが流出するのを防ぐ。キャンセルや通信エラーはそのまま上位へ伝播させる。
+            if (_prefetchTask != null)
+            {
+                Task<IpcMessage> staleTask = _prefetchTask;
+                _prefetchTask = null;
+                await staleTask;
+            }
+
+            // 初回フレーム or 非連続要求: 要求フレームを改めて取得
             readBufferIndex = _bufferIndex;
             var request = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,
                 new RequestFrameMessage { FrameIndex = frame, BufferIndex = readBufferIndex });
@@ -66,6 +78,7 @@ internal sealed class IpcFrameProvider : IFrameProvider
         if (nextFrame < FrameCount)
         {
             _prefetchBufferIndex = 1 - readBufferIndex;
+            _prefetchFrameIndex = nextFrame;
             var nextRequest = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,
                 new RequestFrameMessage { FrameIndex = nextFrame, BufferIndex = _prefetchBufferIndex });
             _prefetchTask = _connection.SendAndReceiveAsync(nextRequest).AsTask();

--- a/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs
@@ -46,8 +46,8 @@ internal sealed class IpcFrameProvider : IFrameProvider
         else
         {
             // プリフェッチ中だが要求フレームと一致しない場合 (シーク等の非連続要求)。
-            // 参照を捨てるだけでなく必ず await して完了を待つことで、先行リクエストの応答を
-            // このフレームの応答として取り違えたり、ホストへ非順次のリクエストが流出するのを防ぐ。
+            // 非多重化接続では応答が送信順に読まれるため、捨てる前に必ず await して先行リクエストの
+            // 応答を消費しないと、次の新規リクエストがこの古い応答を読み取り ID 不一致になる。
             if (_prefetchTask != null)
             {
                 Task<IpcMessage> staleTask = _prefetchTask;


### PR DESCRIPTION
## Description

`IpcFrameProvider.RenderFrame(long frame)` double-buffers by prefetching `frame_prev + 1` into `_prefetchTask`. On the next call it reused that in-flight prefetch **unconditionally**, without checking that the prefetched frame matched the requested `frame`. On any non-sequential request — timeline seek, frame-step, reverse play, keyframe-editing preview — the caller therefore received the **wrong frame**, and a non-sequential `RequestFrame` could leak to the host worker (surfacing as `OperationCanceledException`, etc.).

Fix (mirrors the paired audio provider):
- Track the prefetched frame index in a new `_prefetchFrameIndex` field.
- Reuse the prefetch **only** when `_prefetchFrameIndex == frame`.
- On a mismatch (seek / first frame), `await` and **discard** the stale prefetch before issuing a fresh `RequestFrame` for the requested frame — so responses are never mismatched and non-sequential requests never flow to the host out of order.

This is the exact bug that was fixed for the sibling `IpcSampleProvider` in `d14cb099d` (#1732); this PR brings the paired **video** provider in line.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)

## Breaking changes
None — behavior-preserving on the sequential happy path; only the non-sequential (seek) path changes, and only to return the correct frame. GPL-only worker code; no GPL/MIT boundary change.

## Test plan
- `dotnet build src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj -f net10.0` → **succeeded, 0 warnings / 0 errors**.
- `dotnet format Beutl.slnx --include src/Beutl.FFmpegWorker/Providers/IpcFrameProvider.cs --verify-no-changes` → **clean**.
- **No unit test added.** `IpcFrameProvider` is `internal sealed` inside the GPL-only `Beutl.FFmpegWorker`, depends on the `public sealed` `IpcConnection` (no interface / not mockable), and no GPL worker test project exists (`Beutl.FFmpegIpc.Tests` references only the MIT `Beutl.FFmpegIpc`). The sibling fix `d14cb099d` (#1732) shipped testless for the same structural reason. Correctness is established by symmetry with that merged fix.

## Follow-ups
- The prefetch/seek-coordination pattern (record prefetched key → validate against request → await-and-discard on mismatch) is now duplicated by hand in both `IpcSampleProvider` and `IpcFrameProvider`. A future refactor could extract it into a small, **MIT-side**, unit-testable helper in `Beutl.FFmpegIpc` and unify both providers onto it (orthogonality + testability). Captured as AI-Review board context; out of scope for this minimal fix.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[Bug] IpcFrameProvider が非順次フレーム要求時にプリフェッチ結果を誤って返す")
- Sibling fix: d14cb099d (#1732)