### PR TITLE
fix(extensibility): compare encoder extensions case-insensitively in IsSupported

### DIFF
--- a/src/Beutl.Extensibility/ControllableEncodingExtension.cs
+++ b/src/Beutl.Extensibility/ControllableEncodingExtension.cs
@@ -4,7 +4,7 @@ public abstract class ControllableEncodingExtension : Extension
 {
     public virtual bool IsSupported(string file)
     {
-        return SupportExtensions().Contains(Path.GetExtension(file));
+        return SupportExtensions().Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase);
     }
 
     public abstract IEnumerable<string> SupportExtensions();

--- a/tests/Beutl.UnitTests/Editor/ControllableEncodingExtensionTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ControllableEncodingExtensionTests.cs
@@ -1,0 +1,34 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Editor;
+
+public class ControllableEncodingExtensionTests
+{
+    // The default IsSupported must match on extension regardless of the on-disk casing,
+    // mirroring the (now removed) IEncoderInfo.IsSupported which used StringComparer.OrdinalIgnoreCase.
+    [TestCase("video.mp4", ExpectedResult = true)]
+    [TestCase("video.MP4", ExpectedResult = true)]
+    [TestCase("video.Mp4", ExpectedResult = true)]
+    [TestCase("clip.mov", ExpectedResult = true)]
+    [TestCase("clip.MOV", ExpectedResult = true)]
+    [TestCase("archive.mkv", ExpectedResult = false)]
+    [TestCase("archive.MKV", ExpectedResult = false)]
+    [TestCase("noextension", ExpectedResult = false)]
+    public bool IsSupported_MatchesExtensionCaseInsensitively(string file)
+    {
+        var extension = new TestEncodingExtension();
+        return extension.IsSupported(file);
+    }
+
+    private sealed class TestEncodingExtension : ControllableEncodingExtension
+    {
+        public override IEnumerable<string> SupportExtensions()
+        {
+            yield return ".mp4";
+            yield return ".mov";
+        }
+
+        public override EncodingController CreateController(string file)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Description
- `ControllableEncodingExtension.IsSupported` compared `Path.GetExtension(file)` against `SupportExtensions()` using the default **ordinal** comparer.
- `Path.GetExtension` preserves the on-disk casing, so a destination file such as `video.MP4` yielded `.MP4`, which never matched the lowercase literals every implementation returns (`FFmpegControlledEncodingExtension`, `AVFEncodingExtension` both `yield return ".mp4"`, `.mov`, …). A perfectly valid uppercase-extension target was reported as **unsupported**.
- The removed legacy `IEncoderInfo.IsSupported` used `StringComparer.OrdinalIgnoreCase`; this restores that behavior at the new default comparison site (one-line change).

```diff
- return SupportExtensions().Contains(Path.GetExtension(file));
+ return SupportExtensions().Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase);
```

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. The default `IsSupported(string)` signature is unchanged; the fix only widens matching to be case-insensitive (previously-rejected uppercase extensions are now correctly accepted), matching the established `IEncoderInfo.IsSupported` convention.

## Test plan
New NUnit fixture `tests/Beutl.UnitTests/Editor/ControllableEncodingExtensionTests.cs` (8 `[TestCase]` rows over a minimal `ControllableEncodingExtension` subclass yielding `.mp4` / `.mov`).

Baseline-first verification:
- **Before the fix** (characterization run against unmodified code): 3 failed / 5 passed — exactly the uppercase/mixed-case rows `video.MP4`, `video.Mp4`, `clip.MOV` returned `False`, confirming the test captures the bug.
- **After the fix**: 8 passed / 0 failed.
- `dotnet format --verify-no-changes` clean on both touched files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("ControllableEncodingExtension.IsSupported should compare extensions case-insensitively")
- Pre-existing gap surfaced during review of PR #1905 (refactor!: remove legacy encoder pipeline).