### PR TITLE
fix(engine): dispose child AudioBuffer consumed by SpeedProcessor.Read

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -241,7 +241,10 @@ public sealed class SpeedNode : AudioNode
                 context.AnimationSampler,
                 context.OriginalTimeRange);
 
-            var result = _speedNode.Inputs[0].Process(subContext);
+            // Read consumes the child buffer fully into the interleaved span and never returns it, so
+            // dispose its pooled MemoryPool<float> lease here; otherwise every resampler iteration leaks
+            // one input buffer (matches the disposal contract the sibling audio nodes already honor).
+            using var result = _speedNode.Inputs[0].Process(subContext);
             var leftData = result.GetChannelData(0);
             var rightData = result.GetChannelData(1);
             int samplesToRead = Math.Min(count, result.SampleCount);

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
@@ -69,6 +69,18 @@ public class AudioNodeBufferDisposalTests
         return property;
     }
 
+    private static IProperty<float> AnimatedSpeed(float fromPercent, float toPercent, double durationSeconds)
+    {
+        var property = Property.CreateAnimatable(fromPercent);
+        property.SetAttributes("Speed", []);
+
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float> { KeyTime = TimeSpan.Zero, Value = fromPercent, Easing = new LinearEasing() });
+        animation.KeyFrames.Add(new KeyFrame<float> { KeyTime = TimeSpan.FromSeconds(durationSeconds), Value = toPercent, Easing = new LinearEasing() });
+        property.Animation = animation;
+        return property;
+    }
+
     [Test]
     public void CompressorNode_DisposesConsumedInput()
     {
@@ -236,6 +248,58 @@ public class AudioNodeBufferDisposalTests
         AudioBuffer result = node.Process(CreateContext(200));
 
         Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "matching rate must pass the input through");
+        Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
+        result.Dispose();
+    }
+
+    // SpeedNode's resampler reads the upstream through SpeedProcessor.Read, which calls Inputs[0].Process
+    // once per resampler iteration. Each call leases a fresh pooled AudioBuffer that is read and dropped;
+    // every one must be disposed. (Missed by the #127 sweep, which covered the sibling nodes but not the
+    // SpeedProcessor.Read call site.)
+    [Test]
+    public void SpeedNode_NonUnitySpeed_DisposesConsumedInputs()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new SpeedNode { Speed = Static(200f) };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False, "a speed change must emit a new buffer");
+        }
+
+        Assert.That(inputNode.Produced, Is.Not.Empty, "the resampler must have read at least one input buffer");
+        foreach (AudioBuffer produced in inputNode.Produced)
+            Assert.That(IsDisposed(produced), Is.True, "every consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void SpeedNode_AnimatedSpeed_DisposesConsumedInputs()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new SpeedNode { Speed = AnimatedSpeed(50f, 200f, 1.0) };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False);
+        }
+
+        Assert.That(inputNode.Produced, Is.Not.Empty, "the resampler must have read at least one input buffer");
+        foreach (AudioBuffer produced in inputNode.Produced)
+            Assert.That(IsDisposed(produced), Is.True, "every consumed input buffer must be disposed");
+    }
+
+    [Test]
+    public void SpeedNode_UnitySpeed_PassesInputThroughWithoutDisposing()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new SpeedNode { Speed = Static(100f) };
+        node.AddInput(inputNode);
+
+        AudioBuffer result = node.Process(CreateContext());
+
+        Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "unity speed must pass the input through");
         Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
         result.Dispose();
     }

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
@@ -254,8 +254,7 @@ public class AudioNodeBufferDisposalTests
 
     // SpeedNode's resampler reads the upstream through SpeedProcessor.Read, which calls Inputs[0].Process
     // once per resampler iteration. Each call leases a fresh pooled AudioBuffer that is read and dropped;
-    // every one must be disposed. (Missed by the #127 sweep, which covered the sibling nodes but not the
-    // SpeedProcessor.Read call site.)
+    // every one must be disposed.
     [Test]
     public void SpeedNode_NonUnitySpeed_DisposesConsumedInputs()
     {


### PR DESCRIPTION
## Description
- `SpeedNode`'s resampler reads its upstream through `SpeedProcessor.Read`, which calls `Inputs[0].Process(...)` **once per resampler iteration**, copies the returned `AudioBuffer` into the interleaved span, and then **dropped it without disposing** — leaking one pooled `MemoryPool<float>.Shared` lease per read (multiple per rendered chunk, every chunk, during playback at any non-unity speed).
- The earlier buffer-disposal sweep (PR #1893, board item #127) fixed the sibling audio nodes — `Compressor`/`Delay`/`Equalizer`/`Gain`/`Mixer`/`Resample` — but **missed this second `Process()` call site** inside `SpeedProcessor.Read`.
- Fix: dispose the consumed buffer with `using var` (`Read` reads it fully and synchronously and never returns it). The unity-speed pass-through (`ProcessStaticSpeed` returning `Inputs[0].Process(context)`) is unaffected — it still hands ownership to the caller.

```diff
- var result = _speedNode.Inputs[0].Process(subContext);
+ using var result = _speedNode.Inputs[0].Process(subContext);
```

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Behavior-preserving except for releasing a previously-leaked pooled buffer; the audio output is unchanged.

## Test plan
Extended `tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs` (the same fixture that pins the #127 contract) with three `SpeedNode` cases via the existing `CapturingInputNode` + `IsDisposed` helpers:
- `SpeedNode_NonUnitySpeed_DisposesConsumedInputs` — static 200%; asserts every buffer in `Produced` is disposed.
- `SpeedNode_AnimatedSpeed_DisposesConsumedInputs` — animated 50%→200%; same assertion (covers the `ProcessBufferWithVariableSpeed` → `Read` path).
- `SpeedNode_UnitySpeed_PassesInputThroughWithoutDisposing` — 100% pass-through must NOT dispose the returned buffer.

Baseline-first verification:
- **Before the fix**: the two non-unity cases fail (`IsDisposed` → False) — 2 failed / 11 passed — confirming the leak; the unity pass-through passes.
- **After the fix**: 23 passed / 0 failed across `AudioNodeBufferDisposalTests` + `SpeedNodeTests` (the streaming/resampling regression suite stays green, so disposal does not perturb the resampler).
- `dotnet format --verify-no-changes` clean on both touched files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("AudioBuffer from child Process() not disposed in audio nodes" / "AudioBuffer not disposed in audio nodes")
- Follows up PR #1893 (board #127), which disposed the sibling nodes but not the `SpeedProcessor.Read` call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio speed/resampling buffer handling to ensure consumed upstream buffers are properly released during repeated processing iterations.
  * Unity speed now correctly passes the input buffer through without altering ownership.
* **Tests**
  * Added unit test coverage for speed node buffer disposal behavior, including non-unity speeds, animated non-unity speeds, and unity pass-through cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->