### PR TITLE
refactor!: make GainNode.Gain a required non-null property

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/AudioContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioContext.cs
@@ -164,9 +164,10 @@ public sealed class AudioContext : IDisposable
                 .FirstOrDefault(n => n.Gain == gain);
             if (existing != null)
             {
+                // Matched by Gain reference, so existing.Gain already == gain; no re-assignment needed
+                // (and Gain is now init-only).
                 _previousNodes.Remove(existing);
                 existing.ClearInputs();
-                existing.Gain = gain;
                 return AddNode(existing);
             }
         }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -4,7 +4,7 @@ namespace Beutl.Audio.Graph.Nodes;
 
 public sealed class GainNode : AudioNode
 {
-    public IProperty<float>? Gain { get; set; }
+    public required IProperty<float> Gain { get; init; }
 
     public override AudioBuffer Process(AudioProcessContext context)
     {
@@ -15,12 +15,12 @@ public sealed class GainNode : AudioNode
 
         // Guard on Animation (an actual keyframe), not IsAnimatable (always true for animatable
         // properties), so an unkeyed Gain skips the per-sample animated path.
-        if (Gain?.Animation is null)
+        if (Gain.Animation is null)
         {
             return ProcessStaticGain(input);
         }
 
-        // Gain is non-null past the guard; pass it in so the helper need not re-check.
+        // Past the guard Gain has a keyframe animation; pass it in so the helper need not re-check.
         return ProcessAnimatedGain(Gain, input, context);
     }
 
@@ -81,7 +81,7 @@ public sealed class GainNode : AudioNode
 
     private AudioBuffer ProcessStaticGain(AudioBuffer input)
     {
-        float gain = (Gain?.CurrentValue ?? 100f) / 100f;
+        float gain = Gain.CurrentValue / 100f;
         // Unity gain: pass the input through (caller owns it, don't dispose).
         if (System.Math.Abs(gain - 1.0f) < float.Epsilon)
             return input;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -13,14 +13,11 @@ public sealed class GainNode : AudioNode
 
         var input = Inputs[0].Process(context);
 
-        // Guard on Animation (an actual keyframe), not IsAnimatable (always true for animatable
-        // properties), so an unkeyed Gain skips the per-sample animated path.
         if (Gain.Animation is null)
         {
             return ProcessStaticGain(input);
         }
 
-        // Past the guard Gain has a keyframe animation; pass it in so the helper need not re-check.
         return ProcessAnimatedGain(Gain, input, context);
     }
 

--- a/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GainNodeTests.cs
@@ -95,4 +95,21 @@ public class GainNodeTests
             Assert.That(float.IsFinite(sample), Is.True);
         }
     }
+
+    // CreateGainNode reuses a matching GainNode from the previous frame (so streaming/resampler state
+    // survives a graph rebuild). The reuse path matches by Gain reference, so the node it returns already
+    // carries that exact Gain — this guards the removal of the redundant `existing.Gain = gain` write that
+    // the `required init` Gain makes impossible.
+    [Test]
+    public void CreateGainNode_ReusesPreviousNodeMatchingByGain()
+    {
+        var gain = Property.CreateAnimatable(50f);
+        var previous = new GainNode { Gain = gain };
+        using var context = new AudioContext(SampleRate, 2, new[] { previous });
+
+        GainNode created = context.CreateGainNode(gain);
+
+        Assert.That(created, Is.SameAs(previous), "must reuse the previous-frame node matching by Gain reference");
+        Assert.That(created.Gain, Is.SameAs(gain), "the reused node must keep the supplied Gain");
+    }
 }


### PR DESCRIPTION
## Description
`GainNode.Gain` was declared `public IProperty<float>? Gain { get; set; }` — nullable **and** settable — which forced defensive `Gain?.` null-guards in `Process` even though the property is never legitimately null in practice:
- The only production constructor, `AudioContext.CreateGainNode`, does `ArgumentNullException.ThrowIfNull(gain)` and always assigns a non-null `Gain`.
- Every other construction site (and all tests) supply `Gain` via an object initializer.

This aligns `GainNode` with the stronger `CompressorNode` shape (`required IProperty<float> { get; init; }`), so plugin authors don't copy the weak nullable pattern, and removes the now-dead null-guards.

```diff
- public IProperty<float>? Gain { get; set; }
+ public required IProperty<float> Gain { get; init; }
...
- if (Gain?.Animation is null)
+ if (Gain.Animation is null)
...
- float gain = (Gain?.CurrentValue ?? 100f) / 100f;
+ float gain = Gain.CurrentValue / 100f;
```

The `set` → `init` change removes the single write site — `AudioContext.CreateGainNode`'s `existing.Gain = gain` — which was a **redundant no-op**: the reuse candidate is selected by `FirstOrDefault(n => n.Gain == gain)`, so `existing.Gain` already equals `gain`.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
`GainNode.Gain` is now `required` and **init-only** (`required IProperty<float> { get; init; }`) instead of a nullable, settable `IProperty<float>?`. Construct `GainNode` with an object initializer supplying a non-null `Gain` (`new GainNode { Gain = ... }`); the property can no longer be left unset or reassigned after construction. `GainNode` is constructed internally only (via `AudioContext.CreateGainNode`), so in-tree impact is nil; the change is flagged breaking because the type is public.

## Test plan
- Behavior-preserving change. Existing `GainNodeTests` / `AudioNodeBufferDisposalTests` construct `new GainNode { Gain = ... }` and compile unchanged against `required init`.
- Added `GainNodeTests.CreateGainNode_ReusesPreviousNodeMatchingByGain` — drives `AudioContext.CreateGainNode` through its previous-frame reuse path (matching by `Gain` reference) and asserts the same instance is returned with the same `Gain`, guarding the removal of the redundant `existing.Gain = gain` write.
- Baseline-first: the new reuse test is **green against the unmodified code** (characterization), then stays green after the change.
- Full `dotnet test Beutl.slnx -f net10.0 --settings coverlet.runsettings` after the change: **3092 + 18 + 12 tests passed, 0 failed, 0 build errors** (the `required` modifier is enforced solution-wide, so a missed construction site would be a build break — none occurred).
- `dotnet format --verify-no-changes` clean on the three touched files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("GainNode のプロパティを required 非null に統一")
- Origin: design review of the audio-compressor branch (`beutl-design-reviewer`).

## Follow-ups
- `DelayNode` is internally contradictory: it already declares `required IProperty<float>` for `DelayTime`/`Feedback`/`DryMix`/`WetMix`, yet its body still null-guards (`DelayTime?.CurrentValue ?? DelayTimeDefault`, with a "matching GainNode" comment). Those dead guards can be stripped to match `CompressorNode`. Intentionally out of scope for this GainNode-scoped item; tracked as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio node reuse behavior so reused gain nodes keep the existing gain reference while refreshing graph inputs.
  * Updated gain processing logic to rely on whether gain animation keyframes exist, with simpler static-gain computation.

* **New Features**
  * Strengthened the `Gain` property contract on Gain nodes to be required and initialized once (non-null, init-only).

* **Tests**
  * Added coverage to verify gain-node reuse only when the provided `Gain` instance matches exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->