### PR TITLE
refactor: remove stale InternalsVisibleTo for deleted Beutl.PackageTools CLI

### DIFF
--- a/src/Beutl.Api/Properties/AssemblyInfo.cs
+++ b/src/Beutl.Api/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Beutl")]
-[assembly: InternalsVisibleTo("Beutl.PackageTools")]
 [assembly: InternalsVisibleTo("Beutl.PackageTools.UI")]

--- a/src/Beutl.Core/Properties/AssemblyInfo.cs
+++ b/src/Beutl.Core/Properties/AssemblyInfo.cs
@@ -7,7 +7,6 @@
 [assembly: InternalsVisibleTo("Beutl.Configuration")]
 [assembly: InternalsVisibleTo("Beutl.Engine")]
 [assembly: InternalsVisibleTo("Beutl.ProjectSystem")]
-[assembly: InternalsVisibleTo("Beutl.PackageTools")]
 [assembly: InternalsVisibleTo("Beutl.PackageTools.UI")]
 [assembly: InternalsVisibleTo("Beutl.Api")]
 [assembly: InternalsVisibleTo("Beutl.NodeGraph")]


### PR DESCRIPTION
## Description
The `Beutl.PackageTools` CLI project was removed in commit `b7bca70c0` ("delete: Beutl.PackageTools cli tool"), but two `AssemblyInfo.cs` files still grant `[assembly: InternalsVisibleTo("Beutl.PackageTools")]` to the now-nonexistent assembly:

- `src/Beutl.Core/Properties/AssemblyInfo.cs` — line removed
- `src/Beutl.Api/Properties/AssemblyInfo.cs` — line removed

The sibling `Beutl.PackageTools.UI` lines are **kept intact** (that project still exists).

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None. Removes an `InternalsVisibleTo` attribute for a non-existent assembly; no runtime or compile-time behavior change.

## Test plan
- `dotnet build Beutl.slnx`: 0 errors (the deleted CLI project does not exist to break).
- No unit test applicable (removing access for a nonexistent consumer has no observable effect).

## Fixed issues / References
- Project board: b-editor/projects/9 ("Stale [InternalsVisibleTo("Beutl.PackageTools")] in AssemblyInfo.cs (for the deleted CLI) is removable separately.")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal assembly visibility settings to reorganize component dependencies.

---

**Note:** This release contains internal structural changes with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->