### PR TITLE
refactor: strip dead null-guards from DelayNode body

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -44,13 +44,10 @@ public sealed class DelayNode : AudioNode
         }
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
-        // Guard on Animation (an actual keyframe), not IsAnimatable (always true for animatable
-        // properties), so an unkeyed property skips the per-sample path. The null-conditional lets a
-        // null property fall back to static defaults instead of throwing, matching GainNode.
-        bool hasAnimation = DelayTime?.Animation != null ||
-                            Feedback?.Animation != null ||
-                            DryMix?.Animation != null ||
-                            WetMix?.Animation != null;
+        bool hasAnimation = DelayTime.Animation != null ||
+                            Feedback.Animation != null ||
+                            DryMix.Animation != null ||
+                            WetMix.Animation != null;
 
         if (!hasAnimation)
         {
@@ -81,10 +78,10 @@ public sealed class DelayNode : AudioNode
 
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
-        float delayTime = DelayTime?.CurrentValue ?? DelayTimeDefault;
-        float feedback = (Feedback?.CurrentValue ?? FeedbackDefault) / 100f;
-        float dryMix = (DryMix?.CurrentValue ?? DryMixDefault) / 100f;
-        float wetMix = (WetMix?.CurrentValue ?? WetMixDefault) / 100f;
+        float delayTime = DelayTime.CurrentValue;
+        float feedback = Feedback.CurrentValue / 100f;
+        float dryMix = DryMix.CurrentValue / 100f;
+        float wetMix = WetMix.CurrentValue / 100f;
 
         int delaySamples = (int)(delayTime / 1000f * context.SampleRate);
         delaySamples = System.Math.Clamp(delaySamples, 0, _maxDelaySamples - 1);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -44,6 +44,7 @@ public sealed class DelayNode : AudioNode
         }
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
+        // Check Animation (actual keyframe), not IsAnimatable (always true for animatable properties).
         bool hasAnimation = DelayTime.Animation != null ||
                             Feedback.Animation != null ||
                             DryMix.Animation != null ||


### PR DESCRIPTION
## Description
`DelayNode` declares `required IProperty<float>` for all four properties (`DelayTime`, `Feedback`, `DryMix`, `WetMix` — init-only, non-null), yet its `Process` body still used null-conditional access (`DelayTime?.Animation`, `DelayTime?.CurrentValue ?? DelayTimeDefault`) with a comment "matching GainNode".

Now that GainNode is also required non-null (PR #1921 / board #118), strip the dead guards so DelayNode matches the strong `CompressorNode` pattern (direct `.CurrentValue` / `.Animation` access, no fallback defaults).

> **Note:** This branch was forked before #1921 merged into `main`. `GainNode.Gain` still appears nullable in this branch's tree; the `required` declaration lands via the merge base once this PR merges. The justification ("GainNode is now required") refers to `main` after #1921.

```diff
- bool hasAnimation = DelayTime?.Animation != null || Feedback?.Animation != null || ...
+ bool hasAnimation = DelayTime.Animation != null || Feedback.Animation != null || ...

- float delayTime = DelayTime?.CurrentValue ?? DelayTimeDefault;
+ float delayTime = DelayTime.CurrentValue;
```

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Property declarations are unchanged (`required init` since their introduction); only dead internal null-defensiveness is removed.

## Test plan
- Behavior-preserving. Existing `DelayNodeTests` + `AudioNodeBufferDisposalTests` (14 tests) pass unchanged.
- `dotnet format --verify-no-changes` clean.

## Fixed issues / References
- Project board: b-editor/projects/9 ("設計改善: DelayNode の死んだ null ガードを除去（required 宣言に整合）")
- Follow-up to PR #1921 (board #118: GainNode required non-null).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved delay audio node parameter handling and animation detection.
  * Corrected feedback and dry/wet mix level calculations in delay audio processing to ensure accurate parameter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->