### PR TITLE
fix(test): gamma-encode linear HDR pixels to sRGB in Graphics3DTests debug PNGs

### DIFF
--- a/tests/Beutl.Graphics3DTests/Program.cs
+++ b/tests/Beutl.Graphics3DTests/Program.cs
@@ -189,11 +189,31 @@ return 0;
 
 static void SaveRenderOutput(IRenderer3D renderer, int width, int height, string outputPath)
 {
+    // DownloadPixels returns RGBA16Float (8 bytes/pixel, linear HDR). Convert to sRGB BGRA8888
+    // so the debug PNGs look correct in standard viewers.
     var pixelData = renderer.DownloadPixels();
+    int pixelCount = width * height;
+    var srgbPixels = new byte[pixelCount * 4];
+
+    for (int i = 0; i < pixelCount; i++)
+    {
+        int srcOff = i * 8; // 4 × Half (2 bytes each) = 8 bytes per pixel
+        float r = (float)BitConverter.ToHalf(pixelData, srcOff);
+        float g = (float)BitConverter.ToHalf(pixelData, srcOff + 2);
+        float b = (float)BitConverter.ToHalf(pixelData, srcOff + 4);
+        float a = (float)BitConverter.ToHalf(pixelData, srcOff + 6);
+
+        int dstOff = i * 4; // BGRA8888
+        srgbPixels[dstOff] = LinearToSrgbByte(b);
+        srgbPixels[dstOff + 1] = LinearToSrgbByte(g);
+        srgbPixels[dstOff + 2] = LinearToSrgbByte(r);
+        srgbPixels[dstOff + 3] = (byte)Math.Clamp(a * 255f + 0.5f, 0f, 255f);
+    }
+
     using var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
     unsafe
     {
-        fixed (byte* ptr = pixelData)
+        fixed (byte* ptr = srgbPixels)
         {
             bitmap.SetPixels((IntPtr)ptr);
         }
@@ -202,6 +222,15 @@ static void SaveRenderOutput(IRenderer3D renderer, int width, int height, string
     using var data = image.Encode(SKEncodedImageFormat.Png, 100);
     using var stream = File.OpenWrite(outputPath);
     data.SaveTo(stream);
+}
+
+static byte LinearToSrgbByte(float linear)
+{
+    float clamped = Math.Clamp(linear, 0f, 1f);
+    float srgb = clamped <= 0.0031308f
+        ? clamped * 12.92f
+        : 1.055f * MathF.Pow(clamped, 1f / 2.4f) - 0.055f;
+    return (byte)(srgb * 255f + 0.5f);
 }
 
 // === Shadow Test Scene ===


### PR DESCRIPTION
## Description
`SaveRenderOutput()` in `tests/Beutl.Graphics3DTests/Program.cs` took `Renderer3D.DownloadPixels()` — which returns **RGBA16Float** linear HDR data (8 bytes/pixel from the `TextureFormat.RGBA16Float` output texture) — and wrote the raw bytes directly into an `SKBitmap(Bgra8888, Premul)`.

This had two problems:
1. **Format mismatch**: RGBA16Float (half-float, 8 bytes/pixel) was reinterpreted as BGRA8888 (byte, 4 bytes/pixel), garbling the pixel data.
2. **No gamma encoding**: even if the format had matched, linear-light values saved to a PNG (which implies sRGB) appear washed-out/over-bright with banding.

Fix: decode each pixel's four `Half` channels, apply the sRGB transfer function (IEC 61966-2-1), swap RGBA→BGRA channel order, and write the result as proper BGRA8888 bytes.

```csharp
float r = (float)BitConverter.ToHalf(pixelData, srcOff);
// ... linear → sRGB gamma encode → byte
srgbPixels[dstOff] = LinearToSrgbByte(b);  // B
srgbPixels[dstOff + 1] = LinearToSrgbByte(g);  // G
srgbPixels[dstOff + 2] = LinearToSrgbByte(r);  // R
srgbPixels[dstOff + 3] = (byte)(a * 255f);     // A (linear)
```

Test-harness-only debug quality improvement; no product code impact.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

(Test harness only.)

## Breaking changes
None. Test-harness-only change; no public API or product behavior affected.

## Test plan
- `dotnet build tests/Beutl.Graphics3DTests/Beutl.Graphics3DTests.csproj`: 0 errors, 0 warnings.
- Visual verification requires a GPU-capable host running the harness (`dotnet run`); the output PNGs (`render_pbr_grid.png`, `shadow_*.png`) should show correct contrast and hue instead of the current washed-out appearance.
- `dotnet format --verify-no-changes` clean.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Fix washed-out colors in Beutl.Graphics3DTests debug PNG dumps (sRGB encode)")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PNG export to properly convert HDR render output to standard color format, ensuring correct color representation when viewing saved images in standard applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->