### PR TITLE
refactor: remove unused ReactiveUI.Avalonia references from WaitingDialog and PackageTools.UI

### DIFF
--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -21,7 +21,6 @@
     </PackageReference>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="DynamicData" />

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -18,7 +18,6 @@
 
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="FluentAvaloniaUI" />


### PR DESCRIPTION
## Description
- Removed unused `ReactiveUI.Avalonia` `PackageReference` from both `Beutl.WaitingDialog` and `Beutl.PackageTools.UI`.
- Neither project imports any `ReactiveUI` namespace in C# or XAML — the references were leftover from an earlier design.
- Both projects still reference `System.Reactive` (which is in use) and `Avalonia` directly.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Verified with `grep -rn "ReactiveUI"` that neither project uses any ReactiveUI type in `.cs` or `.axaml` files.
- Full solution build (`dotnet build Beutl.slnx`): 0 errors.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Beutl.WaitingDialog / Beutl.PackageTools.UI may carry unused ReactiveUI.Avalonia refs")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused package dependencies to streamline builds across multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->