### PR TITLE
fix(worker): stop prefetch before disposing ReaderState in DecodingHandler.Dispose

### DIFF
--- a/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
@@ -251,6 +251,8 @@ internal sealed partial class DecodingHandler : IDisposable
     {
         foreach (var state in _readers.Values)
         {
+            state.RingBuffer?.StopPrefetch();
+            state.ReaderLock.Wait();
             state.Dispose();
         }
         _readers.Clear();

--- a/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/DecodingHandler.cs
@@ -249,12 +249,14 @@ internal sealed partial class DecodingHandler : IDisposable
 
     public void Dispose()
     {
-        foreach (var state in _readers.Values)
+        foreach (var readerId in _readers.Keys)
         {
-            state.RingBuffer?.StopPrefetch();
-            state.ReaderLock.Wait();
-            state.Dispose();
+            if (_readers.TryRemove(readerId, out var state))
+            {
+                state.RingBuffer?.StopPrefetch();
+                state.ReaderLock.Wait();
+                state.Dispose();
+            }
         }
-        _readers.Clear();
     }
 }


### PR DESCRIPTION
## Description
- `DecodingHandler.Dispose()` called `state.Dispose()` directly without stopping the prefetch task or waiting for in-progress read operations. A prefetch task holding `ReaderLock` could race with the disposal of `RingBuffer` and `FFmpegReader`.
- Added `state.RingBuffer?.StopPrefetch()` + `state.ReaderLock.Wait()` before each `state.Dispose()`, matching the pattern already used in `HandleClose` (line 207-211) and `HandleUpdateDecoderSettings` (line 227-229).

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- No unit test added: `Beutl.FFmpegWorker` is GPL and not referenced by any MIT test project. Process-level tests live in `tests/Beutl.FFmpegIpc.Tests/`, but the dispose race requires process-shutdown timing to trigger and is not reliably reproducible in a contract test.
- The fix is a 2-line addition that mirrors the existing `HandleClose` pattern verbatim.
- `dotnet build src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj`: 0 errors.

## Fixed issues / References
- Project board: b-editor/projects/9 ("FFmpegWorker: DecodingHandler.Dispose() should StopPrefetch before disposing ReaderState")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of video decoding resources during application shutdown to ensure prefetch operations are properly halted and in-flight decode operations complete before resource disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->