### PR TITLE
fix(worker): respect BEUTL_HOME when locating FFmpeg libraries

### DIFF
--- a/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
+++ b/src/Beutl.FFmpegWorker/FFmpegLoaderWorker.cs
@@ -9,13 +9,8 @@ namespace Beutl.FFmpegWorker;
 
 internal static class FFmpegLoaderWorker
 {
-    private static readonly string s_defaultFFmpegPath;
-
-    static FFmpegLoaderWorker()
-    {
-        s_defaultFFmpegPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".beutl", "ffmpeg");
-    }
+    private static readonly string s_defaultFFmpegPath =
+        Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "ffmpeg");
 
     public static void Initialize()
     {


### PR DESCRIPTION
## Description
- `FFmpegLoaderWorker` hardcoded the FFmpeg search root to `~/.beutl/ffmpeg` (`Environment.SpecialFolder.UserProfile + ".beutl/ffmpeg"`), ignoring the `BEUTL_HOME` environment variable.
- `FFmpegInstallService.GetFFmpegInstallPath()` extracts libraries to `$BEUTL_HOME/ffmpeg` via `BeutlEnvironment.GetHomeDirectoryPath()`. When `BEUTL_HOME` was set to a custom directory, the installer extracted there but the worker searched the default `~/.beutl/ffmpeg`, so FFmpeg was reported as not found.
- Replaced the hardcoded path with `BeutlEnvironment.GetHomeDirectoryPath()` + `"ffmpeg"` so both installer and worker resolve the same directory.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- No unit test: `Beutl.FFmpegWorker` is GPL and not referenced by MIT test projects. The fix is a one-line change replacing a hardcoded path with the shared `BeutlEnvironment` API already used by the rest of the codebase.
- `dotnet build src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj`: 0 errors.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Worker ignores BEUTL_HOME when locating FFmpeg libraries")
- Also closes duplicate: b-editor/projects/9 item #173 (same title)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized FFmpeg library path initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->