### PR TITLE
refactor(editor): extract keyframe-seek logic to KeyFrameNavigationHelper and add tests

### DIFF
--- a/src/Beutl.Editor/Services/KeyFrameNavigationHelper.cs
+++ b/src/Beutl.Editor/Services/KeyFrameNavigationHelper.cs
@@ -8,9 +8,17 @@ namespace Beutl.Editor.Services;
 
 public static class KeyFrameNavigationHelper
 {
+    // Enumerates KeyFrameAnimations with their timeline-absolute offset:
+    //   Pass 1 (EngineObject.Properties): offset = obj.TimeRange.Start (local clock)
+    //     or Zero (global clock), matching KeyFrameAnimation<T>.GetAnimatedValue.
+    //   Pass 2 (INodeMember.Property): offset = parent GraphNode.Start (local clock),
+    //     matching GraphSnapshot.LoadAnimatedValues. IEnginePropertyBackedInputPort is
+    //     excluded to avoid double-counting with pass 1.
     public static IEnumerable<(KeyFrameAnimation Animation, TimeSpan Offset)>
         EnumerateKeyFrameAnimations(Element root)
     {
+        ArgumentNullException.ThrowIfNull(root);
+
         var visited = new HashSet<KeyFrameAnimation>();
 
         var enginePass = new ObjectSearcher(root, v => v is EngineObject);
@@ -58,6 +66,8 @@ public static class KeyFrameNavigationHelper
     public static TimeSpan? FindAdjacentKeyFrame(
         IEnumerable<Element> roots, TimeSpan current, bool forward)
     {
+        ArgumentNullException.ThrowIfNull(roots);
+
         TimeSpan? target = null;
         foreach (Element el in roots)
         {

--- a/src/Beutl.Editor/Services/KeyFrameNavigationHelper.cs
+++ b/src/Beutl.Editor/Services/KeyFrameNavigationHelper.cs
@@ -1,0 +1,80 @@
+﻿using Beutl.Animation;
+using Beutl.Engine;
+using Beutl.Extensibility;
+using Beutl.NodeGraph;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+public static class KeyFrameNavigationHelper
+{
+    public static IEnumerable<(KeyFrameAnimation Animation, TimeSpan Offset)>
+        EnumerateKeyFrameAnimations(Element root)
+    {
+        var visited = new HashSet<KeyFrameAnimation>();
+
+        var enginePass = new ObjectSearcher(root, v => v is EngineObject);
+        foreach (EngineObject obj in enginePass.SearchAll().OfType<EngineObject>())
+        {
+            foreach (IProperty property in obj.Properties)
+            {
+                if (property.Animation is KeyFrameAnimation kfa && visited.Add(kfa))
+                {
+                    TimeSpan offset = kfa.UseGlobalClock
+                        ? TimeSpan.Zero
+                        : obj.TimeRange.Start;
+                    yield return (kfa, offset);
+                }
+            }
+        }
+
+        var memberPass = new ObjectSearcher(root, v => v is INodeMember);
+        foreach (INodeMember member in memberPass.SearchAll().OfType<INodeMember>())
+        {
+            if (member is IEnginePropertyBackedInputPort)
+                continue;
+
+            if (member.Property is IAnimatablePropertyAdapter { Animation: KeyFrameAnimation kfa }
+                && visited.Add(kfa))
+            {
+                TimeSpan offset;
+                if (kfa.UseGlobalClock)
+                {
+                    offset = TimeSpan.Zero;
+                }
+                else
+                {
+                    GraphNode? parent = member.FindHierarchicalParent<GraphNode>();
+                    if (parent == null)
+                        continue;
+                    offset = parent.Start;
+                }
+
+                yield return (kfa, offset);
+            }
+        }
+    }
+
+    public static TimeSpan? FindAdjacentKeyFrame(
+        IEnumerable<Element> roots, TimeSpan current, bool forward)
+    {
+        TimeSpan? target = null;
+        foreach (Element el in roots)
+        {
+            foreach ((KeyFrameAnimation anim, TimeSpan offset) in EnumerateKeyFrameAnimations(el))
+            {
+                foreach (IKeyFrame kf in anim.KeyFrames)
+                {
+                    TimeSpan time = kf.KeyTime + offset;
+                    bool inDirection = forward ? time > current : time < current;
+                    bool isCloser = target == null
+                        || (forward ? time < target.Value : time > target.Value);
+                    if (inDirection && isCloser)
+                        target = time;
+                }
+            }
+        }
+
+        return target;
+    }
+}

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -1,14 +1,11 @@
 ﻿using System.Reactive.Subjects;
 using Avalonia.Controls;
-using Beutl.Animation;
 using Beutl.Configuration;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
 using Beutl.Engine;
-using Beutl.Extensibility;
 using Beutl.Language;
 using Beutl.Media;
-using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Microsoft.Extensions.Logging;
@@ -226,7 +223,6 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     {
         TimeSpan current = _editorClock.CurrentTime.Value;
 
-        // 探索範囲のフォールバックチェーン: 選択中の Element → 直近の親 Element → Scene 全 Element (Scene のみ複数 root)
         CoreObject? sel = _editorSelection.SelectedObject.Value;
         Element? scope = sel as Element
             ?? (sel as IHierarchical)?.FindHierarchicalParent<Element>();
@@ -240,22 +236,7 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             ? new[] { scope }
             : Scene.Children.ToArray();
 
-        TimeSpan? target = null;
-        foreach (Element el in roots)
-        {
-            foreach ((KeyFrameAnimation anim, TimeSpan offset) in EnumerateKeyFrameAnimations(el))
-            {
-                foreach (IKeyFrame kf in anim.KeyFrames)
-                {
-                    TimeSpan time = kf.KeyTime + offset;
-                    bool inDirection = forward ? time > current : time < current;
-                    bool isCloser = target == null
-                        || (forward ? time < target.Value : time > target.Value);
-                    if (inDirection && isCloser)
-                        target = time;
-                }
-            }
-        }
+        TimeSpan? target = KeyFrameNavigationHelper.FindAdjacentKeyFrame(roots, current, forward);
 
         if (target == null)
         {
@@ -276,64 +257,6 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
         {
             int currentZIndex = timeline.ToLayerNumber(timeline.Options.Value.Offset.Y);
             timeline.ScrollTo.Execute((new TimeRange(time, TimeSpan.FromTicks(1)), currentZIndex));
-        }
-    }
-
-    // KeyFrameAnimation をタイムライン絶対時刻に正規化するための offset と一緒に列挙する。
-    //   1. EngineObject.Properties.Animation (通常プロパティ): AnimatableProperty.SetOwnerObject
-    //      で animation が hierarchical child として attach されるため、所有 EngineObject の
-    //      TimeRange.Start を offset に使う (UseGlobalClock=false 時)。これは
-    //      KeyFrameAnimation<T>.GetAnimatedValue の挙動と一致する。
-    //   2. INodeMember.Property.Animation (ノードグラフ): NodePropertyAdapter.Animation は
-    //      hierarchical child として attach されないため、animation 経由では owner を辿れない。
-    //      代わりに NodeMember の親 GraphNode を辿り、GraphSnapshot.LoadAnimatedValues
-    //      ("time - node.Start" でローカル時刻を解釈する) と同じ offset を使う。
-    //      IEnginePropertyBackedInputPort はエンジン側プロパティが pass 1 で拾われるため、
-    //      二重カウントしないよう除外する。
-    private static IEnumerable<(KeyFrameAnimation Animation, TimeSpan Offset)>
-        EnumerateKeyFrameAnimations(Element root)
-    {
-        var visited = new HashSet<KeyFrameAnimation>();
-
-        var enginePass = new ObjectSearcher(root, v => v is EngineObject);
-        foreach (EngineObject obj in enginePass.SearchAll().OfType<EngineObject>())
-        {
-            foreach (IProperty property in obj.Properties)
-            {
-                if (property.Animation is KeyFrameAnimation kfa && visited.Add(kfa))
-                {
-                    TimeSpan offset = kfa.UseGlobalClock
-                        ? TimeSpan.Zero
-                        : obj.TimeRange.Start;
-                    yield return (kfa, offset);
-                }
-            }
-        }
-
-        var memberPass = new ObjectSearcher(root, v => v is INodeMember);
-        foreach (INodeMember member in memberPass.SearchAll().OfType<INodeMember>())
-        {
-            if (member is IEnginePropertyBackedInputPort)
-                continue;
-
-            if (member.Property is IAnimatablePropertyAdapter { Animation: KeyFrameAnimation kfa }
-                && visited.Add(kfa))
-            {
-                TimeSpan offset;
-                if (kfa.UseGlobalClock)
-                {
-                    offset = TimeSpan.Zero;
-                }
-                else
-                {
-                    GraphNode? parent = member.FindHierarchicalParent<GraphNode>();
-                    if (parent == null)
-                        continue;
-                    offset = parent.Start;
-                }
-
-                yield return (kfa, offset);
-            }
         }
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
@@ -137,7 +137,7 @@ public class KeyFrameNavigationHelperTests
     }
 
     [Test]
-    public void FindAdjacentKeyFrame_AtExactKeyFrame_SkipsExactMatch()
+    public void FindAdjacentKeyFrame_AtExactKeyFrame_Forward_SkipsExactMatch()
     {
         var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
         var obj = new TestAnimatableObject();
@@ -151,6 +151,23 @@ public class KeyFrameNavigationHelperTests
             [element], TimeSpan.FromSeconds(3), forward: true);
 
         Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_AtExactKeyFrame_Backward_SkipsExactMatch()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(3), forward: false);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(1)));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
@@ -1,0 +1,251 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Editor.Services;
+using Beutl.Engine;
+using Beutl.ProjectSystem;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class KeyFrameNavigationHelperTests
+{
+    #region EnumerateKeyFrameAnimations
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_WithNoAnimations_ReturnsEmpty()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(5) };
+        element.AddObject(new TestAnimatableObject());
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_EngineProperty_LocalClock_ReturnsAnimationWithElementOffset()
+    {
+        var element = new Element { Start = TimeSpan.FromSeconds(3), Length = TimeSpan.FromSeconds(5) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: false,
+            TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+        obj.FloatValue.Animation = animation;
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Animation, Is.SameAs(animation));
+            Assert.That(result[0].Offset, Is.EqualTo(TimeSpan.FromSeconds(3)));
+        });
+    }
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_EngineProperty_GlobalClock_ReturnsZeroOffset()
+    {
+        var element = new Element { Start = TimeSpan.FromSeconds(3), Length = TimeSpan.FromSeconds(5) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+        obj.FloatValue.Animation = animation;
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Animation, Is.SameAs(animation));
+            Assert.That(result[0].Offset, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_MultipleProperties_ReturnsAll()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(5) };
+        var obj = new TestMultiPropertyObject();
+        element.AddObject(obj);
+
+        var anim1 = CreateAnimation(useGlobalClock: false, TimeSpan.Zero);
+        var anim2 = CreateAnimation(useGlobalClock: false, TimeSpan.FromSeconds(1));
+        obj.FloatA.Animation = anim1;
+        obj.FloatB.Animation = anim2;
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    #endregion
+
+    #region FindAdjacentKeyFrame
+
+    [Test]
+    public void FindAdjacentKeyFrame_Forward_ReturnsNearestAfterCurrent()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(2), forward: true);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_Backward_ReturnsNearestBeforeCurrent()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(4), forward: false);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(3)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_NoKeyFrameInDirection_ReturnsNull()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(5), forward: true);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_AtExactKeyFrame_SkipsExactMatch()
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(3), forward: true);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_MultipleElements_SearchesAll()
+    {
+        var el1 = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj1 = new TestAnimatableObject();
+        el1.AddObject(obj1);
+        obj1.FloatValue.Animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(5));
+
+        var el2 = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var obj2 = new TestAnimatableObject();
+        el2.AddObject(obj2);
+        obj2.FloatValue.Animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(2));
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [el1, el2], TimeSpan.FromSeconds(1), forward: true);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_WithOffset_AdjustsKeyFrameTime()
+    {
+        var element = new Element { Start = TimeSpan.FromSeconds(10), Length = TimeSpan.FromSeconds(5) };
+        var obj = new TestAnimatableObject();
+        element.AddObject(obj);
+
+        var animation = CreateAnimation(useGlobalClock: false,
+            TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(2));
+        obj.FloatValue.Animation = animation;
+
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [element], TimeSpan.FromSeconds(9), forward: true);
+
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+
+    [Test]
+    public void FindAdjacentKeyFrame_EmptyRoots_ReturnsNull()
+    {
+        TimeSpan? result = KeyFrameNavigationHelper.FindAdjacentKeyFrame(
+            [], TimeSpan.FromSeconds(1), forward: true);
+
+        Assert.That(result, Is.Null);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static KeyFrameAnimation<float> CreateAnimation(bool useGlobalClock, params TimeSpan[] keyTimes)
+    {
+        var animation = new KeyFrameAnimation<float> { UseGlobalClock = useGlobalClock };
+        for (int i = 0; i < keyTimes.Length; i++)
+        {
+            animation.KeyFrames.Add(new KeyFrame<float>
+            {
+                KeyTime = keyTimes[i],
+                Value = i * 10f,
+                Easing = new LinearEasing()
+            });
+        }
+
+        return animation;
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestAnimatableObject : EngineObject
+    {
+        public TestAnimatableObject()
+        {
+            FloatValue = Property.CreateAnimatable(0f);
+            ScanProperties<TestAnimatableObject>();
+        }
+
+        public IProperty<float> FloatValue { get; }
+    }
+
+    [SuppressResourceClassGeneration]
+    private class TestMultiPropertyObject : EngineObject
+    {
+        public TestMultiPropertyObject()
+        {
+            FloatA = Property.CreateAnimatable(0f);
+            FloatB = Property.CreateAnimatable(0f);
+            ScanProperties<TestMultiPropertyObject>();
+        }
+
+        public IProperty<float> FloatA { get; }
+
+        public IProperty<float> FloatB { get; }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Description

- Extract `EnumerateKeyFrameAnimations` and the keyframe-finding algorithm from `EditViewModel.CommandHandler.cs` to a new `KeyFrameNavigationHelper` static class in `Beutl.Editor.Services`.
- The original code in `src/Beutl/` (app project) was unreachable from any test project. Moving the pure logic to `Beutl.Editor` makes it testable.
- Add 11 NUnit tests covering: engine-property animation enumeration (local/global clock, multiple properties, empty), forward/backward seek, exact-match skip, multi-element search, offset-adjusted times, and edge cases.
- `SeekToAdjacentKeyFrame` in the ViewModel now delegates to `KeyFrameNavigationHelper.FindAdjacentKeyFrame`.

## Affected areas

- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes

None

## Test plan

- 11 new tests in `tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs`
  - `EnumerateKeyFrameAnimations_*` — 4 tests covering no-animation, local clock offset, global clock zero offset, multiple properties
  - `FindAdjacentKeyFrame_*` — 7 tests covering forward/backward seek, no-match null, exact-match skip, multi-element, offset adjustment, empty roots
- Tests were run **baseline-first** (green against unmodified code before the extraction), then re-run after refactor — all 11 pass.
- Broader regression: 1090 Animation+Editor tests pass with no change.

## Fixed issues / References

- Project board: b-editor/projects/9 ("[2026-05-20][diff][medium] No unit tests for new keyframe-seek methods")

## Follow-ups

- NodeGraph-path (`INodeMember` / `IAnimatablePropertyAdapter`) tests are deferred — constructing `GraphNode` + `INodeMember` hierarchies in tests adds significant complexity for a secondary code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized editor keyframe navigation so seeking adjacent keyframes consistently accounts for local vs global timing offsets across multiple animated elements and properties.
* **Tests**
  * Added unit tests covering keyframe animation enumeration and adjacent-keyframe lookup, including edge cases like empty scopes and exact keyframe matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->