### PR TITLE
fix(app): replace window-capture stop busy-spin with a single-flight async gate

### DIFF
--- a/src/Beutl.Threading/SingleFlightAsyncOperation.cs
+++ b/src/Beutl.Threading/SingleFlightAsyncOperation.cs
@@ -1,0 +1,85 @@
+﻿namespace Beutl.Threading;
+
+/// <summary>
+/// Runs an asynchronous operation at most once at a time. Concurrent callers join the
+/// in-flight run (<see cref="RunOrJoinAsync"/>) or skip it (<see cref="TryRunAsync"/>)
+/// rather than queuing their own; the run is exposed as a <see cref="Task"/> so joiners
+/// can await it instead of busy-waiting on a shared flag.
+/// </summary>
+public sealed class SingleFlightAsyncOperation
+{
+    private readonly object _gate = new();
+    private Task? _inFlight;
+
+    /// <summary>
+    /// Gets the currently running operation, or <see langword="null"/> if none is in flight.
+    /// </summary>
+    public Task? InFlight
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _inFlight;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> if none is in flight and returns <see langword="true"/>.
+    /// If one is already in flight, returns <see langword="false"/> immediately without awaiting it.
+    /// </summary>
+    public Task<bool> TryRunAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: false);
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> if none is in flight and returns <see langword="true"/>.
+    /// If one is already in flight, awaits its completion and returns <see langword="false"/>.
+    /// </summary>
+    public Task<bool> RunOrJoinAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: true);
+
+    private async Task<bool> RunCoreAsync(Func<Task> operation, bool joinInFlight)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        Task? existing;
+        TaskCompletionSource? owned = null;
+        lock (_gate)
+        {
+            existing = _inFlight;
+            if (existing is null)
+            {
+                owned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _inFlight = owned.Task;
+            }
+        }
+
+        if (existing is not null)
+        {
+            if (joinInFlight)
+            {
+                // Joiners only wait for the run to finish; the owner observes any failure.
+                try { await existing.ConfigureAwait(false); }
+                catch { }
+            }
+
+            return false;
+        }
+
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _inFlight = null;
+            }
+
+            // Signal completion so joiners resume regardless of the owner's outcome.
+            owned!.TrySetResult();
+        }
+
+        return true;
+    }
+}

--- a/src/Beutl.Threading/SingleFlightAsyncOperation.cs
+++ b/src/Beutl.Threading/SingleFlightAsyncOperation.cs
@@ -6,13 +6,21 @@
 /// rather than queuing their own; the run is exposed as a <see cref="Task"/> so joiners
 /// can await it instead of busy-waiting on a shared flag.
 /// </summary>
+/// <remarks>
+/// Unlike a classic single-flight cache, joiners (and anyone awaiting <see cref="InFlight"/>)
+/// wait only for the run to finish; they do not observe its result or exception. A failure
+/// thrown by the operation propagates solely on the owning caller's returned task.
+/// </remarks>
 public sealed class SingleFlightAsyncOperation
 {
     private readonly object _gate = new();
     private Task? _inFlight;
 
     /// <summary>
-    /// Gets the currently running operation, or <see langword="null"/> if none is in flight.
+    /// Gets a task that completes when the in-flight run finishes, or <see langword="null"/> if
+    /// none is in flight. This is a completion signal, not the operation's own task: it always
+    /// completes successfully even when the operation throws, so awaiting it never observes the
+    /// owner's failure.
     /// </summary>
     public Task? InFlight
     {
@@ -26,15 +34,27 @@ public sealed class SingleFlightAsyncOperation
     }
 
     /// <summary>
-    /// Runs <paramref name="operation"/> if none is in flight and returns <see langword="true"/>.
-    /// If one is already in flight, returns <see langword="false"/> immediately without awaiting it.
+    /// Runs <paramref name="operation"/> if none is in flight; if one is already in flight, returns
+    /// immediately without running or awaiting it.
     /// </summary>
+    /// <param name="operation">The operation to run at most once at a time.</param>
+    /// <returns>
+    /// <see langword="true"/> if this caller ran <paramref name="operation"/>; <see langword="false"/>
+    /// if it was skipped because another run was already in flight. <see langword="true"/> means the
+    /// operation was executed, not that it succeeded — a failure it throws propagates on the returned task.
+    /// </returns>
     public Task<bool> TryRunAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: false);
 
     /// <summary>
-    /// Runs <paramref name="operation"/> if none is in flight and returns <see langword="true"/>.
-    /// If one is already in flight, awaits its completion and returns <see langword="false"/>.
+    /// Runs <paramref name="operation"/> if none is in flight; if one is already in flight, awaits its
+    /// completion instead of starting a new run.
     /// </summary>
+    /// <param name="operation">The operation to run at most once at a time.</param>
+    /// <returns>
+    /// <see langword="true"/> if this caller ran <paramref name="operation"/>; <see langword="false"/>
+    /// if it joined an in-flight run. A joiner waits for the in-flight run to finish but does not observe
+    /// its result or exception; only the owning caller's returned task propagates a failure it throws.
+    /// </returns>
     public Task<bool> RunOrJoinAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: true);
 
     private async Task<bool> RunCoreAsync(Func<Task> operation, bool joinInFlight)
@@ -57,9 +77,10 @@ public sealed class SingleFlightAsyncOperation
         {
             if (joinInFlight)
             {
-                // Joiners only wait for the run to finish; the owner observes any failure.
-                try { await existing.ConfigureAwait(false); }
-                catch { }
+                // existing is the in-flight TaskCompletionSource task, completed only via
+                // TrySetResult below, so awaiting it cannot throw. Joiners wait for the run
+                // to finish without observing the owner's result or exception.
+                await existing.ConfigureAwait(false);
             }
 
             return false;

--- a/src/Beutl.Threading/SingleFlightAsyncOperation.cs
+++ b/src/Beutl.Threading/SingleFlightAsyncOperation.cs
@@ -3,13 +3,11 @@
 /// <summary>
 /// Runs an asynchronous operation at most once at a time. Concurrent callers join the
 /// in-flight run (<see cref="RunOrJoinAsync"/>) or skip it (<see cref="TryRunAsync"/>)
-/// rather than queuing their own; the run is exposed as a <see cref="Task"/> so joiners
-/// can await it instead of busy-waiting on a shared flag.
+/// instead of queuing their own.
 /// </summary>
 /// <remarks>
-/// Unlike a classic single-flight cache, joiners (and anyone awaiting <see cref="InFlight"/>)
-/// wait only for the run to finish; they do not observe its result or exception. A failure
-/// thrown by the operation propagates solely on the owning caller's returned task.
+/// Joiners (and anyone awaiting <see cref="InFlight"/>) only wait for the run to finish; a
+/// failure thrown by the operation propagates solely on the owning caller's returned task.
 /// </remarks>
 public sealed class SingleFlightAsyncOperation
 {
@@ -18,9 +16,8 @@ public sealed class SingleFlightAsyncOperation
 
     /// <summary>
     /// Gets a task that completes when the in-flight run finishes, or <see langword="null"/> if
-    /// none is in flight. This is a completion signal, not the operation's own task: it always
-    /// completes successfully even when the operation throws, so awaiting it never observes the
-    /// owner's failure.
+    /// none is in flight. It is a completion signal, not the operation's own task, so it never
+    /// faults even when the operation throws.
     /// </summary>
     public Task? InFlight
     {
@@ -34,27 +31,19 @@ public sealed class SingleFlightAsyncOperation
     }
 
     /// <summary>
-    /// Runs <paramref name="operation"/> if none is in flight; if one is already in flight, returns
-    /// immediately without running or awaiting it.
+    /// Runs <paramref name="operation"/> if none is in flight; otherwise returns immediately without
+    /// running or awaiting the in-flight run.
     /// </summary>
     /// <param name="operation">The operation to run at most once at a time.</param>
-    /// <returns>
-    /// <see langword="true"/> if this caller ran <paramref name="operation"/>; <see langword="false"/>
-    /// if it was skipped because another run was already in flight. <see langword="true"/> means the
-    /// operation was executed, not that it succeeded — a failure it throws propagates on the returned task.
-    /// </returns>
+    /// <returns><see langword="true"/> if this caller ran the operation; <see langword="false"/> if it was skipped.</returns>
     public Task<bool> TryRunAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: false);
 
     /// <summary>
-    /// Runs <paramref name="operation"/> if none is in flight; if one is already in flight, awaits its
-    /// completion instead of starting a new run.
+    /// Runs <paramref name="operation"/> if none is in flight; otherwise awaits the in-flight run
+    /// instead of starting a new one.
     /// </summary>
     /// <param name="operation">The operation to run at most once at a time.</param>
-    /// <returns>
-    /// <see langword="true"/> if this caller ran <paramref name="operation"/>; <see langword="false"/>
-    /// if it joined an in-flight run. A joiner waits for the in-flight run to finish but does not observe
-    /// its result or exception; only the owning caller's returned task propagates a failure it throws.
-    /// </returns>
+    /// <returns><see langword="true"/> if this caller ran the operation; <see langword="false"/> if it joined an in-flight run.</returns>
     public Task<bool> RunOrJoinAsync(Func<Task> operation) => RunCoreAsync(operation, joinInFlight: true);
 
     private async Task<bool> RunCoreAsync(Func<Task> operation, bool joinInFlight)
@@ -77,9 +66,7 @@ public sealed class SingleFlightAsyncOperation
         {
             if (joinInFlight)
             {
-                // existing is the in-flight TaskCompletionSource task, completed only via
-                // TrySetResult below, so awaiting it cannot throw. Joiners wait for the run
-                // to finish without observing the owner's result or exception.
+                // Completed only via TrySetResult below, so the await never throws.
                 await existing.ConfigureAwait(false);
             }
 

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -10,6 +10,7 @@ using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.Services.Tutorials;
 using Beutl.Services.WindowCapture;
+using Beutl.Threading;
 using Beutl.Utilities;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dialogs;
@@ -31,7 +32,7 @@ public sealed partial class MainView : UserControl
     private readonly CompositeDisposable _disposables = [];
     private readonly Dictionary<ToolWindowExtension, List<Window>> _openToolWindows = new();
     private WindowCaptureSession? _captureSession;
-    private bool _captureStopInProgress;
+    private readonly SingleFlightAsyncOperation _captureStop = new();
 
     public MainView()
     {
@@ -476,57 +477,48 @@ public sealed partial class MainView : UserControl
 
     internal async Task StopWindowCaptureAsync()
     {
-        // Re-entrancy guard: a second Stop click while the first is in flight would
-        // otherwise re-enter with the same session, call StopAsync() (which returns
-        // immediately because _stopped=true), and emit a duplicate "Saved" toast
-        // while the first stop is still finalizing.
-        if (_captureStopInProgress) return;
-        WindowCaptureSession? session = _captureSession;
-        if (session is null)
+        // Coalesce a re-entrant Stop click to a single run so it can't emit a duplicate
+        // "Saved" toast while the first stop is still finalizing.
+        await _captureStop.TryRunAsync(async () =>
         {
-            NotificationService.ShowWarning("Window Capture", "No active capture session.");
-            return;
-        }
+            WindowCaptureSession? session = _captureSession;
+            if (session is null)
+            {
+                NotificationService.ShowWarning("Window Capture", "No active capture session.");
+                return;
+            }
 
-        _captureStopInProgress = true;
-        try
-        {
-            await session.StopAsync();
-            _captureSession = null;
-            NotificationService.ShowSuccess(
-                "Window Capture",
-                $"Saved: {session.OutputPath}\nCaptured {session.CapturedFrameCount} frames (dropped {session.DroppedFrameCount}).");
-        }
-        catch (Exception ex)
-        {
-            _captureSession = null;
-            _logger.LogError(ex, "Failed to stop window capture.");
-            NotificationService.ShowError("Window Capture", ex.Message);
-        }
-        finally
-        {
-            _captureStopInProgress = false;
-        }
+            try
+            {
+                await session.StopAsync();
+                _captureSession = null;
+                NotificationService.ShowSuccess(
+                    "Window Capture",
+                    $"Saved: {session.OutputPath}\nCaptured {session.CapturedFrameCount} frames (dropped {session.DroppedFrameCount}).");
+            }
+            catch (Exception ex)
+            {
+                _captureSession = null;
+                _logger.LogError(ex, "Failed to stop window capture.");
+                NotificationService.ShowError("Window Capture", ex.Message);
+            }
+        });
     }
 
     internal bool HasActiveCapture => _captureSession is not null;
 
     internal async Task EnsureCaptureStoppedAsync()
     {
-        if (_captureStopInProgress)
+        // Join an in-flight user stop (await it, no busy-spin) so close waits for the
+        // same teardown; otherwise perform the shutdown stop here.
+        await _captureStop.RunOrJoinAsync(async () =>
         {
-            // A user-initiated stop is already running; spin briefly until it finishes
-            // so window close waits for the same teardown rather than racing with it.
-            while (_captureStopInProgress)
-                await Task.Yield();
-            return;
-        }
-
-        WindowCaptureSession? session = _captureSession;
-        if (session is null) return;
-        try { await session.StopAsync(); }
-        catch (Exception ex) { _logger.LogWarning(ex, "Failed to stop capture during shutdown."); }
-        finally { _captureSession = null; }
+            WindowCaptureSession? session = _captureSession;
+            if (session is null) return;
+            try { await session.StopAsync(); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Failed to stop capture during shutdown."); }
+            finally { _captureSession = null; }
+        });
     }
 
     private async void GoToInformationPage(object? sender, RoutedEventArgs e) => await GoToInformationPageAsync();

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -477,8 +477,7 @@ public sealed partial class MainView : UserControl
 
     internal async Task StopWindowCaptureAsync()
     {
-        // Coalesce a re-entrant Stop click to a single run so it can't emit a duplicate
-        // "Saved" toast while the first stop is still finalizing.
+        // Coalesce a re-entrant Stop click so it can't emit a duplicate "Saved" toast.
         await _captureStop.TryRunAsync(async () =>
         {
             WindowCaptureSession? session = _captureSession;
@@ -509,8 +508,7 @@ public sealed partial class MainView : UserControl
 
     internal async Task EnsureCaptureStoppedAsync()
     {
-        // Join an in-flight user stop (await it, no busy-spin) so close waits for the
-        // same teardown; otherwise perform the shutdown stop here.
+        // Join an in-flight user stop so close waits for it; otherwise stop here.
         await _captureStop.RunOrJoinAsync(async () =>
         {
             WindowCaptureSession? session = _captureSession;

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Beutl.Threading\Beutl.Threading.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
     <ProjectReference Include="..\..\src\Beutl.NodeGraph\Beutl.NodeGraph.csproj" />
     <ProjectReference Include="..\..\src\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />

--- a/tests/Beutl.UnitTests/Threading/SingleFlightAsyncOperationTests.cs
+++ b/tests/Beutl.UnitTests/Threading/SingleFlightAsyncOperationTests.cs
@@ -1,0 +1,208 @@
+﻿using Beutl.Threading;
+
+namespace Beutl.UnitTests.Threading;
+
+[TestFixture]
+public class SingleFlightAsyncOperationTests
+{
+    [Test]
+    public async Task RunOrJoinAsync_WhenIdle_RunsOperationAndReturnsTrue()
+    {
+        var op = new SingleFlightAsyncOperation();
+        int runs = 0;
+
+        bool owned = await op.RunOrJoinAsync(() =>
+        {
+            runs++;
+            return Task.CompletedTask;
+        });
+
+        Assert.That(owned, Is.True);
+        Assert.That(runs, Is.EqualTo(1));
+        Assert.That(op.InFlight, Is.Null);
+    }
+
+    [Test]
+    public async Task TryRunAsync_WhenIdle_RunsOperationAndReturnsTrue()
+    {
+        var op = new SingleFlightAsyncOperation();
+        int runs = 0;
+
+        bool owned = await op.TryRunAsync(() =>
+        {
+            runs++;
+            return Task.CompletedTask;
+        });
+
+        Assert.That(owned, Is.True);
+        Assert.That(runs, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task TryRunAsync_WhenBusy_SkipsWithoutRunningOrAwaiting()
+    {
+        var op = new SingleFlightAsyncOperation();
+        var release = new TaskCompletionSource();
+        int runs = 0;
+
+        Task<bool> owner = op.RunOrJoinAsync(async () =>
+        {
+            runs++;
+            await release.Task;
+        });
+
+        Assert.That(op.InFlight, Is.Not.Null);
+
+        // A second caller skips the body and returns without awaiting the owner.
+        bool second = await op.TryRunAsync(() =>
+        {
+            runs++;
+            return Task.CompletedTask;
+        });
+
+        Assert.That(second, Is.False);
+        Assert.That(runs, Is.EqualTo(1));
+        Assert.That(owner.IsCompleted, Is.False);
+
+        release.SetResult();
+        Assert.That(await owner, Is.True);
+        Assert.That(runs, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RunOrJoinAsync_WhenBusy_JoinsInFlightAndReturnsFalse()
+    {
+        var op = new SingleFlightAsyncOperation();
+        var release = new TaskCompletionSource();
+        int runs = 0;
+
+        Task<bool> owner = op.RunOrJoinAsync(async () =>
+        {
+            runs++;
+            await release.Task;
+        });
+
+        Task<bool> joiner = op.RunOrJoinAsync(() =>
+        {
+            runs++;
+            return Task.CompletedTask;
+        });
+
+        // The joiner must wait for the owner rather than starting its own run.
+        Assert.That(joiner.IsCompleted, Is.False);
+
+        release.SetResult();
+
+        Assert.That(await owner, Is.True);
+        Assert.That(await joiner, Is.False);
+        Assert.That(runs, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RunOrJoinAsync_ManyConcurrentCallers_RunBodyExactlyOnce()
+    {
+        var op = new SingleFlightAsyncOperation();
+        var release = new TaskCompletionSource();
+        int runs = 0;
+
+        Task<bool> owner = op.RunOrJoinAsync(async () =>
+        {
+            Interlocked.Increment(ref runs);
+            await release.Task;
+        });
+
+        var joiners = Enumerable.Range(0, 16)
+            .Select(_ => op.RunOrJoinAsync(() =>
+            {
+                Interlocked.Increment(ref runs);
+                return Task.CompletedTask;
+            }))
+            .ToArray();
+
+        release.SetResult();
+
+        bool ownerResult = await owner;
+        bool[] joinerResults = await Task.WhenAll(joiners);
+
+        Assert.That(ownerResult, Is.True);
+        Assert.That(joinerResults, Is.All.False);
+        Assert.That(runs, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RunOrJoinAsync_AfterCompletion_CanRunAgain()
+    {
+        var op = new SingleFlightAsyncOperation();
+        int runs = 0;
+
+        bool first = await op.RunOrJoinAsync(() => { runs++; return Task.CompletedTask; });
+        bool second = await op.RunOrJoinAsync(() => { runs++; return Task.CompletedTask; });
+
+        Assert.That(first, Is.True);
+        Assert.That(second, Is.True);
+        Assert.That(runs, Is.EqualTo(2));
+        Assert.That(op.InFlight, Is.Null);
+    }
+
+    [Test]
+    public void RunOrJoinAsync_OwnerThrows_PropagatesToOwnerAndResetsGate()
+    {
+        var op = new SingleFlightAsyncOperation();
+
+        Assert.That(
+            async () => await op.RunOrJoinAsync(() => throw new InvalidOperationException("boom")),
+            Throws.TypeOf<InvalidOperationException>());
+
+        // The gate must reset so subsequent operations can run.
+        Assert.That(op.InFlight, Is.Null);
+    }
+
+    [Test]
+    public async Task RunOrJoinAsync_OperationCatchesOwnException_OwnerSucceedsAndGateResets()
+    {
+        // Mirrors the call sites, where the lambda handles its own exceptions.
+        var op = new SingleFlightAsyncOperation();
+        bool ran = false;
+
+        bool owned = await op.RunOrJoinAsync(async () =>
+        {
+            await Task.Yield();
+            try
+            {
+                throw new InvalidOperationException("boom");
+            }
+            catch
+            {
+                ran = true;
+            }
+        });
+
+        Assert.That(owned, Is.True);
+        Assert.That(ran, Is.True);
+        Assert.That(op.InFlight, Is.Null);
+
+        // Gate is reusable after a self-handled failure.
+        Assert.That(await op.RunOrJoinAsync(() => Task.CompletedTask), Is.True);
+    }
+
+    [Test]
+    public async Task RunOrJoinAsync_JoinerDoesNotObserveOwnerFailure()
+    {
+        var op = new SingleFlightAsyncOperation();
+        var release = new TaskCompletionSource();
+
+        Task<bool> owner = op.RunOrJoinAsync(async () =>
+        {
+            await release.Task;
+            throw new InvalidOperationException("boom");
+        });
+
+        Task<bool> joiner = op.RunOrJoinAsync(() => Task.CompletedTask);
+
+        release.SetResult();
+
+        Assert.That(async () => await owner, Throws.TypeOf<InvalidOperationException>());
+        // The joiner only waits for teardown to finish; it must complete without throwing.
+        Assert.That(await joiner, Is.False);
+    }
+}


### PR DESCRIPTION
## Description
`MainView.EnsureCaptureStoppedAsync` busy-waited on a non-volatile `_captureStopInProgress` flag via `while (...) await Task.Yield()`. That (1) spins until the in-flight `StopAsync` finishes (up to its 10s timeout) and (2) relies on the memory ordering of a field written from threadpool continuations rather than a real signal.

- Add `SingleFlightAsyncOperation` to `Beutl.Threading` — a reusable coordination primitive that runs an async operation at most once at a time and exposes the in-flight run as a `Task`. Callers either join it (`RunOrJoinAsync`) or skip it (`TryRunAsync`).
- `EnsureCaptureStoppedAsync` (window-close path) now **awaits** the in-flight user stop instead of busy-spinning; if none is running it performs the shutdown stop itself.
- `StopWindowCaptureAsync` (user click) coalesces a re-entrant click to a single run via `TryRunAsync`. The gate itself is the atomic guard, so the redundant pre-check was removed and the no-session warning moved inside the gated run.
- Behavior-preserving: re-entrancy guard, single "Saved" toast, and shutdown teardown are unchanged.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] Build / CI / docs only
<!-- also: src/Beutl (app shell) and src/Beutl.Threading -->

## Breaking changes
None. `SingleFlightAsyncOperation` is a new public type; no existing API changed.

## Test plan
- New `tests/Beutl.UnitTests/Threading/SingleFlightAsyncOperationTests.cs` (9 NUnit tests) covers the primitive: idle run, skip-when-busy (no await), join-when-busy, N-way coalescing to a single run, reuse after completion, owner-exception propagation + gate reset, self-handled-exception path, and joiner not observing the owner's failure.
- Verified baseline-first: the new tests build and pass (9/9) against the primitive; `dotnet build src/Beutl/Beutl.csproj -f net10.0` succeeds (0 errors); `dotnet format --verify-no-changes` is clean on the changed files.
- The window-capture feature itself is `[Conditional("DEBUG")]` UI glue in `src/Beutl` (not referenced by any test project); the testable concurrency logic was extracted into `Beutl.Threading` so it ships with the required NUnit coverage.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-17][diff][medium] EnsureCaptureStoppedAsync busy-spins with non-volatile bool -- unbounded spin up to 10s")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window-capture stopping behavior: repeated stop actions during an in-progress stop are now coalesced into a single completion flow, preventing duplicate “Saved” notifications and removing the prior shutdown busy-wait behavior.

* **New Features**
  * Added a concurrency-safe single-in-flight helper that lets callers either start work or join an in-progress run without double-executing.

* **Tests**
  * Added unit tests for the new single-in-flight helper, including owner vs joiner behavior, concurrency, reusability, and exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->