### PR TITLE
test(editor): cover KeyFrameNavigationHelper NodeGraph member path

### DIFF
--- a/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs
@@ -2,6 +2,8 @@
 using Beutl.Animation.Easings;
 using Beutl.Editor.Services;
 using Beutl.Engine;
+using Beutl.Media;
+using Beutl.NodeGraph;
 using Beutl.ProjectSystem;
 
 namespace Beutl.UnitTests.Editor.Services;
@@ -79,6 +81,70 @@ public class KeyFrameNavigationHelperTests
         var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
 
         Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    #endregion
+
+    #region EnumerateKeyFrameAnimations - NodeGraph members
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_NodeGraphMember_LocalClock_ReturnsAnimationWithGraphNodeOffset()
+    {
+        (Element element, KeyFrameNavTestGraphNode node) = CreateNodeGraphElement(
+            new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5)));
+
+        var animation = CreateAnimation(useGlobalClock: false,
+            TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+        node.Items.Add(new TestNodeMember<float>("Value", animation));
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Animation, Is.SameAs(animation));
+            Assert.That(result[0].Offset, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_NodeGraphMember_GlobalClock_ReturnsZeroOffset()
+    {
+        (Element element, KeyFrameNavTestGraphNode node) = CreateNodeGraphElement(
+            new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5)));
+
+        var animation = CreateAnimation(useGlobalClock: true,
+            TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+        node.Items.Add(new TestNodeMember<float>("Value", animation));
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Animation, Is.SameAs(animation));
+            Assert.That(result[0].Offset, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void EnumerateKeyFrameAnimations_EnginePropertyBackedInputPort_IsExcluded()
+    {
+        (Element element, KeyFrameNavTestGraphNode node) = CreateNodeGraphElement(
+            new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5)));
+
+        // The engine-property pass already covers EngineObject-backed properties, so the node-graph
+        // pass skips IEnginePropertyBackedInputPort to avoid double-counting. The backing object is
+        // intentionally kept out of the searched tree, so the excluded port is the only path that
+        // could otherwise surface its animation.
+        var backing = new TestAnimatableObject();
+        backing.FloatValue.Animation = CreateAnimation(useGlobalClock: false,
+            TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        node.Items.Add(new EnginePropertyBackedInputPort<float>(backing, backing.FloatValue));
+
+        var result = KeyFrameNavigationHelper.EnumerateKeyFrameAnimations(element).ToList();
+
+        Assert.That(result, Is.Empty);
     }
 
     #endregion
@@ -264,5 +330,31 @@ public class KeyFrameNavigationHelperTests
         public IProperty<float> FloatB { get; }
     }
 
+    private static (Element Element, KeyFrameNavTestGraphNode Node) CreateNodeGraphElement(TimeRange nodeTimeRange)
+    {
+        var element = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(10) };
+        var drawable = new NodeGraphDrawable();
+        element.AddObject(drawable);
+
+        GraphModel model = drawable.Model.CurrentValue!;
+        var node = new KeyFrameNavTestGraphNode { TimeRange = nodeTimeRange };
+        model.Nodes.Add(node);
+
+        return (element, node);
+    }
+
+    private sealed class TestNodeMember<T> : NodeMember<T>
+    {
+        public TestNodeMember(string name, IAnimation<T>? animation = null)
+        {
+            Property = new NodePropertyAdapter<T>(name, default, animation);
+        }
+    }
+
     #endregion
+}
+
+// Top-level (not nested) so the EngineObject Resource source generator can reference it.
+internal sealed partial class KeyFrameNavTestGraphNode : GraphNode
+{
 }


### PR DESCRIPTION
## Description
Adds unit coverage for the **node-graph member pass** of `KeyFrameNavigationHelper.EnumerateKeyFrameAnimations` (`src/Beutl.Editor/Services/KeyFrameNavigationHelper.cs`). Before this PR, only the `EngineObject.Properties` pass was covered; the `INodeMember` / `IAnimatablePropertyAdapter` branch (GraphNode-based offset and `IEnginePropertyBackedInputPort` exclusion) had no tests.

Three focused cases build an `Element → NodeGraphDrawable → GraphModel → GraphNode → INodeMember` hierarchy:
- **Local clock** → offset is taken from the parent `GraphNode.Start` (`FindHierarchicalParent<GraphNode>()`).
- **Global clock** → offset is `Zero`.
- **`IEnginePropertyBackedInputPort` is excluded** → avoids double-counting with the engine-property pass; the backing object is kept out of the searched tree so the excluded port is the only path that could otherwise surface its animation.

The local/global-clock cases assert both the returned count and the offset value (which can only originate from the node-graph branch), so they prove the pass actually runs and reaches the member via `ObjectSearcher`; the exclusion case then asserts the engine-backed port is filtered out.

Test-only change; no production code is modified.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`) — test only, `tests/Beutl.UnitTests/Editor/Services/`
- [x] Build / CI / docs only — adds tests

## Breaking changes
None (test-only).

## Test plan
- Added 3 NUnit cases to `tests/Beutl.UnitTests/Editor/Services/KeyFrameNavigationHelperTests.cs`:
  - `EnumerateKeyFrameAnimations_NodeGraphMember_LocalClock_ReturnsAnimationWithGraphNodeOffset`
  - `EnumerateKeyFrameAnimations_NodeGraphMember_GlobalClock_ReturnsZeroOffset`
  - `EnumerateKeyFrameAnimations_EnginePropertyBackedInputPort_IsExcluded`
- Baseline-first: the new tests pass against the unmodified `KeyFrameNavigationHelper`, characterizing current behavior.
- `KeyFrameNavigationHelperTests`: 15 passed / 0 failed.
- Surrounding `Beutl.UnitTests.Editor` regression filter: 887 passed / 0 failed.
- `dotnet format` verified clean on the changed file.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Add unit tests for KeyFrameNavigationHelper NodeGraph path (INodeMember / IAnimatablePropertyAdapter)")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for animation enumeration with improved validation of offset behavior in different clock modes and regression testing to prevent animation double-counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->