### PR TITLE
refactor(ffmpeg-ipc): relocate IPC frame/sample providers to MIT Beutl.FFmpegIpc + add seek/cancel tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Claude Code skills are provided as `/beutl-build`, `/beutl-test`, `/beutl-format
 | `Beutl.Editor.Components`, `Beutl.Controls` | Avalonia UI layer (views / controls / ViewModels) |
 | `Beutl.Extensibility` | Plugin abstractions |
 | `Beutl.NodeGraph` | Node editor |
-| `Beutl.FFmpegIpc` | **MIT** IPC layer |
+| `Beutl.FFmpegIpc` | **MIT** IPC layer (transport: Protocol / Transport / SharedMemory). Also hosts the IPC client providers under `Providers/`, which translate frame/sample messages into `Beutl.Media` / `Beutl.Extensibility` types; that adapter role is why this project deliberately takes `ProjectReference`s to `Beutl.Engine` + `Beutl.Extensibility` rather than staying dependency-free. |
 | `Beutl.FFmpegWorker` | **GPL** separate process; reach it only via IPC |
 | `Beutl.Api` | Server API client |
 

--- a/src/Beutl.FFmpegIpc/Beutl.FFmpegIpc.csproj
+++ b/src/Beutl.FFmpegIpc/Beutl.FFmpegIpc.csproj
@@ -7,7 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The IPC client providers (Providers/) translate frame/sample IPC messages into
+         Beutl.Media / Beutl.Extensibility types, so the transport library needs these refs. -->
+    <ProjectReference Include="..\Beutl.Engine\Beutl.Engine.csproj" />
+    <ProjectReference Include="..\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Beutl.FFmpegIpc.Tests" />
+    <!-- The GPL worker constructs the internal providers; it reaches them via IVT, not public API. -->
+    <InternalsVisibleTo Include="Beutl.FFmpegWorker" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -5,7 +5,7 @@ using Beutl.FFmpegIpc.SharedMemory;
 using Beutl.FFmpegIpc.Transport;
 using Beutl.Media;
 
-namespace Beutl.FFmpegWorker.Providers;
+namespace Beutl.FFmpegIpc.Providers;
 
 internal sealed class IpcFrameProvider : IFrameProvider
 {

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -6,7 +6,7 @@ using Beutl.FFmpegIpc.Transport;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
 
-namespace Beutl.FFmpegWorker.Providers;
+namespace Beutl.FFmpegIpc.Providers;
 
 internal sealed class IpcSampleProvider : ISampleProvider
 {

--- a/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
@@ -1,9 +1,9 @@
 ﻿using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
+using Beutl.FFmpegIpc.Providers;
 using Beutl.FFmpegIpc.SharedMemory;
 using Beutl.FFmpegIpc.Transport;
 using Beutl.FFmpegWorker.Encoding;
-using Beutl.FFmpegWorker.Providers;
 using Beutl.Media;
 
 namespace Beutl.FFmpegWorker.Handlers;

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -135,7 +135,10 @@ public class IpcProviderContractTests
         var hostTask = RunFrameServingHost(server, buffers, received, gate, hostCts.Token);
 
         using var conn = new IpcConnection(client);
-        var provider = new IpcFrameProvider(conn, buffers, frameCount: 100, frameRate: new Rational(30, 1));
+        // frameCount: 6 makes frame 5 the last frame, so RenderFrame(5) issues no post-seek prefetch.
+        // This keeps the test self-contained: no dangling prefetch task survives into teardown to
+        // raise an unobserved exception when the pipe/buffers are disposed.
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 6, frameRate: new Rational(30, 1));
 
         try
         {
@@ -148,9 +151,8 @@ public class IpcProviderContractTests
                 Assert.That(ReadFrameSignature(frame5), Is.EqualTo(5L), "seek returns frame 5, not the prefetched frame 1");
             });
 
-            // render(0), prefetch(1, drained), fresh seek(5). The post-seek prefetch of 6 fires inside
-            // RenderFrame(5), but the non-multiplexed _requestLock serialises it after frame 5's reply,
-            // so 6 can never reach the host as the 3rd message — [0, 1, 5] is guaranteed before any 6.
+            // render(0), prefetch(1, drained), fresh seek(5). Frame 5 is the last frame, so no further
+            // prefetch fires — the host receives exactly [0, 1, 5].
             await WaitUntil(() => { lock (gate) return received.Count >= 3; },
                 TimeSpan.FromSeconds(5), "host receives render + prefetch + fresh seek request");
 
@@ -180,7 +182,8 @@ public class IpcProviderContractTests
 
         try
         {
-            Assert.CatchAsync<OperationCanceledException>(async () => await provider.RenderFrame(0));
+            Assert.That(async () => await provider.RenderFrame(0),
+                Throws.TypeOf<OperationCanceledException>());
         }
         finally
         {
@@ -202,7 +205,8 @@ public class IpcProviderContractTests
 
         try
         {
-            Assert.CatchAsync<OperationCanceledException>(async () => await provider.Sample(0, 1024));
+            Assert.That(async () => await provider.Sample(0, 1024),
+                Throws.TypeOf<OperationCanceledException>());
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -1,0 +1,213 @@
+﻿using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using Beutl.FFmpegIpc.Protocol;
+using Beutl.FFmpegIpc.Protocol.Messages;
+using Beutl.FFmpegIpc.Providers;
+using Beutl.FFmpegIpc.SharedMemory;
+using Beutl.FFmpegIpc.Transport;
+using Beutl.Media;
+
+namespace Beutl.FFmpegIpc.Tests;
+
+/// <summary>
+/// Pins the IPC client-side providers (relocated from the GPL worker into MIT Beutl.FFmpegIpc)
+/// against a fake host driven over a real NamedPipe. The providers use the non-multiplexed
+/// <see cref="IpcConnection.SendAndReceiveAsync"/> path, so the host answers requests sequentially.
+/// </summary>
+[TestFixture, NonParallelizable]
+public class IpcProviderContractTests
+{
+    // 1x1 RgbaF16 frame: 4 channels * 2 bytes. The host writes a frame signature into the first
+    // bytes of the shared buffer so the test can read back which frame the provider actually returned.
+    private const int FrameDataLength = 8;
+    private const long BufferCapacity = 4096;
+
+    private static string NewName() => "beutl-ipc-prov-" + Guid.NewGuid().ToString("N")[..8];
+
+    private static (NamedPipeServerStream Server, NamedPipeClientStream Client) ConnectPair()
+    {
+        string name = NewName();
+        var server = new NamedPipeServerStream(
+            name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+        var serverConnectTask = server.WaitForConnectionAsync();
+        client.Connect(TimeSpan.FromSeconds(5));
+        serverConnectTask.GetAwaiter().GetResult();
+        return (server, client);
+    }
+
+    private static SharedMemoryBuffer[] CreateBuffers() =>
+        [SharedMemoryBuffer.Create(NewName(), BufferCapacity), SharedMemoryBuffer.Create(NewName(), BufferCapacity)];
+
+    private static void DisposeBuffers(SharedMemoryBuffer[] buffers)
+    {
+        foreach (var b in buffers)
+            b.Dispose();
+    }
+
+    private static long ReadFrameSignature(Bitmap bmp)
+    {
+        byte[] buf = new byte[FrameDataLength];
+        Marshal.Copy(bmp.Data, buf, 0, FrameDataLength);
+        return BitConverter.ToInt64(buf);
+    }
+
+    // Fake host: serves each RequestFrame by writing that frame's signature into the requested
+    // buffer slot and replying ProvideFrame. Records the received frame indices in order.
+    private static Task RunFrameServingHost(
+        NamedPipeServerStream server, SharedMemoryBuffer[] buffers, List<long> received, object gate, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var payload = req.GetPayload<RequestFrameMessage>()!;
+                lock (gate)
+                    received.Add(payload.FrameIndex);
+
+                buffers[payload.BufferIndex].Write(BitConverter.GetBytes(payload.FrameIndex));
+
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideFrame, new ProvideFrameMessage
+                {
+                    Width = 1,
+                    Height = 1,
+                    BytesPerPixel = FrameDataLength,
+                    DataLength = FrameDataLength,
+                    Premul = false,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
+    // Fake host that answers every request with CancelEncode (the worker-cancel signal).
+    private static Task RunCancelingHost(NamedPipeServerStream server, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var resp = IpcMessage.CreateSimple(req.Id, MessageType.CancelEncode);
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout, string description)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!predicate() && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        if (!predicate())
+            Assert.Fail($"Timeout {timeout.TotalMilliseconds}ms waiting for: {description}");
+    }
+
+    private static async Task StopHost(CancellationTokenSource cts, NamedPipeServerStream server, Task hostTask)
+    {
+        cts.Cancel();
+        server.Dispose();
+        try { await hostTask; }
+        catch (OperationCanceledException) { }
+        catch (IOException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    [Test]
+    public async Task RenderFrame_SeekAfterPrefetch_ReturnsRequestedFrameAndIssuesFreshRequest()
+    {
+        // RenderFrame(0) arms a prefetch of frame 1. A seek to frame 5 must drain that stale prefetch
+        // and issue a fresh RequestFrame{5}, returning frame 5's data — not the prefetched frame 1.
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var received = new List<long>();
+        var gate = new object();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunFrameServingHost(server, buffers, received, gate, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 100, frameRate: new Rational(30, 1));
+
+        try
+        {
+            using Bitmap frame0 = await provider.RenderFrame(0);
+            using Bitmap frame5 = await provider.RenderFrame(5);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReadFrameSignature(frame0), Is.EqualTo(0L), "first render returns frame 0");
+                Assert.That(ReadFrameSignature(frame5), Is.EqualTo(5L), "seek returns frame 5, not the prefetched frame 1");
+            });
+
+            // render(0), prefetch(1, drained), fresh seek(5). The post-seek prefetch of 6 fires inside
+            // RenderFrame(5), but the non-multiplexed _requestLock serialises it after frame 5's reply,
+            // so 6 can never reach the host as the 3rd message — [0, 1, 5] is guaranteed before any 6.
+            await WaitUntil(() => { lock (gate) return received.Count >= 3; },
+                TimeSpan.FromSeconds(5), "host receives render + prefetch + fresh seek request");
+
+            long[] firstThree;
+            lock (gate)
+                firstThree = received.Take(3).ToArray();
+            Assert.That(firstThree, Is.EqualTo(new[] { 0L, 1L, 5L }),
+                "the drained prefetch (1) proves a fresh RequestFrame{5} was issued after the seek");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task RenderFrame_WhenHostCancels_ThrowsOperationCanceled()
+    {
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunCancelingHost(server, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 100, frameRate: new Rational(30, 1));
+
+        try
+        {
+            Assert.CatchAsync<OperationCanceledException>(async () => await provider.RenderFrame(0));
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_WhenHostCancels_ThrowsOperationCanceled()
+    {
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunCancelingHost(server, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 48000, sampleRate: 48000);
+
+        try
+        {
+            Assert.CatchAsync<OperationCanceledException>(async () => await provider.Sample(0, 1024));
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`IpcFrameProvider` / `IpcSampleProvider` are the IPC client-side adapters that pull host-rendered
frames/samples back into the FFmpeg encode worker. They were `internal` to the **GPL**
`Beutl.FFmpegWorker`, so no test project could reference them and the prefetch/seek-guard fix
(branch `yuto-trd/ipcframe-prefetch-seek-guard`) shipped untested.

- Both types translate IPC messages into MIT types only (`Beutl.Extensibility` `IFrameProvider`/
  `ISampleProvider`, `Beutl.FFmpegIpc` transport, `Beutl.Media`), so they are relocated **down into
  the MIT `Beutl.FFmpegIpc` project** (`Providers/`) where tests can reach them.
- They stay `internal sealed`; the GPL worker reaches them via `InternalsVisibleTo("Beutl.FFmpegWorker")`.
- `Beutl.FFmpegIpc` gains `ProjectReference`s to `Beutl.Engine` + `Beutl.Extensibility`. This is a
  deliberate layering trade-off (the transport project was previously dependency-free); it is now
  documented in the `AGENTS.md` module-boundary table. Placement follows the board item's explicit
  request; the alternative of a separate `Beutl.FFmpegIpc.Providers` project was considered and
  declined to keep the diff minimal.
- New regression tests drive both providers against a fake host over a real `NamedPipe` +
  `SharedMemoryBuffer`, pinning: (1) a seek after a prefetch issues a fresh `RequestFrame{5}` and
  returns frame 5 (not the prefetched frame 1); (2) a worker `CancelEncode` response surfaces as
  `OperationCanceledException` for both the frame and sample providers.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Extensibility` (plugin abstractions) — only as a new transitive ref target; no API change

## Breaking changes
None. The moved types were `internal` (no public surface); only their namespace changed
(`Beutl.FFmpegWorker.Providers` → `Beutl.FFmpegIpc.Providers`), and the sole in-tree caller
(`EncodingHandler`) is updated in the same change. The two new `ProjectReference`s do not change the
effective dependency closure of any existing consumer (they already reference `Beutl.Engine` /
`Beutl.Extensibility`). GPL/MIT boundary unchanged — no MIT→`Beutl.FFmpegWorker` reference is added.

## Test plan
- Added `tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs` (3 NUnit tests, fake host over
  `NamedPipe` + `SharedMemoryBuffer`):
  - `RenderFrame_SeekAfterPrefetch_ReturnsRequestedFrameAndIssuesFreshRequest`
  - `RenderFrame_WhenHostCancels_ThrowsOperationCanceled`
  - `Sample_WhenHostCancels_ThrowsOperationCanceled`
- `dotnet test tests/Beutl.FFmpegIpc.Tests -f net10.0` → **21 passed / 0 failed** (18 existing + 3 new).
- Built `Beutl.FFmpegWorker` and `Beutl.Extensions.FFmpeg` (net10.0) green; `dotnet format` clean on
  changed files.

## Follow-ups
- **Provider teardown leak (pre-existing, not a regression).** Both providers hold an in-flight
  prefetch `Task` referencing a `Bitmap` / `Pcm<Stereo32BitFloat>`; if a provider is abandoned
  mid-encode (e.g. `RenderFrame` throws `OperationCanceledException`) while a prefetch is in flight,
  that pending result is never awaited or disposed. Now that the types are testable, a follow-up can
  add `IDisposable` (drain + discard the pending prefetch, dispose the cached chunk) with a
  no-deadlock test mirroring `IpcConnectionMultiplexedTests`.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Make IpcFrameProvider/IpcSampleProvider testable (relocate to MIT Beutl.FFmpegIpc) and add seek/cancel regression tests")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated FFmpeg IPC module documentation to provide clearer guidance on responsibilities and how messages are translated between components.

* **Tests**
  * Added new IPC contract tests using real named-pipe communication to verify frame request ordering, seek-after-prefetch freshness, and correct cancellation behavior for both frame rendering and sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->