### PR TITLE
fix(editor): read onion-skin config on the UI thread in PlayerViewModel.OnSceneEdited

### DIFF
--- a/src/Beutl.Editor/Services/OnionSkinHelper.cs
+++ b/src/Beutl.Editor/Services/OnionSkinHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace Beutl.Editor.Services;
+﻿using Beutl.Media;
+
+namespace Beutl.Editor.Services;
 
 public readonly record struct OnionSkinSample(TimeSpan Time, bool IsPrev, float Alpha);
 
@@ -72,5 +74,38 @@ public static class OnionSkinHelper
         }
 
         return samples;
+    }
+
+    // Decide whether an edit touching `affectedRange` changes any frame the preview is
+    // currently showing: the playhead frame, plus the onion-skin neighbor frames while the
+    // overlay is active. Onion-skin settings are passed in (snapshotted by the caller on the
+    // UI thread) so this stays a pure function and does not read shared mutable config off-thread.
+    public static bool IsEditAffectingPreview(
+        IReadOnlyList<TimeRange> affectedRange,
+        TimeSpan currentTime,
+        bool onionSkinEnabled,
+        int prevCount, float prevOpacity,
+        int nextCount, float nextOpacity,
+        int frameRate, TimeSpan sceneStart, TimeSpan sceneDuration)
+    {
+        if (affectedRange.Any(v => v.Contains(currentTime)))
+            return true;
+
+        if (!onionSkinEnabled)
+            return false;
+
+        // Mirror the opacity-folding the render path uses: a zero-opacity side contributes
+        // nothing, so it should not keep the preview alive either.
+        int effectivePrev = prevOpacity > 0f ? prevCount : 0;
+        int effectiveNext = nextOpacity > 0f ? nextCount : 0;
+        if (effectivePrev == 0 && effectiveNext == 0)
+            return false;
+
+        int frame = (int)Math.Round(currentTime.ToFrameNumber(frameRate), MidpointRounding.AwayFromZero);
+        IReadOnlyList<OnionSkinSample> samples = EnumerateOnionSkinTimes(
+            frame, sceneStart, sceneDuration, frameRate,
+            effectivePrev, effectiveNext, prevOpacity, nextOpacity);
+
+        return samples.Any(s => affectedRange.Any(v => v.Contains(s.Time)));
     }
 }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -257,6 +257,26 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void OnSceneEdited(object? sender, EventArgs e)
     {
+        // Scene.Edited can fire off the UI thread (e.g. parallel element load during
+        // deserialization), so marshal before IsEditAffectingPreview reads EditorConfig
+        // CoreProperty getters against CoreObject's non-synchronized value dictionary.
+        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            HandleSceneEdited(e);
+        }
+        else
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(
+                () => HandleSceneEdited(e),
+                Avalonia.Threading.DispatcherPriority.Background);
+        }
+    }
+
+    private void HandleSceneEdited(EventArgs e)
+    {
+        // Runs on the UI thread (directly or via the OnSceneEdited post). IsPlaying and the
+        // onion-skin config are read here, at handling time, so the off-thread post observes
+        // current state rather than whatever was live when the edit was raised.
         if (e is ElementEditedEventArgs elementEdited
             && !IsEditAffectingPreview(elementEdited.AffectedRange))
         {
@@ -269,38 +289,21 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     // The preview only needs to re-render when an edit touches a currently visible frame.
     // Normally that is just the playhead frame, but while the onion-skin overlay is active the
     // neighboring sample frames are visible too, so an edit confined to one of them must still
-    // invalidate the preview.
+    // invalidate the preview. Must run on the UI thread (see OnSceneEdited).
     private bool IsEditAffectingPreview(IReadOnlyList<TimeRange> affectedRange)
     {
-        TimeSpan time = _editorClock.CurrentTime.Value;
-        if (affectedRange.Any(v => v.Contains(time)))
-        {
-            return true;
-        }
-
         EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
-        if (!editorConfig.IsOnionSkinEnabled || IsPlaying.Value || Scene is null)
-        {
-            return false;
-        }
+        Scene? scene = Scene;
+        bool onionSkinEnabled = editorConfig.IsOnionSkinEnabled && !IsPlaying.Value && scene is not null;
 
-        // Mirror the opacity-folding the render path uses: a zero-opacity side contributes
-        // nothing, so it should not keep the preview alive either.
-        int prevCount = editorConfig.OnionSkinPrevOpacity > 0f ? editorConfig.OnionSkinPrevCount : 0;
-        int nextCount = editorConfig.OnionSkinNextOpacity > 0f ? editorConfig.OnionSkinNextCount : 0;
-        if (prevCount == 0 && nextCount == 0)
-        {
-            return false;
-        }
-
-        int rate = GetFrameRate();
-        int frame = (int)Math.Round(time.ToFrameNumber(rate), MidpointRounding.AwayFromZero);
-        IReadOnlyList<OnionSkinSample> samples = OnionSkinHelper.EnumerateOnionSkinTimes(
-            frame, Scene.Start, Scene.Duration, rate,
-            prevCount, nextCount,
-            editorConfig.OnionSkinPrevOpacity, editorConfig.OnionSkinNextOpacity);
-
-        return samples.Any(s => affectedRange.Any(v => v.Contains(s.Time)));
+        return OnionSkinHelper.IsEditAffectingPreview(
+            affectedRange,
+            _editorClock.CurrentTime.Value,
+            onionSkinEnabled,
+            editorConfig.OnionSkinPrevCount, editorConfig.OnionSkinPrevOpacity,
+            editorConfig.OnionSkinNextCount, editorConfig.OnionSkinNextOpacity,
+            GetFrameRate(),
+            scene?.Start ?? default, scene?.Duration ?? default);
     }
 
     public Subject<Unit> AfterRendered { get; } = new();

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -257,9 +257,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void OnSceneEdited(object? sender, EventArgs e)
     {
-        // Scene.Edited can fire off the UI thread (e.g. parallel element load during
-        // deserialization), so marshal before IsEditAffectingPreview reads EditorConfig
-        // CoreProperty getters against CoreObject's non-synchronized value dictionary.
+        // Scene raises Edited synchronously with no thread guarantee, so marshal onto the UI thread
+        // before HandleSceneEdited reads the EditorConfig CoreProperty getters: those hit CoreObject's
+        // non-synchronized value dictionary and would race the UI-thread write-back if read off-thread.
+        // This mirrors QueueRender, which already snapshots the same config on the UI thread; keeping
+        // both paths consistent is defense-in-depth, not a fix for a known off-thread caller.
         if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
         {
             HandleSceneEdited(e);
@@ -274,9 +276,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void HandleSceneEdited(EventArgs e)
     {
-        // Runs on the UI thread (directly or via the OnSceneEdited post). IsPlaying and the
-        // onion-skin config are read here, at handling time, so the off-thread post observes
-        // current state rather than whatever was live when the edit was raised.
+        // Runs on the UI thread (directly or via the OnSceneEdited post). A Background-priority post
+        // can still be pumped after DisposeAsync nulls Scene and unsubscribes, so bail out once the
+        // view model is torn down (mirrors the Scene null check on the ShuttleCore post below).
+        if (Scene is null)
+        {
+            return;
+        }
+
+        // IsPlaying and the onion-skin config are read here, at handling time, so the off-thread
+        // post observes current state rather than whatever was live when the edit was raised.
         if (e is ElementEditedEventArgs elementEdited
             && !IsEditAffectingPreview(elementEdited.AffectedRange))
         {

--- a/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
+++ b/tests/Beutl.UnitTests/Editor/OnionSkinTests.cs
@@ -1,8 +1,10 @@
 ﻿using Beutl.Configuration;
 using Beutl.Editor.Services;
+using Beutl.Media;
 
 namespace Beutl.UnitTests.Editor;
 
+[TestFixture]
 public class OnionSkinTests
 {
     // Mirror of the shared frame<->time conversion (int.ToTimeSpan(rate)) so expected sample
@@ -425,5 +427,107 @@ public class OnionSkinTests
 
         Assert.That(config.NodeCacheMaxPixels, Is.EqualTo(1));
         Assert.That(config.NodeCacheMinPixels, Is.EqualTo(1));
+    }
+
+    // A TimeRange that contains the given frame's time (Contains is [Start, End)).
+    private static TimeRange RangeAtFrame(int frame, int rate) =>
+        new(FrameTime(frame, rate), TimeSpan.FromMilliseconds(1));
+
+    [Test]
+    public void IsEditAffectingPreview_EditOnPlayhead_ReturnsTrue_EvenWhenOnionDisabled()
+    {
+        int rate = 30, playhead = 100;
+
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: false,
+            prevCount: 0, prevOpacity: 0f,
+            nextCount: 0, nextOpacity: 0f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsEditAffectingPreview_EditAwayFromPlayhead_OnionDisabled_ReturnsFalse()
+    {
+        int rate = 30, playhead = 100;
+
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead - 5, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: false,
+            prevCount: 3, prevOpacity: 0.5f,
+            nextCount: 3, nextOpacity: 0.5f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsEditAffectingPreview_EditOnPrevNeighbor_OnionEnabled_ReturnsTrue()
+    {
+        int rate = 30, playhead = 100;
+
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead - 1, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: true,
+            prevCount: 2, prevOpacity: 0.5f,
+            nextCount: 0, nextOpacity: 0f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsEditAffectingPreview_EditOnNextNeighbor_OnionEnabled_ReturnsTrue()
+    {
+        int rate = 30, playhead = 100;
+
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead + 1, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: true,
+            prevCount: 0, prevOpacity: 0f,
+            nextCount: 2, nextOpacity: 0.5f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsEditAffectingPreview_EditOnNeighbor_ButSideOpacityZero_ReturnsFalse()
+    {
+        int rate = 30, playhead = 100;
+
+        // prevOpacity == 0 folds prevCount to 0, so the prev neighbor is not visible.
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead - 1, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: true,
+            prevCount: 2, prevOpacity: 0f,
+            nextCount: 2, nextOpacity: 0.5f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsEditAffectingPreview_EditBetweenVisibleFrames_ReturnsFalse()
+    {
+        int rate = 30, playhead = 100;
+
+        // The edit sits on frame playhead-3, outside both the playhead and the +/-1 neighbors.
+        bool result = OnionSkinHelper.IsEditAffectingPreview(
+            [RangeAtFrame(playhead - 3, rate)],
+            currentTime: FrameTime(playhead, rate),
+            onionSkinEnabled: true,
+            prevCount: 1, prevOpacity: 0.5f,
+            nextCount: 1, nextOpacity: 0.5f,
+            frameRate: rate, sceneStart: TimeSpan.Zero, sceneDuration: TimeSpan.FromMinutes(1));
+
+        Assert.That(result, Is.False);
     }
 }


### PR DESCRIPTION
## Description
`PlayerViewModel.OnSceneEdited` previously read `EditorConfig` CoreProperty getters (`IsOnionSkinEnabled`, `OnionSkinPrevCount`/`OnionSkinPrevOpacity`, etc.) directly inside `IsEditAffectingPreview`, with no guarantee of running on the UI thread. Those getters hit CoreObject's non-synchronized value dictionary, so an off-thread read would race the UI-thread write-back subscriptions. `QueueRender` already snapshots the same getters on the UI thread for exactly this reason — `OnSceneEdited` was the one inconsistent path. This change is **defense-in-depth + consistency with `QueueRender`** (see the *Rationale correction* note below), not a fix for a demonstrated off-thread caller.

- `PlayerViewModel.OnSceneEdited` now marshals to the UI thread before the decision: `Dispatcher.UIThread.CheckAccess()` fast path when already on it (the normal edit case — unchanged behavior), otherwise `Dispatcher.UIThread.Post(..., Background)`.
- The preview-affecting decision moved into a pure `OnionSkinHelper.IsEditAffectingPreview(...)` (in `Beutl.Editor`) that takes snapshotted onion-skin settings instead of reading shared config, so the logic ships with unit tests. `PlayerViewModel.IsEditAffectingPreview` is now a thin UI-thread adapter that snapshots config + scene and delegates.
- The original combined early-return (`!IsOnionSkinEnabled || IsPlaying.Value || Scene is null`) is folded into the `onionSkinEnabled` argument; the playhead-containment check still runs first, so an edit on the playhead frame still invalidates the preview even while playing / with onion-skin off.

### Rationale correction (review follow-up)
An earlier draft of this description and the first commit message (38cf75c8) claimed the bug was reachable because `Scene.Edited` fires on a thread-pool thread via the parallel element load (`Children.AddRange(urisAdd.AsParallel().Select(...))`). A closer trace shows that specific path does **not** deliver an off-thread `Scene.Edited` to a subscribed `PlayerViewModel`:

- PLINQ parallelizes only the `RestoreFromUri` projection. `CoreList.InsertRange` drives the consuming enumeration and raises `CollectionChanged` → `Scene.Edited` on the **calling** thread (the UI thread in the `OpenProject` path), not on a worker thread.
- The `Scene` is fully deserialized before `EditViewModel`/`PlayerViewModel` are constructed and subscribe (`Scene.Edited += OnSceneEdited` runs in the ctor), so there is no subscriber during that load.

No currently-reachable off-thread `Scene.Edited` path was found while the VM is subscribed. The marshalling is therefore kept as defense-in-depth and to keep `OnSceneEdited` consistent with `QueueRender`'s existing UI-thread config snapshot. Follow-up commit `0287af9` corrects the in-code comment accordingly and adds a `Scene` null guard at the top of `HandleSceneEdited` — a Background-priority post can still be pumped after `DisposeAsync` nulls `Scene`, which would otherwise let `QueueRender` resurrect a `CancellationTokenSource` on a torn-down view model (benign today, but the guard makes it explicit and mirrors the existing `ShuttleCore` post check).

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
<!-- src/Beutl (PlayerViewModel) + src/Beutl.Editor (OnionSkinHelper) -->

## Breaking changes
None. `OnionSkinHelper.IsEditAffectingPreview` is a new public static method; no existing API changed. The normal UI-thread edit path is behavior-preserving.

## Test plan
- 6 new NUnit tests in `tests/Beutl.UnitTests/Editor/OnionSkinTests.cs` cover `IsEditAffectingPreview`: edit on the playhead (true even when onion disabled), edit away from playhead with onion disabled (false), edit on a prev/next neighbor with onion enabled (true), neighbor edit with that side's opacity 0 → folded out (false), and an edit between visible frames (false).
- `dotnet test ... --filter OnionSkinTests` → 26/26 pass. `dotnet build src/Beutl/Beutl.csproj -f net10.0` → 0 errors (verified again after the follow-up commit). `dotnet format --verify-no-changes` clean on the changed files.
- The marshaling glue itself lives in `src/Beutl/` (not referenced by any test project per `.claude/rules/csharp.md`); the testable logic was extracted to `Beutl.Editor` to satisfy the new-logic-needs-tests rule.

## Follow-ups
- `OnionSkinHelper.IsEditAffectingPreview` takes 9 positional parameters including two structurally identical `(count, opacity)` pairs, and groups them differently from the sibling `EnumerateOnionSkinTimes`. Consider a small `OnionSkinSettings` snapshot record struct shared by both methods if this area is touched again. Current call sites use named arguments, so there is no live transposition risk — deferred as a non-blocking cleanup.
- The VM-side fold `IsOnionSkinEnabled && !IsPlaying.Value && scene is not null` (the `IsPlaying` gate in particular) is not unit-testable because `src/Beutl` is not referenced by any test project. Optionally extract the foldable predicate into `Beutl.Editor` to close the coverage gap.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-31][diff][medium] IsEditAffectingPreview reads CoreProperty from OnSceneEdited without UI-thread guarantee")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced onion-skin preview handling to intelligently determine which edits affect the currently displayed preview and neighboring frames.

* **Tests**
  * Added comprehensive test coverage for onion-skin preview invalidation logic, including edge cases for disabled onion-skin, neighbor frame opacity, and playhead positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
