### PR TITLE
perf(ffmpeg): make the three codec property editors async + cached

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -39,7 +39,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         Extension = extension;
         _selectedIndex = new ReactivePropertySlim<int>(-1).DisposeWith(_disposables);
 
-        // CorePropertyAdapterからFFmpegAudioEncoderSettingsを取得
+        // Resolve the FFmpegAudioEncoderSettings from the CorePropertyAdapter.
         if (property is CorePropertyAdapter<AudioFormat> cpa)
         {
             _settings = cpa.Object as FFmpegAudioEncoderSettings;
@@ -47,13 +47,13 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
         if (_settings != null)
         {
-            // コーデック変更を監視
+            // Watch for codec changes.
             _settings.GetObservable(FFmpegAudioEncoderSettings.CodecProperty)
                 .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
-        // 現在値の変更を監視してSelectedIndexを更新
+        // Watch the current value to keep SelectedIndex in sync.
         _property.GetObservable()
             .Subscribe(format =>
             {
@@ -63,7 +63,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             })
             .DisposeWith(_disposables);
 
-        // 初期化
+        // Initialize.
         RequestUpdate();
     }
 
@@ -96,7 +96,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
     {
         _updateCts?.Cancel();
         _updateCts?.Dispose();
-        var cts = _updateCts = new CancellationTokenSource();
+        _updateCts = null;
 
         if (_settings == null)
         {
@@ -111,6 +111,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
+        var cts = _updateCts = new CancellationTokenSource();
         _ = UpdateAsync(_settings, key, cts.Token);
     }
 
@@ -137,7 +138,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
             try
             {
-                s_logger.LogWarning(ex, "Failed to query audio formats from FFmpeg worker");
+                s_logger.LogWarning(ex, "Failed to refresh audio formats from FFmpeg worker");
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     if (!ct.IsCancellationRequested)
@@ -154,7 +155,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
     private void ApplyFormats(AudioFormat[] supportedFmts)
     {
-        // Default ("Auto") を先頭に追加
+        // Prepend Default ("Auto") to the list.
         _currentFormats = [AudioFormat.Default, .. supportedFmts];
         _currentItems = _currentFormats
             .Select(f => new EnumItem(
@@ -163,19 +164,19 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
                 f))
             .ToArray();
 
-        // エディタのアイテムを更新
+        // Update the editor's items.
         if (_editorRef?.TryGetTarget(out var editor) == true)
         {
             editor.Items = _currentItems;
         }
 
-        // 現在値がリストにあるか確認
+        // Check whether the current value is present in the list.
         var currentValue = _property.GetValue();
         int index = Array.IndexOf(_currentFormats, currentValue);
-        _selectedIndex.Value = -1; // 一旦リセット
+        _selectedIndex.Value = -1; // Reset once.
         if (index < 0 && currentValue != AudioFormat.Default)
         {
-            // 非対応フォーマットが選択されていたらAutoにリセット
+            // Reset to Auto when an unsupported format is selected.
             _property.SetValue(AudioFormat.Default);
             _selectedIndex.Value = 0;
         }
@@ -200,13 +201,17 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
     private static AudioFormat[] GetAllFormats()
     {
-        return Enum.GetValues<AudioFormat>();
+        // ApplyFormats prepends AudioFormat.Default ("Auto"), so exclude it here to avoid a duplicate.
+        return Enum.GetValues<AudioFormat>()
+            .Where(f => f != AudioFormat.Default)
+            .ToArray();
     }
 
     private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
     {
         string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
-        return $"{codec}|{settings.OutputFile}";
+        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
+        return $"{codec}\0{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -2,13 +2,16 @@
 using System.Text.Json.Nodes;
 using Avalonia;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Extensibility;
 using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
+using Beutl.Logging;
 using Beutl.PropertyAdapters;
 using Beutl.Reactive;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 using AudioFormat = Beutl.Extensions.FFmpeg.Encoding.FFmpegAudioEncoderSettings.AudioFormat;
 
@@ -16,14 +19,17 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(AudioFormatEditorViewModel));
     private readonly IPropertyAdapter<AudioFormat> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
+    private readonly FFmpegOptionsCache<AudioFormat> _cache = new();
 
     private FFmpegAudioEncoderSettings? _settings;
     private AudioFormat[] _currentFormats = [];
     private IReadOnlyList<EnumItem> _currentItems = [];
     private WeakReference<EnumEditor>? _editorRef;
+    private CancellationTokenSource? _updateCts;
 
     public AudioFormatEditorViewModel(
         IPropertyAdapter<AudioFormat> property,
@@ -43,7 +49,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         {
             // コーデック変更を監視
             _settings.GetObservable(FFmpegAudioEncoderSettings.CodecProperty)
-                .Subscribe(_ => UpdateAudioFormats())
+                .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
@@ -58,7 +64,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             .DisposeWith(_disposables);
 
         // 初期化
-        UpdateAudioFormats();
+        RequestUpdate();
     }
 
     public PropertyEditorExtension Extension { get; }
@@ -82,81 +88,125 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private void UpdateAudioFormats()
+    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
+    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
+    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
+    // _updateCts swap below needs no synchronization.
+    private void RequestUpdate()
+    {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        var cts = _updateCts = new CancellationTokenSource();
+
+        if (_settings == null)
+        {
+            ApplyFormats(GetAllFormats());
+            return;
+        }
+
+        string key = BuildCacheKey(_settings);
+        if (_cache.TryGetCached(key, out AudioFormat[]? cached))
+        {
+            ApplyFormats(cached);
+            return;
+        }
+
+        _ = UpdateAsync(_settings, key, cts.Token);
+    }
+
+    private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
     {
         try
         {
-            AudioFormat[] supportedFmts = _settings != null
-                ? GetCodecFormats(_settings)
-                : GetAllFormats();
+            AudioFormat[] supportedFmts = await _cache
+                .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(settings))
+                .ConfigureAwait(false);
 
-            // Default ("Auto") を先頭に追加
-            _currentFormats = [AudioFormat.Default, .. supportedFmts];
-            _currentItems = _currentFormats
-                .Select(f => new EnumItem(
-                    f == AudioFormat.Default ? "Auto" : f.ToString(),
-                    null,
-                    f))
-                .ToArray();
-
-            // エディタのアイテムを更新
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
+            // so a superseded codec selection can never clobber the latest one.
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                editor.Items = _currentItems;
-            }
-
-            // 現在値がリストにあるか確認
-            var currentValue = _property.GetValue();
-            int index = Array.IndexOf(_currentFormats, currentValue);
-            _selectedIndex.Value = -1; // 一旦リセット
-            if (index < 0 && currentValue != AudioFormat.Default)
-            {
-                // 非対応フォーマットが選択されていたらAutoにリセット
-                _property.SetValue(AudioFormat.Default);
-                _selectedIndex.Value = 0;
-            }
-            else
-            {
-                _selectedIndex.Value = Math.Max(index, 0);
-            }
+                if (!ct.IsCancellationRequested)
+                    ApplyFormats(supportedFmts);
+            });
         }
-        catch
+        catch (Exception ex)
         {
-            // エラー時はAutoのみ表示
-            _currentFormats = [AudioFormat.Default];
-            _currentItems = [new EnumItem("Auto", null, AudioFormat.Default)];
-            _selectedIndex.Value = 0;
+            if (ct.IsCancellationRequested)
+                return;
 
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            try
             {
-                editor.Items = _currentItems;
+                s_logger.LogWarning(ex, "Failed to query audio formats from FFmpeg worker");
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (!ct.IsCancellationRequested)
+                        ApplyFormats(GetAllFormats());
+                });
+            }
+            catch (Exception dispatchEx)
+            {
+                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
+                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying audio-format fallback");
             }
         }
     }
 
-    private static AudioFormat[] GetCodecFormats(FFmpegAudioEncoderSettings settings)
+    private void ApplyFormats(AudioFormat[] supportedFmts)
     {
-        try
+        // Default ("Auto") を先頭に追加
+        _currentFormats = [AudioFormat.Default, .. supportedFmts];
+        _currentItems = _currentFormats
+            .Select(f => new EnumItem(
+                f == AudioFormat.Default ? "Auto" : f.ToString(),
+                null,
+                f))
+            .ToArray();
+
+        // エディタのアイテムを更新
+        if (_editorRef?.TryGetTarget(out var editor) == true)
         {
-            var connection = FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().GetAwaiter().GetResult();
-            var response = connection.RequestAsync<QueryAudioFormatsRequest, QueryAudioFormatsResponse>(
-                MessageType.QueryAudioFormats, MessageType.QueryAudioFormatsResult,
-                new QueryAudioFormatsRequest
-                {
-                    CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                    OutputFile = settings.OutputFile
-                }).AsTask().GetAwaiter().GetResult();
-            return response.Formats.Select(f => (AudioFormat)f).ToArray();
+            editor.Items = _currentItems;
         }
-        catch
+
+        // 現在値がリストにあるか確認
+        var currentValue = _property.GetValue();
+        int index = Array.IndexOf(_currentFormats, currentValue);
+        _selectedIndex.Value = -1; // 一旦リセット
+        if (index < 0 && currentValue != AudioFormat.Default)
         {
-            return Enum.GetValues<AudioFormat>();
+            // 非対応フォーマットが選択されていたらAutoにリセット
+            _property.SetValue(AudioFormat.Default);
+            _selectedIndex.Value = 0;
         }
+        else
+        {
+            _selectedIndex.Value = Math.Max(index, 0);
+        }
+    }
+
+    private static async Task<AudioFormat[]> QueryAudioFormatsAsync(FFmpegAudioEncoderSettings settings)
+    {
+        var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
+        var response = await connection.RequestAsync<QueryAudioFormatsRequest, QueryAudioFormatsResponse>(
+            MessageType.QueryAudioFormats, MessageType.QueryAudioFormatsResult,
+            new QueryAudioFormatsRequest
+            {
+                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+                OutputFile = settings.OutputFile
+            }).ConfigureAwait(false);
+        return response.Formats.Select(f => (AudioFormat)f).ToArray();
     }
 
     private static AudioFormat[] GetAllFormats()
     {
         return Enum.GetValues<AudioFormat>();
+    }
+
+    private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
+    {
+        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+        return $"{codec}|{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
@@ -179,6 +229,9 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        _updateCts = null;
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -102,7 +102,8 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        string key = BuildCacheKey(_settings);
+        QueryParams query = CreateQueryParams(_settings);
+        string key = BuildCacheKey(query);
         if (_cache.TryGetCached(key, out AudioFormat[]? cached))
         {
             _refresh.Supersede();
@@ -111,19 +112,16 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         }
 
         CancellationToken ct = _refresh.StartNew();
-        _ = UpdateAsync(_settings, key, ct);
+        _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
+    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
     {
-        AudioFormat[] supportedFmts;
+        OptionsQueryResult<AudioFormat> result;
         try
         {
-            // Empty is not cached: the worker returns an empty payload both for "no constrained
-            // formats" and as a soft fallback when its codec lookup throws, so caching it would pin a
-            // possibly transient empty for this editor's lifetime.
-            supportedFmts = await _cache
-                .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(settings), cacheEmptyResults: false)
+            result = await _cache
+                .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(query))
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -138,7 +136,10 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(supportedFmts)).ConfigureAwait(false);
+        // Applying the degraded (empty) fallback would mark the current format unsupported and reset
+        // the model value to Default, so show every format instead — matching the catch above.
+        AudioFormat[] formats = result.Degraded ? GetAllFormats() : result.Items;
+        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(formats)).ConfigureAwait(false);
     }
 
     // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
@@ -193,17 +194,18 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private static async Task<AudioFormat[]> QueryAudioFormatsAsync(FFmpegAudioEncoderSettings settings)
+    private static async Task<OptionsQueryResult<AudioFormat>> QueryAudioFormatsAsync(QueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QueryAudioFormatsRequest, QueryAudioFormatsResponse>(
             MessageType.QueryAudioFormats, MessageType.QueryAudioFormatsResult,
             new QueryAudioFormatsRequest
             {
-                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                OutputFile = settings.OutputFile
+                CodecName = query.CodecName,
+                OutputFile = query.OutputFile
             }).ConfigureAwait(false);
-        return response.Formats.Select(f => (AudioFormat)f).ToArray();
+        return new OptionsQueryResult<AudioFormat>(
+            response.Formats.Select(f => (AudioFormat)f).ToArray(), response.Degraded);
     }
 
     private static AudioFormat[] GetAllFormats()
@@ -214,12 +216,18 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             .ToArray();
     }
 
-    private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
-    {
-        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
+    // _settings mutates mid-flight.
+    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
+
+    private static QueryParams CreateQueryParams(FFmpegAudioEncoderSettings settings)
+        => new(
+            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+            settings.OutputFile);
+
+    private static string BuildCacheKey(QueryParams query)
         // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        return $"{codec}\0{settings.OutputFile}";
-    }
+        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -19,17 +19,18 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 {
-    private static readonly ILogger s_logger = Log.CreateLogger(typeof(AudioFormatEditorViewModel));
+    private static readonly ILogger s_logger = Log.CreateLogger<AudioFormatEditorViewModel>();
     private readonly IPropertyAdapter<AudioFormat> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
     private readonly FFmpegOptionsCache<AudioFormat> _cache = new();
+    private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegAudioEncoderSettings? _settings;
     private AudioFormat[] _currentFormats = [];
     private IReadOnlyList<EnumItem> _currentItems = [];
     private WeakReference<EnumEditor>? _editorRef;
-    private CancellationTokenSource? _updateCts;
+    private bool _disposed;
 
     public AudioFormatEditorViewModel(
         IPropertyAdapter<AudioFormat> property,
@@ -88,18 +89,15 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
-    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
-    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
-    // _updateCts swap below needs no synchronization.
+    // Kicks off a non-blocking refresh. A cached result is applied synchronously; otherwise a fresh
+    // codec switch supersedes the previous (stale) query via _refresh so it cannot clobber the latest
+    // selection. Expected to run on the UI thread (constructor + UI-driven property-change
+    // observables); _refresh is not synchronized for concurrent callers.
     private void RequestUpdate()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
-
         if (_settings == null)
         {
+            _refresh.Supersede();
             ApplyFormats(GetAllFormats());
             return;
         }
@@ -107,49 +105,58 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         string key = BuildCacheKey(_settings);
         if (_cache.TryGetCached(key, out AudioFormat[]? cached))
         {
+            _refresh.Supersede();
             ApplyFormats(cached);
             return;
         }
 
-        var cts = _updateCts = new CancellationTokenSource();
-        _ = UpdateAsync(_settings, key, cts.Token);
+        CancellationToken ct = _refresh.StartNew();
+        _ = UpdateAsync(_settings, key, ct);
     }
 
     private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
     {
+        AudioFormat[] supportedFmts;
         try
         {
-            AudioFormat[] supportedFmts = await _cache
-                .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(settings))
+            // Empty is not cached: the worker returns an empty payload both for "no constrained
+            // formats" and as a soft fallback when its codec lookup throws, so caching it would pin a
+            // possibly transient empty for this editor's lifetime.
+            supportedFmts = await _cache
+                .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(settings), cacheEmptyResults: false)
                 .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A superseded query is no longer the latest request, so it neither logs nor applies.
+            if (LatestRefreshTracker.IsCurrent(ct))
+            {
+                s_logger.LogWarning(ex, "Failed to refresh audio formats from FFmpeg worker");
+                await ApplyOnUiThreadAsync(ct, () => ApplyFormats(GetAllFormats())).ConfigureAwait(false);
+            }
 
-            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
-            // so a superseded codec selection can never clobber the latest one.
+            return;
+        }
+
+        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(supportedFmts)).ConfigureAwait(false);
+    }
+
+    // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
+    // this request is still the latest and the editor is alive. A dispatcher fault during teardown is
+    // logged distinctly from a worker-query failure and never escapes this fire-and-forget task.
+    private async Task ApplyOnUiThreadAsync(CancellationToken ct, Action apply)
+    {
+        try
+        {
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                if (!ct.IsCancellationRequested)
-                    ApplyFormats(supportedFmts);
+                if (!_disposed && LatestRefreshTracker.IsCurrent(ct))
+                    apply();
             });
         }
         catch (Exception ex)
         {
-            if (ct.IsCancellationRequested)
-                return;
-
-            try
-            {
-                s_logger.LogWarning(ex, "Failed to refresh audio formats from FFmpeg worker");
-                await Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    if (!ct.IsCancellationRequested)
-                        ApplyFormats(GetAllFormats());
-                });
-            }
-            catch (Exception dispatchEx)
-            {
-                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
-                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying audio-format fallback");
-            }
+            s_logger.LogDebug(ex, "Dispatcher unavailable while applying audio formats");
         }
     }
 
@@ -234,9 +241,8 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
+        _disposed = true;
+        _refresh.Dispose();
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -1,0 +1,75 @@
+﻿namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>
+/// Caches per-codec option arrays (sample rates / pixel formats / audio formats) queried
+/// asynchronously from the FFmpeg worker, keyed by an opaque string (codec + output file).
+/// Successful results are cached; concurrent requests for the same key share a single
+/// in-flight query (single-flight). Failed queries are not cached so the next request retries.
+/// </summary>
+/// <remarks>
+/// The property editors used to block the UI thread with
+/// <c>EnsureStartedAsync().GetAwaiter().GetResult()</c>; this type keeps the data flow async and
+/// avoids re-querying the worker when a codec is revisited. The shared query is intentionally not
+/// tied to any single caller's <see cref="CancellationToken"/>: callers decide whether to apply a
+/// (possibly stale) result themselves, so abandoning one request never faults the result for the
+/// others that joined the same in-flight query.
+/// </remarks>
+internal sealed class FFmpegOptionsCache<T>
+{
+    private readonly Dictionary<string, T[]> _cache = [];
+    private readonly Dictionary<string, Task<T[]>> _inflight = [];
+    private readonly object _gate = new();
+
+    /// <summary>Returns the cached result for <paramref name="key"/> without querying the worker.</summary>
+    public bool TryGetCached(string key, out T[] value)
+    {
+        lock (_gate)
+        {
+            return _cache.TryGetValue(key, out value!);
+        }
+    }
+
+    /// <summary>
+    /// Returns the cached result for <paramref name="key"/>, or runs <paramref name="factory"/>
+    /// once and caches its result. Repeated calls for an already-cached key never invoke
+    /// <paramref name="factory"/> again; concurrent calls for the same uncached key share one task.
+    /// </summary>
+    public Task<T[]> GetOrQueryAsync(string key, Func<Task<T[]>> factory)
+    {
+        lock (_gate)
+        {
+            if (_cache.TryGetValue(key, out var cached))
+                return Task.FromResult(cached);
+            if (_inflight.TryGetValue(key, out var running))
+                return running;
+
+            Task<T[]> task = RunAsync(key, factory);
+            _inflight[key] = task;
+            return task;
+        }
+    }
+
+    private async Task<T[]> RunAsync(string key, Func<Task<T[]>> factory)
+    {
+        // Yield before invoking the factory so it never runs while the caller holds _gate
+        // (GetOrQueryAsync starts this task inside the lock).
+        await Task.Yield();
+        try
+        {
+            T[] result = await factory().ConfigureAwait(false);
+            lock (_gate)
+            {
+                _cache[key] = result;
+            }
+
+            return result;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _inflight.Remove(key);
+            }
+        }
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -51,12 +51,12 @@ internal sealed class FFmpegOptionsCache<T>
 
     private async Task<T[]> RunAsync(string key, Func<Task<T[]>> factory)
     {
-        // Yield before invoking the factory so it never runs while the caller holds _gate
-        // (GetOrQueryAsync starts this task inside the lock).
-        await Task.Yield();
         try
         {
-            T[] result = await factory().ConfigureAwait(false);
+            // Run the factory on the thread pool so it never executes while the caller holds _gate
+            // (GetOrQueryAsync starts this task inside the lock) and never resumes on the UI thread's
+            // synchronization context, where the worker's synchronous startup work would stutter the UI.
+            T[] result = await Task.Run(factory).ConfigureAwait(false);
             lock (_gate)
             {
                 _cache[key] = result;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -1,4 +1,6 @@
-﻿namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 /// <summary>
 /// Caches per-codec option arrays (sample rates / pixel formats / audio formats) queried
@@ -13,6 +15,14 @@
 /// tied to any single caller's <see cref="CancellationToken"/>: callers decide whether to apply a
 /// (possibly stale) result themselves, so abandoning one request never faults the result for the
 /// others that joined the same in-flight query.
+/// <para>
+/// An empty successful result can optionally be left uncached (see the <c>cacheEmptyResults</c>
+/// parameter of <see cref="GetOrQueryAsync"/>). The worker returns an empty payload both for a
+/// genuine "no constrained options" answer and as a soft fallback when its own codec lookup throws;
+/// the two are indistinguishable across the IPC boundary, so a caller that cannot tell them apart
+/// can decline to cache empties and let the next visit re-query instead of pinning a possibly
+/// transient empty for the editor's lifetime.
+/// </para>
 /// </remarks>
 internal sealed class FFmpegOptionsCache<T>
 {
@@ -21,11 +31,11 @@ internal sealed class FFmpegOptionsCache<T>
     private readonly object _gate = new();
 
     /// <summary>Returns the cached result for <paramref name="key"/> without querying the worker.</summary>
-    public bool TryGetCached(string key, out T[] value)
+    public bool TryGetCached(string key, [MaybeNullWhen(false)] out T[] value)
     {
         lock (_gate)
         {
-            return _cache.TryGetValue(key, out value!);
+            return _cache.TryGetValue(key, out value);
         }
     }
 
@@ -33,8 +43,10 @@ internal sealed class FFmpegOptionsCache<T>
     /// Returns the cached result for <paramref name="key"/>, or runs <paramref name="factory"/>
     /// once and caches its result. Repeated calls for an already-cached key never invoke
     /// <paramref name="factory"/> again; concurrent calls for the same uncached key share one task.
+    /// When <paramref name="cacheEmptyResults"/> is <see langword="false"/>, an empty result is
+    /// still returned to callers but is not stored, so the next request re-queries.
     /// </summary>
-    public Task<T[]> GetOrQueryAsync(string key, Func<Task<T[]>> factory)
+    public Task<T[]> GetOrQueryAsync(string key, Func<Task<T[]>> factory, bool cacheEmptyResults = true)
     {
         lock (_gate)
         {
@@ -43,13 +55,13 @@ internal sealed class FFmpegOptionsCache<T>
             if (_inflight.TryGetValue(key, out var running))
                 return running;
 
-            Task<T[]> task = RunAsync(key, factory);
+            Task<T[]> task = RunAsync(key, factory, cacheEmptyResults);
             _inflight[key] = task;
             return task;
         }
     }
 
-    private async Task<T[]> RunAsync(string key, Func<Task<T[]>> factory)
+    private async Task<T[]> RunAsync(string key, Func<Task<T[]>> factory, bool cacheEmptyResults)
     {
         try
         {
@@ -57,9 +69,12 @@ internal sealed class FFmpegOptionsCache<T>
             // (GetOrQueryAsync starts this task inside the lock) and never resumes on the UI thread's
             // synchronization context, where the worker's synchronous startup work would stutter the UI.
             T[] result = await Task.Run(factory).ConfigureAwait(false);
-            lock (_gate)
+            if (cacheEmptyResults || result.Length > 0)
             {
-                _cache[key] = result;
+                lock (_gate)
+                {
+                    _cache[key] = result;
+                }
             }
 
             return result;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -3,31 +3,25 @@
 namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 /// <summary>
+/// One option query's outcome: the items, plus whether they are a worker fallback
+/// (<see cref="Degraded"/>) rather than an authoritative answer.
+/// </summary>
+internal readonly record struct OptionsQueryResult<T>(T[] Items, bool Degraded);
+
+/// <summary>
 /// Caches per-codec option arrays (sample rates / pixel formats / audio formats) queried
 /// asynchronously from the FFmpeg worker, keyed by an opaque string (codec + output file).
-/// Successful results are cached; concurrent requests for the same key share a single
-/// in-flight query (single-flight). Failed queries are not cached so the next request retries.
+/// Concurrent requests for the same key share a single in-flight query (single-flight).
 /// </summary>
 /// <remarks>
-/// The property editors used to block the UI thread with
-/// <c>EnsureStartedAsync().GetAwaiter().GetResult()</c>; this type keeps the data flow async and
-/// avoids re-querying the worker when a codec is revisited. The shared query is intentionally not
-/// tied to any single caller's <see cref="CancellationToken"/>: callers decide whether to apply a
-/// (possibly stale) result themselves, so abandoning one request never faults the result for the
-/// others that joined the same in-flight query.
-/// <para>
-/// An empty successful result can optionally be left uncached (see the <c>cacheEmptyResults</c>
-/// parameter of <see cref="GetOrQueryAsync"/>). The worker returns an empty payload both for a
-/// genuine "no constrained options" answer and as a soft fallback when its own codec lookup throws;
-/// the two are indistinguishable across the IPC boundary, so a caller that cannot tell them apart
-/// can decline to cache empties and let the next visit re-query instead of pinning a possibly
-/// transient empty for the editor's lifetime.
-/// </para>
+/// The shared query is not tied to any caller's <see cref="CancellationToken"/>, so abandoning one
+/// request never faults the result for others that joined the same query. Degraded results are
+/// surfaced to every awaiter but never cached, so the next visit re-queries.
 /// </remarks>
 internal sealed class FFmpegOptionsCache<T>
 {
     private readonly Dictionary<string, T[]> _cache = [];
-    private readonly Dictionary<string, Task<T[]>> _inflight = [];
+    private readonly Dictionary<string, Task<OptionsQueryResult<T>>> _inflight = [];
     private readonly object _gate = new();
 
     /// <summary>Returns the cached result for <paramref name="key"/> without querying the worker.</summary>
@@ -40,40 +34,39 @@ internal sealed class FFmpegOptionsCache<T>
     }
 
     /// <summary>
-    /// Returns the cached result for <paramref name="key"/>, or runs <paramref name="factory"/>
-    /// once and caches its result. Repeated calls for an already-cached key never invoke
-    /// <paramref name="factory"/> again; concurrent calls for the same uncached key share one task.
-    /// When <paramref name="cacheEmptyResults"/> is <see langword="false"/>, an empty result is
-    /// still returned to callers but is not stored, so the next request re-queries.
+    /// Returns the cached result for <paramref name="key"/>, or runs <paramref name="factory"/> once
+    /// and caches its items unless the result is degraded. Concurrent calls for the same uncached key
+    /// share one task and all receive the same <see cref="OptionsQueryResult{T}"/>.
     /// </summary>
-    public Task<T[]> GetOrQueryAsync(string key, Func<Task<T[]>> factory, bool cacheEmptyResults = true)
+    public Task<OptionsQueryResult<T>> GetOrQueryAsync(string key, Func<Task<OptionsQueryResult<T>>> factory)
     {
         lock (_gate)
         {
+            // A cached entry is authoritative by construction (degraded results are never stored).
             if (_cache.TryGetValue(key, out var cached))
-                return Task.FromResult(cached);
+                return Task.FromResult(new OptionsQueryResult<T>(cached, Degraded: false));
             if (_inflight.TryGetValue(key, out var running))
                 return running;
 
-            Task<T[]> task = RunAsync(key, factory, cacheEmptyResults);
+            Task<OptionsQueryResult<T>> task = RunAsync(key, factory);
             _inflight[key] = task;
             return task;
         }
     }
 
-    private async Task<T[]> RunAsync(string key, Func<Task<T[]>> factory, bool cacheEmptyResults)
+    private async Task<OptionsQueryResult<T>> RunAsync(string key, Func<Task<OptionsQueryResult<T>>> factory)
     {
         try
         {
             // Run the factory on the thread pool so it never executes while the caller holds _gate
             // (GetOrQueryAsync starts this task inside the lock) and never resumes on the UI thread's
             // synchronization context, where the worker's synchronous startup work would stutter the UI.
-            T[] result = await Task.Run(factory).ConfigureAwait(false);
-            if (cacheEmptyResults || result.Length > 0)
+            OptionsQueryResult<T> result = await Task.Run(factory).ConfigureAwait(false);
+            if (!result.Degraded)
             {
                 lock (_gate)
                 {
-                    _cache[key] = result;
+                    _cache[key] = result.Items;
                 }
             }
 

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/LatestRefreshTracker.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/LatestRefreshTracker.cs
@@ -1,0 +1,41 @@
+﻿namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>
+/// Tracks the latest refresh request of a codec property editor so a superseded request cannot
+/// apply its now-stale result over the most recent selection. Each request is represented by a
+/// <see cref="CancellationToken"/>; <see cref="IsCurrent"/> reports whether a token is still the
+/// latest one.
+/// </summary>
+/// <remarks>
+/// The mutating members (<see cref="StartNew"/>, <see cref="Supersede"/>, <see cref="Dispose"/>)
+/// are expected to be called on a single thread — the UI thread for the editors — and are not
+/// synchronized for concurrent callers. Only <see cref="IsCurrent"/> is read cross-thread: a
+/// captured token's cancelled state stays readable even after its source has been disposed, which
+/// is what lets a fire-and-forget update marshal back to the UI thread and re-check whether it is
+/// still the latest request.
+/// </remarks>
+internal sealed class LatestRefreshTracker : IDisposable
+{
+    private CancellationTokenSource? _cts;
+
+    /// <summary>Supersedes any in-flight request and begins a new one, returning its token.</summary>
+    public CancellationToken StartNew()
+    {
+        Supersede();
+        _cts = new CancellationTokenSource();
+        return _cts.Token;
+    }
+
+    /// <summary>Supersedes any in-flight request without starting a new one (e.g. a synchronous apply).</summary>
+    public void Supersede()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    /// <summary>True while <paramref name="token"/> still represents the latest request.</summary>
+    public static bool IsCurrent(CancellationToken token) => !token.IsCancellationRequested;
+
+    public void Dispose() => Supersede();
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -19,17 +19,18 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 {
-    private static readonly ILogger s_logger = Log.CreateLogger(typeof(PixelFormatEditorViewModel));
+    private static readonly ILogger s_logger = Log.CreateLogger<PixelFormatEditorViewModel>();
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
     private readonly FFmpegOptionsCache<PixelFormatInfo> _cache = new();
+    private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegVideoEncoderSettings? _settings;
     private int[] _currentFormats = [];
     private IReadOnlyList<EnumItem> _currentItems = [];
     private WeakReference<EnumEditor>? _editorRef;
-    private CancellationTokenSource? _updateCts;
+    private bool _disposed;
 
     public PixelFormatEditorViewModel(
         IPropertyAdapter<int> property,
@@ -88,18 +89,15 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
-    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
-    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
-    // _updateCts swap below needs no synchronization.
+    // Kicks off a non-blocking refresh. A cached result is applied synchronously; otherwise a fresh
+    // codec switch supersedes the previous (stale) query via _refresh so it cannot clobber the latest
+    // selection. Expected to run on the UI thread (constructor + UI-driven property-change
+    // observables); _refresh is not synchronized for concurrent callers.
     private void RequestUpdate()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
-
         if (_settings == null)
         {
+            _refresh.Supersede();
             ApplyFallback();
             return;
         }
@@ -107,49 +105,55 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         string key = BuildCacheKey(_settings);
         if (_cache.TryGetCached(key, out PixelFormatInfo[]? cached))
         {
+            _refresh.Supersede();
             ApplyFormats(cached);
             return;
         }
 
-        var cts = _updateCts = new CancellationTokenSource();
-        _ = UpdateAsync(_settings, key, cts.Token);
+        CancellationToken ct = _refresh.StartNew();
+        _ = UpdateAsync(_settings, key, ct);
     }
 
     private async Task UpdateAsync(FFmpegVideoEncoderSettings settings, string key, CancellationToken ct)
     {
+        PixelFormatInfo[] formatInfos;
         try
         {
-            PixelFormatInfo[] formatInfos = await _cache
+            formatInfos = await _cache
                 .GetOrQueryAsync(key, () => QueryPixelFormatsAsync(settings))
                 .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A superseded query is no longer the latest request, so it neither logs nor applies.
+            if (LatestRefreshTracker.IsCurrent(ct))
+            {
+                s_logger.LogWarning(ex, "Failed to refresh pixel formats from FFmpeg worker");
+                await ApplyOnUiThreadAsync(ct, ApplyFallback).ConfigureAwait(false);
+            }
 
-            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
-            // so a superseded codec selection can never clobber the latest one.
+            return;
+        }
+
+        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(formatInfos)).ConfigureAwait(false);
+    }
+
+    // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
+    // this request is still the latest and the editor is alive. A dispatcher fault during teardown is
+    // logged distinctly from a worker-query failure and never escapes this fire-and-forget task.
+    private async Task ApplyOnUiThreadAsync(CancellationToken ct, Action apply)
+    {
+        try
+        {
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                if (!ct.IsCancellationRequested)
-                    ApplyFormats(formatInfos);
+                if (!_disposed && LatestRefreshTracker.IsCurrent(ct))
+                    apply();
             });
         }
         catch (Exception ex)
         {
-            if (ct.IsCancellationRequested)
-                return;
-
-            try
-            {
-                s_logger.LogWarning(ex, "Failed to refresh pixel formats from FFmpeg worker");
-                await Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    if (!ct.IsCancellationRequested)
-                        ApplyFallback();
-                });
-            }
-            catch (Exception dispatchEx)
-            {
-                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
-                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying pixel-format fallback");
-            }
+            s_logger.LogDebug(ex, "Dispatcher unavailable while applying pixel formats");
         }
     }
 
@@ -236,9 +240,8 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
+        _disposed = true;
+        _refresh.Dispose();
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -2,28 +2,34 @@
 using System.Text.Json.Nodes;
 using Avalonia;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Extensibility;
 using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.FFmpegIpc;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
+using Beutl.Logging;
 using Beutl.PropertyAdapters;
 using Beutl.Reactive;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
 namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(PixelFormatEditorViewModel));
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
+    private readonly FFmpegOptionsCache<PixelFormatInfo> _cache = new();
 
     private FFmpegVideoEncoderSettings? _settings;
     private int[] _currentFormats = [];
     private IReadOnlyList<EnumItem> _currentItems = [];
     private WeakReference<EnumEditor>? _editorRef;
+    private CancellationTokenSource? _updateCts;
 
     public PixelFormatEditorViewModel(
         IPropertyAdapter<int> property,
@@ -43,7 +49,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         {
             // コーデック変更を監視
             _settings.GetObservable(FFmpegVideoEncoderSettings.CodecProperty)
-                .Subscribe(_ => UpdatePixelFormats())
+                .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
@@ -58,7 +64,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             .DisposeWith(_disposables);
 
         // 初期化
-        UpdatePixelFormats();
+        RequestUpdate();
     }
 
     public PropertyEditorExtension Extension { get; }
@@ -82,73 +88,130 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private void UpdatePixelFormats()
+    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
+    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
+    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
+    // _updateCts swap below needs no synchronization.
+    private void RequestUpdate()
+    {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        var cts = _updateCts = new CancellationTokenSource();
+
+        if (_settings == null)
+        {
+            ApplyFallback();
+            return;
+        }
+
+        string key = BuildCacheKey(_settings);
+        if (_cache.TryGetCached(key, out PixelFormatInfo[]? cached))
+        {
+            ApplyFormats(cached);
+            return;
+        }
+
+        _ = UpdateAsync(_settings, key, cts.Token);
+    }
+
+    private async Task UpdateAsync(FFmpegVideoEncoderSettings settings, string key, CancellationToken ct)
     {
         try
         {
-            PixelFormatInfo[] formatInfos = GetCodecFormatInfos(_settings);
+            PixelFormatInfo[] formatInfos = await _cache
+                .GetOrQueryAsync(key, () => QueryPixelFormatsAsync(settings))
+                .ConfigureAwait(false);
 
-            // FFPixelFormat.None ("Auto") を先頭に追加
-            _currentFormats = [FFPixelFormat.None, .. formatInfos.Select(f => f.Value)];
-            _currentItems = new EnumItem[] { new("Auto", null, FFPixelFormat.None) }
-                .Concat(formatInfos.Select(f => new EnumItem(f.Name, null, f.Value)))
-                .ToArray();
-
-            // エディタのアイテムを更新
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
+            // so a superseded codec selection can never clobber the latest one.
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                editor.Items = _currentItems;
-            }
-
-            // 現在値がリストにあるか確認
-            var currentValue = _property.GetValue();
-            int index = Array.IndexOf(_currentFormats, currentValue);
-            _selectedIndex.Value = -1; // 一旦リセット
-            if (index < 0 && currentValue != FFPixelFormat.None)
-            {
-                // 非対応フォーマットが選択されていたらAutoにリセット
-                _property.SetValue(FFPixelFormat.None);
-                _selectedIndex.Value = 0;
-            }
-            else
-            {
-                _selectedIndex.Value = Math.Max(index, 0);
-            }
+                if (!ct.IsCancellationRequested)
+                    ApplyFormats(formatInfos);
+            });
         }
-        catch
+        catch (Exception ex)
         {
-            // エラー時はAutoのみ表示
-            _currentFormats = [FFPixelFormat.None];
-            _currentItems = [new EnumItem("Auto", null, FFPixelFormat.None)];
-            _selectedIndex.Value = 0;
+            if (ct.IsCancellationRequested)
+                return;
 
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            try
             {
-                editor.Items = _currentItems;
+                s_logger.LogWarning(ex, "Failed to query pixel formats from FFmpeg worker");
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (!ct.IsCancellationRequested)
+                        ApplyFallback();
+                });
+            }
+            catch (Exception dispatchEx)
+            {
+                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
+                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying pixel-format fallback");
             }
         }
     }
 
-    private static PixelFormatInfo[] GetCodecFormatInfos(FFmpegVideoEncoderSettings? settings)
+    private void ApplyFormats(PixelFormatInfo[] formatInfos)
     {
-        if (settings == null) return [];
+        // FFPixelFormat.None ("Auto") を先頭に追加
+        _currentFormats = [FFPixelFormat.None, .. formatInfos.Select(f => f.Value)];
+        _currentItems = new EnumItem[] { new("Auto", null, FFPixelFormat.None) }
+            .Concat(formatInfos.Select(f => new EnumItem(f.Name, null, f.Value)))
+            .ToArray();
 
-        try
+        // エディタのアイテムを更新
+        if (_editorRef?.TryGetTarget(out var editor) == true)
         {
-            var connection = FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().GetAwaiter().GetResult();
-            var response = connection.RequestAsync<QueryPixelFormatsRequest, QueryPixelFormatsResponse>(
-                MessageType.QueryPixelFormats, MessageType.QueryPixelFormatsResult,
-                new QueryPixelFormatsRequest
-                {
-                    CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                    OutputFile = settings.OutputFile
-                }).AsTask().GetAwaiter().GetResult();
-            return response.Formats;
+            editor.Items = _currentItems;
         }
-        catch
+
+        // 現在値がリストにあるか確認
+        var currentValue = _property.GetValue();
+        int index = Array.IndexOf(_currentFormats, currentValue);
+        _selectedIndex.Value = -1; // 一旦リセット
+        if (index < 0 && currentValue != FFPixelFormat.None)
         {
-            return [];
+            // 非対応フォーマットが選択されていたらAutoにリセット
+            _property.SetValue(FFPixelFormat.None);
+            _selectedIndex.Value = 0;
         }
+        else
+        {
+            _selectedIndex.Value = Math.Max(index, 0);
+        }
+    }
+
+    private void ApplyFallback()
+    {
+        // エラー時はAutoのみ表示
+        _currentFormats = [FFPixelFormat.None];
+        _currentItems = [new EnumItem("Auto", null, FFPixelFormat.None)];
+        _selectedIndex.Value = 0;
+
+        if (_editorRef?.TryGetTarget(out var editor) == true)
+        {
+            editor.Items = _currentItems;
+        }
+    }
+
+    private static async Task<PixelFormatInfo[]> QueryPixelFormatsAsync(FFmpegVideoEncoderSettings settings)
+    {
+        var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
+        var response = await connection.RequestAsync<QueryPixelFormatsRequest, QueryPixelFormatsResponse>(
+            MessageType.QueryPixelFormats, MessageType.QueryPixelFormatsResult,
+            new QueryPixelFormatsRequest
+            {
+                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+                OutputFile = settings.OutputFile
+            }).ConfigureAwait(false);
+        return response.Formats;
+    }
+
+    private static string BuildCacheKey(FFmpegVideoEncoderSettings settings)
+    {
+        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+        return $"{codec}|{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
@@ -171,6 +234,9 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        _updateCts = null;
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -39,7 +39,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         Extension = extension;
         _selectedIndex = new ReactivePropertySlim<int>(-1).DisposeWith(_disposables);
 
-        // CorePropertyAdapterからFFmpegVideoEncoderSettingsを取得
+        // Resolve the FFmpegVideoEncoderSettings from the CorePropertyAdapter.
         if (property is CorePropertyAdapter<int> cpa)
         {
             _settings = cpa.Object as FFmpegVideoEncoderSettings;
@@ -47,13 +47,13 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
         if (_settings != null)
         {
-            // コーデック変更を監視
+            // Watch for codec changes.
             _settings.GetObservable(FFmpegVideoEncoderSettings.CodecProperty)
                 .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
-        // 現在値の変更を監視してSelectedIndexを更新
+        // Watch the current value to keep SelectedIndex in sync.
         _property.GetObservable()
             .Subscribe(format =>
             {
@@ -63,7 +63,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             })
             .DisposeWith(_disposables);
 
-        // 初期化
+        // Initialize.
         RequestUpdate();
     }
 
@@ -96,7 +96,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
     {
         _updateCts?.Cancel();
         _updateCts?.Dispose();
-        var cts = _updateCts = new CancellationTokenSource();
+        _updateCts = null;
 
         if (_settings == null)
         {
@@ -111,6 +111,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
+        var cts = _updateCts = new CancellationTokenSource();
         _ = UpdateAsync(_settings, key, cts.Token);
     }
 
@@ -137,7 +138,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
             try
             {
-                s_logger.LogWarning(ex, "Failed to query pixel formats from FFmpeg worker");
+                s_logger.LogWarning(ex, "Failed to refresh pixel formats from FFmpeg worker");
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     if (!ct.IsCancellationRequested)
@@ -154,25 +155,25 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
     private void ApplyFormats(PixelFormatInfo[] formatInfos)
     {
-        // FFPixelFormat.None ("Auto") を先頭に追加
+        // Prepend FFPixelFormat.None ("Auto") to the list.
         _currentFormats = [FFPixelFormat.None, .. formatInfos.Select(f => f.Value)];
         _currentItems = new EnumItem[] { new("Auto", null, FFPixelFormat.None) }
             .Concat(formatInfos.Select(f => new EnumItem(f.Name, null, f.Value)))
             .ToArray();
 
-        // エディタのアイテムを更新
+        // Update the editor's items.
         if (_editorRef?.TryGetTarget(out var editor) == true)
         {
             editor.Items = _currentItems;
         }
 
-        // 現在値がリストにあるか確認
+        // Check whether the current value is present in the list.
         var currentValue = _property.GetValue();
         int index = Array.IndexOf(_currentFormats, currentValue);
-        _selectedIndex.Value = -1; // 一旦リセット
+        _selectedIndex.Value = -1; // Reset once.
         if (index < 0 && currentValue != FFPixelFormat.None)
         {
-            // 非対応フォーマットが選択されていたらAutoにリセット
+            // Reset to Auto when an unsupported format is selected.
             _property.SetValue(FFPixelFormat.None);
             _selectedIndex.Value = 0;
         }
@@ -184,7 +185,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
     private void ApplyFallback()
     {
-        // エラー時はAutoのみ表示
+        // On error, show only Auto.
         _currentFormats = [FFPixelFormat.None];
         _currentItems = [new EnumItem("Auto", null, FFPixelFormat.None)];
         _selectedIndex.Value = 0;
@@ -211,7 +212,8 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
     private static string BuildCacheKey(FFmpegVideoEncoderSettings settings)
     {
         string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
-        return $"{codec}|{settings.OutputFile}";
+        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
+        return $"{codec}\0{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -102,7 +102,8 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        string key = BuildCacheKey(_settings);
+        QueryParams query = CreateQueryParams(_settings);
+        string key = BuildCacheKey(query);
         if (_cache.TryGetCached(key, out PixelFormatInfo[]? cached))
         {
             _refresh.Supersede();
@@ -111,16 +112,16 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         }
 
         CancellationToken ct = _refresh.StartNew();
-        _ = UpdateAsync(_settings, key, ct);
+        _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(FFmpegVideoEncoderSettings settings, string key, CancellationToken ct)
+    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
     {
-        PixelFormatInfo[] formatInfos;
+        OptionsQueryResult<PixelFormatInfo> result;
         try
         {
-            formatInfos = await _cache
-                .GetOrQueryAsync(key, () => QueryPixelFormatsAsync(settings))
+            result = await _cache
+                .GetOrQueryAsync(key, () => QueryPixelFormatsAsync(query))
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -135,7 +136,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(formatInfos)).ConfigureAwait(false);
+        await ApplyOnUiThreadAsync(ct, () => ApplyFormats(result.Items)).ConfigureAwait(false);
     }
 
     // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
@@ -200,25 +201,31 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private static async Task<PixelFormatInfo[]> QueryPixelFormatsAsync(FFmpegVideoEncoderSettings settings)
+    private static async Task<OptionsQueryResult<PixelFormatInfo>> QueryPixelFormatsAsync(QueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QueryPixelFormatsRequest, QueryPixelFormatsResponse>(
             MessageType.QueryPixelFormats, MessageType.QueryPixelFormatsResult,
             new QueryPixelFormatsRequest
             {
-                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                OutputFile = settings.OutputFile
+                CodecName = query.CodecName,
+                OutputFile = query.OutputFile
             }).ConfigureAwait(false);
-        return response.Formats;
+        return new OptionsQueryResult<PixelFormatInfo>(response.Formats, response.Degraded);
     }
 
-    private static string BuildCacheKey(FFmpegVideoEncoderSettings settings)
-    {
-        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
+    // _settings mutates mid-flight.
+    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
+
+    private static QueryParams CreateQueryParams(FFmpegVideoEncoderSettings settings)
+        => new(
+            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+            settings.OutputFile);
+
+    private static string BuildCacheKey(QueryParams query)
         // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        return $"{codec}\0{settings.OutputFile}";
-    }
+        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -37,7 +37,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         Extension = extension;
         _text = new ReactivePropertySlim<string>(property.GetValue().ToString()).DisposeWith(_disposables);
 
-        // CorePropertyAdapterからFFmpegAudioEncoderSettingsを取得
+        // Resolve the FFmpegAudioEncoderSettings from the CorePropertyAdapter.
         if (property is CorePropertyAdapter<int> cpa)
         {
             _settings = cpa.Object as FFmpegAudioEncoderSettings;
@@ -45,13 +45,13 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 
         if (_settings != null)
         {
-            // コーデック変更を監視
+            // Watch for codec changes.
             _settings.GetObservable(FFmpegAudioEncoderSettings.CodecProperty)
                 .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
-        // 現在値の変更を監視してテキストを更新
+        // Watch the current value to keep the text in sync.
         _property.GetObservable()
             .Subscribe(value =>
             {
@@ -61,7 +61,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             })
             .DisposeWith(_disposables);
 
-        // 初期化
+        // Initialize.
         RequestUpdate();
     }
 
@@ -94,7 +94,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
     {
         _updateCts?.Cancel();
         _updateCts?.Dispose();
-        var cts = _updateCts = new CancellationTokenSource();
+        _updateCts = null;
 
         if (_settings == null)
         {
@@ -109,6 +109,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             return;
         }
 
+        var cts = _updateCts = new CancellationTokenSource();
         _ = UpdateAsync(_settings, key, cts.Token);
     }
 
@@ -135,7 +136,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 
             try
             {
-                s_logger.LogWarning(ex, "Failed to query sample rates from FFmpeg worker");
+                s_logger.LogWarning(ex, "Failed to refresh sample rates from FFmpeg worker");
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     if (!ct.IsCancellationRequested)
@@ -175,7 +176,8 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
     private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
     {
         string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
-        return $"{codec}|{settings.OutputFile}";
+        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
+        return $"{codec}\0{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
@@ -188,7 +190,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             }
             else
             {
-                // 無効な値の場合、現在値に戻す
+                // Revert to the current value when the input is invalid.
                 _text.Value = _property.GetValue().ToString();
             }
         }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -18,16 +18,17 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 {
-    private static readonly ILogger s_logger = Log.CreateLogger(typeof(SampleRateEditorViewModel));
+    private static readonly ILogger s_logger = Log.CreateLogger<SampleRateEditorViewModel>();
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<string> _text;
     private readonly FFmpegOptionsCache<int> _cache = new();
+    private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegAudioEncoderSettings? _settings;
     private string[] _currentSuggestions = [];
     private WeakReference<AutoCompleteStringEditor>? _editorRef;
-    private CancellationTokenSource? _updateCts;
+    private bool _disposed;
 
     public SampleRateEditorViewModel(
         IPropertyAdapter<int> property,
@@ -86,18 +87,15 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         }
     }
 
-    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
-    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
-    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
-    // _updateCts swap below needs no synchronization.
+    // Kicks off a non-blocking refresh. A cached result is applied synchronously; otherwise a fresh
+    // codec switch supersedes the previous (stale) query via _refresh so it cannot clobber the latest
+    // selection. Expected to run on the UI thread (constructor + UI-driven property-change
+    // observables); _refresh is not synchronized for concurrent callers.
     private void RequestUpdate()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
-
         if (_settings == null)
         {
+            _refresh.Supersede();
             ApplySuggestions([]);
             return;
         }
@@ -105,49 +103,58 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         string key = BuildCacheKey(_settings);
         if (_cache.TryGetCached(key, out int[]? cached))
         {
+            _refresh.Supersede();
             ApplySuggestions(cached);
             return;
         }
 
-        var cts = _updateCts = new CancellationTokenSource();
-        _ = UpdateAsync(_settings, key, cts.Token);
+        CancellationToken ct = _refresh.StartNew();
+        _ = UpdateAsync(_settings, key, ct);
     }
 
     private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
     {
+        int[] supportedRates;
         try
         {
-            int[] supportedRates = await _cache
-                .GetOrQueryAsync(key, () => QuerySampleRatesAsync(settings))
+            // Empty is not cached: the worker returns an empty payload both for "any rate allowed" and
+            // as a soft fallback when its codec lookup throws, so caching it would pin a possibly
+            // transient empty for this editor's lifetime.
+            supportedRates = await _cache
+                .GetOrQueryAsync(key, () => QuerySampleRatesAsync(settings), cacheEmptyResults: false)
                 .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A superseded query is no longer the latest request, so it neither logs nor applies.
+            if (LatestRefreshTracker.IsCurrent(ct))
+            {
+                s_logger.LogWarning(ex, "Failed to refresh sample rates from FFmpeg worker");
+                await ApplyOnUiThreadAsync(ct, () => ApplySuggestions([])).ConfigureAwait(false);
+            }
 
-            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
-            // so a superseded codec selection can never clobber the latest one.
+            return;
+        }
+
+        await ApplyOnUiThreadAsync(ct, () => ApplySuggestions(supportedRates)).ConfigureAwait(false);
+    }
+
+    // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
+    // this request is still the latest and the editor is alive. A dispatcher fault during teardown is
+    // logged distinctly from a worker-query failure and never escapes this fire-and-forget task.
+    private async Task ApplyOnUiThreadAsync(CancellationToken ct, Action apply)
+    {
+        try
+        {
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                if (!ct.IsCancellationRequested)
-                    ApplySuggestions(supportedRates);
+                if (!_disposed && LatestRefreshTracker.IsCurrent(ct))
+                    apply();
             });
         }
         catch (Exception ex)
         {
-            if (ct.IsCancellationRequested)
-                return;
-
-            try
-            {
-                s_logger.LogWarning(ex, "Failed to refresh sample rates from FFmpeg worker");
-                await Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    if (!ct.IsCancellationRequested)
-                        ApplySuggestions(Array.Empty<int>());
-                });
-            }
-            catch (Exception dispatchEx)
-            {
-                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
-                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying sample-rate fallback");
-            }
+            s_logger.LogDebug(ex, "Dispatcher unavailable while applying sample rates");
         }
     }
 
@@ -206,9 +213,8 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
-        _updateCts?.Cancel();
-        _updateCts?.Dispose();
-        _updateCts = null;
+        _disposed = true;
+        _refresh.Dispose();
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -2,26 +2,32 @@
 using System.Text.Json.Nodes;
 using Avalonia;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Beutl.Controls.PropertyEditors;
 using Beutl.Extensibility;
 using Beutl.Extensions.FFmpeg.Encoding;
 using Beutl.FFmpegIpc.Protocol;
 using Beutl.FFmpegIpc.Protocol.Messages;
+using Beutl.Logging;
 using Beutl.PropertyAdapters;
 using Beutl.Reactive;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
 namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(SampleRateEditorViewModel));
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<string> _text;
+    private readonly FFmpegOptionsCache<int> _cache = new();
 
     private FFmpegAudioEncoderSettings? _settings;
     private string[] _currentSuggestions = [];
     private WeakReference<AutoCompleteStringEditor>? _editorRef;
+    private CancellationTokenSource? _updateCts;
 
     public SampleRateEditorViewModel(
         IPropertyAdapter<int> property,
@@ -41,7 +47,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         {
             // コーデック変更を監視
             _settings.GetObservable(FFmpegAudioEncoderSettings.CodecProperty)
-                .Subscribe(_ => UpdateSampleRates())
+                .Subscribe(_ => RequestUpdate())
                 .DisposeWith(_disposables);
         }
 
@@ -56,7 +62,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             .DisposeWith(_disposables);
 
         // 初期化
-        UpdateSampleRates();
+        RequestUpdate();
     }
 
     public PropertyEditorExtension Extension { get; }
@@ -80,54 +86,96 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private void UpdateSampleRates()
+    // Kicks off a non-blocking refresh; cached results are applied immediately and a fresh codec
+    // switch cancels the previous (stale) query so it cannot clobber the latest selection.
+    // Always invoked on the UI thread (constructor + UI-driven property-change observables), so the
+    // _updateCts swap below needs no synchronization.
+    private void RequestUpdate()
+    {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        var cts = _updateCts = new CancellationTokenSource();
+
+        if (_settings == null)
+        {
+            ApplySuggestions([]);
+            return;
+        }
+
+        string key = BuildCacheKey(_settings);
+        if (_cache.TryGetCached(key, out int[]? cached))
+        {
+            ApplySuggestions(cached);
+            return;
+        }
+
+        _ = UpdateAsync(_settings, key, cts.Token);
+    }
+
+    private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
     {
         try
         {
-            int[] supportedRates = GetCodecSampleRates(_settings);
+            int[] supportedRates = await _cache
+                .GetOrQueryAsync(key, () => QuerySampleRatesAsync(settings))
+                .ConfigureAwait(false);
 
-            _currentSuggestions = supportedRates
-                .Select(r => r.ToString())
-                .ToArray();
-
-            // エディタのItemsSourceを更新
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            // The cancellation check runs on the UI thread, where RequestUpdate cancels the token,
+            // so a superseded codec selection can never clobber the latest one.
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                editor.ItemsSource = _currentSuggestions;
-            }
+                if (!ct.IsCancellationRequested)
+                    ApplySuggestions(supportedRates);
+            });
         }
-        catch
+        catch (Exception ex)
         {
-            // エラー時は補完候補なし（自由入力のみ）
-            _currentSuggestions = [];
+            if (ct.IsCancellationRequested)
+                return;
 
-            if (_editorRef?.TryGetTarget(out var editor) == true)
+            try
             {
-                editor.ItemsSource = _currentSuggestions;
+                s_logger.LogWarning(ex, "Failed to query sample rates from FFmpeg worker");
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (!ct.IsCancellationRequested)
+                        ApplySuggestions(Array.Empty<int>());
+                });
+            }
+            catch (Exception dispatchEx)
+            {
+                // The dispatcher can fault during shutdown; never let it escape this fire-and-forget task.
+                s_logger.LogDebug(dispatchEx, "Dispatcher unavailable while applying sample-rate fallback");
             }
         }
     }
 
-    private static int[] GetCodecSampleRates(FFmpegAudioEncoderSettings? settings)
+    private void ApplySuggestions(int[] supportedRates)
     {
-        if (settings == null) return [];
+        _currentSuggestions = supportedRates.Select(r => r.ToString()).ToArray();
+        if (_editorRef?.TryGetTarget(out var editor) == true)
+        {
+            editor.ItemsSource = _currentSuggestions;
+        }
+    }
 
-        try
-        {
-            var connection = FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().GetAwaiter().GetResult();
-            var response = connection.RequestAsync<QuerySampleRatesRequest, QuerySampleRatesResponse>(
-                MessageType.QuerySampleRates, MessageType.QuerySampleRatesResult,
-                new QuerySampleRatesRequest
-                {
-                    CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                    OutputFile = settings.OutputFile
-                }).AsTask().GetAwaiter().GetResult();
-            return response.SampleRates;
-        }
-        catch
-        {
-            return [];
-        }
+    private static async Task<int[]> QuerySampleRatesAsync(FFmpegAudioEncoderSettings settings)
+    {
+        var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
+        var response = await connection.RequestAsync<QuerySampleRatesRequest, QuerySampleRatesResponse>(
+            MessageType.QuerySampleRates, MessageType.QuerySampleRatesResult,
+            new QuerySampleRatesRequest
+            {
+                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+                OutputFile = settings.OutputFile
+            }).ConfigureAwait(false);
+        return response.SampleRates;
+    }
+
+    private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
+    {
+        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+        return $"{codec}|{settings.OutputFile}";
     }
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
@@ -156,6 +204,9 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 
     public void Dispose()
     {
+        _updateCts?.Cancel();
+        _updateCts?.Dispose();
+        _updateCts = null;
         _disposables.Dispose();
         _editorRef = null;
         _settings = null;

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -100,7 +100,8 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        string key = BuildCacheKey(_settings);
+        QueryParams query = CreateQueryParams(_settings);
+        string key = BuildCacheKey(query);
         if (_cache.TryGetCached(key, out int[]? cached))
         {
             _refresh.Supersede();
@@ -109,19 +110,16 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         }
 
         CancellationToken ct = _refresh.StartNew();
-        _ = UpdateAsync(_settings, key, ct);
+        _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(FFmpegAudioEncoderSettings settings, string key, CancellationToken ct)
+    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
     {
-        int[] supportedRates;
+        OptionsQueryResult<int> result;
         try
         {
-            // Empty is not cached: the worker returns an empty payload both for "any rate allowed" and
-            // as a soft fallback when its codec lookup throws, so caching it would pin a possibly
-            // transient empty for this editor's lifetime.
-            supportedRates = await _cache
-                .GetOrQueryAsync(key, () => QuerySampleRatesAsync(settings), cacheEmptyResults: false)
+            result = await _cache
+                .GetOrQueryAsync(key, () => QuerySampleRatesAsync(query))
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -136,7 +134,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        await ApplyOnUiThreadAsync(ct, () => ApplySuggestions(supportedRates)).ConfigureAwait(false);
+        await ApplyOnUiThreadAsync(ct, () => ApplySuggestions(result.Items)).ConfigureAwait(false);
     }
 
     // Marshals the apply back to the UI thread, where _refresh is mutated, and applies only while
@@ -167,25 +165,31 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private static async Task<int[]> QuerySampleRatesAsync(FFmpegAudioEncoderSettings settings)
+    private static async Task<OptionsQueryResult<int>> QuerySampleRatesAsync(QueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QuerySampleRatesRequest, QuerySampleRatesResponse>(
             MessageType.QuerySampleRates, MessageType.QuerySampleRatesResult,
             new QuerySampleRatesRequest
             {
-                CodecName = settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-                OutputFile = settings.OutputFile
+                CodecName = query.CodecName,
+                OutputFile = query.OutputFile
             }).ConfigureAwait(false);
-        return response.SampleRates;
+        return new OptionsQueryResult<int>(response.SampleRates, response.Degraded);
     }
 
-    private static string BuildCacheKey(FFmpegAudioEncoderSettings settings)
-    {
-        string codec = settings.Codec.Equals(CodecRecord.Default) ? "<default>" : settings.Codec.Name;
+    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
+    // _settings mutates mid-flight.
+    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
+
+    private static QueryParams CreateQueryParams(FFmpegAudioEncoderSettings settings)
+        => new(
+            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
+            settings.OutputFile);
+
+    private static string BuildCacheKey(QueryParams query)
         // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        return $"{codec}\0{settings.OutputFile}";
-    }
+        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/src/Beutl.FFmpegIpc/Protocol/Messages/CodecQueryMessages.cs
+++ b/src/Beutl.FFmpegIpc/Protocol/Messages/CodecQueryMessages.cs
@@ -26,6 +26,9 @@ public sealed class QueryPixelFormatsRequest
 public sealed class QueryPixelFormatsResponse
 {
     public PixelFormatInfo[] Formats { get; set; } = [];
+
+    /// <summary>True when the worker could not resolve codec-specific options and returned a fallback.</summary>
+    public bool Degraded { get; set; }
 }
 
 public sealed class PixelFormatInfo
@@ -43,6 +46,9 @@ public sealed class QuerySampleRatesRequest
 public sealed class QuerySampleRatesResponse
 {
     public int[] SampleRates { get; set; } = [];
+
+    /// <summary>True when the worker could not resolve codec-specific options and returned a fallback.</summary>
+    public bool Degraded { get; set; }
 }
 
 public sealed class QueryAudioFormatsRequest
@@ -54,4 +60,7 @@ public sealed class QueryAudioFormatsRequest
 public sealed class QueryAudioFormatsResponse
 {
     public int[] Formats { get; set; } = [];
+
+    /// <summary>True when the worker could not resolve codec-specific options and returned a fallback.</summary>
+    public bool Degraded { get; set; }
 }

--- a/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/CodecQueryHandler.cs
@@ -58,7 +58,7 @@ internal sealed class CodecQueryHandler
                 .ToArray();
 
             return IpcMessage.Create(msg.Id, MessageType.QueryPixelFormatsResult,
-                new QueryPixelFormatsResponse { Formats = allFmts });
+                new QueryPixelFormatsResponse { Formats = allFmts, Degraded = true });
         }
     }
 
@@ -78,7 +78,7 @@ internal sealed class CodecQueryHandler
         {
             WorkerLog.Warning($"QuerySampleRates: codec-specific query failed: {ex.Message}", ex);
             return IpcMessage.Create(msg.Id, MessageType.QuerySampleRatesResult,
-                new QuerySampleRatesResponse { SampleRates = [] });
+                new QuerySampleRatesResponse { SampleRates = [], Degraded = true });
         }
     }
 
@@ -98,7 +98,7 @@ internal sealed class CodecQueryHandler
         {
             WorkerLog.Warning($"QueryAudioFormats: codec-specific query failed: {ex.Message}", ex);
             return IpcMessage.Create(msg.Id, MessageType.QueryAudioFormatsResult,
-                new QueryAudioFormatsResponse { Formats = [] });
+                new QueryAudioFormatsResponse { Formats = [], Degraded = true });
         }
     }
 

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -80,6 +80,60 @@ public class FFmpegOptionsCacheTests
     }
 
     [Test]
+    public async Task GetOrQueryAsync_EmptyResult_NotCached_WhenCacheEmptyResultsFalse()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        int[] first = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(Array.Empty<int>()); }, cacheEmptyResults: false);
+
+        // An empty payload can be a transient worker-side soft-failure rather than a genuine
+        // "no options", so it must not be pinned in the cache: the next request re-queries.
+        Assert.That(first, Is.Empty);
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
+
+        int[] second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); }, cacheEmptyResults: false);
+
+        Assert.That(calls, Is.EqualTo(2));
+        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_NonEmptyResult_StillCached_WhenCacheEmptyResultsFalse()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); }, cacheEmptyResults: false);
+        int[] second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); }, cacheEmptyResults: false);
+
+        // Excluding empties does not affect a non-empty result: it is cached and served as usual.
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_EmptyResult_Cached_ByDefault()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(Array.Empty<int>()); });
+
+        // The default still caches an empty result (used where empty is authoritative).
+        Assert.That(cache.TryGetCached("aac", out _), Is.True);
+        int[] second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); });
+
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(second, Is.Empty);
+    }
+
+    [Test]
     public async Task GetOrQueryAsync_ConcurrentSameKey_SharesSingleInFlightQuery()
     {
         var cache = new FFmpegOptionsCache<int>();

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -5,17 +5,24 @@ namespace Beutl.UnitTests.Extensions.FFmpeg;
 [TestFixture]
 public class FFmpegOptionsCacheTests
 {
+    private static Task<OptionsQueryResult<int>> Ok(params int[] items)
+        => Task.FromResult(new OptionsQueryResult<int>(items, Degraded: false));
+
+    private static Task<OptionsQueryResult<int>> Degraded(params int[] items)
+        => Task.FromResult(new OptionsQueryResult<int>(items, Degraded: true));
+
     [Test]
     public async Task GetOrQueryAsync_FirstCall_InvokesFactory()
     {
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        int[] result = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { 44100, 48000 }); });
+        OptionsQueryResult<int> result = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(44100, 48000); });
 
         Assert.That(calls, Is.EqualTo(1));
-        Assert.That(result, Is.EqualTo(new[] { 44100, 48000 }));
+        Assert.That(result.Items, Is.EqualTo(new[] { 44100, 48000 }));
+        Assert.That(result.Degraded, Is.False);
     }
 
     [Test]
@@ -24,14 +31,16 @@ public class FFmpegOptionsCacheTests
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
-        int[] second = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); });
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Ok(48000); });
+        OptionsQueryResult<int> second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(-1); });
 
         // The cached value is returned and the factory is not invoked a second time
         // (this is what stops the editor re-blocking / re-querying the worker on re-selection).
         Assert.That(calls, Is.EqualTo(1));
-        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+        Assert.That(second.Items, Is.EqualTo(new[] { 48000 }));
+        // A cached entry is authoritative by construction.
+        Assert.That(second.Degraded, Is.False);
     }
 
     [Test]
@@ -40,12 +49,12 @@ public class FFmpegOptionsCacheTests
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
-        int[] other = await cache.GetOrQueryAsync(
-            "mp3", () => { calls++; return Task.FromResult(new[] { 44100 }); });
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Ok(48000); });
+        OptionsQueryResult<int> other = await cache.GetOrQueryAsync(
+            "mp3", () => { calls++; return Ok(44100); });
 
         Assert.That(calls, Is.EqualTo(2));
-        Assert.That(other, Is.EqualTo(new[] { 44100 }));
+        Assert.That(other.Items, Is.EqualTo(new[] { 44100 }));
     }
 
     [Test]
@@ -56,13 +65,14 @@ public class FFmpegOptionsCacheTests
 
         Assert.ThrowsAsync<InvalidOperationException>(
             () => cache.GetOrQueryAsync(
-                "aac", () => { calls++; return Task.FromException<int[]>(new InvalidOperationException()); }));
+                "aac",
+                () => { calls++; return Task.FromException<OptionsQueryResult<int>>(new InvalidOperationException()); }));
 
         // A failed query must not be cached, so the next request runs the factory again and can succeed.
-        int[] retry = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
+        OptionsQueryResult<int> retry = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(48000); });
 
-        Assert.That(retry, Is.EqualTo(new[] { 48000 }));
+        Assert.That(retry.Items, Is.EqualTo(new[] { 48000 }));
         Assert.That(calls, Is.EqualTo(2));
     }
 
@@ -73,64 +83,64 @@ public class FFmpegOptionsCacheTests
 
         Assert.That(cache.TryGetCached("aac", out _), Is.False);
 
-        await cache.GetOrQueryAsync("aac", () => Task.FromResult(new[] { 48000 }));
+        await cache.GetOrQueryAsync("aac", () => Ok(48000));
 
         Assert.That(cache.TryGetCached("aac", out int[]? cached), Is.True);
         Assert.That(cached, Is.EqualTo(new[] { 48000 }));
     }
 
     [Test]
-    public async Task GetOrQueryAsync_EmptyResult_NotCached_WhenCacheEmptyResultsFalse()
+    public async Task GetOrQueryAsync_DegradedResult_NotCached_AndRetries()
     {
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        int[] first = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(Array.Empty<int>()); }, cacheEmptyResults: false);
+        // A degraded (worker-fallback) result is surfaced to the caller but must not be pinned in the
+        // cache, so the next request re-queries instead of serving the stale fallback forever.
+        OptionsQueryResult<int> first = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Degraded(44100, 48000); });
 
-        // An empty payload can be a transient worker-side soft-failure rather than a genuine
-        // "no options", so it must not be pinned in the cache: the next request re-queries.
-        Assert.That(first, Is.Empty);
+        Assert.That(first.Items, Is.EqualTo(new[] { 44100, 48000 }));
+        Assert.That(first.Degraded, Is.True);
         Assert.That(cache.TryGetCached("aac", out _), Is.False);
 
-        int[] second = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); }, cacheEmptyResults: false);
+        OptionsQueryResult<int> second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(48000); });
 
         Assert.That(calls, Is.EqualTo(2));
-        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+        Assert.That(second.Items, Is.EqualTo(new[] { 48000 }));
     }
 
     [Test]
-    public async Task GetOrQueryAsync_NonEmptyResult_StillCached_WhenCacheEmptyResultsFalse()
+    public async Task GetOrQueryAsync_AuthoritativeResult_Cached()
     {
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); }, cacheEmptyResults: false);
-        int[] second = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); }, cacheEmptyResults: false);
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Ok(48000); });
+        OptionsQueryResult<int> second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(-1); });
 
-        // Excluding empties does not affect a non-empty result: it is cached and served as usual.
+        // A non-degraded result is cached and served like any cached value.
         Assert.That(calls, Is.EqualTo(1));
-        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+        Assert.That(second.Items, Is.EqualTo(new[] { 48000 }));
     }
 
     [Test]
-    public async Task GetOrQueryAsync_EmptyResult_Cached_ByDefault()
+    public async Task GetOrQueryAsync_AuthoritativeEmptyResult_Cached()
     {
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
 
-        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(Array.Empty<int>()); });
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Ok(); });
 
-        // The default still caches an empty result (used where empty is authoritative).
+        // An authoritative empty result ("no constrained options") is genuine, so it is cached.
         Assert.That(cache.TryGetCached("aac", out _), Is.True);
-        int[] second = await cache.GetOrQueryAsync(
-            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); });
+        OptionsQueryResult<int> second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(-1); });
 
         Assert.That(calls, Is.EqualTo(1));
-        Assert.That(second, Is.Empty);
+        Assert.That(second.Items, Is.Empty);
     }
 
     [Test]
@@ -138,18 +148,38 @@ public class FFmpegOptionsCacheTests
     {
         var cache = new FFmpegOptionsCache<int>();
         int calls = 0;
-        var gate = new TaskCompletionSource<int[]>();
+        var gate = new TaskCompletionSource<OptionsQueryResult<int>>();
 
-        Task<int[]> first = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
-        Task<int[]> second = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
+        Task<OptionsQueryResult<int>> first = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
+        Task<OptionsQueryResult<int>> second = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
 
-        gate.SetResult([48000]);
-        int[][] results = await Task.WhenAll(first, second);
+        gate.SetResult(new OptionsQueryResult<int>([48000], Degraded: false));
+        OptionsQueryResult<int>[] results = await Task.WhenAll(first, second);
 
         // Single-flight: the second caller joins the in-flight query rather than launching its own.
         Assert.That(calls, Is.EqualTo(1));
-        Assert.That(results[0], Is.EqualTo(new[] { 48000 }));
-        Assert.That(results[1], Is.EqualTo(new[] { 48000 }));
+        Assert.That(results[0].Items, Is.EqualTo(new[] { 48000 }));
+        Assert.That(results[1].Items, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_InFlightJoiner_AlsoSeesDegradedFlag()
+    {
+        // A joiner shares the in-flight task, so it must observe the same Degraded verdict — otherwise a
+        // joiner could apply a degraded (empty) result as authoritative and clobber the user's selection.
+        var cache = new FFmpegOptionsCache<int>();
+        var gate = new TaskCompletionSource<OptionsQueryResult<int>>();
+
+        Task<OptionsQueryResult<int>> first = cache.GetOrQueryAsync("aac", () => gate.Task);
+        Task<OptionsQueryResult<int>> joiner = cache.GetOrQueryAsync("aac", () => Ok(-1));
+
+        gate.SetResult(new OptionsQueryResult<int>([], Degraded: true));
+        OptionsQueryResult<int>[] results = await Task.WhenAll(first, joiner);
+
+        Assert.That(results[0].Degraded, Is.True);
+        Assert.That(results[1].Degraded, Is.True);
+        // And the shared degraded result is not pinned in the cache.
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
     }
 
     [Test]
@@ -158,15 +188,15 @@ public class FFmpegOptionsCacheTests
         // Regression guard: the shared in-flight task must not be tied to any single caller, so a
         // caller that joins after another has stopped awaiting still receives the completed result.
         var cache = new FFmpegOptionsCache<int>();
-        var gate = new TaskCompletionSource<int[]>();
+        var gate = new TaskCompletionSource<OptionsQueryResult<int>>();
 
-        Task<int[]> abandoned = cache.GetOrQueryAsync("aac", () => gate.Task);
-        Task<int[]> joiner = cache.GetOrQueryAsync("aac", () => Task.FromResult(new[] { -1 }));
+        Task<OptionsQueryResult<int>> abandoned = cache.GetOrQueryAsync("aac", () => gate.Task);
+        Task<OptionsQueryResult<int>> joiner = cache.GetOrQueryAsync("aac", () => Ok(-1));
         // Simulate the first caller losing interest (e.g. its codec selection was superseded).
         _ = abandoned;
 
-        gate.SetResult([48000]);
+        gate.SetResult(new OptionsQueryResult<int>([48000], Degraded: false));
 
-        Assert.That(await joiner, Is.EqualTo(new[] { 48000 }));
+        Assert.That((await joiner).Items, Is.EqualTo(new[] { 48000 }));
     }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -1,0 +1,118 @@
+﻿using Beutl.Extensions.FFmpeg.PropertyEditors;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegOptionsCacheTests
+{
+    [Test]
+    public async Task GetOrQueryAsync_FirstCall_InvokesFactory()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        int[] result = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { 44100, 48000 }); });
+
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(result, Is.EqualTo(new[] { 44100, 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_SecondCallSameKey_ServesFromCacheWithoutReinvoking()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
+        int[] second = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { -1 }); });
+
+        // The cached value is returned and the factory is not invoked a second time
+        // (this is what stops the editor re-blocking / re-querying the worker on re-selection).
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(second, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_DifferentKey_InvokesFactoryAgain()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
+        int[] other = await cache.GetOrQueryAsync(
+            "mp3", () => { calls++; return Task.FromResult(new[] { 44100 }); });
+
+        Assert.That(calls, Is.EqualTo(2));
+        Assert.That(other, Is.EqualTo(new[] { 44100 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_FactoryThrows_NotCached_AndRetriesOnNextCall()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            () => cache.GetOrQueryAsync(
+                "aac", () => { calls++; return Task.FromException<int[]>(new InvalidOperationException()); }));
+
+        // A failed query must not be cached, so the next request runs the factory again and can succeed.
+        int[] retry = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Task.FromResult(new[] { 48000 }); });
+
+        Assert.That(retry, Is.EqualTo(new[] { 48000 }));
+        Assert.That(calls, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task TryGetCached_ReflectsCacheState()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
+
+        await cache.GetOrQueryAsync("aac", () => Task.FromResult(new[] { 48000 }));
+
+        Assert.That(cache.TryGetCached("aac", out int[]? cached), Is.True);
+        Assert.That(cached, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_ConcurrentSameKey_SharesSingleInFlightQuery()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+        var gate = new TaskCompletionSource<int[]>();
+
+        Task<int[]> first = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
+        Task<int[]> second = cache.GetOrQueryAsync("aac", () => { calls++; return gate.Task; });
+
+        gate.SetResult([48000]);
+        int[][] results = await Task.WhenAll(first, second);
+
+        // Single-flight: the second caller joins the in-flight query rather than launching its own.
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo(new[] { 48000 }));
+        Assert.That(results[1], Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task GetOrQueryAsync_JoinerStillGetsResult_WhenAnEarlierCallerAbandonsItsAwait()
+    {
+        // Regression guard: the shared in-flight task must not be tied to any single caller, so a
+        // caller that joins after another has stopped awaiting still receives the completed result.
+        var cache = new FFmpegOptionsCache<int>();
+        var gate = new TaskCompletionSource<int[]>();
+
+        Task<int[]> abandoned = cache.GetOrQueryAsync("aac", () => gate.Task);
+        Task<int[]> joiner = cache.GetOrQueryAsync("aac", () => Task.FromResult(new[] { -1 }));
+        // Simulate the first caller losing interest (e.g. its codec selection was superseded).
+        _ = abandoned;
+
+        gate.SetResult([48000]);
+
+        Assert.That(await joiner, Is.EqualTo(new[] { 48000 }));
+    }
+}

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/LatestRefreshTrackerTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/LatestRefreshTrackerTests.cs
@@ -1,0 +1,77 @@
+﻿using Beutl.Extensions.FFmpeg.PropertyEditors;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class LatestRefreshTrackerTests
+{
+    [Test]
+    public void StartNew_ReturnsLiveToken()
+    {
+        using var tracker = new LatestRefreshTracker();
+
+        CancellationToken token = tracker.StartNew();
+
+        Assert.That(LatestRefreshTracker.IsCurrent(token), Is.True);
+    }
+
+    [Test]
+    public void StartNew_SupersedesPreviousToken()
+    {
+        // The anti-clobber invariant: a newer refresh request makes the previous one stale, so the
+        // previous request's marshalled (async) result must be suppressed in favour of the latest.
+        using var tracker = new LatestRefreshTracker();
+
+        CancellationToken first = tracker.StartNew();
+        CancellationToken second = tracker.StartNew();
+
+        Assert.That(LatestRefreshTracker.IsCurrent(first), Is.False);
+        Assert.That(LatestRefreshTracker.IsCurrent(second), Is.True);
+    }
+
+    [Test]
+    public void Supersede_MakesCurrentTokenStale()
+    {
+        // The synchronous cache-hit / no-settings paths call Supersede() so any earlier in-flight
+        // async request can no longer apply over the just-applied synchronous result.
+        using var tracker = new LatestRefreshTracker();
+        CancellationToken token = tracker.StartNew();
+
+        tracker.Supersede();
+
+        Assert.That(LatestRefreshTracker.IsCurrent(token), Is.False);
+    }
+
+    [Test]
+    public void Dispose_MakesCurrentTokenStale()
+    {
+        var tracker = new LatestRefreshTracker();
+        CancellationToken token = tracker.StartNew();
+
+        tracker.Dispose();
+
+        Assert.That(LatestRefreshTracker.IsCurrent(token), Is.False);
+    }
+
+    [Test]
+    public void IsCurrent_OnSupersededToken_DoesNotThrow_AfterSourceDisposed()
+    {
+        // A superseded token's source is cancelled and then disposed, yet the fire-and-forget update
+        // still reads it on the UI thread after the async hop. Reading IsCancellationRequested must
+        // stay safe post-dispose (it does; only WaitHandle/Register throw), and report stale.
+        using var tracker = new LatestRefreshTracker();
+        CancellationToken stale = tracker.StartNew();
+        tracker.StartNew(); // cancels + disposes the first source
+
+        Assert.DoesNotThrow(() => _ = LatestRefreshTracker.IsCurrent(stale));
+        Assert.That(LatestRefreshTracker.IsCurrent(stale), Is.False);
+    }
+
+    [Test]
+    public void IsCurrent_DefaultToken_IsTrue()
+    {
+        // A default token (never cancelled) is treated as current, matching the path where no
+        // CancellationTokenSource is created.
+        Assert.That(LatestRefreshTracker.IsCurrent(CancellationToken.None), Is.True);
+    }
+}


### PR DESCRIPTION
## Description
The three FFmpeg encoder property editors queried the worker synchronously on the UI thread, blocking on every construction and every codec change (`EnsureStartedAsync().GetAwaiter().GetResult()` + `RequestAsync(...).GetAwaiter().GetResult()`), risking stalls/deadlocks. This makes the data flow async and caches results so the editor no longer re-blocks on selection/render.

- Add `FFmpegOptionsCache<T>` — a single-flight, per-codec (codec + output file) cache. Successful results are cached; failed queries are not (so the next request retries). The shared in-flight query is intentionally **not** tied to any single caller's `CancellationToken`, so abandoning one request never faults the result for callers that joined it.
- Convert `SampleRateEditorViewModel`, `PixelFormatEditorViewModel`, `AudioFormatEditorViewModel` to non-blocking async refreshes. Each editor cancels the previous (stale) update via a per-instance `CancellationTokenSource` and decides whether to apply a result **on the UI thread** (inside `Dispatcher.UIThread.InvokeAsync`), where `RequestUpdate` also cancels the token — so a superseded codec selection can neither block the UI nor clobber the latest one.
- Preserve prior fallback behavior on worker failure / missing settings (empty sample-rate suggestions / pixel-format Auto-only / all audio formats), and guard the fallback dispatch so a dispatcher fault during shutdown cannot escape the fire-and-forget task.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary) — MIT extension UI only; no reference to the GPL worker is added.

## Breaking changes
None — behavior-preserving (the editors are `internal`; only the UI-thread blocking is removed). Worker query results are now cached per codec.

## Test plan
- Added `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs` (7 cases): first-call invokes factory; second same-key call serves from cache without re-invoking; distinct key re-queries; failed query is not cached and retries; `TryGetCached` reflects state; concurrent same-key calls share a single in-flight query; a joiner still receives the result when an earlier caller abandons its await.
- `dotnet test tests/Beutl.UnitTests -f net10.0 --filter "FullyQualifiedName~Extensions.FFmpeg"` → 21/21 green.
- `dotnet format --verify-no-changes` clean on all touched files.
- Reviewed twice with the `beutl-reviewer` agent; all findings (incl. one high-severity stale-in-flight-task issue) addressed.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Phase 6: make the 3 sync-over-async FFmpeg property editors async")
- Tracked in `docs/refactoring-plan.md` Phase 6; previously surfaced on PR #1909.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking, cancellation-aware refresh for audio format, pixel format, and sample rate editors, with instant cached results.
  * Introduced single-flight caching for codec/output–specific FFmpeg option queries.
* **Bug Fixes**
  * Prevent stale worker results from overwriting the latest UI state.
  * Keeps selections valid after refresh and falls back to “Auto” when options can’t be retrieved, including during shutdown/teardown.
* **Tests**
  * Added unit tests covering cache single-flight, retry on failure, degraded behavior, empty-result caching, and `LatestRefreshTracker` token validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->