### PR TITLE
fix!: address 003 resolution-independent rendering review follow-ups

### DIFF
--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -364,18 +364,61 @@ public partial class ImmediateCanvas : IDisposable, IPopable
     public void DrawText(FormattedText text, Brush.Resource? fill, Pen.Resource? pen)
     {
         VerifyAccess();
-        SKTextBlob textBlob = text.GetTextBlob();
+        float density = _currentDensity;
+        SKTextBlob textBlob = text.GetTextBlob(density);
 
         ConfigureFillPaint(text.Bounds, fill);
-        Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
-
-        if (pen != null
-            && pen.Thickness > 0
-            && text.GetStrokePath() is { } stroke)
+        if (density == 1f)
         {
-            ConfigureStrokePaint(new(text.Bounds.Size), pen);
-            Canvas.DrawPath(stroke, _sharedStrokePaint);
+            Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
+
+            if (pen != null
+                && pen.Thickness > 0
+                && text.GetStrokePath() is { } stroke)
+            {
+                ConfigureStrokePaint(new(text.Bounds.Size), pen);
+                Canvas.DrawPath(stroke, _sharedStrokePaint);
+            }
         }
+        else
+        {
+            int count = Canvas.Save();
+            try
+            {
+                Canvas.SetMatrix((SKMatrix44)CreateDensityScaledContentTransform(density).ToSKMatrix());
+                Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
+
+                if (pen != null
+                    && pen.Thickness > 0
+                    && text.GetStrokePath(density) is { } stroke)
+                {
+                    ConfigureStrokePaint(new(text.Bounds.Size), pen);
+                    Canvas.DrawPath(stroke, _sharedStrokePaint);
+                }
+            }
+            finally
+            {
+                Canvas.RestoreToCount(count);
+            }
+        }
+    }
+
+    private Matrix CreateDensityScaledContentTransform(float density)
+    {
+        if (density == 1f || _currentBaseTransform.IsIdentity)
+        {
+            return _currentTransform;
+        }
+
+        if (!_currentBaseTransform.TryInvert(out Matrix inverseBase))
+        {
+            return _currentTransform;
+        }
+
+        Matrix logicalTransform = _currentTransform.Append(inverseBase);
+        return Matrix.CreateScale(1f / density, 1f / density)
+            .Append(logicalTransform)
+            .Append(_currentBaseTransform);
     }
 
     internal void DrawSKPath(SKPath skPath, bool strokeOnly, Brush.Resource? fill, Pen.Resource? pen)

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -367,9 +367,9 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         float density = _currentDensity;
         SKTextBlob textBlob = text.GetTextBlob(density);
 
-        ConfigureFillPaint(text.Bounds, fill);
         if (density == 1f)
         {
+            ConfigureFillPaint(text.Bounds, fill);
             Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
 
             if (pen != null
@@ -386,13 +386,20 @@ public partial class ImmediateCanvas : IDisposable, IPopable
             try
             {
                 Canvas.SetMatrix((SKMatrix44)CreateDensityScaledContentTransform(density).ToSKMatrix());
+
+                // The blob is shaped at device density, so the glyphs span the dense
+                // extent (Bounds * density) under this CTM. Configure the brush over that
+                // dense extent at scale 1: the density-compensating CTM already maps the
+                // dense space onto device pixels, so re-densifying the brush (scale:
+                // density) would double-apply the density to tile/drawable patterns.
+                ConfigureFillPaint(text.Bounds * density, fill, scale: 1f);
                 Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
 
                 if (pen != null
                     && pen.Thickness > 0
                     && text.GetStrokePath(density) is { } stroke)
                 {
-                    ConfigureStrokePaint(new(text.Bounds.Size), pen);
+                    ConfigureStrokePaint(new(text.Bounds.Size * density), pen, scale: 1f);
                     Canvas.DrawPath(stroke, _sharedStrokePaint);
                 }
             }
@@ -639,20 +646,20 @@ public partial class ImmediateCanvas : IDisposable, IPopable
         _dispatcher?.VerifyAccess();
     }
 
-    private void ConfigureStrokePaint(Rect bounds, Pen.Resource? pen, BlendMode blendMode = BlendMode.SrcOver)
+    private void ConfigureStrokePaint(Rect bounds, Pen.Resource? pen, BlendMode blendMode = BlendMode.SrcOver, float? scale = null)
     {
         _sharedStrokePaint.Reset();
 
         if (pen != null && pen.Thickness != 0)
         {
             _sharedStrokePaint.IsStroke = false;
-            new BrushConstructor(bounds, pen.Brush, blendMode, _currentDensity, MaxWorkingScale).ConfigurePaint(_sharedStrokePaint);
+            new BrushConstructor(bounds, pen.Brush, blendMode, scale ?? _currentDensity, MaxWorkingScale).ConfigurePaint(_sharedStrokePaint);
         }
     }
 
-    private void ConfigureFillPaint(Rect bounds, Brush.Resource? brush, BlendMode blendMode = BlendMode.SrcOver)
+    private void ConfigureFillPaint(Rect bounds, Brush.Resource? brush, BlendMode blendMode = BlendMode.SrcOver, float? scale = null)
     {
         _sharedFillPaint.Reset();
-        new BrushConstructor(bounds, brush, blendMode, _currentDensity, MaxWorkingScale).ConfigurePaint(_sharedFillPaint);
+        new BrushConstructor(bounds, brush, blendMode, scale ?? _currentDensity, MaxWorkingScale).ConfigurePaint(_sharedFillPaint);
     }
 }

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -365,7 +365,12 @@ public partial class ImmediateCanvas : IDisposable, IPopable
     {
         VerifyAccess();
         float density = _currentDensity;
-        SKTextBlob textBlob = text.GetTextBlob(density);
+        SKTextBlob? textBlob = text.GetTextBlob(density);
+        if (textBlob is null)
+        {
+            // Empty text shapes to no glyphs, so there is nothing to fill or stroke.
+            return;
+        }
 
         if (density == 1f)
         {

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -387,11 +387,8 @@ public partial class ImmediateCanvas : IDisposable, IPopable
             {
                 Canvas.SetMatrix((SKMatrix44)CreateDensityScaledContentTransform(density).ToSKMatrix());
 
-                // The blob is shaped at device density, so the glyphs span the dense
-                // extent (Bounds * density) under this CTM. Configure the brush over that
-                // dense extent at scale 1: the density-compensating CTM already maps the
-                // dense space onto device pixels, so re-densifying the brush (scale:
-                // density) would double-apply the density to tile/drawable patterns.
+                // The blob is shaped at device density, so its glyphs already span Bounds * density
+                // under this CTM. Pass scale 1 so the density isn't applied twice to brush patterns.
                 ConfigureFillPaint(text.Bounds * density, fill, scale: 1f);
                 Canvas.DrawText(textBlob, 0, 0, _sharedFillPaint);
 

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -13,7 +13,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
 
     private (RenderTarget RT, Drawable.Resource? Resource, int? Version, float Density)? _cachedRenderTarget;
     private Rect _drawableBounds;
-    // Requested output density used to decide whether the cached particle drawable must be rebuilt.
+    // Requested output density; a change invalidates the cached particle drawable.
     private float _renderScale = 1f;
 
     public (ParticleEmitter.Resource Resource, int Version)? Particle { get; private set; } = particle.Capture();

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -11,9 +11,9 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
 {
     private static readonly ILogger s_logger = Log.CreateLogger("ParticleRenderNode");
 
-    private (RenderTarget RT, Drawable.Resource? Resource, int? Version)? _cachedRenderTarget;
+    private (RenderTarget RT, Drawable.Resource? Resource, int? Version, float Density)? _cachedRenderTarget;
     private Rect _drawableBounds;
-    // Working density the cached particle-drawable buffer was rasterized at.
+    // Requested output density used to decide whether the cached particle drawable must be rebuilt.
     private float _renderScale = 1f;
 
     public (ParticleEmitter.Resource Resource, int Version)? Particle { get; private set; } = particle.Capture();
@@ -37,7 +37,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         var particles = resource.GetAliveParticles();
         if (particles.Length == 0) return [];
 
-        float w = context.OutputScale;
+        float w = RenderNodeContext.ResolveWorkingScale([], context.OutputScale, context.MaxWorkingScale);
         if (!_cachedRenderTarget.HasValue ||
             _renderScale != w ||
             !ReferenceEquals(_cachedRenderTarget.Value.Resource, resource.ParticleDrawable) ||
@@ -86,14 +86,15 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
 
         // Capture references for the lambda
         RenderTarget cachedRT = _cachedRenderTarget.Value.RT;
+        float cachedDensity = _cachedRenderTarget.Value.Density;
         Rect drawableBounds = _drawableBounds;
 
         return
         [
             RenderNodeOperation.CreateLambda(
                 totalBounds,
-                canvas => DrawAllParticles(canvas, cachedRT, particles, drawableBounds, w),
-                effectiveScale: EffectiveScale.At(w))
+                canvas => DrawAllParticles(canvas, cachedRT, particles, drawableBounds, cachedDensity),
+                effectiveScale: EffectiveScale.At(cachedDensity))
         ];
     }
 
@@ -175,7 +176,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         }
     }
 
-    private static (RenderTarget, Drawable.Resource, int)? RenderDrawableToTarget(
+    private static (RenderTarget, Drawable.Resource, int, float)? RenderDrawableToTarget(
         Drawable.Resource drawable,
         float nominalScale,
         float maxWorkingScale,
@@ -229,13 +230,16 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
             }
         }
 
-        return (renderTarget, drawable, drawable.Version);
+        return (renderTarget, drawable, drawable.Version, w);
     }
 
-    private static (RenderTarget, Drawable.Resource?, int?)? RenderFallbackEllipse(
+    private static (RenderTarget, Drawable.Resource?, int?, float)? RenderFallbackEllipse(
         float w, float maxWorkingScale, out Rect bounds)
     {
         bounds = new Rect(-5, -5, 10, 10);
+        w = w > 1f
+            ? RenderNodeContext.ClampWorkingScaleToBufferBudget(bounds, w)
+            : w;
 
         int dim = w == 1f ? 10 : (int)MathF.Ceiling(10 * w);
         var renderTarget = RenderTarget.Create(dim, dim);
@@ -256,7 +260,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
             }
         }
 
-        return (renderTarget, null, null);
+        return (renderTarget, null, null, w);
     }
 
     protected override void OnDispose(bool disposing)

--- a/src/Beutl.Engine/Graphics/Rendering/PenHelper.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/PenHelper.cs
@@ -54,9 +54,11 @@ internal static class PenHelper
 
     public static void ConfigureStrokePaint(
         Pen.Resource pen,
-        SKPaint paint, Size size)
+        SKPaint paint, Size size,
+        float scale = 1f)
     {
-        float thickness = pen.Thickness;
+        scale = float.IsFinite(scale) && scale > 0f ? scale : 1f;
+        float thickness = pen.Thickness * scale;
         switch (pen.StrokeAlignment)
         {
             case StrokeAlignment.Outside:
@@ -129,16 +131,17 @@ internal static class PenHelper
         return outer ?? inner;
     }
 
-    internal static SKPath? CreateOffsetPath(SKPath fillPath, Pen.Resource pen, Rect bounds)
+    internal static SKPath? CreateOffsetPath(SKPath fillPath, Pen.Resource pen, Rect bounds, float scale = 1f)
     {
         if (pen.Offset == 0)
             return null;
 
+        scale = float.IsFinite(scale) && scale > 0f ? scale : 1f;
         var offsetPath = new SKPath();
         using var offsetPaint = new SKPaint
         {
             IsStroke = true,
-            StrokeWidth = Math.Abs(pen.Offset) * 2,
+            StrokeWidth = Math.Abs(pen.Offset) * 2 * scale,
             StrokeJoin = (SKStrokeJoin)pen.StrokeJoin,
             StrokeCap = (SKStrokeCap)pen.StrokeCap,
             StrokeMiter = pen.MiterLimit,
@@ -206,9 +209,10 @@ internal static class PenHelper
         }
     }
 
-    public static SKPath CreateStrokePath(SKPath fillPath, Pen.Resource pen, Rect bounds)
+    public static SKPath CreateStrokePath(SKPath fillPath, Pen.Resource pen, Rect bounds, float scale = 1f)
     {
-        SKPath? offsetFillPath = CreateOffsetPath(fillPath, pen, bounds);
+        scale = float.IsFinite(scale) && scale > 0f ? scale : 1f;
+        SKPath? offsetFillPath = CreateOffsetPath(fillPath, pen, bounds, scale);
         if (offsetFillPath != null)
             fillPath = offsetFillPath;
 
@@ -216,7 +220,7 @@ internal static class PenHelper
 
         using (var paint = new SKPaint())
         {
-            ConfigureStrokePaint(pen, paint, bounds.Size);
+            ConfigureStrokePaint(pen, paint, bounds.Size, scale);
 
             switch (pen.StrokeAlignment)
             {

--- a/src/Beutl.Engine/Graphics3D/Scene3DRenderNode.cs
+++ b/src/Beutl.Engine/Graphics3D/Scene3DRenderNode.cs
@@ -56,9 +56,10 @@ internal sealed class Scene3DRenderNode(Scene3D.Resource scene) : RenderNode
         if (width <= 0 || height <= 0)
             return [];
 
-        // Render the 3D scene at output density. The 3D projection matrix is adjusted to
+        // Render the 3D scene at the resolved output density. The 3D projection matrix is adjusted to
         // compensate so that logical coordinates remain unchanged despite the dense surface.
-        float w = RenderNodeContext.ClampWorkingScaleToBufferBudget(new Rect(0, 0, width, height), context.OutputScale);
+        float resolved = RenderNodeContext.ResolveWorkingScale([], context.OutputScale, context.MaxWorkingScale);
+        float w = RenderNodeContext.ClampWorkingScaleToBufferBudget(new Rect(0, 0, width, height), resolved);
         int dw = w == 1f ? width : (int)MathF.Ceiling(width * w);
         int dh = w == 1f ? height : (int)MathF.Ceiling(height * w);
 

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -26,7 +26,27 @@ public class FormattedText : IEquatable<FormattedText>
     private SKTextBlob? _textBlob;
     private SKPath? _fillPath;
     private SKPath? _strokePath;
+    private readonly Dictionary<float, ScaledTextCache> _scaledTextCache = [];
     private List<SKPathGeometry.Resource> _pathList = [];
+
+    private sealed class ScaledTextCache : IDisposable
+    {
+        public ScaledTextCache(SKTextBlob? textBlob, SKPath? strokePath)
+        {
+            TextBlob = textBlob;
+            StrokePath = strokePath;
+        }
+
+        public SKTextBlob? TextBlob { get; }
+
+        public SKPath? StrokePath { get; }
+
+        public void Dispose()
+        {
+            TextBlob?.Dispose();
+            StrokePath?.Dispose();
+        }
+    }
 
     public FormattedText()
     {
@@ -173,16 +193,39 @@ public class FormattedText : IEquatable<FormattedText>
         return _strokePath;
     }
 
+    internal SKPath? GetStrokePath(float density)
+    {
+        density = NormalizeDensity(density);
+        if (density == 1f)
+        {
+            return GetStrokePath();
+        }
+
+        return GetScaledTextCache(density).StrokePath;
+    }
+
     internal SKTextBlob GetTextBlob()
     {
         MeasureAndSetField();
         return _textBlob!;
     }
 
-    internal SKFont ToSKFont()
+    internal SKTextBlob GetTextBlob(float density)
     {
+        density = NormalizeDensity(density);
+        if (density == 1f)
+        {
+            return GetTextBlob();
+        }
+
+        return GetScaledTextCache(density).TextBlob!;
+    }
+
+    internal SKFont ToSKFont(float density = 1f)
+    {
+        density = NormalizeDensity(density);
         var typeface = new Typeface(Font, Style, Weight);
-        var font = new SKFont(typeface.ToSkia(), Size)
+        var font = new SKFont(typeface.ToSkia(), Size * density)
         {
             Edging = SKFontEdging.Antialias,
             Subpixel = true,
@@ -200,7 +243,23 @@ public class FormattedText : IEquatable<FormattedText>
 
     private void Measure()
     {
-        using SKFont font = ToSKFont();
+        (SKTextBlob? textBlob, SKPath fillPath, SKPath? strokePath, FontMetrics metrics, Rect bounds, Rect actualBounds)
+            = MeasureCore(1f, updatePathList: true);
+
+        (_metrics, _bounds, _actualBounds) = (metrics, bounds, actualBounds);
+
+        (_textBlob, _fillPath, _strokePath).DisposeAll();
+        (_textBlob, _fillPath, _strokePath) = (textBlob, fillPath, strokePath);
+        ClearScaledTextCache();
+    }
+
+    private (SKTextBlob? TextBlob, SKPath FillPath, SKPath? StrokePath, FontMetrics Metrics, Rect Bounds, Rect ActualBounds)
+        MeasureCore(float density, bool updatePathList)
+    {
+        density = NormalizeDensity(density);
+        float spacing = Spacing * density;
+
+        using SKFont font = ToSKFont(density);
 
         using var shaper = new SKShaper(font.Typeface);
         using var buffer = new HarfBuzzSharp.Buffer();
@@ -216,14 +275,19 @@ public class FormattedText : IEquatable<FormattedText>
         var fillPath = new SKPath();
         Span<ushort> glyphs = run.Glyphs;
         Span<SKPoint> positions = run.Positions;
-        CollectionsMarshal.SetCount(_pathList, result.Codepoints.Length);
-        Span<SKPathGeometry.Resource> pathList = CollectionsMarshal.AsSpan(_pathList);
+        Span<SKPathGeometry.Resource> pathList = default;
+        if (updatePathList)
+        {
+            CollectionsMarshal.SetCount(_pathList, result.Codepoints.Length);
+            pathList = CollectionsMarshal.AsSpan(_pathList);
+        }
+
         for (int i = 0; i < result.Codepoints.Length; i++)
         {
             glyphs[i] = (ushort)result.Codepoints[i];
 
             SKPoint point = result.Points[i];
-            point.X += i * Spacing;
+            point.X += i * spacing;
             positions[i] = point;
 
             SKPath? tmp = font.GetGlyphPath(glyphs[i]);
@@ -231,21 +295,28 @@ public class FormattedText : IEquatable<FormattedText>
             {
                 fillPath.AddPath(tmp, point.X, point.Y);
 
-                tmp.Transform(SKMatrix.CreateTranslation(point.X, point.Y));
-
-                ref SKPathGeometry.Resource? exist = ref pathList[i]!;
-                if (exist is null)
+                if (updatePathList)
                 {
-                    var geom = new SKPathGeometry();
-                    geom.SetSKPath(tmp, false);
-                    exist = geom.ToResource(CompositionContext.Default);
+                    tmp.Transform(SKMatrix.CreateTranslation(point.X, point.Y));
+
+                    ref SKPathGeometry.Resource? exist = ref pathList[i]!;
+                    if (exist is null)
+                    {
+                        var geom = new SKPathGeometry();
+                        geom.SetSKPath(tmp, false);
+                        exist = geom.ToResource(CompositionContext.Default);
+                    }
+                    else
+                    {
+                        exist.GetOriginal().SetSKPath(tmp, false);
+                    }
                 }
                 else
                 {
-                    exist.GetOriginal().SetSKPath(tmp, false);
+                    tmp.Dispose();
                 }
             }
-            else
+            else if (updatePathList)
             {
                 ref SKPathGeometry.Resource? exist = ref pathList[i]!;
                 if (exist is null)
@@ -263,7 +334,7 @@ public class FormattedText : IEquatable<FormattedText>
 
         SKPath? strokePath = null;
         // 空白で開始または、終了した場合
-        var bounds = new Rect(0, 0, (glyphs.Length - 1) * Spacing + result.Width, fillPath.TightBounds.Height);
+        var bounds = new Rect(0, 0, (glyphs.Length - 1) * spacing + result.Width, fillPath.TightBounds.Height);
         Rect actualBounds = fillPath.TightBounds.ToGraphicsRect();
         SKTextBlob? textBlob = builder.Build();
 
@@ -271,15 +342,12 @@ public class FormattedText : IEquatable<FormattedText>
         {
             if (Pen != null && Pen.Thickness > 0)
             {
-                strokePath = PenHelper.CreateStrokePath(fillPath, Pen, actualBounds);
+                strokePath = PenHelper.CreateStrokePath(fillPath, Pen, actualBounds, density);
                 actualBounds = strokePath.TightBounds.ToGraphicsRect();
             }
         }
 
-        (_metrics, _bounds, _actualBounds) = (font.Metrics.ToFontMetrics(), bounds, actualBounds);
-
-        (_textBlob, _fillPath, _strokePath).DisposeAll();
-        (_textBlob, _fillPath, _strokePath) = (textBlob, fillPath, strokePath);
+        return (textBlob, fillPath, strokePath, font.Metrics.ToFontMetrics(), bounds, actualBounds);
     }
 
     private void SetProperty<T>(ref T field, T value)
@@ -298,6 +366,42 @@ public class FormattedText : IEquatable<FormattedText>
             Measure();
             _isDirty = false;
         }
+    }
+
+    private ScaledTextCache GetScaledTextCache(float density)
+    {
+        MeasureAndSetField();
+        if (!_scaledTextCache.TryGetValue(density, out ScaledTextCache? cache))
+        {
+            (SKTextBlob? textBlob, SKPath fillPath, SKPath? strokePath, _, _, _) =
+                MeasureCore(density, updatePathList: false);
+            fillPath.Dispose();
+
+            cache = new ScaledTextCache(textBlob, strokePath);
+            _scaledTextCache.Add(density, cache);
+        }
+
+        return cache;
+    }
+
+    private void ClearScaledTextCache()
+    {
+        foreach (ScaledTextCache item in _scaledTextCache.Values)
+        {
+            item.Dispose();
+        }
+
+        _scaledTextCache.Clear();
+    }
+
+    private static float NormalizeDensity(float density)
+    {
+        if (!float.IsFinite(density) || density <= 0f)
+        {
+            return 1f;
+        }
+
+        return MathF.Abs(density - 1f) < 1e-6f ? 1f : density;
     }
 
     public override bool Equals(object? obj)

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -26,20 +26,28 @@ public class FormattedText : IEquatable<FormattedText>
     private SKTextBlob? _textBlob;
     private SKPath? _fillPath;
     private SKPath? _strokePath;
+    // Bounds the per-density blob/stroke cache so continuously varying densities
+    // (e.g. Fit-to-previewer scale during a window resize) cannot grow it without
+    // bound; the least-recently-used density is evicted past this many entries.
+    private const int MaxScaledTextCacheEntries = 8;
     private readonly Dictionary<float, ScaledTextCache> _scaledTextCache = [];
+    private readonly LinkedList<float> _scaledTextCacheLru = new();
     private List<SKPathGeometry.Resource> _pathList = [];
 
     private sealed class ScaledTextCache : IDisposable
     {
-        public ScaledTextCache(SKTextBlob? textBlob, SKPath? strokePath)
+        public ScaledTextCache(SKTextBlob? textBlob, SKPath? strokePath, LinkedListNode<float> lruNode)
         {
             TextBlob = textBlob;
             StrokePath = strokePath;
+            LruNode = lruNode;
         }
 
         public SKTextBlob? TextBlob { get; }
 
         public SKPath? StrokePath { get; }
+
+        public LinkedListNode<float> LruNode { get; }
 
         public void Dispose()
         {
@@ -371,16 +379,29 @@ public class FormattedText : IEquatable<FormattedText>
     private ScaledTextCache GetScaledTextCache(float density)
     {
         MeasureAndSetField();
-        if (!_scaledTextCache.TryGetValue(density, out ScaledTextCache? cache))
+        if (_scaledTextCache.TryGetValue(density, out ScaledTextCache? cache))
         {
-            (SKTextBlob? textBlob, SKPath fillPath, SKPath? strokePath, _, _, _) =
-                MeasureCore(density, updatePathList: false);
-            fillPath.Dispose();
-
-            cache = new ScaledTextCache(textBlob, strokePath);
-            _scaledTextCache.Add(density, cache);
+            _scaledTextCacheLru.Remove(cache.LruNode);
+            _scaledTextCacheLru.AddFirst(cache.LruNode);
+            return cache;
         }
 
+        (SKTextBlob? textBlob, SKPath fillPath, SKPath? strokePath, _, _, _) =
+            MeasureCore(density, updatePathList: false);
+        fillPath.Dispose();
+
+        while (_scaledTextCache.Count >= MaxScaledTextCacheEntries && _scaledTextCacheLru.Last is { } lru)
+        {
+            _scaledTextCacheLru.RemoveLast();
+            if (_scaledTextCache.Remove(lru.Value, out ScaledTextCache? evicted))
+            {
+                evicted.Dispose();
+            }
+        }
+
+        LinkedListNode<float> node = _scaledTextCacheLru.AddFirst(density);
+        cache = new ScaledTextCache(textBlob, strokePath, node);
+        _scaledTextCache.Add(density, cache);
         return cache;
     }
 
@@ -392,6 +413,7 @@ public class FormattedText : IEquatable<FormattedText>
         }
 
         _scaledTextCache.Clear();
+        _scaledTextCacheLru.Clear();
     }
 
     private static float NormalizeDensity(float density)

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -226,7 +226,8 @@ public class FormattedText : IEquatable<FormattedText>
             return GetTextBlob();
         }
 
-        return GetScaledTextCache(density).TextBlob!;
+        return GetScaledTextCache(density).TextBlob
+            ?? throw new InvalidOperationException("Text blob was not created for the given density.");
     }
 
     internal SKFont ToSKFont(float density = 1f)
@@ -342,7 +343,7 @@ public class FormattedText : IEquatable<FormattedText>
 
         SKPath? strokePath = null;
         // 空白で開始または、終了した場合
-        var bounds = new Rect(0, 0, (glyphs.Length - 1) * spacing + result.Width, fillPath.TightBounds.Height);
+        var bounds = new Rect(0, 0, Math.Max(0, glyphs.Length - 1) * spacing + result.Width, fillPath.TightBounds.Height);
         Rect actualBounds = fillPath.TightBounds.ToGraphicsRect();
         SKTextBlob? textBlob = builder.Build();
 

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -26,9 +26,8 @@ public class FormattedText : IEquatable<FormattedText>
     private SKTextBlob? _textBlob;
     private SKPath? _fillPath;
     private SKPath? _strokePath;
-    // Bounds the per-density blob/stroke cache so continuously varying densities
-    // (e.g. Fit-to-previewer scale during a window resize) cannot grow it without
-    // bound; the least-recently-used density is evicted past this many entries.
+    // Caps the per-density blob/stroke cache so varying densities (e.g. window-resize
+    // scaling) can't grow it without bound; the least-recently-used density is evicted.
     private const int MaxScaledTextCacheEntries = 8;
     private readonly Dictionary<float, ScaledTextCache> _scaledTextCache = [];
     private readonly LinkedList<float> _scaledTextCacheLru = new();

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -211,13 +211,13 @@ public class FormattedText : IEquatable<FormattedText>
         return GetScaledTextCache(density).StrokePath;
     }
 
-    internal SKTextBlob GetTextBlob()
+    internal SKTextBlob? GetTextBlob()
     {
         MeasureAndSetField();
-        return _textBlob!;
+        return _textBlob;
     }
 
-    internal SKTextBlob GetTextBlob(float density)
+    internal SKTextBlob? GetTextBlob(float density)
     {
         density = NormalizeDensity(density);
         if (density == 1f)
@@ -225,8 +225,7 @@ public class FormattedText : IEquatable<FormattedText>
             return GetTextBlob();
         }
 
-        return GetScaledTextCache(density).TextBlob
-            ?? throw new InvalidOperationException("Text blob was not created for the given density.");
+        return GetScaledTextCache(density).TextBlob;
     }
 
     internal SKFont ToSKFont(float density = 1f)

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Graphics;
 using Beutl.Media;
 using Beutl.Media.TextFormatting;

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
@@ -1,0 +1,57 @@
+using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine;
+
+public class FormattedTextDeviceScaleTests
+{
+    [Test]
+    public void GetTextBlob_WithDeviceDensity_ShapesAtScaledFontSize()
+    {
+        FormattedText text = CreateText();
+        Rect logicalLayoutBounds = text.Bounds;
+
+        SKRect logicalBounds = text.GetTextBlob().Bounds;
+        SKRect deviceBounds = text.GetTextBlob(2f).Bounds;
+
+        Assert.That(deviceBounds.Width, Is.GreaterThan(logicalBounds.Width * 1.5f));
+        Assert.That(deviceBounds.Height, Is.GreaterThan(logicalBounds.Height * 1.5f));
+        Assert.That(text.Bounds, Is.EqualTo(logicalLayoutBounds));
+    }
+
+    [Test]
+    public void GetStrokePath_WithDeviceDensity_KeepsLogicalPathUnscaled()
+    {
+        FormattedText text = CreateText();
+        text.Pen = new Pen
+        {
+            Thickness = { CurrentValue = 2f },
+            Brush = { CurrentValue = Brushes.White }
+        }.ToResource(CompositionContext.Default);
+        Rect logicalActualBounds = text.ActualBounds;
+
+        SKPath logicalStroke = text.GetStrokePath()!;
+        SKPath deviceStroke = text.GetStrokePath(2f)!;
+
+        Assert.That(deviceStroke.Bounds.Width, Is.GreaterThan(logicalStroke.Bounds.Width * 1.5f));
+        Assert.That(deviceStroke.Bounds.Height, Is.GreaterThan(logicalStroke.Bounds.Height * 1.5f));
+        Assert.That(text.ActualBounds, Is.EqualTo(logicalActualBounds));
+    }
+
+    private static FormattedText CreateText()
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        return new FormattedText
+        {
+            Font = typeface.FontFamily,
+            Style = typeface.Style,
+            Weight = typeface.Weight,
+            Size = 24f,
+            Spacing = 1f,
+            Text = "Scale"
+        };
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
@@ -6,6 +6,7 @@ using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine;
 
+[TestFixture]
 public class FormattedTextDeviceScaleTests
 {
     [Test]

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs
@@ -15,8 +15,8 @@ public class FormattedTextDeviceScaleTests
         FormattedText text = CreateText();
         Rect logicalLayoutBounds = text.Bounds;
 
-        SKRect logicalBounds = text.GetTextBlob().Bounds;
-        SKRect deviceBounds = text.GetTextBlob(2f).Bounds;
+        SKRect logicalBounds = text.GetTextBlob()!.Bounds;
+        SKRect deviceBounds = text.GetTextBlob(2f)!.Bounds;
 
         Assert.That(deviceBounds.Width, Is.GreaterThan(logicalBounds.Width * 1.5f));
         Assert.That(deviceBounds.Height, Is.GreaterThan(logicalBounds.Height * 1.5f));
@@ -24,7 +24,7 @@ public class FormattedTextDeviceScaleTests
     }
 
     [Test]
-    public void GetStrokePath_WithDeviceDensity_KeepsLogicalPathUnscaled()
+    public void GetStrokePath_WithDeviceDensity_ReturnsDenseScaledPathWithoutMutatingLogicalBounds()
     {
         FormattedText text = CreateText();
         text.Pen = new Pen
@@ -40,6 +40,16 @@ public class FormattedTextDeviceScaleTests
         Assert.That(deviceStroke.Bounds.Width, Is.GreaterThan(logicalStroke.Bounds.Width * 1.5f));
         Assert.That(deviceStroke.Bounds.Height, Is.GreaterThan(logicalStroke.Bounds.Height * 1.5f));
         Assert.That(text.ActualBounds, Is.EqualTo(logicalActualBounds));
+    }
+
+    [Test]
+    public void GetTextBlob_EmptyText_ReturnsNullInsteadOfThrowing()
+    {
+        FormattedText text = CreateText();
+        text.Text = string.Empty;
+
+        Assert.That(text.GetTextBlob(), Is.Null);
+        Assert.That(text.GetTextBlob(2f), Is.Null);
     }
 
     private static FormattedText CreateText()

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
@@ -1,6 +1,9 @@
 ﻿using Beutl.Composition;
+using Beutl.Graphics;
 using Beutl.Graphics.Particles;
 using Beutl.Graphics.Rendering;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
 using Beutl.UnitTests.Engine.Graphics.Backend;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
@@ -16,6 +19,20 @@ public class ParticleRenderNodeScaleTests
     private static ParticleEmitter.Resource BuildResourceWithAliveParticles()
     {
         var emitter = new ParticleEmitter();
+        var ctx = new CompositionContext(TimeSpan.FromSeconds(1.0));
+        return (ParticleEmitter.Resource)emitter.ToResource(ctx);
+    }
+
+    private static ParticleEmitter.Resource BuildResourceWithLargeParticleDrawable()
+    {
+        var particle = new RectShape();
+        particle.Width.CurrentValue = 4000;
+        particle.Height.CurrentValue = 10;
+        particle.Fill.CurrentValue = Brushes.White;
+
+        var emitter = new ParticleEmitter();
+        emitter.ParticleDrawable.CurrentValue = particle;
+
         var ctx = new CompositionContext(TimeSpan.FromSeconds(1.0));
         return (ParticleEmitter.Resource)emitter.ToResource(ctx);
     }
@@ -50,6 +67,32 @@ public class ParticleRenderNodeScaleTests
                 $"the particle composite was not tagged At(w) with w == s_out ({outputScale})");
             Assert.That(ops[0].EffectiveScale.IsUnbounded, Is.False,
                 "the particle composite was over-reported as re-rasterizable vector (Unbounded)");
+
+            DisposeAll(ops);
+        });
+    }
+
+    [Test]
+    public void Process_WhenParticleDrawableBufferClamps_TagsActualDensity()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            ParticleEmitter.Resource resource = BuildResourceWithLargeParticleDrawable();
+            Assert.That(resource.GetAliveParticles().Length, Is.GreaterThanOrEqualTo(1),
+                "precondition: at least one alive particle is required for Process to emit an op");
+
+            using var node = new ParticleRenderNode(resource);
+            var context = new RenderNodeContext([], outputScale: 8f);
+
+            RenderNodeOperation[] ops = node.Process(context);
+
+            Assert.That(ops, Is.Not.Empty, "ParticleRenderNode emitted no op despite alive particles");
+            Assert.That(ops[0].EffectiveScale.IsUnbounded, Is.False);
+            Assert.That(ops[0].EffectiveScale.Value, Is.LessThan(8f),
+                "the particle op must report the clamped buffer density, not the nominal output scale");
+            Assert.That(ops[0].EffectiveScale.Value, Is.EqualTo(
+                RenderNodeContext.ClampWorkingScaleToBufferBudget(new Rect(0, 0, 4000, 10), 8f)).Within(1e-3f));
 
             DisposeAll(ops);
         });

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs
@@ -78,7 +78,7 @@ public class ParticleRenderNodeScaleTests
         VulkanTestEnvironment.EnsureAvailable();
         VulkanTestEnvironment.InvokeOnRenderThread(() =>
         {
-            ParticleEmitter.Resource resource = BuildResourceWithLargeParticleDrawable();
+            using ParticleEmitter.Resource resource = BuildResourceWithLargeParticleDrawable();
             Assert.That(resource.GetAliveParticles().Length, Is.GreaterThanOrEqualTo(1),
                 "precondition: at least one alive particle is required for Process to emit an op");
 

--- a/tests/Beutl.UnitTests/Engine/Graphics3D/Scene3DRenderNodeScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics3D/Scene3DRenderNodeScaleTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Composition;
+﻿using Beutl.Composition;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics3D;
 using Beutl.UnitTests.Engine.Graphics.Backend;

--- a/tests/Beutl.UnitTests/Engine/Graphics3D/Scene3DRenderNodeScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics3D/Scene3DRenderNodeScaleTests.cs
@@ -1,0 +1,49 @@
+using Beutl.Composition;
+using Beutl.Graphics.Rendering;
+using Beutl.Graphics3D;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics3D;
+
+[NonParallelizable]
+[TestFixture]
+public class Scene3DRenderNodeScaleTests
+{
+    [Test]
+    public void Process_RespectsMaxWorkingScale_WhenOutputScaleIsHigher()
+    {
+        var graphicsContext = VulkanTestEnvironment.EnsureAvailable();
+        if (!graphicsContext.Supports3DRendering)
+        {
+            Assert.Ignore("3D rendering is not supported on this GPU.");
+        }
+
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            var scene = new Scene3D();
+            scene.RenderWidth.CurrentValue = 32;
+            scene.RenderHeight.CurrentValue = 32;
+            var resource = (Scene3D.Resource)scene.ToResource(CompositionContext.Default);
+
+            using var node = new Scene3DRenderNode(resource);
+            var context = new RenderNodeContext([], outputScale: 2f, maxWorkingScale: 0.5f);
+
+            RenderNodeOperation[] ops = node.Process(context);
+
+            Assert.That(ops, Is.Not.Empty, "Scene3DRenderNode emitted no operation for a valid scene");
+            Assert.That(ops[0].EffectiveScale.IsUnbounded, Is.False);
+            Assert.That(ops[0].EffectiveScale.Value, Is.EqualTo(0.5f).Within(1e-4f));
+
+            DisposeAll(ops);
+            resource.Dispose();
+        });
+    }
+
+    private static void DisposeAll(RenderNodeOperation[] ops)
+    {
+        foreach (RenderNodeOperation op in ops)
+        {
+            op.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Follow-up fixes from a multi-agent ("ultracode") review of commit `e322d3587` (003 resolution-independent rendering pipeline, #1886). The review surfaced four valid HIGH/MEDIUM items; this PR addresses them. Remaining LOW/nit items and spec-deferred test gaps are tracked as Draft items on the project board (see References).

- **Shape text at device density (FR-012)** — `FormattedText` now shapes glyphs at `Size × density` and caches per-density blobs/stroke paths; `ImmediateCanvas.DrawText` draws the device-shaped blob under `Scale(1/density) · logicalTransform · baseTransform` so the final size matches the logical layout while text is grid-fit at device resolution. The `density == 1` path is byte-identical to before. (`28ae9e0ff`)
- **Require density-aware `ICanvas` members** — `LogicalSize`, `Density`, `SurfaceDensity`, `PushDeviceSpace` are now required (no default-interface-impl), per the public-api contract. The previous `PushDeviceSpace() => Push()` default silently mis-rendered for out-of-tree implementers. `ImmediateCanvas` already implements all four, so no in-tree change was needed. (`3ff7ceb56`)
- **Report clamped render densities** — `ParticleRenderNode` and `Scene3DRenderNode` now tag `EffectiveScale` with the actual clamped buffer density (via `ResolveWorkingScale` + `ClampWorkingScaleToBufferBudget`) instead of the nominal output scale, so parent `ResolveWorkingScale` consumers no longer over-allocate. `MaxWorkingScale` is now consulted for both nodes. (`73a052955`)
- **Record the breaking-change migration footer** — the squash-merged `e322d3587` shipped without a `BREAKING CHANGE:` footer; an empty commit records the migration surface for changelog tooling. (`4762e184e`)

A reported `BrushConstructor` tile-transform "bug" from the review was confirmed to be a **false positive** (SkiaSharp `PreConcat` is right-multiply, so the existing order is correct) and was intentionally not "fixed"; defensive test coverage for it is tracked on the board.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

**Yes.** `ICanvas` implementers must now provide `LogicalSize`, `Density`, `SurfaceDensity`, and `PushDeviceSpace` (previously defaulted). Device-space drawing can no longer silently fall back to logical `Push()` semantics. See the `BREAKING CHANGE:` footers on `3ff7ceb56` and `4762e184e`.

## Test plan

Unit tests added/updated:
- `tests/Beutl.UnitTests/Engine/FormattedTextDeviceScaleTests.cs` — shaping at scaled font size; logical `Bounds`/`ActualBounds` stay unchanged.
- `tests/Beutl.UnitTests/Engine/Graphics/Rendering/ParticleRenderNodeScaleTests.cs` — buffer-clamp path tags the actual (clamped) density, not the nominal output scale.
- `tests/Beutl.UnitTests/Engine/Graphics3D/Scene3DRenderNodeScaleTests.cs` — `MaxWorkingScale` is respected when output scale is higher.

Verified locally (Windows, Vulkan available):
- `dotnet build src/Beutl.Engine` → 0 warnings / 0 errors.
- `FormattedTextDeviceScaleTests` (2), `ParticleRenderNodeScaleTests` + `Scene3DRenderNodeScaleTests` (5), and `ScaleOneContentCoverageTests` / `Slice1ReducedScaleTests` / `Slice1SkiaFilterTests` (7) all pass — the scale=1 golden regression confirms text byte-identity is preserved.

## Fixed issues / References
- Originates from the ultracode review of #1886 (`e322d3587`).
- Project board: b-editor/projects/9 ("AI Review") — remaining LOW/nit and spec-deferred follow-ups registered as Draft items (NodeGraph scale-forwarding test, FR-005 frozen golden, FR-019(a) pixel oracle, BufferedPlayer CTS leak, dead `DrawFrame()`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved density-aware text rendering, including correct handling of empty text and density-scaled blobs/stroke paths.
  * Enhanced particle rendering by caching buffers per effective density and keeping draw scaling consistent.
  * Improved 3D rendering scale resolution by clamping to buffer budgets.
  * Fixed stroke/brush setup to respect density scaling without double-applying it.
* **Tests**
  * Added/expanded coverage for density scaling behavior in text, particles, and 3D rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->