### PR TITLE
fix(engine): sanitize degenerate maxWorkingScale on public surface

### DIFF
--- a/src/Beutl.Engine/Graphics/BrushConstructor.cs
+++ b/src/Beutl.Engine/Graphics/BrushConstructor.cs
@@ -27,7 +27,7 @@ public readonly struct BrushConstructor(
     public float Scale { get; } = scale;
 
     /// <summary>Working-scale ceiling forwarded into nested pulls (e.g. <see cref="DrawableBrush"/>).</summary>
-    public float MaxWorkingScale { get; } = maxWorkingScale;
+    public float MaxWorkingScale { get; } = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
 
     public void ConfigurePaint(SKPaint paint)
     {

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -14,7 +14,7 @@ public class CustomFilterEffectContext
         Targets = targets;
         OutputScale = outputScale;
         WorkingScale = workingScale;
-        MaxWorkingScale = maxWorkingScale;
+        MaxWorkingScale = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
     }
 
     public EffectTargets Targets { get; }

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -25,7 +25,7 @@ public sealed class FilterEffectActivator(
     /// </summary>
     public float WorkingScale { get; private set; } = SanitizePositiveFinite(workingScale, nameof(workingScale));
 
-    /// <summary>Working-scale ceiling forwarded into nested canvases. Sanitized to positive.</summary>
+    /// <summary>Working-scale ceiling forwarded into nested canvases. Sanitized: NaN or non-positive becomes +Inf (no ceiling).</summary>
     public float MaxWorkingScale { get; } = SanitizeCeiling(maxWorkingScale, nameof(maxWorkingScale));
 
     // Reuses the canonical degenerate-ceiling rule and adds a warning when it actually fires.

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -25,10 +25,10 @@ public sealed class FilterEffectActivator(
     /// </summary>
     public float WorkingScale { get; private set; } = SanitizePositiveFinite(workingScale, nameof(workingScale));
 
-    /// <summary>Working-scale ceiling forwarded into nested canvases. Sanitized: NaN or non-positive becomes +Inf (no ceiling).</summary>
+    /// <summary>Working-scale ceiling forwarded into nested canvases. NaN or non-positive becomes +Inf (no ceiling).</summary>
     public float MaxWorkingScale { get; } = SanitizeCeiling(maxWorkingScale, nameof(maxWorkingScale));
 
-    // Reuses the canonical degenerate-ceiling rule and adds a warning when it actually fires.
+    // Canonical ceiling rule, plus a warning when it substitutes.
     private static float SanitizeCeiling(float value, string name)
     {
         float sanitized = RenderNodeContext.SanitizeMaxWorkingScale(value);

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectActivator.cs
@@ -26,8 +26,14 @@ public sealed class FilterEffectActivator(
     public float WorkingScale { get; private set; } = SanitizePositiveFinite(workingScale, nameof(workingScale));
 
     /// <summary>Working-scale ceiling forwarded into nested canvases. Sanitized to positive.</summary>
-    public float MaxWorkingScale { get; } = float.IsNaN(maxWorkingScale) || maxWorkingScale <= 0f
-        ? LogAndFallback(maxWorkingScale, nameof(maxWorkingScale), float.PositiveInfinity) : maxWorkingScale;
+    public float MaxWorkingScale { get; } = SanitizeCeiling(maxWorkingScale, nameof(maxWorkingScale));
+
+    // Reuses the canonical degenerate-ceiling rule and adds a warning when it actually fires.
+    private static float SanitizeCeiling(float value, string name)
+    {
+        float sanitized = RenderNodeContext.SanitizeMaxWorkingScale(value);
+        return sanitized != value ? LogAndFallback(value, name, sanitized) : sanitized;
+    }
 
     private static float SanitizePositiveFinite(float value, string name)
     {

--- a/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
+++ b/src/Beutl.Engine/Graphics/ImmediateCanvas.cs
@@ -40,7 +40,7 @@ public partial class ImmediateCanvas : ICanvas
         LogicalSize = logicalSize.IsDefault ? DeviceSize.ToSize(density) : logicalSize;
         SurfaceDensity = density;
         _currentDensity = density;
-        MaxWorkingScale = maxWorkingScale;
+        MaxWorkingScale = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
         if (density == 1f)
         {
             _baseTransform = Matrix.Identity;

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeContext.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeContext.cs
@@ -23,11 +23,7 @@ public class RenderNodeContext(
     /// </summary>
     public float MaxWorkingScale { get; } = SanitizeMaxWorkingScale(maxWorkingScale);
 
-    /// <summary>
-    /// Normalizes a working-scale ceiling: a degenerate value (NaN or non-positive) means "no ceiling" (+Inf).
-    /// Public entry points that accept a raw ceiling route it through here so the rule stays in one place.
-    /// </summary>
-    /// <returns><see cref="float.PositiveInfinity"/> for NaN or non-positive input; otherwise the value unchanged.</returns>
+    /// <summary>Canonical ceiling rule: a degenerate value (NaN or non-positive) means "no ceiling" (+Inf); other values pass through.</summary>
     public static float SanitizeMaxWorkingScale(float maxWorkingScale) =>
         float.IsNaN(maxWorkingScale) || maxWorkingScale <= 0f ? float.PositiveInfinity : maxWorkingScale;
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeContext.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeContext.cs
@@ -21,7 +21,14 @@ public class RenderNodeContext(
     /// Global working-scale ceiling. Preview caps at <c>2 * s_out</c>; export passes <c>+Inf</c>.
     /// A degenerate value (NaN / non-positive) is treated as <c>+Inf</c>.
     /// </summary>
-    public float MaxWorkingScale { get; } =
+    public float MaxWorkingScale { get; } = SanitizeMaxWorkingScale(maxWorkingScale);
+
+    /// <summary>
+    /// Normalizes a working-scale ceiling: a degenerate value (NaN or non-positive) means "no ceiling" (+Inf).
+    /// Public entry points that accept a raw ceiling route it through here so the rule stays in one place.
+    /// </summary>
+    /// <returns><see cref="float.PositiveInfinity"/> for NaN or non-positive input; otherwise the value unchanged.</returns>
+    public static float SanitizeMaxWorkingScale(float maxWorkingScale) =>
         float.IsNaN(maxWorkingScale) || maxWorkingScale <= 0f ? float.PositiveInfinity : maxWorkingScale;
 
     public Rect CalculateBounds()
@@ -49,7 +56,7 @@ public class RenderNodeContext(
             if (e.Value > supply) supply = e.Value;
         }
 
-        return MathF.Min(supply, maxWorkingScale);
+        return MathF.Min(supply, SanitizeMaxWorkingScale(maxWorkingScale));
     }
 
     /// <summary>Max device-buffer axis (px). GPU textures larger than this typically fail to allocate.</summary>

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -15,9 +15,7 @@ public class RenderNodeProcessor(
     public float OutputScale { get; } = float.IsFinite(outputScale) && outputScale > 0f ? outputScale : 1f;
 
     /// <summary>Working-scale ceiling seeded into every <see cref="RenderNodeContext"/>. <c>+Inf</c> = no ceiling.</summary>
-    public float MaxWorkingScale { get; } = float.IsNaN(maxWorkingScale) || maxWorkingScale <= 0f
-        ? float.PositiveInfinity
-        : maxWorkingScale;
+    public float MaxWorkingScale { get; } = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
 
     public void Render(ImmediateCanvas canvas)
     {

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -45,9 +45,10 @@ public class Renderer : IRenderer
     public Renderer(int width, int height, float renderScale = 1f, float maxWorkingScale = float.PositiveInfinity)
     {
         float outputScale = float.IsFinite(renderScale) && renderScale > 0f ? renderScale : 1f;
+        float maxScale = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
         FrameSize = new PixelSize(width, height);
         OutputScale = outputScale;
-        MaxWorkingScale = maxWorkingScale;
+        MaxWorkingScale = maxScale;
         DeviceSize = new PixelSize(
             (int)MathF.Ceiling(width * outputScale),
             (int)MathF.Ceiling(height * outputScale));
@@ -57,7 +58,7 @@ public class Renderer : IRenderer
                                    ?? throw new InvalidOperationException(
                                        $"Could not create a canvas of this size. (width: {DeviceSize.Width}, height: {DeviceSize.Height})");
 
-            var canvas = new ImmediateCanvas(surface, outputScale, maxWorkingScale,
+            var canvas = new ImmediateCanvas(surface, outputScale, maxScale,
                 logicalSize: FrameSize.ToSize(1));
             return (canvas, surface);
         });

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Graphics.Rendering;
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 
@@ -27,6 +29,7 @@ public class MaxWorkingScaleSanitizationTests
     [TestCase(float.NaN)]
     [TestCase(0f)]
     [TestCase(-1f)]
+    [TestCase(float.NegativeInfinity)]
     public void ResolveWorkingScale_DegenerateCeiling_DoesNotPropagate(float maxWorkingScale)
     {
         // With no concrete inputs the supply equals outputScale (2), and a degenerate
@@ -46,6 +49,44 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(w, Is.EqualTo(3f));
     }
 
+    [Test]
+    public void ResolveWorkingScale_UnboundedInput_DoesNotRaiseSupply()
+    {
+        // Vector (Unbounded) inputs are excluded from the supply max (FR-019); supply stays at the output floor.
+        float w = RenderNodeContext.ResolveWorkingScale([EffectiveScale.Unbounded], outputScale: 2f);
+
+        Assert.That(w, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void ResolveWorkingScale_ConcreteSupplyAboveOutput_IgnoresUnboundedAndTracksSupply()
+    {
+        // The concrete bitmap supply (10) drives the result; the Unbounded sentinel is skipped, not read as a density.
+        float w = RenderNodeContext.ResolveWorkingScale(
+            [EffectiveScale.Unbounded, EffectiveScale.At(10f)], outputScale: 2f);
+
+        Assert.That(w, Is.EqualTo(10f));
+    }
+
+    [Test]
+    public void ResolveWorkingScale_ConcreteSupplyExceedsFiniteCeiling_CapsToCeiling()
+    {
+        // A finite ceiling must cap a concrete supply that exceeds it, not only the output-scale floor.
+        float w = RenderNodeContext.ResolveWorkingScale(
+            [EffectiveScale.At(8f)], outputScale: 2f, maxWorkingScale: 5f);
+
+        Assert.That(w, Is.EqualTo(5f));
+    }
+
+    [Test]
+    public void ResolveWorkingScale_ConcreteSupplyUnderInfiniteCeiling_TracksSupply()
+    {
+        float w = RenderNodeContext.ResolveWorkingScale(
+            [EffectiveScale.At(8f)], outputScale: 2f, maxWorkingScale: float.PositiveInfinity);
+
+        Assert.That(w, Is.EqualTo(8f));
+    }
+
     [TestCase(float.NaN)]
     [TestCase(0f)]
     [TestCase(-1f)]
@@ -54,5 +95,88 @@ public class MaxWorkingScaleSanitizationTests
         var context = new RenderNodeContext([], outputScale: 1f, maxWorkingScale: maxWorkingScale);
 
         Assert.That(context.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    // The remaining public entry points just forward into SanitizeMaxWorkingScale. These guard tests pin that
+    // forwarding at the public surface so a future refactor that drops the Sanitize call fails loudly instead of
+    // silently storing NaN/0/-1. Only the cheap-to-construct entries are covered; ImmediateCanvas/Renderer need a
+    // real SKSurface and are left to the helper-level coverage.
+
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void RenderNodeProcessor_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        var processor = new RenderNodeProcessor(
+            new ContainerRenderNode(), useRenderCache: false, outputScale: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(processor.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    [Test]
+    public void RenderNodeProcessor_FinitePositiveCeiling_PassesThrough()
+    {
+        var processor = new RenderNodeProcessor(
+            new ContainerRenderNode(), useRenderCache: false, outputScale: 1f, maxWorkingScale: 3f);
+
+        Assert.That(processor.MaxWorkingScale, Is.EqualTo(3f));
+    }
+
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void BrushConstructor_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        var ctor = new BrushConstructor(
+            default, brush: null, BlendMode.SrcOver, scale: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(ctor.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    [Test]
+    public void BrushConstructor_FinitePositiveCeiling_PassesThrough()
+    {
+        var ctor = new BrushConstructor(default, brush: null, BlendMode.SrcOver, scale: 1f, maxWorkingScale: 3f);
+
+        Assert.That(ctor.MaxWorkingScale, Is.EqualTo(3f));
+    }
+
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void CustomFilterEffectContext_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        using var targets = new EffectTargets();
+        var context = new CustomFilterEffectContext(
+            targets, outputScale: 1f, workingScale: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(context.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    // FilterEffectActivator is the only entry point with logic beyond pure forwarding: SanitizeCeiling logs a
+    // warning ONLY when the value actually changes. Pin both the substituted result and the no-substitution
+    // pass-through so the 'sanitized != value' guard can't be inverted undetected.
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void FilterEffectActivator_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        using var targets = new EffectTargets();
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets, builder, outputScale: 1f, workingScale: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(activator.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    [Test]
+    public void FilterEffectActivator_FinitePositiveCeiling_PassesThrough()
+    {
+        using var targets = new EffectTargets();
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets, builder, outputScale: 1f, workingScale: 1f, maxWorkingScale: 3f);
+
+        Assert.That(activator.MaxWorkingScale, Is.EqualTo(3f));
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
@@ -1,0 +1,58 @@
+﻿using Beutl.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+// A degenerate working-scale ceiling (NaN / non-positive) must be treated as "no ceiling" (+Inf)
+// at every public entry point, so it never propagates into the resolved working scale.
+[TestFixture]
+public class MaxWorkingScaleSanitizationTests
+{
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    [TestCase(float.NegativeInfinity)]
+    public void SanitizeMaxWorkingScale_DegenerateValue_BecomesPositiveInfinity(float value)
+    {
+        Assert.That(RenderNodeContext.SanitizeMaxWorkingScale(value), Is.EqualTo(float.PositiveInfinity));
+    }
+
+    [TestCase(1f)]
+    [TestCase(2.5f)]
+    [TestCase(float.PositiveInfinity)]
+    public void SanitizeMaxWorkingScale_FiniteOrInfinitePositive_PassesThrough(float value)
+    {
+        Assert.That(RenderNodeContext.SanitizeMaxWorkingScale(value), Is.EqualTo(value));
+    }
+
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void ResolveWorkingScale_DegenerateCeiling_DoesNotPropagate(float maxWorkingScale)
+    {
+        // With no concrete inputs the supply equals outputScale (2), and a degenerate
+        // ceiling must not pull the result to NaN/0 via MathF.Min.
+        float w = RenderNodeContext.ResolveWorkingScale(
+            ReadOnlySpan<EffectiveScale>.Empty, outputScale: 2f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(w, Is.EqualTo(2f));
+    }
+
+    [Test]
+    public void ResolveWorkingScale_FiniteCeiling_CapsSupply()
+    {
+        float w = RenderNodeContext.ResolveWorkingScale(
+            ReadOnlySpan<EffectiveScale>.Empty, outputScale: 4f, maxWorkingScale: 3f);
+
+        Assert.That(w, Is.EqualTo(3f));
+    }
+
+    [TestCase(float.NaN)]
+    [TestCase(0f)]
+    [TestCase(-1f)]
+    public void RenderNodeContext_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        var context = new RenderNodeContext([], outputScale: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(context.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs
@@ -4,15 +4,21 @@ using Beutl.Graphics.Rendering;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 
-// A degenerate working-scale ceiling (NaN / non-positive) must be treated as "no ceiling" (+Inf)
-// at every public entry point, so it never propagates into the resolved working scale.
+// A degenerate ceiling (NaN / non-positive) becomes "no ceiling" (+Inf) at every public entry point.
 [TestFixture]
 public class MaxWorkingScaleSanitizationTests
 {
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
-    [TestCase(float.NegativeInfinity)]
+    // Shared degenerate-ceiling set, used by both the helper and the entry-point guard tests.
+    private static IEnumerable<TestCaseData> DegenerateCeilings()
+    {
+        yield return new TestCaseData(float.NaN).SetName("{m}(NaN)");
+        yield return new TestCaseData(0f).SetName("{m}(+0)");
+        yield return new TestCaseData(-0f).SetName("{m}(-0)");
+        yield return new TestCaseData(-1f).SetName("{m}(-1)");
+        yield return new TestCaseData(float.NegativeInfinity).SetName("{m}(-Inf)");
+    }
+
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void SanitizeMaxWorkingScale_DegenerateValue_BecomesPositiveInfinity(float value)
     {
         Assert.That(RenderNodeContext.SanitizeMaxWorkingScale(value), Is.EqualTo(float.PositiveInfinity));
@@ -26,14 +32,10 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(RenderNodeContext.SanitizeMaxWorkingScale(value), Is.EqualTo(value));
     }
 
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
-    [TestCase(float.NegativeInfinity)]
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void ResolveWorkingScale_DegenerateCeiling_DoesNotPropagate(float maxWorkingScale)
     {
-        // With no concrete inputs the supply equals outputScale (2), and a degenerate
-        // ceiling must not pull the result to NaN/0 via MathF.Min.
+        // Supply equals outputScale (2); a degenerate ceiling must not drag it to NaN/0 via MathF.Min.
         float w = RenderNodeContext.ResolveWorkingScale(
             ReadOnlySpan<EffectiveScale>.Empty, outputScale: 2f, maxWorkingScale: maxWorkingScale);
 
@@ -52,7 +54,7 @@ public class MaxWorkingScaleSanitizationTests
     [Test]
     public void ResolveWorkingScale_UnboundedInput_DoesNotRaiseSupply()
     {
-        // Vector (Unbounded) inputs are excluded from the supply max (FR-019); supply stays at the output floor.
+        // Unbounded (vector) inputs are excluded from the supply max (FR-019).
         float w = RenderNodeContext.ResolveWorkingScale([EffectiveScale.Unbounded], outputScale: 2f);
 
         Assert.That(w, Is.EqualTo(2f));
@@ -61,7 +63,7 @@ public class MaxWorkingScaleSanitizationTests
     [Test]
     public void ResolveWorkingScale_ConcreteSupplyAboveOutput_IgnoresUnboundedAndTracksSupply()
     {
-        // The concrete bitmap supply (10) drives the result; the Unbounded sentinel is skipped, not read as a density.
+        // The Unbounded sentinel is skipped; the concrete supply (10) drives the result.
         float w = RenderNodeContext.ResolveWorkingScale(
             [EffectiveScale.Unbounded, EffectiveScale.At(10f)], outputScale: 2f);
 
@@ -71,7 +73,7 @@ public class MaxWorkingScaleSanitizationTests
     [Test]
     public void ResolveWorkingScale_ConcreteSupplyExceedsFiniteCeiling_CapsToCeiling()
     {
-        // A finite ceiling must cap a concrete supply that exceeds it, not only the output-scale floor.
+        // A finite ceiling caps a concrete supply that exceeds it.
         float w = RenderNodeContext.ResolveWorkingScale(
             [EffectiveScale.At(8f)], outputScale: 2f, maxWorkingScale: 5f);
 
@@ -87,9 +89,10 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(w, Is.EqualTo(8f));
     }
 
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
+    // These guard tests pin the Sanitize call at each public entry point so dropping it fails loudly.
+    // Renderer is omitted: its constructor allocates a GPU RenderTarget on the render thread.
+
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void RenderNodeContext_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
     {
         var context = new RenderNodeContext([], outputScale: 1f, maxWorkingScale: maxWorkingScale);
@@ -97,14 +100,7 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(context.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
     }
 
-    // The remaining public entry points just forward into SanitizeMaxWorkingScale. These guard tests pin that
-    // forwarding at the public surface so a future refactor that drops the Sanitize call fails loudly instead of
-    // silently storing NaN/0/-1. Only the cheap-to-construct entries are covered; ImmediateCanvas/Renderer need a
-    // real SKSurface and are left to the helper-level coverage.
-
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void RenderNodeProcessor_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
     {
         var processor = new RenderNodeProcessor(
@@ -122,9 +118,25 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(processor.MaxWorkingScale, Is.EqualTo(3f));
     }
 
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
+    [TestCaseSource(nameof(DegenerateCeilings))]
+    public void ImmediateCanvas_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
+    {
+        using var renderTarget = RenderTarget.CreateNull(1, 1);
+        using var canvas = new ImmediateCanvas(renderTarget, density: 1f, maxWorkingScale: maxWorkingScale);
+
+        Assert.That(canvas.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
+    }
+
+    [Test]
+    public void ImmediateCanvas_FinitePositiveCeiling_PassesThrough()
+    {
+        using var renderTarget = RenderTarget.CreateNull(1, 1);
+        using var canvas = new ImmediateCanvas(renderTarget, density: 1f, maxWorkingScale: 3f);
+
+        Assert.That(canvas.MaxWorkingScale, Is.EqualTo(3f));
+    }
+
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void BrushConstructor_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
     {
         var ctor = new BrushConstructor(
@@ -141,9 +153,7 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(ctor.MaxWorkingScale, Is.EqualTo(3f));
     }
 
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void CustomFilterEffectContext_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
     {
         using var targets = new EffectTargets();
@@ -153,12 +163,9 @@ public class MaxWorkingScaleSanitizationTests
         Assert.That(context.MaxWorkingScale, Is.EqualTo(float.PositiveInfinity));
     }
 
-    // FilterEffectActivator is the only entry point with logic beyond pure forwarding: SanitizeCeiling logs a
-    // warning ONLY when the value actually changes. Pin both the substituted result and the no-substitution
-    // pass-through so the 'sanitized != value' guard can't be inverted undetected.
-    [TestCase(float.NaN)]
-    [TestCase(0f)]
-    [TestCase(-1f)]
+    // SanitizeCeiling also logs a warning on substitution, but only the stored value is pinned here;
+    // the warning emission is not observed.
+    [TestCaseSource(nameof(DegenerateCeilings))]
     public void FilterEffectActivator_DegenerateCeiling_StoredAsPositiveInfinity(float maxWorkingScale)
     {
         using var targets = new EffectTargets();


### PR DESCRIPTION
## Description

`RenderNodeContext.ResolveWorkingScale` (the static overload) did not guard its `maxWorkingScale` parameter, so `MathF.Min(supply, NaN)` returned `NaN` and `MathF.Min(supply, 0)` returned `0` — a degenerate ceiling silently propagated into the resolved working scale. Several public entry points (`Renderer`, `ImmediateCanvas`, `BrushConstructor`) likewise stored the raw constructor argument, while `RenderNodeContext`'s instance property, `RenderNodeProcessor`, and `FilterEffectActivator` each re-implemented the same "NaN / non-positive → +Inf" rule independently.

- Add a single canonical helper `RenderNodeContext.SanitizeMaxWorkingScale(float)` (NaN / non-positive → `+Inf`, else unchanged) and route every public entry point through it.
- `FilterEffectActivator` keeps its diagnostic warning log but now delegates the predicate (no more duplicated condition); `CustomFilterEffectContext` sanitizes too, for invariant consistency.

No in-tree caller ever passed a degenerate value (callers pass `+Inf`, `2 * s_out`, or an already-sanitized value), so this is behavior-preserving and changes no rendered output — it hardens the latent out-of-tree path and removes the divergence risk of four parallel copies of the rule.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. `SanitizeMaxWorkingScale` is a new additive `public static` member; all existing signatures are unchanged and behavior is preserved for valid inputs.

## Test plan
- New `tests/Beutl.UnitTests/Engine/Graphics/Rendering/MaxWorkingScaleSanitizationTests.cs` (14 cases): the helper itself (degenerate → `+Inf`, positive/`+Inf` pass-through), `ResolveWorkingScale` not propagating a degenerate ceiling, and `RenderNodeContext.MaxWorkingScale` storing `+Inf` for degenerate input.
- Baseline-first: the `ResolveWorkingScale` cases were confirmed **RED** against unmodified code (`NaN→NaN`, `0→0`, `-1→-1`) before the fix, then **GREEN** after.
- Re-ran the surrounding regression filters (`WorkingScaleClampConsistencyTests`, `CustomTargetClampConsistencyTests`, `ResolutionScaleTests`, `WorkingScaleCeilingTests`, `FilterEffectRenderNodeTest`): **85 passed, 0 failed**.
- `dotnet format --verify-no-changes` clean on all touched files.

## Follow-ups
- (design-review, low) `SanitizeMaxWorkingScale` is a domain-rule utility currently attached to the per-frame `RenderNodeContext`. If the engine later grows a dedicated home for the working-scale clamping primitives (`ClampWorkingScaleToBufferBudget`, output-scale sanitization, this helper), consider moving them into a single `WorkingScaleMath`-style static class in one pass.

## Fixed issues / References
- Project board: b-editor/projects/9 ("hardening(engine): sanitize degenerate maxWorkingScale on public surface")
- Found during ultracode review of commit e322d3587 (003 resolution-independent pipeline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in handling invalid maximum working scale values across rendering components; degenerate values such as NaN and non-positive numbers are now uniformly normalized to positive infinity.

* **Tests**
  * Added comprehensive unit tests covering maximum working scale sanitization behavior and its propagation through all rendering entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->