### PR TITLE
test: deflake Counter<T> ParallelTryAddRefRace race-window guard

### DIFF
--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -232,8 +232,9 @@ public class CounterTests
         // from a handful to hundreds of thousands across machines. Requiring a
         // proportional threshold here couples the test to the scheduler and is
         // flaky on warm-pool / low-core CI runners; one success across the
-        // 200 x 5_000 attempts is enough to prove the window is reachable.
+        // Trials x ConsumerIterations attempts is enough to prove the window
+        // is reachable.
         Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(0),
-            $"Race window collapsed: no TryAddRef hits across {Trials} trials");
+            $"Race window collapsed: no TryAddRef hits across {Trials} trials ({(long)Trials * ConsumerIterations} attempts)");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs
@@ -224,12 +224,16 @@ public class CounterTests
             totalTryAddRefSuccesses += tryAddRefSuccesses;
         }
 
-        // The releaser yields once after the barrier, so the consumer
-        // should generally enter its TryAddRef loop before the unbalanced
-        // Release lands. Require at least Trials/2 successful hits across
-        // 200 trials: large enough to fail if the race window collapses,
-        // small enough to stay reliable under noisy CI schedulers.
-        Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(Trials / 2),
-            $"Race window collapsed: only {totalTryAddRefSuccesses} TryAddRef hits across {Trials} trials");
+        // Sanity guard that the race actually exercised the TryAddRef path
+        // rather than the consumer always losing to the unbalanced Release
+        // (which would make the assertions above pass vacuously). How many
+        // hits land is a pure scheduling artifact — the consumer's head start
+        // depends on thread-pool injection timing and core count, so it swings
+        // from a handful to hundreds of thousands across machines. Requiring a
+        // proportional threshold here couples the test to the scheduler and is
+        // flaky on warm-pool / low-core CI runners; one success across the
+        // 200 x 5_000 attempts is enough to prove the window is reachable.
+        Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(0),
+            $"Race window collapsed: no TryAddRef hits across {Trials} trials");
     }
 }


### PR DESCRIPTION
## Description

`ParallelTryAddRefRace_NeverObservesDisposedValue` frequently fails on CI. The root cause is the final assertion, **not** a `Counter<T>` defect:

```
Assert.That(totalTryAddRefSuccesses, Is.GreaterThan(Trials / 2), ...) // > 100
```

- `totalTryAddRefSuccesses` counts how many times the consumer's `TryAddRef` won the race against the releaser's unbalanced `Release`. That is a **pure scheduling artifact** — the consumer's head start depends on thread-pool injection timing and core count.
- On fast multi-core dev machines the consumer wins by a huge margin (measured 260k–690k hits), so the threshold passes trivially. On warm-pool / low-core CI runners the releaser frequently lands its `Release` before the consumer's first `TryAddRef`, dropping the total below 100 and failing the test even though `Counter<T>` behaved correctly.
- The test's real guarantees — `observedDisposed == 0` and `fake.DisposeCount == 1` — are deterministic under the lock-based `Counter<T>` (since #1823 replaced `volatile+CAS` with `System.Threading.Lock`) and are **unchanged**.

Fix: weaken the race-window guard from `> Trials/2` to `> 0`. One success across the 200 × 5,000 attempts still proves the window is reachable (guarding against a fully collapsed `TryAddRef`), without coupling the assertion to the scheduler. The "always returns false" regression is additionally covered by `TryAddRef_WhileAlive_ReturnsTrueAndIncrementsRefCount`.

## Affected areas
- [x] Build / CI / docs only (test-only change under `tests/Beutl.UnitTests/`)

## Breaking changes
None.

## Test plan
- Modified `tests/Beutl.UnitTests/Engine/Media/Source/CounterTests.cs` (`ParallelTryAddRefRace_NeverObservesDisposedValue`).
- Ran the test repeatedly under 16-way CPU oversubscription locally; passes. The flaky assertion's failure mode is CI-scheduler-specific and could not be reproduced on the 8-core dev Mac, but the analysis above isolates it to the timing-coupled guard.

## Fixed issues / References
- None.

https://claude.ai/code/session_01B9eXsdC7NDhrYeDQo4U9wS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reduced flakiness in a concurrency-focused reference counting test by relaxing scheduler-sensitive success-count expectations and adding a basic sanity check to ensure at least one `TryAddRef` success occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->