### PR TITLE
fix(player): stop transform-handle overlay from blocking the UI during playback

### DIFF
--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -46,7 +46,8 @@ public partial class PlayerView : UserControl
     private IDisposable? _boundsSubscription;
     internal Control image = null!;
 
-    // _transformHandleResource is RenderThread-owned: only mutate inside RenderThread.Dispatcher.
+    // The Resource is RenderThread-owned: create/update/dispose only via RenderThread.Dispatcher.
+    // The UI thread may null these references to detach, but never touches the resource itself.
     private BtlDrawable.Resource? _transformHandleResource;
     private BtlDrawable? _transformHandleResourceTarget;
 
@@ -472,7 +473,7 @@ public partial class PlayerView : UserControl
             {
                 resource.Dispose();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
             {
                 _logger.LogError(ex, "Failed to dispose the transform-handle resource on the render thread.");
             }

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -330,6 +330,8 @@ public partial class PlayerView : UserControl
     private void UpdateTransformHandles()
     {
         if (DataContext is not PlayerViewModel vm) return;
+        // The overlay is hidden during playback; skip the blocking RenderThread query.
+        if (vm.IsPlaying.Value) return;
         if (!vm.IsMoveMode.Value)
         {
             ClearTransformHandleOverlay();
@@ -457,16 +459,23 @@ public partial class PlayerView : UserControl
 
     private void InvalidateTransformHandleResource()
     {
-        if (_transformHandleResource == null) return;
+        BtlDrawable.Resource? resource = _transformHandleResource;
+        if (resource == null) return;
 
-        // _transformHandleResource is created inside RenderThread.Dispatcher.Invoke, so the matching
-        // Dispose must run there too — UI-thread paths (OnDataContextChanged, OnDetachedFromVisualTree,
-        // ClearTransformHandleOverlay) would otherwise race in-flight RenderThread updates.
-        RenderThread.Dispatcher.Invoke(() =>
+        // Detach on the UI thread, then dispose on the RenderThread fire-and-forget. A blocking Invoke
+        // here would stall the UI thread during playback (the render thread is busy generating frames).
+        _transformHandleResource = null;
+        _transformHandleResourceTarget = null;
+        RenderThread.Dispatcher.Dispatch(() =>
         {
-            _transformHandleResource?.Dispose();
-            _transformHandleResource = null;
-            _transformHandleResourceTarget = null;
+            try
+            {
+                resource.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispose the transform-handle resource on the render thread.");
+            }
         });
     }
 


### PR DESCRIPTION
## Description
- `UpdateTransformHandles` / `InvalidateTransformHandleResource` each ran a synchronous `RenderThread.Dispatcher.Invoke`. During playback the render thread is busy generating frames, so these blocking Invokes (`Task.Wait`) stalled the UI thread.
- `UpdateTransformHandles`: the bounds and selection reactive subscriptions can reach it mid-playback without a guard (unlike the visibility subscriber and `Player_PreviewInvalidated`, which already early-out). Add an `IsPlaying` early-out so every caller is covered — the overlay is hidden during playback anyway, and the visibility subscriber rebuilds it once playback stops.
- `InvalidateTransformHandleResource`: the visibility subscriber fires `ClearTransformHandleOverlay` -> `InvalidateTransformHandleResource` the moment playback starts (the reported stack trace). Detach the fields on the UI thread, then dispose the RenderThread-owned resource fire-and-forget via `Dispatch`. Both the disposal and any subsequent rebuild queue on the same dispatcher at the default priority, so dispose-before-rebuild ordering holds without the UI-thread wait.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None

## Test plan
- No automated test: `src/Beutl` is not referenced by any test project (per `.claude/rules/csharp.md`). Verified by reviewing all `UpdateTransformHandles` / `InvalidateTransformHandleResource` callers; built `src/Beutl` (`net10.0-windows`) with 0 errors.
- Manual: enter Move mode with an element selected, start playback -> UI no longer stalls; stop playback -> overlay rebuilds.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback performance by avoiding UI blocking caused by transform-handle updates during playback
  * Enhanced responsiveness and stability of transform controls while actively playing video
  * Optimized transform-handle overlay resource invalidation to reduce overhead and prevent slowdowns during long editing sessions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->