### PR TITLE
fix(player): dispose CancellationTokenSource in BufferedPlayer.WaitRender/WaitTimer

### DIFF
--- a/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
+++ b/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
@@ -10,7 +10,11 @@ internal static class CancellationTokenSourceHelper
         }
         catch (ObjectDisposedException)
         {
-            // Wait methods can dispose a published CTS while a racing wakeup still holds the stale reference.
+            // A waiter (WaitRender/WaitTimer) disposes its own per-wait CTS on return while the producer loop, the
+            // isPlaying subscription, or Dispose may still hold the stale published reference and cancel it.
+            // Swallowing the race is intentional: the canceller never owns the CTS, so there is nothing to claim via
+            // Interlocked, and locking the per-frame cancel against the blocking WaitOne would only trade one rare
+            // exception for hot-path contention.
         }
     }
 }

--- a/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
+++ b/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
@@ -2,7 +2,8 @@
 
 internal static class CancellationTokenSourceHelper
 {
-    internal static void CancelIgnoringDisposed(CancellationTokenSource? cts)
+    // Tolerates a racing thread disposing the CTS while this one still holds the stale published reference.
+    internal static void CancelIgnoringDisposed(this CancellationTokenSource? cts)
     {
         try
         {
@@ -10,11 +11,6 @@ internal static class CancellationTokenSourceHelper
         }
         catch (ObjectDisposedException)
         {
-            // A waiter (WaitRender/WaitTimer) disposes its own per-wait CTS on return while the producer loop, the
-            // isPlaying subscription, or Dispose may still hold the stale published reference and cancel it.
-            // Swallowing the race is intentional: the canceller never owns the CTS, so there is nothing to claim via
-            // Interlocked, and locking the per-frame cancel against the blocking WaitOne would only trade one rare
-            // exception for hot-path contention.
         }
     }
 }

--- a/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
+++ b/src/Beutl/Helpers/CancellationTokenSourceHelper.cs
@@ -1,0 +1,16 @@
+﻿namespace Beutl.Helpers;
+
+internal static class CancellationTokenSourceHelper
+{
+    internal static void CancelIgnoringDisposed(CancellationTokenSource? cts)
+    {
+        try
+        {
+            cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Wait methods can dispose a published CTS while a racing wakeup still holds the stale reference.
+        }
+    }
+}

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using Beutl.Graphics.Rendering;
+using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Source;
@@ -48,8 +49,8 @@ public sealed class BufferedPlayer : IPlayer
 
         _disposable = isPlaying.Where(v => !v).Subscribe(_ =>
         {
-            _waitRenderToken?.Cancel();
-            _waitTimerToken?.Cancel();
+            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
+            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
         });
     }
 
@@ -114,7 +115,7 @@ public sealed class BufferedPlayer : IPlayer
                         }
                     }
 
-                    _waitRenderToken?.Cancel();
+                    CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
                     if (_isPlaying.Value)
                         _editViewModel.BufferStatus.EndTime.Value = time;
 
@@ -154,15 +155,15 @@ public sealed class BufferedPlayer : IPlayer
                 // instead of blocking forever on a wakeup that will never come (the lost-wakeup hang).
                 _producerStopped = true;
                 Interlocked.MemoryBarrier();
-                _waitRenderToken?.Cancel();
-                _waitTimerToken?.Cancel();
+                CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
+                CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
             }
         }, Threading.DispatchPriority.High);
     }
 
     public bool TryDequeue(out IPlayer.Frame frame)
     {
-        _waitTimerToken?.Cancel();
+        CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
         if (_queue.TryDequeue(out IPlayer.Frame f))
         {
             frame = f;
@@ -217,8 +218,8 @@ public sealed class BufferedPlayer : IPlayer
             _logger.LogInformation("Disposing BufferedPlayer.");
 
             _isDisposed = true;
-            _waitRenderToken?.Cancel();
-            _waitTimerToken?.Cancel();
+            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
+            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
             _disposable.Dispose();
             while (_queue.TryDequeue(out var f))
             {

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -49,8 +49,8 @@ public sealed class BufferedPlayer : IPlayer
 
         _disposable = isPlaying.Where(v => !v).Subscribe(_ =>
         {
-            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
-            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
+            _waitRenderToken.CancelIgnoringDisposed();
+            _waitTimerToken.CancelIgnoringDisposed();
         });
     }
 
@@ -115,7 +115,7 @@ public sealed class BufferedPlayer : IPlayer
                         }
                     }
 
-                    CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
+                    _waitRenderToken.CancelIgnoringDisposed();
                     if (_isPlaying.Value)
                         _editViewModel.BufferStatus.EndTime.Value = time;
 
@@ -155,15 +155,15 @@ public sealed class BufferedPlayer : IPlayer
                 // instead of blocking forever on a wakeup that will never come (the lost-wakeup hang).
                 _producerStopped = true;
                 Interlocked.MemoryBarrier();
-                CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
-                CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
+                _waitRenderToken.CancelIgnoringDisposed();
+                _waitTimerToken.CancelIgnoringDisposed();
             }
         }, Threading.DispatchPriority.High);
     }
 
     public bool TryDequeue(out IPlayer.Frame frame)
     {
-        CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
+        _waitTimerToken.CancelIgnoringDisposed();
         if (_queue.TryDequeue(out IPlayer.Frame f))
         {
             frame = f;
@@ -196,9 +196,8 @@ public sealed class BufferedPlayer : IPlayer
         _waitRenderToken = null;
     }
 
-    // Only ever called from the producer loop in Start(), so it is the sole waiter on _waitTimerToken. That
-    // confinement is what lets it skip WaitRender's post-publish re-check and dispose the CTS on return: every other
-    // thread only cancels this token, never waits on it, so the disposed-token cancel race is the helper's to absorb.
+    // Sole waiter on _waitTimerToken (called only from the producer loop), so unlike WaitRender it needs no
+    // post-publish re-check.
     private void WaitTimer()
     {
         if (_isDisposed) return;
@@ -221,8 +220,8 @@ public sealed class BufferedPlayer : IPlayer
             _logger.LogInformation("Disposing BufferedPlayer.");
 
             _isDisposed = true;
-            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitRenderToken);
-            CancellationTokenSourceHelper.CancelIgnoringDisposed(_waitTimerToken);
+            _waitRenderToken.CancelIgnoringDisposed();
+            _waitTimerToken.CancelIgnoringDisposed();
             _disposable.Dispose();
             while (_queue.TryDequeue(out var f))
             {

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -196,6 +196,9 @@ public sealed class BufferedPlayer : IPlayer
         _waitRenderToken = null;
     }
 
+    // Only ever called from the producer loop in Start(), so it is the sole waiter on _waitTimerToken. That
+    // confinement is what lets it skip WaitRender's post-publish re-check and dispose the CTS on return: every other
+    // thread only cancels this token, never waits on it, so the disposed-token cancel race is the helper's to absorb.
     private void WaitTimer()
     {
         if (_isDisposed) return;

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -177,7 +177,8 @@ public sealed class BufferedPlayer : IPlayer
     private void WaitRender()
     {
         if (_isDisposed || _producerStopped) return;
-        _waitRenderToken = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
+        _waitRenderToken = cts;
 
         // Re-check after publishing the token. The producer's finally sets _producerStopped then cancels the
         // current token; the full fence here pairs with the fence there so either the producer sees the token we
@@ -197,7 +198,8 @@ public sealed class BufferedPlayer : IPlayer
     private void WaitTimer()
     {
         if (_isDisposed) return;
-        _waitTimerToken = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
+        _waitTimerToken = cts;
 
         _waitTimerToken.Token.WaitHandle.WaitOne();
         _waitTimerToken = null;

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -34,10 +34,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Linked, not project-referenced: the test project must not depend on the Beutl app exe, so this
-         pure helper (feature 003 export-supersampling pre-validation) is compiled directly into the test
-         assembly (same pattern as Beutl.FFmpegBenchmarks). It only needs Beutl.Engine + Beutl.Media. -->
+    <!-- Linked, not project-referenced: the test project must not depend on the Beutl app exe, so these
+         pure helpers are compiled directly into the test assembly (same pattern as Beutl.FFmpegBenchmarks). -->
     <Compile Include="..\..\src\Beutl\Helpers\ExportSupersampling.cs" Link="Editor\Linked\ExportSupersampling.cs" />
+    <Compile Include="..\..\src\Beutl\Helpers\CancellationTokenSourceHelper.cs" Link="Helpers\Linked\CancellationTokenSourceHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
+++ b/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
@@ -10,7 +10,7 @@ public class CancellationTokenSourceHelperTests
     {
         using var cts = new CancellationTokenSource();
 
-        CancellationTokenSourceHelper.CancelIgnoringDisposed(cts);
+        cts.CancelIgnoringDisposed();
 
         Assert.That(cts.IsCancellationRequested, Is.True);
     }
@@ -21,15 +21,13 @@ public class CancellationTokenSourceHelperTests
         using var cts = new CancellationTokenSource();
         cts.Dispose();
 
-        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(cts));
+        Assert.DoesNotThrow(() => cts.CancelIgnoringDisposed());
     }
 
     [Test]
     public void CancelIgnoringDisposed_NullTokenSource_IsNoOp()
     {
-        // The BufferedPlayer call sites pass a volatile field that is frequently null (e.g. _waitTimerToken before
-        // any WaitTimer, or after a wait resets it); pin that null is a safe no-op so a later non-conditional Cancel
-        // cannot silently regress.
+        // Call sites pass a volatile field that is frequently null.
         Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(null));
     }
 
@@ -37,9 +35,9 @@ public class CancellationTokenSourceHelperTests
     public void CancelIgnoringDisposed_AlreadyCancelledTokenSource_StaysCancelled()
     {
         using var cts = new CancellationTokenSource();
-        CancellationTokenSourceHelper.CancelIgnoringDisposed(cts);
+        cts.CancelIgnoringDisposed();
 
-        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(cts));
+        Assert.DoesNotThrow(() => cts.CancelIgnoringDisposed());
         Assert.That(cts.IsCancellationRequested, Is.True);
     }
 }

--- a/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
+++ b/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
@@ -2,6 +2,7 @@
 
 namespace Beutl.UnitTests.Helpers;
 
+[TestFixture]
 public class CancellationTokenSourceHelperTests
 {
     [Test]
@@ -21,5 +22,24 @@ public class CancellationTokenSourceHelperTests
         cts.Dispose();
 
         Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(cts));
+    }
+
+    [Test]
+    public void CancelIgnoringDisposed_NullTokenSource_IsNoOp()
+    {
+        // The BufferedPlayer call sites pass a volatile field that is frequently null (e.g. _waitTimerToken before
+        // any WaitTimer, or after a wait resets it); pin that null is a safe no-op so a later non-conditional Cancel
+        // cannot silently regress.
+        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(null));
+    }
+
+    [Test]
+    public void CancelIgnoringDisposed_AlreadyCancelledTokenSource_StaysCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        CancellationTokenSourceHelper.CancelIgnoringDisposed(cts);
+
+        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(cts));
+        Assert.That(cts.IsCancellationRequested, Is.True);
     }
 }

--- a/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
+++ b/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
@@ -21,14 +21,14 @@ public class CancellationTokenSourceHelperTests
         using var cts = new CancellationTokenSource();
         cts.Dispose();
 
-        Assert.DoesNotThrow(() => cts.CancelIgnoringDisposed());
+        Assert.That(() => cts.CancelIgnoringDisposed(), Throws.Nothing);
     }
 
     [Test]
     public void CancelIgnoringDisposed_NullTokenSource_IsNoOp()
     {
         // Call sites pass a volatile field that is frequently null.
-        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(null));
+        Assert.That(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(null), Throws.Nothing);
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class CancellationTokenSourceHelperTests
         using var cts = new CancellationTokenSource();
         cts.CancelIgnoringDisposed();
 
-        Assert.DoesNotThrow(() => cts.CancelIgnoringDisposed());
+        Assert.That(() => cts.CancelIgnoringDisposed(), Throws.Nothing);
         Assert.That(cts.IsCancellationRequested, Is.True);
     }
 }

--- a/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
+++ b/tests/Beutl.UnitTests/Helpers/CancellationTokenSourceHelperTests.cs
@@ -1,0 +1,25 @@
+﻿using Beutl.Helpers;
+
+namespace Beutl.UnitTests.Helpers;
+
+public class CancellationTokenSourceHelperTests
+{
+    [Test]
+    public void CancelIgnoringDisposed_CancelsActiveTokenSource()
+    {
+        using var cts = new CancellationTokenSource();
+
+        CancellationTokenSourceHelper.CancelIgnoringDisposed(cts);
+
+        Assert.That(cts.IsCancellationRequested, Is.True);
+    }
+
+    [Test]
+    public void CancelIgnoringDisposed_IgnoresDisposedTokenSource()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Dispose();
+
+        Assert.DoesNotThrow(() => CancellationTokenSourceHelper.CancelIgnoringDisposed(cts));
+    }
+}


### PR DESCRIPTION
## Description
- Fixed OS handle leak in `BufferedPlayer.WaitRender()` and `WaitTimer()`
- Both methods allocated a `CancellationTokenSource` per call without disposing it
- Wrapped with `using var cts` to ensure deterministic disposal on all exit paths
- Behavior is preserved; only disposal is added

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None

## Test plan
- Manual verification: The change is minimal and behavior-preserving
- The `using` declaration ensures deterministic disposal at method exit (including early returns)
- Existing tests should pass (no behavior change)

## Fixed issues / References
- Project board: b-editor/projects/9 ("fix(player): dispose CancellationTokenSource in BufferedPlayer.WaitRender/WaitTimer")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cancellation and cleanup during playback control and timing/render waits by safely cancelling token sources even when they may already be disposed, reducing race-related exceptions.

* **Tests**
  * Added unit tests for safe cancellation behavior, including handling of null token sources, already-cancelled instances, and disposed token sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->