### PR TITLE
refactor!: remove RenderNodeCache LastAccessedTime

### DIFF
--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -75,8 +75,7 @@ plugin-facing: batch them into one `refactor!:` release train with a
   cross-type conversion matrices (no production consumer, contains copy-paste
   bugs), `IKeyFrame.SetParent/GetParent`, `TransformParser.Parse`,
   `GraphicsException`, `FpsText`/`IRenderer.DrawFps`, 8 of 15 `AudioMath` helpers,
-  csproj-excluded `VertexMode.cs`, `RenderNodeCache` test-only members and
-  never-read `LastAccessedTime`.
+  csproj-excluded `VertexMode.cs`, and `RenderNodeCache` test-only members.
 
 **Core / Controls / App / Api**
 - `UnmanagedArray`/`UnmanagedList` (759 lines, already excluded from compilation),

--- a/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCache.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Cache/RenderNodeCache.cs
@@ -30,8 +30,6 @@ public sealed class RenderNodeCache(RenderNode node) : IDisposable
     /// </summary>
     public float Density { get; private set; } = 1f;
 
-    public DateTime LastAccessedTime { get; private set; }
-
     public bool IsDisposed { get; private set; }
 
     public void ReportRenderCount(int count)
@@ -116,8 +114,6 @@ public sealed class RenderNodeCache(RenderNode node) : IDisposable
 
         _cache.Add((renderTarget.ShallowCopy(), bounds));
         Density = density;
-
-        LastAccessedTime = DateTime.UtcNow;
     }
 
     public IEnumerable<(RenderTarget RenderTarget, Rect Bounds)> UseCache()
@@ -135,6 +131,5 @@ public sealed class RenderNodeCache(RenderNode node) : IDisposable
         }
 
         Density = density;
-        LastAccessedTime = DateTime.UtcNow;
     }
 }


### PR DESCRIPTION
## Summary

- Remove the unused `RenderNodeCache.LastAccessedTime` property.
- Stop writing access timestamps when storing render-node cache entries.
- Update the refactoring plan so the removed member is no longer listed as pending dead surface.

## Tests

- `dotnet build src/Beutl.Engine/Beutl.Engine.csproj`
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter RenderNodeCache`

## Breaking Change

- `RenderNodeCache` no longer exposes `LastAccessedTime`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary last-accessed-time tracking from the rendering cache, simplifying cache management.

* **Documentation**
  * Updated refactoring documentation to reflect cleanup of unused cache tracking features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->