### PR TITLE
fix(audio): dispose output buffer on failure across all audio nodes

### DIFF
--- a/src/Beutl.Engine/Audio/Composing/Composer.cs
+++ b/src/Beutl.Engine/Audio/Composing/Composer.cs
@@ -95,37 +95,48 @@ public class Composer : IComposer
     {
         // Multiple contexts - need to mix
         var buffers = new List<AudioBuffer>();
-
-        // Process each context
-        foreach (var item in _currentEntry)
+        AudioBuffer? mixedBuffer = null;
+        try
         {
-            if (item.OutputNodes is not { } outputNodes) continue;
-            var processContext = new AudioProcessContext(range, SampleRate, _animationSampler, range);
-            foreach (var outputNode in outputNodes)
+            // Process each context
+            foreach (var item in _currentEntry)
             {
-                buffers.Add(outputNode.Process(processContext));
+                if (item.OutputNodes is not { } outputNodes) continue;
+                var processContext = new AudioProcessContext(range, SampleRate, _animationSampler, range);
+                foreach (var outputNode in outputNodes)
+                {
+                    buffers.Add(outputNode.Process(processContext));
+                }
+            }
+
+            // Mix all buffers
+            mixedBuffer = MixBuffers(buffers);
+
+            if (mixedBuffer == null)
+            {
+                return new AudioBuffer(SampleRate, 2, AudioProcessContext.GetSampleCount(range, SampleRate));
+            }
+
+            // Apply master effects
+            ApplyMasterEffects(mixedBuffer);
+
+            // Convert to output format
+            return mixedBuffer;
+        }
+        catch
+        {
+            // Don't leak the mix buffer if a step after the mix throws.
+            mixedBuffer?.Dispose();
+            throw;
+        }
+        finally
+        {
+            // Dispose every consumed per-node buffer, even on a throw partway through.
+            foreach (var buffer in buffers)
+            {
+                buffer.Dispose();
             }
         }
-
-        // Mix all buffers
-        var mixedBuffer = MixBuffers(buffers);
-
-        // Dispose individual buffers
-        foreach (var buffer in buffers)
-        {
-            buffer.Dispose();
-        }
-
-        if (mixedBuffer == null)
-        {
-            return new AudioBuffer(SampleRate, 2, AudioProcessContext.GetSampleCount(range, SampleRate));
-        }
-
-        // Apply master effects
-        ApplyMasterEffects(mixedBuffer);
-
-        // Convert to output format
-        return mixedBuffer;
     }
 
     private AudioBuffer? MixBuffers(List<AudioBuffer> buffers)
@@ -136,27 +147,36 @@ public class Composer : IComposer
         var firstBuffer = buffers[0];
         var mixedBuffer = new AudioBuffer(firstBuffer.SampleRate, firstBuffer.ChannelCount, firstBuffer.SampleCount);
 
-        // Mix all buffers
-        for (int ch = 0; ch < mixedBuffer.ChannelCount; ch++)
+        // Dispose the mix buffer rather than leak it if a (possibly disposed) source read throws.
+        try
         {
-            var mixedChannel = mixedBuffer.GetChannelData(ch);
-
-            foreach (var buffer in buffers)
+            // Mix all buffers
+            for (int ch = 0; ch < mixedBuffer.ChannelCount; ch++)
             {
-                if (buffer.ChannelCount > ch)
-                {
-                    var sourceChannel = buffer.GetChannelData(ch);
-                    var sampleCount = Math.Min(mixedBuffer.SampleCount, buffer.SampleCount);
+                var mixedChannel = mixedBuffer.GetChannelData(ch);
 
-                    for (int i = 0; i < sampleCount; i++)
+                foreach (var buffer in buffers)
+                {
+                    if (buffer.ChannelCount > ch)
                     {
-                        mixedChannel[i] += sourceChannel[i];
+                        var sourceChannel = buffer.GetChannelData(ch);
+                        var sampleCount = Math.Min(mixedBuffer.SampleCount, buffer.SampleCount);
+
+                        for (int i = 0; i < sampleCount; i++)
+                        {
+                            mixedChannel[i] += sourceChannel[i];
+                        }
                     }
                 }
             }
-        }
 
-        return mixedBuffer;
+            return mixedBuffer;
+        }
+        catch
+        {
+            mixedBuffer.Dispose();
+            throw;
+        }
     }
 
     private static void ApplyMasterEffects(AudioBuffer buffer)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
@@ -39,16 +39,25 @@ public class ClipNode : AudioNode
             context.SampleRate,
             buffer.ChannelCount,
             context.GetSampleCount());
-        // padBefore のサンプル換算は (int)切り捨て、入力 buffer.SampleCount は Math.Ceiling 由来で
-        // 浮動小数点誤差によりそれぞれ独立に ±1 ズレうる。
-        // newBuffer のサイズを超えないようクランプしてコピーする (超過分は範囲外の padding 想定で破棄)。
-        int offset = (int)(padBefore.TotalSeconds * context.SampleRate);
-        if (offset < 0) offset = 0;
-        int copyCount = Math.Min(buffer.SampleCount, newBuffer.SampleCount - offset);
-        if (copyCount > 0)
+        try
         {
-            buffer.CopyTo(newBuffer, offset, copyCount);
+            // padBefore (truncated) and buffer.SampleCount (from Math.Ceiling) can each drift by ±1,
+            // so clamp the copy to newBuffer's capacity; the overflow is out-of-range padding.
+            int offset = (int)(padBefore.TotalSeconds * context.SampleRate);
+            if (offset < 0) offset = 0;
+            int copyCount = Math.Min(buffer.SampleCount, newBuffer.SampleCount - offset);
+            if (copyCount > 0)
+            {
+                buffer.CopyTo(newBuffer, offset, copyCount);
+            }
+
+            return newBuffer;
         }
-        return newBuffer;
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            newBuffer.Dispose();
+            throw;
+        }
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -106,169 +106,57 @@ public sealed class CompressorNode : AudioNode
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        EffectiveParameters p = ReadStaticParameters();
-
-        float attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
-        float releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
-        float slope = 1f - 1f / p.Ratio;
-
-        int channels = input.ChannelCount;
-        int sampleCount = input.SampleCount;
-        var (inputChannels, outputChannels) = MapChannels(input, output);
-
-        // Materialize the channel spans ONCE for the mono/stereo fast path to avoid the per-sample
-        // Memory.Span getter the >2-channel fallback still pays. Span<float>[] is impossible (ref
-        // struct), hence the explicit locals.
-        if (channels <= 2)
+        try
         {
-            Span<float> in0 = inputChannels[0].Span;
-            Span<float> out0 = outputChannels[0].Span;
-            Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
-            Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+            EffectiveParameters p = ReadStaticParameters();
 
-            for (int i = 0; i < sampleCount; i++)
+            float attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+            float releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+            float slope = 1f - 1f / p.Ratio;
+
+            int channels = input.ChannelCount;
+            int sampleCount = input.SampleCount;
+            var (inputChannels, outputChannels) = MapChannels(input, output);
+
+            // Materialize the channel spans ONCE for the mono/stereo fast path to avoid the per-sample
+            // Memory.Span getter the >2-channel fallback still pays. Span<float>[] is impossible (ref
+            // struct), hence the explicit locals.
+            if (channels <= 2)
             {
-                float s0 = in0[i];
-                float peak = MathF.Abs(s0);
-                float s1 = 0f;
-                if (channels == 2)
+                Span<float> in0 = inputChannels[0].Span;
+                Span<float> out0 = outputChannels[0].Span;
+                Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+                Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
+                for (int i = 0; i < sampleCount; i++)
                 {
-                    s1 = in1[i];
-                    float a1 = MathF.Abs(s1);
-                    if (a1 > peak) peak = a1;
-                }
-
-                float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
-
-                out0[i] = SanitizeOutput(s0 * gainLinear);
-                if (channels == 2)
-                {
-                    out1[i] = SanitizeOutput(s1 * gainLinear);
-                }
-            }
-        }
-        else
-        {
-            for (int i = 0; i < sampleCount; i++)
-            {
-                float peak = 0f;
-                for (int ch = 0; ch < channels; ch++)
-                {
-                    float a = MathF.Abs(inputChannels[ch].Span[i]);
-                    if (a > peak) peak = a;
-                }
-
-                float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
-
-                for (int ch = 0; ch < channels; ch++)
-                {
-                    float sample = inputChannels[ch].Span[i] * gainLinear;
-                    outputChannels[ch].Span[i] = SanitizeOutput(sample);
-                }
-            }
-        }
-
-        return output;
-    }
-
-    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
-    {
-        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        const int maxChunkSize = 1024;
-        int bufferSize = Math.Min(maxChunkSize, input.SampleCount);
-        Span<float> thresholds = stackalloc float[bufferSize];
-        Span<float> ratios = stackalloc float[bufferSize];
-        Span<float> attacks = stackalloc float[bufferSize];
-        Span<float> releases = stackalloc float[bufferSize];
-        Span<float> knees = stackalloc float[bufferSize];
-        Span<float> makeups = stackalloc float[bufferSize];
-
-        // Fallbacks for when an animated parameter samples to NaN/Infinity (e.g. malformed
-        // KeyFrame); otherwise one non-finite value would zero out every output sample.
-        EffectiveParameters fallback = ReadStaticParameters();
-
-        int channels = input.ChannelCount;
-        int sampleCount = input.SampleCount;
-        var (inputChannels, outputChannels) = MapChannels(input, output);
-
-        // Materialize the channel spans once (matching ProcessStatic) for the mono/stereo fast path;
-        // the >2-channel path keeps Memory indexing where the getter cost is negligible.
-        Span<float> in0 = channels <= 2 ? inputChannels[0].Span : default;
-        Span<float> out0 = channels <= 2 ? outputChannels[0].Span : default;
-        Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
-        Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
-
-        int processed = 0;
-
-        // Seed with NaN so the first comparison is always unequal and coefficients compute on
-        // sample 0; afterwards Exp runs only when the animated ms value changes.
-        float lastAttackMs = float.NaN;
-        float lastReleaseMs = float.NaN;
-        float attackCoeff = 0f;
-        float releaseCoeff = 0f;
-
-        while (processed < sampleCount)
-        {
-            int chunkSize = Math.Min(bufferSize, sampleCount - processed);
-
-            var chunkStart = context.GetTimeForSample(processed);
-            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
-
-            context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Ratio, chunkRange, context.SampleRate, ratios[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Attack, chunkRange, context.SampleRate, attacks[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Knee, chunkRange, context.SampleRate, knees[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
-
-            for (int i = 0; i < chunkSize; i++)
-            {
-                int idx = processed + i;
-
-                EffectiveParameters p = SanitizeAnimated(
-                    thresholds[i], ratios[i], attacks[i], releases[i], knees[i], makeups[i], fallback);
-
-                if (p.Attack != lastAttackMs)
-                {
-                    attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
-                    lastAttackMs = p.Attack;
-                }
-                if (p.Release != lastReleaseMs)
-                {
-                    releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
-                    lastReleaseMs = p.Release;
-                }
-                float slope = 1f - 1f / p.Ratio;
-
-                if (channels <= 2)
-                {
-                    float s0 = in0[idx];
+                    float s0 = in0[i];
                     float peak = MathF.Abs(s0);
                     float s1 = 0f;
                     if (channels == 2)
                     {
-                        s1 = in1[idx];
+                        s1 = in1[i];
                         float a1 = MathF.Abs(s1);
                         if (a1 > peak) peak = a1;
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
 
-                    out0[idx] = SanitizeOutput(s0 * gainLinear);
+                    out0[i] = SanitizeOutput(s0 * gainLinear);
                     if (channels == 2)
                     {
-                        out1[idx] = SanitizeOutput(s1 * gainLinear);
+                        out1[i] = SanitizeOutput(s1 * gainLinear);
                     }
                 }
-                else
+            }
+            else
+            {
+                for (int i = 0; i < sampleCount; i++)
                 {
                     float peak = 0f;
                     for (int ch = 0; ch < channels; ch++)
                     {
-                        float a = MathF.Abs(inputChannels[ch].Span[idx]);
+                        float a = MathF.Abs(inputChannels[ch].Span[i]);
                         if (a > peak) peak = a;
                     }
 
@@ -276,16 +164,144 @@ public sealed class CompressorNode : AudioNode
 
                     for (int ch = 0; ch < channels; ch++)
                     {
-                        float sample = inputChannels[ch].Span[idx] * gainLinear;
-                        outputChannels[ch].Span[idx] = SanitizeOutput(sample);
+                        float sample = inputChannels[ch].Span[i] * gainLinear;
+                        outputChannels[ch].Span[i] = SanitizeOutput(sample);
                     }
                 }
             }
 
-            processed += chunkSize;
+            return output;
         }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
+    }
 
-        return output;
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        try
+        {
+            const int maxChunkSize = 1024;
+            int bufferSize = Math.Min(maxChunkSize, input.SampleCount);
+            Span<float> thresholds = stackalloc float[bufferSize];
+            Span<float> ratios = stackalloc float[bufferSize];
+            Span<float> attacks = stackalloc float[bufferSize];
+            Span<float> releases = stackalloc float[bufferSize];
+            Span<float> knees = stackalloc float[bufferSize];
+            Span<float> makeups = stackalloc float[bufferSize];
+
+            // Fallbacks for when an animated parameter samples to NaN/Infinity (e.g. malformed
+            // KeyFrame); otherwise one non-finite value would zero out every output sample.
+            EffectiveParameters fallback = ReadStaticParameters();
+
+            int channels = input.ChannelCount;
+            int sampleCount = input.SampleCount;
+            var (inputChannels, outputChannels) = MapChannels(input, output);
+
+            // Materialize the channel spans once (matching ProcessStatic) for the mono/stereo fast path;
+            // the >2-channel path keeps Memory indexing where the getter cost is negligible.
+            Span<float> in0 = channels <= 2 ? inputChannels[0].Span : default;
+            Span<float> out0 = channels <= 2 ? outputChannels[0].Span : default;
+            Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+            Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
+            int processed = 0;
+
+            // Seed with NaN so the first comparison is always unequal and coefficients compute on
+            // sample 0; afterwards Exp runs only when the animated ms value changes.
+            float lastAttackMs = float.NaN;
+            float lastReleaseMs = float.NaN;
+            float attackCoeff = 0f;
+            float releaseCoeff = 0f;
+
+            while (processed < sampleCount)
+            {
+                int chunkSize = Math.Min(bufferSize, sampleCount - processed);
+
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+                context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Ratio, chunkRange, context.SampleRate, ratios[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Attack, chunkRange, context.SampleRate, attacks[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Knee, chunkRange, context.SampleRate, knees[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
+
+                for (int i = 0; i < chunkSize; i++)
+                {
+                    int idx = processed + i;
+
+                    EffectiveParameters p = SanitizeAnimated(
+                        thresholds[i], ratios[i], attacks[i], releases[i], knees[i], makeups[i], fallback);
+
+                    if (p.Attack != lastAttackMs)
+                    {
+                        attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+                        lastAttackMs = p.Attack;
+                    }
+                    if (p.Release != lastReleaseMs)
+                    {
+                        releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+                        lastReleaseMs = p.Release;
+                    }
+                    float slope = 1f - 1f / p.Ratio;
+
+                    if (channels <= 2)
+                    {
+                        float s0 = in0[idx];
+                        float peak = MathF.Abs(s0);
+                        float s1 = 0f;
+                        if (channels == 2)
+                        {
+                            s1 = in1[idx];
+                            float a1 = MathF.Abs(s1);
+                            if (a1 > peak) peak = a1;
+                        }
+
+                        float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                        out0[idx] = SanitizeOutput(s0 * gainLinear);
+                        if (channels == 2)
+                        {
+                            out1[idx] = SanitizeOutput(s1 * gainLinear);
+                        }
+                    }
+                    else
+                    {
+                        float peak = 0f;
+                        for (int ch = 0; ch < channels; ch++)
+                        {
+                            float a = MathF.Abs(inputChannels[ch].Span[idx]);
+                            if (a > peak) peak = a;
+                        }
+
+                        float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
+
+                        for (int ch = 0; ch < channels; ch++)
+                        {
+                            float sample = inputChannels[ch].Span[idx] * gainLinear;
+                            outputChannels[ch].Span[idx] = SanitizeOutput(sample);
+                        }
+                    }
+                }
+
+                processed += chunkSize;
+            }
+
+            return output;
+        }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
     }
 
     // Caches per-channel Memory handles, reusing the backing arrays across calls (reallocated only

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -28,8 +28,11 @@ public sealed class DelayNode : AudioNode
         // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
         using var input = Inputs[0].Process(context);
 
-        // Initialize delay lines if needed or sample rate changed
-        if (_delayLines == null || _lastSampleRate != context.SampleRate)
+        // Reinitialize on a sample-rate or channel-count change; otherwise a channel-count increase
+        // would leave the extra channels unprocessed (silent).
+        if (_delayLines == null
+            || _lastSampleRate != context.SampleRate
+            || _delayLines.Length != input.ChannelCount)
         {
             InitializeDelayLines(context.SampleRate, input.ChannelCount);
             _lastSampleRate = context.SampleRate;
@@ -88,73 +91,18 @@ public sealed class DelayNode : AudioNode
         delaySamples = System.Math.Clamp(delaySamples, 0, _maxDelaySamples - 1);
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        for (int ch = 0; ch < System.Math.Min(input.ChannelCount, _delayLines!.Length); ch++)
+        try
         {
-            var inData = input.GetChannelData(ch);
-            var outData = output.GetChannelData(ch);
-            var delayLine = _delayLines[ch];
-
-            for (int i = 0; i < input.SampleCount; i++)
+            for (int ch = 0; ch < System.Math.Min(input.ChannelCount, _delayLines!.Length); ch++)
             {
-                float inputSample = inData[i];
-                float delayedSample = delayLine.Read(delaySamples);
-
-                // Write to delay line with feedback
-                delayLine.Write(inputSample + delayedSample * feedback);
-
-                // Mix dry and wet signals
-                outData[i] = inputSample * dryMix + delayedSample * wetMix;
-            }
-        }
-
-        return output;
-    }
-
-    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
-    {
-        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        // Sample animation values for each sample
-        Span<float> delayTimes = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> feedbacks = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> dryMixes = stackalloc float[Math.Min(input.SampleCount, 1024)];
-        Span<float> wetMixes = stackalloc float[Math.Min(input.SampleCount, 1024)];
-
-        int processed = 0;
-        while (processed < input.SampleCount)
-        {
-            int chunkSize = Math.Min(delayTimes.Length, input.SampleCount - processed);
-
-            var chunkStart = context.GetTimeForSample(processed);
-            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
-
-            // Sample animation values for this chunk
-            context.AnimationSampler.SampleBuffer(DelayTime, chunkRange, context.SampleRate, delayTimes[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Feedback, chunkRange, context.SampleRate, feedbacks[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(DryMix, chunkRange, context.SampleRate, dryMixes[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(WetMix, chunkRange, context.SampleRate, wetMixes[..chunkSize]);
-
-            // Process each channel
-            for (int ch = 0; ch < Math.Min(input.ChannelCount, _delayLines!.Length); ch++)
-            {
-                var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
-                var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+                var inData = input.GetChannelData(ch);
+                var outData = output.GetChannelData(ch);
                 var delayLine = _delayLines[ch];
 
-                for (int i = 0; i < chunkSize; i++)
+                for (int i = 0; i < input.SampleCount; i++)
                 {
-                    // Convert delay time from ms to samples
-                    int delaySamples = (int)(delayTimes[i] / 1000f * context.SampleRate);
-                    delaySamples = Math.Clamp(delaySamples, 0, _maxDelaySamples - 1);
-
                     float inputSample = inData[i];
                     float delayedSample = delayLine.Read(delaySamples);
-
-                    float feedback = feedbacks[i] / 100f;
-                    float dryMix = dryMixes[i] / 100f;
-                    float wetMix = wetMixes[i] / 100f;
 
                     // Write to delay line with feedback
                     delayLine.Write(inputSample + delayedSample * feedback);
@@ -164,10 +112,81 @@ public sealed class DelayNode : AudioNode
                 }
             }
 
-            processed += chunkSize;
+            return output;
         }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
+    }
 
-        return output;
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        try
+        {
+            // Sample animation values for each sample
+            Span<float> delayTimes = stackalloc float[Math.Min(input.SampleCount, 1024)];
+            Span<float> feedbacks = stackalloc float[Math.Min(input.SampleCount, 1024)];
+            Span<float> dryMixes = stackalloc float[Math.Min(input.SampleCount, 1024)];
+            Span<float> wetMixes = stackalloc float[Math.Min(input.SampleCount, 1024)];
+
+            int processed = 0;
+            while (processed < input.SampleCount)
+            {
+                int chunkSize = Math.Min(delayTimes.Length, input.SampleCount - processed);
+
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+                // Sample animation values for this chunk
+                context.AnimationSampler.SampleBuffer(DelayTime, chunkRange, context.SampleRate, delayTimes[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Feedback, chunkRange, context.SampleRate, feedbacks[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(DryMix, chunkRange, context.SampleRate, dryMixes[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(WetMix, chunkRange, context.SampleRate, wetMixes[..chunkSize]);
+
+                // Process each channel
+                for (int ch = 0; ch < Math.Min(input.ChannelCount, _delayLines!.Length); ch++)
+                {
+                    var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
+                    var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+                    var delayLine = _delayLines[ch];
+
+                    for (int i = 0; i < chunkSize; i++)
+                    {
+                        // Convert delay time from ms to samples
+                        int delaySamples = (int)(delayTimes[i] / 1000f * context.SampleRate);
+                        delaySamples = Math.Clamp(delaySamples, 0, _maxDelaySamples - 1);
+
+                        float inputSample = inData[i];
+                        float delayedSample = delayLine.Read(delaySamples);
+
+                        float feedback = feedbacks[i] / 100f;
+                        float dryMix = dryMixes[i] / 100f;
+                        float wetMix = wetMixes[i] / 100f;
+
+                        // Write to delay line with feedback
+                        delayLine.Write(inputSample + delayedSample * feedback);
+
+                        // Mix dry and wet signals
+                        outData[i] = inputSample * dryMix + delayedSample * wetMix;
+                    }
+                }
+
+                processed += chunkSize;
+            }
+
+            return output;
+        }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
     }
 
     public void Reset()

--- a/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
@@ -83,108 +83,124 @@ public sealed class EqualizerNode : AudioNode
     private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        // Calculate coefficients for each band
-        for (int bandIndex = 0; bandIndex < Bands.Count; bandIndex++)
+        try
         {
-            var band = Bands[bandIndex];
-            var filterType = band.FilterType.CurrentValue;
-            float frequency = band.Frequency.CurrentValue;
-            float gain = band.Gain.CurrentValue;
-            float q = band.Q.CurrentValue;
-
-            for (int ch = 0; ch < input.ChannelCount; ch++)
+            // Calculate coefficients for each band
+            for (int bandIndex = 0; bandIndex < Bands.Count; bandIndex++)
             {
-                _filters![bandIndex][ch].CalculateCoefficients(filterType, frequency, q, gain, context.SampleRate);
-            }
-        }
+                var band = Bands[bandIndex];
+                var filterType = band.FilterType.CurrentValue;
+                float frequency = band.Frequency.CurrentValue;
+                float gain = band.Gain.CurrentValue;
+                float q = band.Q.CurrentValue;
 
-        // Process each channel
-        for (int ch = 0; ch < input.ChannelCount; ch++)
-        {
-            var inData = input.GetChannelData(ch);
-            var outData = output.GetChannelData(ch);
-
-            // Process first band
-            var firstFilter = _filters![0][ch];
-            for (int i = 0; i < input.SampleCount; i++)
-            {
-                outData[i] = firstFilter.Process(inData[i]);
-            }
-
-            // Cascade remaining bands
-            for (int bandIndex = 1; bandIndex < Bands.Count; bandIndex++)
-            {
-                var filter = _filters[bandIndex][ch];
-                for (int i = 0; i < input.SampleCount; i++)
+                for (int ch = 0; ch < input.ChannelCount; ch++)
                 {
-                    outData[i] = filter.Process(outData[i]);
+                    _filters![bandIndex][ch].CalculateCoefficients(filterType, frequency, q, gain, context.SampleRate);
                 }
             }
-        }
-
-        // Clip protection is the master limiter's job (Composer.ApplyMasterEffects).
-        // Applying it here would also compress hot input that the EQ itself did not amplify.
-        return output;
-    }
-
-    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
-    {
-        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        // Buffers for chunk processing
-        const int maxChunkSize = 1024;
-        Span<float> frequencies = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
-        Span<float> gains = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
-        Span<float> qs = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
-
-        int processed = 0;
-        while (processed < input.SampleCount)
-        {
-            int chunkSize = Math.Min(maxChunkSize, input.SampleCount - processed);
-
-            var chunkStart = context.GetTimeForSample(processed);
-            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
 
             // Process each channel
             for (int ch = 0; ch < input.ChannelCount; ch++)
             {
-                var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
-                var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+                var inData = input.GetChannelData(ch);
+                var outData = output.GetChannelData(ch);
 
-                // Copy input first
-                inData.CopyTo(outData);
-
-                // Cascade each band
-                for (int bandIndex = 0; bandIndex < Bands.Count; bandIndex++)
+                // Process first band
+                var firstFilter = _filters![0][ch];
+                for (int i = 0; i < input.SampleCount; i++)
                 {
-                    var band = Bands[bandIndex];
-                    var filter = _filters![bandIndex][ch];
-                    var filterType = band.FilterType.CurrentValue;
+                    outData[i] = firstFilter.Process(inData[i]);
+                }
 
-                    // Sample animation values
-                    context.AnimationSampler.SampleBuffer(band.Frequency, chunkRange, context.SampleRate, frequencies[..chunkSize]);
-                    context.AnimationSampler.SampleBuffer(band.Gain, chunkRange, context.SampleRate, gains[..chunkSize]);
-                    context.AnimationSampler.SampleBuffer(band.Q, chunkRange, context.SampleRate, qs[..chunkSize]);
-
-                    // Process each sample
-                    for (int i = 0; i < chunkSize; i++)
+                // Cascade remaining bands
+                for (int bandIndex = 1; bandIndex < Bands.Count; bandIndex++)
+                {
+                    var filter = _filters[bandIndex][ch];
+                    for (int i = 0; i < input.SampleCount; i++)
                     {
-                        // Update coefficients
-                        filter.CalculateCoefficients(filterType, frequencies[i], qs[i], gains[i], context.SampleRate);
-                        // Apply filter
                         outData[i] = filter.Process(outData[i]);
                     }
                 }
             }
 
-            processed += chunkSize;
+            // Clip protection is the master limiter's job (Composer.ApplyMasterEffects).
+            // Applying it here would also compress hot input that the EQ itself did not amplify.
+            return output;
         }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
+    }
 
-        // Clip protection is the master limiter's job (Composer.ApplyMasterEffects).
-        // Applying it here would also compress hot input that the EQ itself did not amplify.
-        return output;
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        try
+        {
+            // Buffers for chunk processing
+            const int maxChunkSize = 1024;
+            Span<float> frequencies = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
+            Span<float> gains = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
+            Span<float> qs = stackalloc float[Math.Min(maxChunkSize, input.SampleCount)];
+
+            int processed = 0;
+            while (processed < input.SampleCount)
+            {
+                int chunkSize = Math.Min(maxChunkSize, input.SampleCount - processed);
+
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+                // Process each channel
+                for (int ch = 0; ch < input.ChannelCount; ch++)
+                {
+                    var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
+                    var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+
+                    // Copy input first
+                    inData.CopyTo(outData);
+
+                    // Cascade each band
+                    for (int bandIndex = 0; bandIndex < Bands.Count; bandIndex++)
+                    {
+                        var band = Bands[bandIndex];
+                        var filter = _filters![bandIndex][ch];
+                        var filterType = band.FilterType.CurrentValue;
+
+                        // Sample animation values
+                        context.AnimationSampler.SampleBuffer(band.Frequency, chunkRange, context.SampleRate, frequencies[..chunkSize]);
+                        context.AnimationSampler.SampleBuffer(band.Gain, chunkRange, context.SampleRate, gains[..chunkSize]);
+                        context.AnimationSampler.SampleBuffer(band.Q, chunkRange, context.SampleRate, qs[..chunkSize]);
+
+                        // Process each sample
+                        for (int i = 0; i < chunkSize; i++)
+                        {
+                            // Update coefficients
+                            filter.CalculateCoefficients(filterType, frequencies[i], qs[i], gains[i], context.SampleRate);
+                            // Apply filter
+                            outData[i] = filter.Process(outData[i]);
+                        }
+                    }
+                }
+
+                processed += chunkSize;
+            }
+
+            // Clip protection is the master limiter's job (Composer.ApplyMasterEffects).
+            // Applying it here would also compress hot input that the EQ itself did not amplify.
+            return output;
+        }
+        catch
+        {
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GainNode.cs
@@ -28,51 +28,59 @@ public sealed class GainNode : AudioNode
         {
             // Create output buffer
             var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-            // Sample gain values for each sample
-            Span<float> gains = stackalloc float[System.Math.Min(input.SampleCount, 8192)];
-
-            // Process in chunks to avoid stack overflow for large buffers
-            int processed = 0;
-            while (processed < input.SampleCount)
+            try
             {
-                int chunkSize = System.Math.Min(gains.Length, input.SampleCount - processed);
-                var chunkGains = gains.Slice(0, chunkSize);
+                // Sample gain values for each sample
+                Span<float> gains = stackalloc float[System.Math.Min(input.SampleCount, 8192)];
 
-                var chunkStart = context.GetTimeForSample(processed);
-                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-                // すでにcontext.TimeRange.StartがGetTimeForSampleで加算されている
-                var chunkRange = new Media.TimeRange(chunkStart, chunkEnd - chunkStart);
-
-                // Sample animation values
-                context.AnimationSampler.SampleBuffer(
-                    gain,
-                    chunkRange,
-                    context.SampleRate,
-                    chunkGains);
-
-                // Convert from percentage (0-100) to factor (0-1)
-                for (int i = 0; i < chunkSize; i++)
+                // Process in chunks to avoid stack overflow for large buffers
+                int processed = 0;
+                while (processed < input.SampleCount)
                 {
-                    chunkGains[i] /= 100f;
-                }
+                    int chunkSize = System.Math.Min(gains.Length, input.SampleCount - processed);
+                    var chunkGains = gains.Slice(0, chunkSize);
 
-                // Apply gain to each channel
-                for (int ch = 0; ch < input.ChannelCount; ch++)
-                {
-                    var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
-                    var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+                    var chunkStart = context.GetTimeForSample(processed);
+                    var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                    // context.GetTimeForSample already includes context.TimeRange.Start.
+                    var chunkRange = new Media.TimeRange(chunkStart, chunkEnd - chunkStart);
 
+                    // Sample animation values
+                    context.AnimationSampler.SampleBuffer(
+                        gain,
+                        chunkRange,
+                        context.SampleRate,
+                        chunkGains);
+
+                    // Convert from percentage (0-100) to factor (0-1)
                     for (int i = 0; i < chunkSize; i++)
                     {
-                        outData[i] = inData[i] * chunkGains[i];
+                        chunkGains[i] /= 100f;
                     }
+
+                    // Apply gain to each channel
+                    for (int ch = 0; ch < input.ChannelCount; ch++)
+                    {
+                        var inData = input.GetChannelData(ch).Slice(processed, chunkSize);
+                        var outData = output.GetChannelData(ch).Slice(processed, chunkSize);
+
+                        for (int i = 0; i < chunkSize; i++)
+                        {
+                            outData[i] = inData[i] * chunkGains[i];
+                        }
+                    }
+
+                    processed += chunkSize;
                 }
 
-                processed += chunkSize;
+                return output;
             }
-
-            return output;
+            catch
+            {
+                // Dispose the output the caller never received rather than leak it.
+                output.Dispose();
+                throw;
+            }
         }
     }
 
@@ -87,19 +95,27 @@ public sealed class GainNode : AudioNode
         using (input)
         {
             var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-            for (int ch = 0; ch < input.ChannelCount; ch++)
+            try
             {
-                var inData = input.GetChannelData(ch);
-                var outData = output.GetChannelData(ch);
-
-                for (int i = 0; i < input.SampleCount; i++)
+                for (int ch = 0; ch < input.ChannelCount; ch++)
                 {
-                    outData[i] = inData[i] * gain;
-                }
-            }
+                    var inData = input.GetChannelData(ch);
+                    var outData = output.GetChannelData(ch);
 
-            return output;
+                    for (int i = 0; i < input.SampleCount; i++)
+                    {
+                        outData[i] = inData[i] * gain;
+                    }
+                }
+
+                return output;
+            }
+            catch
+            {
+                // Dispose the output the caller never received rather than leak it.
+                output.Dispose();
+                throw;
+            }
         }
     }
 }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -48,6 +48,9 @@ public sealed class LimiterNode : AudioNode
     private bool _warnedNonFiniteInputSample;
     private bool _warnedEmptyChunk;
 
+    // Test-only counter (via InternalsVisibleTo) of output buffers disposed after Process fails.
+    internal int OutputBuffersDisposedAfterFailure;
+
     public required IProperty<float> Threshold { get; init; }
 
     public required IProperty<float> Release { get; init; }
@@ -261,80 +264,104 @@ public sealed class LimiterNode : AudioNode
         var c = Derive(Threshold.CurrentValue, Release.CurrentValue, Lookahead.CurrentValue, MakeupGain.CurrentValue, context.SampleRate);
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        // Lookahead is constant for the whole call, so the window maximum comes from the
-        // O(1)-amortized deque; rebuild it only when the tracked lookahead length changes.
-        EnsureDeque(c.LookaheadSamples);
-
-        int channelCount = _delayLines!.Length;
-        int sampleCount = input.SampleCount;
-        ReadOnlySpan<float> inRaw = input.GetRawSpan();
-        Span<float> outRaw = output.GetRawSpan();
-
-        for (int i = 0; i < sampleCount; i++)
+        bool succeeded = false;
+        try
         {
-            float currentPeak = IngestSample(inRaw, sampleCount, channelCount, i);
-            float windowPeak = PushWindowPeak(currentPeak, c.LookaheadSamples);
-            EmitSample(outRaw, sampleCount, channelCount, i, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
-        }
+            // Lookahead is constant for the whole call, so the window maximum comes from the
+            // O(1)-amortized deque; rebuild it only when the tracked lookahead length changes.
+            EnsureDeque(c.LookaheadSamples);
 
-        return output;
+            int channelCount = _delayLines!.Length;
+            int sampleCount = input.SampleCount;
+            ReadOnlySpan<float> inRaw = input.GetRawSpan();
+            Span<float> outRaw = output.GetRawSpan();
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float currentPeak = IngestSample(inRaw, sampleCount, channelCount, i);
+                float windowPeak = PushWindowPeak(currentPeak, c.LookaheadSamples);
+                EmitSample(outRaw, sampleCount, channelCount, i, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
+            }
+
+            succeeded = true;
+            return output;
+        }
+        finally
+        {
+            if (!succeeded)
+            {
+                output.Dispose();
+                OutputBuffersDisposedAfterFailure++;
+            }
+        }
     }
 
     private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-
-        // Per-chunk animation-sampling scratch, sized to the actual work (capped at
-        // AnimationChunkSize) so small buffers pay a proportionally small stack cost, matching the
-        // sibling nodes (CompressorNode/DelayNode/GainNode).
-        int scratchSize = Math.Min(AnimationChunkSize, input.SampleCount);
-        Span<float> thresholds = stackalloc float[scratchSize];
-        Span<float> releases = stackalloc float[scratchSize];
-        Span<float> lookaheads = stackalloc float[scratchSize];
-        Span<float> makeups = stackalloc float[scratchSize];
-
-        // Lookahead can vary per sample here, which the deque cannot track, so this path rescans
-        // directly. Invalidate the deque so a later static chunk on the same node rebuilds it.
-        _dequeLookahead = -1;
-
-        int channelCount = _delayLines!.Length;
-        int sampleCount = input.SampleCount;
-        ReadOnlySpan<float> inRaw = input.GetRawSpan();
-        Span<float> outRaw = output.GetRawSpan();
-
-        int processed = 0;
-        while (processed < sampleCount)
+        bool succeeded = false;
+        try
         {
-            int chunkSize = Math.Min(AnimationChunkSize, sampleCount - processed);
+            // Per-chunk animation-sampling scratch, sized to the actual work (capped at
+            // AnimationChunkSize) so small buffers pay a proportionally small stack cost, matching the
+            // sibling nodes (CompressorNode/DelayNode/GainNode).
+            int scratchSize = Math.Min(AnimationChunkSize, input.SampleCount);
+            Span<float> thresholds = stackalloc float[scratchSize];
+            Span<float> releases = stackalloc float[scratchSize];
+            Span<float> lookaheads = stackalloc float[scratchSize];
+            Span<float> makeups = stackalloc float[scratchSize];
 
-            var chunkStart = context.GetTimeForSample(processed);
-            var chunkEnd = context.GetTimeForSample(processed + chunkSize);
-            var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+            // Lookahead can vary per sample here, which the deque cannot track, so this path rescans
+            // directly. Invalidate the deque so a later static chunk on the same node rebuilds it.
+            _dequeLookahead = -1;
 
-            context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(Lookahead, chunkRange, context.SampleRate, lookaheads[..chunkSize]);
-            context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
+            int channelCount = _delayLines!.Length;
+            int sampleCount = input.SampleCount;
+            ReadOnlySpan<float> inRaw = input.GetRawSpan();
+            Span<float> outRaw = output.GetRawSpan();
 
-            for (int i = 0; i < chunkSize; i++)
+            int processed = 0;
+            while (processed < sampleCount)
             {
-                // Derive recomputes one Exp + two Pow per sample — the deliberate cost of
-                // sample-accurate automation. The common no-animation case takes ProcessStatic,
-                // which derives the coefficients once per call.
-                var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
-                int idx = processed + i;
-                // The window maximum comes from ScanWindowPeak over the ring, so IngestSample's
-                // returned peak is ignored here (only its delay-line/peak-ring side-effects matter).
-                _ = IngestSample(inRaw, sampleCount, channelCount, idx);
-                float windowPeak = ScanWindowPeak(c.LookaheadSamples);
-                EmitSample(outRaw, sampleCount, channelCount, idx, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
+                int chunkSize = Math.Min(AnimationChunkSize, sampleCount - processed);
+
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+                context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Lookahead, chunkRange, context.SampleRate, lookaheads[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(MakeupGain, chunkRange, context.SampleRate, makeups[..chunkSize]);
+
+                for (int i = 0; i < chunkSize; i++)
+                {
+                    // Derive recomputes one Exp + two Pow per sample — the deliberate cost of
+                    // sample-accurate automation. The common no-animation case takes ProcessStatic,
+                    // which derives the coefficients once per call.
+                    var c = Derive(thresholds[i], releases[i], lookaheads[i], makeups[i], context.SampleRate);
+                    int idx = processed + i;
+                    // The window maximum comes from ScanWindowPeak over the ring, so IngestSample's
+                    // returned peak is ignored here (only its delay-line/peak-ring side-effects matter).
+                    _ = IngestSample(inRaw, sampleCount, channelCount, idx);
+                    float windowPeak = ScanWindowPeak(c.LookaheadSamples);
+                    EmitSample(outRaw, sampleCount, channelCount, idx, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
+                }
+
+                processed += chunkSize;
             }
 
-            processed += chunkSize;
+            succeeded = true;
+            return output;
         }
-
-        return output;
+        finally
+        {
+            if (!succeeded)
+            {
+                output.Dispose();
+                OutputBuffersDisposedAfterFailure++;
+            }
+        }
     }
 
     // Reads one input sample per channel, coerces non-finite values, feeds the delay lines and the

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -264,7 +264,6 @@ public sealed class LimiterNode : AudioNode
         var c = Derive(Threshold.CurrentValue, Release.CurrentValue, Lookahead.CurrentValue, MakeupGain.CurrentValue, context.SampleRate);
 
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-        bool succeeded = false;
         try
         {
             // Lookahead is constant for the whole call, so the window maximum comes from the
@@ -283,23 +282,20 @@ public sealed class LimiterNode : AudioNode
                 EmitSample(outRaw, sampleCount, channelCount, i, windowPeak, c.ThresholdLin, c.MakeupLin, c.LookaheadSamples, c.ReleaseCoef);
             }
 
-            succeeded = true;
             return output;
         }
-        finally
+        catch
         {
-            if (!succeeded)
-            {
-                output.Dispose();
-                OutputBuffersDisposedAfterFailure++;
-            }
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            OutputBuffersDisposedAfterFailure++;
+            throw;
         }
     }
 
     private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
-        bool succeeded = false;
         try
         {
             // Per-chunk animation-sampling scratch, sized to the actual work (capped at
@@ -351,16 +347,14 @@ public sealed class LimiterNode : AudioNode
                 processed += chunkSize;
             }
 
-            succeeded = true;
             return output;
         }
-        finally
+        catch
         {
-            if (!succeeded)
-            {
-                output.Dispose();
-                OutputBuffersDisposedAfterFailure++;
-            }
+            // Dispose the output the caller never received rather than leak it.
+            output.Dispose();
+            OutputBuffersDisposedAfterFailure++;
+            throw;
         }
     }
 

--- a/src/Beutl.Engine/Audio/Graph/Nodes/MixerNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/MixerNode.cs
@@ -41,30 +41,39 @@ public sealed class MixerNode : AudioNode
 
             // Create output buffer
             var output = new AudioBuffer(firstBuffer.SampleRate, firstBuffer.ChannelCount, firstBuffer.SampleCount);
-
-            // Mix all channels
-            for (int ch = 0; ch < output.ChannelCount; ch++)
+            try
             {
-                var outData = output.GetChannelData(ch);
-
-                // Clear output buffer (already cleared in constructor, but being explicit)
-                outData.Clear();
-
-                // Mix each input
-                for (int i = 0; i < buffers.Length; i++)
+                // Mix all channels
+                for (int ch = 0; ch < output.ChannelCount; ch++)
                 {
-                    var gain = i < _gains.Length ? _gains[i] : 1.0f;
-                    var inData = buffers[i].GetChannelData(ch);
+                    var outData = output.GetChannelData(ch);
 
-                    // Add with gain
-                    for (int s = 0; s < output.SampleCount; s++)
+                    // Clear output buffer (already cleared in constructor, but being explicit)
+                    outData.Clear();
+
+                    // Mix each input
+                    for (int i = 0; i < buffers.Length; i++)
                     {
-                        outData[s] += inData[s] * gain;
+                        var gain = i < _gains.Length ? _gains[i] : 1.0f;
+                        var inData = buffers[i].GetChannelData(ch);
+
+                        // Add with gain
+                        for (int s = 0; s < output.SampleCount; s++)
+                        {
+                            outData[s] += inData[s] * gain;
+                        }
                     }
                 }
-            }
 
-            return output;
+                return output;
+            }
+            catch
+            {
+                // Dispose the output the caller never received rather than leak it
+                // (inputs are released by the outer finally).
+                output.Dispose();
+                throw;
+            }
         }
         finally
         {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/ResampleNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/ResampleNode.cs
@@ -99,22 +99,30 @@ public sealed class ResampleNode : AudioNode
 
             var outputSampleCount = (int)System.Math.Round(input.SampleCount * (double)_targetSampleRate / input.SampleRate);
             var output = new AudioBuffer(_targetSampleRate, input.ChannelCount, outputSampleCount);
-
-            // Read resampled data
-            var buffer = new float[outputSampleCount * input.ChannelCount];
-            int samplesRead = _wdlResampler!.Read(buffer, 0, buffer.Length);
-
-            // Copy interleaved samples back to AudioBuffer
-            for (int ch = 0; ch < input.ChannelCount; ch++)
+            try
             {
-                var channelData = output.GetChannelData(ch);
-                for (int i = 0; i < samplesRead / input.ChannelCount; i++)
-                {
-                    channelData[i] = buffer[i * input.ChannelCount + ch];
-                }
-            }
+                // Read resampled data
+                var buffer = new float[outputSampleCount * input.ChannelCount];
+                int samplesRead = _wdlResampler!.Read(buffer, 0, buffer.Length);
 
-            return output;
+                // Copy interleaved samples back to AudioBuffer
+                for (int ch = 0; ch < input.ChannelCount; ch++)
+                {
+                    var channelData = output.GetChannelData(ch);
+                    for (int i = 0; i < samplesRead / input.ChannelCount; i++)
+                    {
+                        channelData[i] = buffer[i * input.ChannelCount + ch];
+                    }
+                }
+
+                return output;
+            }
+            catch
+            {
+                // Dispose the output the caller never received rather than leak it.
+                output.Dispose();
+                throw;
+            }
         }
 
         public void Dispose()

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
@@ -21,31 +21,40 @@ public sealed class SourceNode : AudioNode
         var start = (int)(context.TimeRange.Start.TotalSeconds * resource.SampleRate);
         var length = (int)Math.Ceiling(context.TimeRange.Duration.TotalSeconds * resource.SampleRate);
 
-        // Read PCM data from source
-        if (resource.Read(start, length, out var pcmRef))
+        try
         {
-            using (pcmRef)
+            // Read PCM data from source
+            if (resource.Read(start, length, out var pcmRef))
             {
-                var pcm = pcmRef.Value;
-                // Convert to stereo float if needed
-                if (pcm is Pcm<Stereo32BitFloat> stereoPcm)
+                using (pcmRef)
                 {
-                    CopyPcmToBuffer(stereoPcm, buffer);
-                }
-                else if (pcm is Pcm<Monaural32BitFloat> monoPcm)
-                {
-                    CopyMonoToStereoBuffer(monoPcm, buffer);
-                }
-                else
-                {
-                    // Convert to stereo float
-                    using var convertedPcm = pcm.Convert<Stereo32BitFloat>();
-                    CopyPcmToBuffer(convertedPcm, buffer);
+                    var pcm = pcmRef.Value;
+                    // Convert to stereo float if needed
+                    if (pcm is Pcm<Stereo32BitFloat> stereoPcm)
+                    {
+                        CopyPcmToBuffer(stereoPcm, buffer);
+                    }
+                    else if (pcm is Pcm<Monaural32BitFloat> monoPcm)
+                    {
+                        CopyMonoToStereoBuffer(monoPcm, buffer);
+                    }
+                    else
+                    {
+                        // Convert to stereo float
+                        using var convertedPcm = pcm.Convert<Stereo32BitFloat>();
+                        CopyPcmToBuffer(convertedPcm, buffer);
+                    }
                 }
             }
-        }
 
-        return buffer;
+            return buffer;
+        }
+        catch
+        {
+            // Dispose the buffer the caller never received rather than leak it.
+            buffer.Dispose();
+            throw;
+        }
     }
 
     private static unsafe void CopyPcmToBuffer(Pcm<Stereo32BitFloat> pcm, AudioBuffer buffer)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -279,27 +279,37 @@ public sealed class SpeedNode : AudioNode
             }
 
             var output = new AudioBuffer(_sampleRate, _channels, expectedOut);
-            float[] dst = new float[expectedOut * _channels];
-
-            int framesDone = 0;
-            while (framesDone < expectedOut)
+            try
             {
-                int want = _rs.ResamplePrepare(expectedOut - framesDone, _channels, out float[] inBuf, out int inOff);
-                int got = Read(inBuf, inOff, want, context);
+                float[] dst = new float[expectedOut * _channels];
 
-                int made = _rs.ResampleOut(dst, framesDone * _channels, got, expectedOut - framesDone, _channels);
+                int framesDone = 0;
+                while (framesDone < expectedOut)
+                {
+                    int want = _rs.ResamplePrepare(expectedOut - framesDone, _channels, out float[] inBuf, out int inOff);
+                    int got = Read(inBuf, inOff, want, context);
 
-                // No output and no input means the source is exhausted; the tail-fill below pads the
-                // rest. (got > 0 with made == 0 just means the resampler needs more lookahead.)
-                if (made == 0 && got == 0)
-                    break;
+                    int made = _rs.ResampleOut(dst, framesDone * _channels, got, expectedOut - framesDone, _channels);
 
-                framesDone += made;
+                    // No output and no input means the source is exhausted; the tail-fill below pads the
+                    // rest. (got > 0 with made == 0 just means the resampler needs more lookahead.)
+                    if (made == 0 && got == 0)
+                        break;
+
+                    framesDone += made;
+                }
+
+                WriteAndPad(output, dst, framesDone, expectedOut);
+                // Advance only on full success.
+                _nextOutputStart = outputStart + (double)expectedOut / _sampleRate;
+                return output;
             }
-
-            WriteAndPad(output, dst, framesDone, expectedOut);
-            _nextOutputStart = outputStart + (double)expectedOut / _sampleRate;
-            return output;
+            catch
+            {
+                // Dispose the output the caller never received rather than leak it.
+                output.Dispose();
+                throw;
+            }
         }
 
         public AudioBuffer ProcessBufferWithVariableSpeed(
@@ -309,39 +319,48 @@ public sealed class SpeedNode : AudioNode
             BeginStream(outputStart, sourceStartSeconds);
 
             var output = new AudioBuffer(_sampleRate, _channels, expectedOut);
-            float[] dst = new float[expectedOut * _channels];
-
-            // Same streaming loop as the constant-speed path, but the rate is updated per block from
-            // the average of the speed curve. ResamplePrepare is the single source of truth for how
-            // many source frames to feed, so there is no hand-rolled cursor to drift out of sync.
-            int framesDone = 0;
-            while (framesDone < expectedOut)
+            try
             {
-                int framesThis = Math.Min(BLOCK, expectedOut - framesDone);
+                float[] dst = new float[expectedOut * _channels];
 
-                double sumSpeed = 0.0;
-                for (int i = 0; i < framesThis; i++)
-                    sumSpeed += speedCurve[framesDone + i];
+                // Same streaming loop as the constant-speed path, but the rate is updated per block from
+                // the average of the speed curve. ResamplePrepare is the single source of truth for how
+                // many source frames to feed, so there is no hand-rolled cursor to drift out of sync.
+                int framesDone = 0;
+                while (framesDone < expectedOut)
+                {
+                    int framesThis = Math.Min(BLOCK, expectedOut - framesDone);
 
-                double vAvg = sumSpeed / framesThis;
-                _rs.SetRates(_sampleRate, _sampleRate / vAvg);
-                float cutoff = 0.97f / (float)vAvg; // vAvg > 1 lowers Nyquist to avoid aliasing
-                _rs.SetFilterParms(cutoff, 0.707f);
+                    double sumSpeed = 0.0;
+                    for (int i = 0; i < framesThis; i++)
+                        sumSpeed += speedCurve[framesDone + i];
 
-                int want = _rs.ResamplePrepare(framesThis, _channels, out float[] inBuf, out int inOff);
-                int got = Read(inBuf, inOff, want, context);
+                    double vAvg = sumSpeed / framesThis;
+                    _rs.SetRates(_sampleRate, _sampleRate / vAvg);
+                    float cutoff = 0.97f / (float)vAvg; // vAvg > 1 lowers Nyquist to avoid aliasing
+                    _rs.SetFilterParms(cutoff, 0.707f);
 
-                int made = _rs.ResampleOut(dst, framesDone * _channels, got, framesThis, _channels);
+                    int want = _rs.ResamplePrepare(framesThis, _channels, out float[] inBuf, out int inOff);
+                    int got = Read(inBuf, inOff, want, context);
 
-                if (made == 0 && got == 0)
-                    break;
+                    int made = _rs.ResampleOut(dst, framesDone * _channels, got, framesThis, _channels);
 
-                framesDone += made;
+                    if (made == 0 && got == 0)
+                        break;
+
+                    framesDone += made;
+                }
+
+                WriteAndPad(output, dst, framesDone, expectedOut);
+                // Advance only on full success.
+                _nextOutputStart = outputStart + (double)expectedOut / _sampleRate;
+                return output;
             }
-
-            WriteAndPad(output, dst, framesDone, expectedOut);
-            _nextOutputStart = outputStart + (double)expectedOut / _sampleRate;
-            return output;
+            catch
+            {
+                output.Dispose();
+                throw;
+            }
         }
 
         // De-interleaves the produced frames into the output and pads any shortfall (source exhausted)

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
@@ -151,4 +151,53 @@ public class DelayNodeTests
         Assert.That(second.GetChannelData(0).ToArray(),
             Is.Not.EqualTo(freshRun.GetChannelData(0).ToArray()).AsCollection);
     }
+
+    // Emits a ramp with a configurable channel count so a reused node can be driven first with one
+    // channel and then with more.
+    private sealed class ConfigurableChannelInputNode(int sampleRate, int channelCount) : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            int count = context.GetSampleCount();
+            var buffer = new AudioBuffer(sampleRate, channelCount, count);
+            int startIndex = (int)(context.TimeRange.Start.TotalSeconds * sampleRate);
+            for (int ch = 0; ch < channelCount; ch++)
+            {
+                Span<float> data = buffer.GetChannelData(ch);
+                for (int i = 0; i < count; i++)
+                {
+                    data[i] = (startIndex + i + 1) * 0.01f * (ch + 1);
+                }
+            }
+
+            return buffer;
+        }
+    }
+
+    // The node is cached across Compose() calls; initialization keyed only on sample rate would keep
+    // a too-short delay-line array after a channel-count increase, leaving the extra channels silent.
+    [Test]
+    public void Process_ChannelCountIncreaseOnReusedNode_ProcessesAllChannels()
+    {
+        using var node = new DelayNode
+        {
+            DelayTime = Property.Create(200f),
+            Feedback = Property.Create(50f),
+            DryMix = Property.Create(60f),
+            WetMix = Property.Create(40f),
+        };
+
+        // First render sizes the cached delay-line array to a single channel.
+        node.AddInput(new ConfigurableChannelInputNode(SampleRate, 1));
+        node.Process(CreateContext()).Dispose();
+
+        // Re-render on the SAME node with a stereo source: the delay lines must grow to 2 channels.
+        node.ClearInputs();
+        node.AddInput(new ConfigurableChannelInputNode(SampleRate, 2));
+        using AudioBuffer stereo = node.Process(CreateContext());
+
+        float[] right = stereo.GetChannelData(1).ToArray();
+        Assert.That(Array.Exists(right, v => v != 0f), Is.True,
+            "The second channel must be processed after a channel-count increase on a reused node.");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -77,6 +77,16 @@ public class LimiterNodeTests
         public override AudioBuffer Process(AudioProcessContext context) => null!;
     }
 
+    private sealed class DisposedInputNode(int sampleRate, int channels, int count) : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            var buffer = new AudioBuffer(sampleRate, channels, count);
+            buffer.Dispose();
+            return buffer;
+        }
+    }
+
     [Test]
     public void Process_BelowThreshold_PassesThroughUnchanged()
     {
@@ -728,6 +738,25 @@ public class LimiterNodeTests
         });
         prop.Animation = animation;
         return prop;
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Process_FailureAfterOutputAllocation_DisposesOutputBuffer(bool animated)
+    {
+        using var node = new LimiterNode
+        {
+            Threshold = animated ? CreateAnimatedConstant(DefaultThresholdDb) : Property.CreateAnimatable(DefaultThresholdDb),
+            Release = Property.CreateAnimatable(DefaultReleaseMs),
+            Lookahead = Property.CreateAnimatable(LookaheadMs),
+            MakeupGain = Property.CreateAnimatable(DefaultMakeupGainDb),
+        };
+        node.AddInput(new DisposedInputNode(SampleRate, 2, 16));
+
+        Assert.Throws<ObjectDisposedException>(() => node.Process(CreateContext(16)));
+
+        Assert.That(node.OutputBuffersDisposedAfterFailure, Is.EqualTo(1),
+            "The node owns a newly allocated output until Process returns it to the caller.");
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -740,6 +740,8 @@ public class LimiterNodeTests
         return prop;
     }
 
+    // A throw after the output buffer is allocated must dispose the buffer (the node owns it until it
+    // returns it to the caller) and propagate, on both the static and animated paths.
     [TestCase(false)]
     [TestCase(true)]
     public void Process_FailureAfterOutputAllocation_DisposesOutputBuffer(bool animated)


### PR DESCRIPTION
## Summary

Extends the original LimiterNode dispose-on-failure fix to **every** audio node that allocates an output `AudioBuffer`, and to the master `Composer`. Previously only `LimiterNode` disposed its freshly allocated output when a mid-process exception (commonly an `ObjectDisposedException` from a disposed upstream buffer) prevented it from returning the buffer to the caller — the identical leak existed in all of its siblings.

- **Per-node inline guard**: each allocating node now wraps its fill in a `try { ...; return output; } catch { output.Dispose(); throw; }`, implementing the "a node owns the buffer it allocates until it returns it" contract individually (no shared helper). Covered nodes: `LimiterNode`, `CompressorNode`, `DelayNode`, `EqualizerNode`, `GainNode`, `MixerNode`, `ResampleNode`, `SpeedNode`, `ClipNode`, `SourceNode`.
- **MixerNode real bug**: its existing `try/finally` disposed only the input buffers; the allocated output leaked on a mid-mix throw. Output is now disposed on failure too (inputs still disposed in the `finally`).
- **Composer**: `BuildFinalOutput` / `MixBuffers` leaked the mix buffer **and** the consumed per-node input buffers on an exception path. `BuildFinalOutput` now disposes consumed inputs in a `finally` and the mix buffer on a throw; `MixBuffers` disposes the partial mix buffer on a throw.
- **Tests**: `LimiterNode` keeps its test-only `OutputBuffersDisposedAfterFailure` counter so both its static and animated failure paths are verified in `LimiterNodeTests`.

## Review-driven fixes

- **DelayNode channel-count reinit** (CodeRabbit, real bug): `DelayNode` only reinitialized its delay lines on a sample-rate change. A channel-count increase left the old shorter delay-line array in place, and the `Math.Min(...)` loops silently dropped the extra channels (output silence). It now also reinitializes on a channel-count change, matching `LimiterNode`. Covered by a new `DelayNodeTests` case.
- **English inline comments** (CodeRabbit): translated the remaining Japanese comments in `ClipNode` and `GainNode` per the repository comment-language rule.

## Testing

- `dotnet build src/Beutl.Engine/Beutl.Engine.csproj -f net10.0` — 0 errors, 0 warnings
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~Engine.Audio"` — 189 passed, 0 failed
- `dotnet format` on the edited files

## Follow-ups

- **Audio nodes: unchecked int overflow in time→sample conversion** — several nodes compute a sample index via `(int)(TimeRange.Start.TotalSeconds * sampleRate)`, which can silently overflow `Int32` for very long sources at high sample rates. Pre-existing correctness concern, **not** a resource leak and out of scope here. Tracked in [b-editor/projects/9](https://github.com/orgs/b-editor/projects/9).

https://claude.ai/code/session_01V4pPWWLdnHdjyBKjPVstoM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling and ensured audio buffers are reliably disposed across audio processing operations to reduce the risk of resource/memory leaks on failures.
  * Fixed delay processing so reused delay nodes correctly expand internal buffers when the input channel count increases.
* **Tests**
  * Added unit test coverage to verify buffers are disposed after output allocation failures and to confirm delay nodes process all channels after channel-count changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->