### PR TITLE
fix: guard limiter deque overflow in release

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -449,9 +449,9 @@ public sealed class LimiterNode : AudioNode
         while (_dqCount > 0 && _dqVal![(_dqHead + _dqCount - 1) & mask] <= value)
             _dqCount--;
 
-        // After the back-eviction the deque holds at most lookaheadSamples + 1 <= cap - 2 entries,
-        // so a free slot is guaranteed. Check before the write so a future change that breaks the
-        // bound is caught before it overwrites the front.
+        // Correct operation keeps the deque at <= lookaheadSamples + 1 (<= cap - 2) entries, so a
+        // slot is always free and this never trips. Checking the physical length (not cap - 2) fires
+        // only when a future bound regression would actually overwrite the front.
         if (_dqCount >= _dqVal!.Length)
         {
             throw new InvalidOperationException(

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Numerics;
+﻿using System.Numerics;
 using Beutl.Audio.Effects;
 using Beutl.Engine;
 using Beutl.Logging;
@@ -451,9 +450,13 @@ public sealed class LimiterNode : AudioNode
             _dqCount--;
 
         // After the back-eviction the deque holds at most lookaheadSamples + 1 <= cap - 2 entries,
-        // so a free slot is guaranteed. Assert before the write so a future change that breaks the
-        // bound is caught before it overwrites the front (Debug-only).
-        Debug.Assert(_dqCount < _dqVal!.Length, "LimiterNode deque overflow: no free slot, front would be overwritten.");
+        // so a free slot is guaranteed. Check before the write so a future change that breaks the
+        // bound is caught before it overwrites the front.
+        if (_dqCount >= _dqVal!.Length)
+        {
+            throw new InvalidOperationException(
+                "LimiterNode deque overflow: no free slot, front would be overwritten.");
+        }
 
         int tail = (_dqHead + _dqCount) & mask;
         _dqVal[tail] = value;

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -26,8 +26,8 @@ public class LimiterNodeTests
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        // Log.LoggerFactory's setter is write-once (??=); only allocate a factory when logging
-        // has not been initialized yet, so we don't create and discard one on every fixture.
+        // Log.LoggerFactory is write-once (??=); skip allocating a factory we would only discard
+        // when another fixture already set one.
         if (Log.LoggerFactory is null)
         {
             Log.LoggerFactory = LoggerFactory.Create(_ => { });

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -1,10 +1,13 @@
-﻿using Beutl.Animation;
+﻿using System.Reflection;
+using Beutl.Animation;
 using Beutl.Audio;
 using Beutl.Audio.Effects;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.Media;
+using Microsoft.Extensions.Logging;
 
 using static Beutl.Audio.Effects.LimiterParameters;
 
@@ -19,6 +22,12 @@ public class LimiterNodeTests
     // DefaultLookaheadMs (which is 0), so the delay-line / lookahead-window behavior stays
     // exercised. Tests that need the zero-lookahead path pass lookaheadMs: 0f.
     private const float LookaheadMs = 5f;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Log.LoggerFactory = LoggerFactory.Create(_ => { });
+    }
 
     private static int LookaheadSamples(int sampleRate = SampleRate, float lookaheadMs = LookaheadMs)
         => (int)(lookaheadMs / 1000f * sampleRate);
@@ -1635,6 +1644,36 @@ public class LimiterNodeTests
             "Quiet tail must recover after the burst leaves the window (deque must evict the stale max).");
         Assert.That(tailPeak, Is.LessThanOrEqualTo(quietAmp + 1e-3f),
             "Quiet tail is below threshold and must not be amplified.");
+    }
+
+    [Test]
+    public void PushWindowPeak_WhenDequeCapacityInvariantBreaks_ThrowsBeforeOverwrite()
+    {
+        static FieldInfo Field(string name)
+            => typeof(LimiterNode).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+               ?? throw new MissingFieldException(typeof(LimiterNode).FullName, name);
+
+        using var input = CreateBuffer(1, 1, (_, _) => 0f);
+        using var node = CreateNode(lookaheadMs: 0f);
+        node.AddInput(new StubInputNode(input));
+
+        using var _ = node.Process(CreateContext(1));
+
+        var dqVal = (float[])Field("_dqVal").GetValue(node)!;
+        Array.Fill(dqVal, float.PositiveInfinity);
+        Field("_dqHead").SetValue(node, 0);
+        Field("_dqCount").SetValue(node, dqVal.Length);
+        Field("_globalPos").SetValue(node, 1L);
+
+        var pushWindowPeak = typeof(LimiterNode).GetMethod(
+            "PushWindowPeak",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => pushWindowPeak.Invoke(node, [0f, 0]));
+
+        Assert.That(ex!.InnerException, Is.TypeOf<InvalidOperationException>());
+        Assert.That(ex.InnerException!.Message, Does.Contain("LimiterNode deque overflow"));
     }
 
     // Step animation: holds `first` for the whole [0, boundary) range and switches to `second` from

--- a/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/LimiterNodeTests.cs
@@ -26,7 +26,12 @@ public class LimiterNodeTests
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        Log.LoggerFactory = LoggerFactory.Create(_ => { });
+        // Log.LoggerFactory's setter is write-once (??=); only allocate a factory when logging
+        // has not been initialized yet, so we don't create and discard one on every fixture.
+        if (Log.LoggerFactory is null)
+        {
+            Log.LoggerFactory = LoggerFactory.Create(_ => { });
+        }
     }
 
     private static int LookaheadSamples(int sampleRate = SampleRate, float lookaheadMs = LookaheadMs)
@@ -1667,7 +1672,8 @@ public class LimiterNodeTests
 
         var pushWindowPeak = typeof(LimiterNode).GetMethod(
             "PushWindowPeak",
-            BindingFlags.Instance | BindingFlags.NonPublic)!;
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMethodException(typeof(LimiterNode).FullName, "PushWindowPeak");
 
         var ex = Assert.Throws<TargetInvocationException>(
             () => pushWindowPeak.Invoke(node, [0f, 0]));


### PR DESCRIPTION
## Summary
- Replace the Debug.Assert-only LimiterNode deque overflow check with a Release-visible InvalidOperationException.
- Add a focused test that corrupts the internal deque state and verifies the guard throws before overwriting the front entry.
- Initialize the LimiterNode test logger factory so the targeted tests also run in Release configuration.

## Tests
- dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter FullyQualifiedName~LimiterNodeTests
- dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 -c Release --filter FullyQualifiedName~LimiterNodeTests
- git diff --check

Project item: https://github.com/orgs/b-editor/projects/9/views/1?pane=issue&itemId=202624468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio limiter now validates deque capacity at runtime to prevent overflow scenarios, replacing debug-only assertions with explicit error handling that throws a clear exception.

* **Tests**
  * Added unit coverage that uses reflection to force an invalid limiter deque state and verifies the non-public peak-pushing behavior throws the expected exception with a deque-overflow message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->