### PR TITLE
fix(engine): avoid double-dispose in RasterizeAndConcat and RasterizeAt when an op throws on Dispose

### DIFF
--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -47,6 +47,9 @@ public class RenderNodeProcessor(
             throw new Exception("RenderTarget is null");
         }
 
+        // Set before op.Dispose() so a throwing OnDispose (which leaves IsDisposed false) is not
+        // re-disposed by the catch — mirrors the consumed++ guard in Rasterize/RasterizeAndConcat.
+        bool opDisposeStarted = false;
         try
         {
             using var canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: op.Bounds.Size);
@@ -56,6 +59,7 @@ public class RenderNodeProcessor(
             using (canvas.PushTransform(Matrix.CreateTranslation(-opBounds.X, -opBounds.Y)))
             {
                 op.Render(canvas);
+                opDisposeStarted = true;
                 op.Dispose();
             }
 
@@ -64,7 +68,8 @@ public class RenderNodeProcessor(
         catch
         {
             renderTarget.Dispose();
-            op.Dispose();
+            if (!opDisposeStarted)
+                op.Dispose();
             throw;
         }
     }

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -151,8 +151,8 @@ public class RenderNodeProcessor(
                 foreach (var op in ops)
                 {
                     op.Render(canvas);
-                    op.Dispose();
                     consumed++;
+                    op.Dispose();
                 }
             }
         }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -38,10 +38,29 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
     }
 
+    [Test]
+    public void RasterizeAndConcat_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("fault", disposed, throwOnDispose: true),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+
+        // The faulting op must be disposed exactly once, and the remaining op must still be
+        // cleaned up: a double-dispose re-runs OnDispose (use-after-free for GPU-backed ops)
+        // and skips the remaining op.
+        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+    }
+
     private static RenderNodeOperation CreateOperation(
         string name,
         ICollection<string> disposed,
-        bool throwOnRender = false)
+        bool throwOnRender = false,
+        bool throwOnDispose = false)
     {
         return RenderNodeOperation.CreateLambda(
             new Rect(0, 0, 4, 4),
@@ -52,7 +71,14 @@ public class RenderNodeProcessorExceptionSafetyTests
                     throw new InvalidOperationException(name);
                 }
             },
-            onDispose: () => disposed.Add(name));
+            onDispose: () =>
+            {
+                disposed.Add(name);
+                if (throwOnDispose)
+                {
+                    throw new InvalidOperationException(name);
+                }
+            });
     }
 
     private sealed class StaticRenderNode(params RenderNodeOperation[] operations) : RenderNode

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -56,6 +56,24 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
     }
 
+    [Test]
+    public void Rasterize_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("fault", disposed, throwOnDispose: true),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        // Rasterize delegates per-op disposal to RasterizeAt, which used to dispose the op once in
+        // its try and again in its catch — re-running a throwing OnDispose (use-after-free).
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("fault"));
+        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+    }
+
     private static RenderNodeOperation CreateOperation(
         string name,
         ICollection<string> disposed,

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -48,8 +48,10 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
 
+        // The propagated exception must be the faulting op's Dispose, not a masked second throw.
+        Assert.That(ex!.Message, Is.EqualTo("fault"));
         // The faulting op must be disposed exactly once, and the remaining op must still be
         // cleaned up: a double-dispose re-runs OnDispose (use-after-free for GPU-backed ops)
         // and skips the remaining op.


### PR DESCRIPTION
## Description
`RenderNodeProcessor.RasterizeAndConcat` placed `consumed++` **after** `op.Dispose()`. When an op throws from `Dispose()`, `consumed` is left pointing at the faulting op, so the `catch` sweep re-disposes `ops[consumed]` — invoking that op's `OnDispose` a second time.

`RenderNodeOperation.Dispose()` is idempotent only when `OnDispose` succeeds: a throwing `OnDispose` never reaches `IsDisposed = true`, so the re-dispose re-runs cleanup. For an op holding an `SKImage` / GPU handle that is a use-after-free, and the remaining trailing ops are leaked.

The fix moves `consumed++` between `Render` and `Dispose`, so the faulting op is excluded from the catch sweep — matching the existing order already used by `Rasterize` and `RasterizeToRenderTargets`. The success path is unchanged.

- Found via `scheduled-code-review.yml` (commit `e322d3587`, the 003 resolution-independent pipeline).

### Also in this PR — the same defect in `RasterizeAt`
Review of the first commit surfaced that `RasterizeAt` had the identical bug in a different shape: it disposed its op inside the `try` (after `Render`) **and again** in the `catch`. A throwing `OnDispose` (which leaves `IsDisposed = false`) made the catch re-dispose — the same use-after-free, reachable from **both** `Rasterize` and `RasterizeToRenderTargets`. Fixed by guarding the catch with a local `opDisposeStarted` flag set between `Render` and `Dispose` (the single-op analog of the `consumed++` guard). The op is still disposed exactly once on the success and Render-throws paths.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None. Behavior-preserving on the success path; only the exception-cleanup ordering changes.

## Test plan
- `tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs`:
  - `RasterizeAndConcat_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows` — RED before the first fix (`disposed` was `["first", "fault", "fault"]`), GREEN after.
  - `Rasterize_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows` (new) — exercises the `RasterizeAt` path: RED before the second fix (`disposed` was `["first", "fault", "fault", "remaining"]`), GREEN after.
  - Both dispose-throw tests now capture the propagated exception and assert `Message == "fault"` (addresses the Copilot review comment).
- Fixture: green. Broader regression `FullyQualifiedName~Engine.Graphics.Rendering`: **388 passed, 0 failed** (golden tests included).
- `dotnet format --verify-no-changes` on both touched files: clean.

## Follow-ups
Surfaced by this review, intentionally **out of scope** for this exception-cleanup fix (different methods/files; all are leak-only — no `catch`, so no double-dispose — and `RenderTarget.Dispose` is idempotent, so the symptom is a GPU/`SKImage` handle leak rather than a use-after-free):

- **Unguarded op-dispose loops leak remaining ops on throw.** `RenderNodeProcessor.Render(ImmediateCanvas)`, `Renderer.RenderDrawable`, `Renderer.RecalculateBoundaries`, and `ParticleRenderNode`'s render loop iterate `op.Render(...); op.Dispose();` with no `try/catch`; a mid-loop throw leaks every remaining op. (`RecalculateBoundaries` does not call `op.Render` in its loop, so its trigger is narrower — `op.Bounds`/`Dispose` throwing.) Fix pattern: the same `consumed`-counter sweep the rasterize methods already use.
- **Catch-sweep is not robust to a throwing sweep-Dispose.** In `Rasterize` / `RasterizeToRenderTargets` / `RasterizeAndConcat`, if an `ops[j].Dispose()` inside the `catch` sweep throws, the loop aborts (subsequent ops leak) and the new exception masks the original; in `RasterizeToRenderTargets` it also skips the trailing render-target disposal loop. Consider wrapping each sweep `Dispose` in its own `try/catch` (swallow or aggregate).

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-18][diff][medium] RasterizeAndConcat: consumed++ after op.Dispose() risks double-dispose in catch")

https://claude.ai/code/session_0153Dq57kQ3eBwaoR3Fsj3VN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception safety during rendering cleanup to avoid double-disposal when an operation throws from its disposal logic.
  * Updated render-loop cleanup accounting so operations are marked as completed at the correct time, even if disposal throws.
* **Tests**
  * Added unit tests for disposal-throw scenarios to verify faulting operations are disposed exactly once and that remaining operations are still cleaned up correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
