### PR TITLE
build: drop blanket dual-TFM default, hoist MSBuild blocks, unify coverlet (Phase 2)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,10 +37,17 @@ jobs:
           # SwiftShader Vulkan ICD fails to load; see GpuGoldenSuiteCanaryTests.
           BEUTL_REQUIRE_GPU: "1"
 
+      - name: Merge coverage reports
+        # Every test project now collects coverage (coverlet.collector is shared via
+        # tests/Directory.Build.props), so dotnet test emits one cobertura file per test
+        # project. Merge them into a single report so the summary de-duplicates packages
+        # instead of listing each package once per test assembly.
+        run: reportgenerator -reports:"tests/**/coverage.cobertura.xml" -targetdir:coveragereport -reporttypes:"Cobertura;Html"
+
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: tests/**/coverage.cobertura.xml
+          filename: coveragereport/Cobertura.xml
           badge: true
           fail_below_min: true
           format: markdown
@@ -58,9 +65,6 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
-
-      - name: Generate Report
-        run: reportgenerator -reports:`find tests/Beutl.UnitTests/TestResults/*/coverage.cobertura.xml | head -n 1 ` -targetdir:coveragereport -reporttypes:Html
 
       - name: Save
         uses: actions/upload-artifact@v7

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,18 +17,10 @@
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <!-- Sideload output layout for dynamically loaded extension packages, opted into with
-       <SideloadOutput>true</SideloadOutput>. Mirrors the package into the user's
-       ~/.beutl/sideloads/<AssemblyName> folder so a local dev build is picked up by the
-       running app. Each consuming project keeps its OWN additional activation guard (e.g.
-       FFmpegBuildIn!=True, or MediaFoundation's non-built-in Choose arm) and only sets
-       SideloadOutput=true inside that guard. The shared Debug / non-CI condition lives here. -->
-  <PropertyGroup Condition="'$(SideloadOutput)' == 'true' And '$(Configuration)'=='Debug' And '$(CI)'!='true'">
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <EnableDynamicLoading>true</EnableDynamicLoading>
-    <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
-  </PropertyGroup>
+  <!-- NOTE: the sideload output-layout block is NOT hoisted here. It sets OutputPath, which must be
+       evaluated before Microsoft.Common.CurrentVersion.targets derives OutDir/TargetDir; a property
+       set in Directory.Build.targets runs too late. It lives in build/props/SideloadOutput.props,
+       imported from each consuming project's body. -->
 
   <!-- Aigamo.ResXGenerator analyzer reference, opted into with <UseResXGenerator>true</UseResXGenerator>.
        The ResXGenerator_* configuration properties stay global in Directory.Build.props; only the

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,4 +5,38 @@
       <_Parameter2>$(Version)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
+
+  <!-- Desktop-exe RID set, opted into with <DesktopExeRids>true</DesktopExeRids>.
+       The base list covers every shippable desktop RID; on a Windows TFM it narrows to
+       win-x64 only (the other RIDs are meaningless for a -windows assembly and would make
+       restore drag in unnecessary runtime packs). -->
+  <PropertyGroup Condition="'$(DesktopExeRids)' == 'true'">
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DesktopExeRids)' == 'true' And $(TargetFramework.Contains('windows'))">
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <!-- Sideload output layout for dynamically loaded extension packages, opted into with
+       <SideloadOutput>true</SideloadOutput>. Mirrors the package into the user's
+       ~/.beutl/sideloads/<AssemblyName> folder so a local dev build is picked up by the
+       running app. Each consuming project keeps its OWN additional activation guard (e.g.
+       FFmpegBuildIn!=True, or MediaFoundation's non-built-in Choose arm) and only sets
+       SideloadOutput=true inside that guard. The shared Debug / non-CI condition lives here. -->
+  <PropertyGroup Condition="'$(SideloadOutput)' == 'true' And '$(Configuration)'=='Debug' And '$(CI)'!='true'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
+  </PropertyGroup>
+
+  <!-- Aigamo.ResXGenerator analyzer reference, opted into with <UseResXGenerator>true</UseResXGenerator>.
+       The ResXGenerator_* configuration properties stay global in Directory.Build.props; only the
+       PackageReference is hoisted here. -->
+  <ItemGroup Condition="'$(UseResXGenerator)' == 'true'">
+    <PackageReference Include="Aigamo.ResXGenerator">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,10 +6,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Desktop-exe RID set, opted into with <DesktopExeRids>true</DesktopExeRids>.
-       The base list covers every shippable desktop RID; on a Windows TFM it narrows to
-       win-x64 only (the other RIDs are meaningless for a -windows assembly and would make
-       restore drag in unnecessary runtime packs). -->
+  <!-- RID set, opted into with <DesktopExeRids>true</DesktopExeRids>; narrowed to win-x64 on a Windows TFM. -->
   <PropertyGroup Condition="'$(DesktopExeRids)' == 'true'">
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
@@ -17,14 +14,10 @@
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <!-- NOTE: the sideload output-layout block is NOT hoisted here. It sets OutputPath, which must be
-       evaluated before Microsoft.Common.CurrentVersion.targets derives OutDir/TargetDir; a property
-       set in Directory.Build.targets runs too late. It lives in build/props/SideloadOutput.props,
-       imported from each consuming project's body. -->
+  <!-- Sideload output layout is not hoisted here: it sets OutputPath, which must be set before
+       OutDir is derived (too late in this file). See build/props/SideloadOutput.props. -->
 
-  <!-- Aigamo.ResXGenerator analyzer reference, opted into with <UseResXGenerator>true</UseResXGenerator>.
-       The ResXGenerator_* configuration properties stay global in Directory.Build.props; only the
-       PackageReference is hoisted here. -->
+  <!-- Aigamo.ResXGenerator reference, opted into with <UseResXGenerator>true</UseResXGenerator>. -->
   <ItemGroup Condition="'$(UseResXGenerator)' == 'true'">
     <PackageReference Include="Aigamo.ResXGenerator">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/build/props/SideloadOutput.props
+++ b/build/props/SideloadOutput.props
@@ -1,16 +1,7 @@
 <Project>
-  <!-- Sideload output layout for dynamically loaded extension packages. Mirrors the package into
-       the user's ~/.beutl/sideloads/<AssemblyName> folder so a local dev build is picked up by
-       the running app.
-
-       This is IMPORTED from the consuming project's body (props-time) rather than hoisted into
-       Directory.Build.targets: OutputPath must be set before Microsoft.Common.CurrentVersion.targets
-       derives OutDir/TargetDir from it. A Directory.Build.targets PropertyGroup runs after that
-       derivation, so the build output would land in bin/ instead of ~/.beutl/sideloads.
-
-       Guarded by SideloadOutput, which the importing project sets (inside its own activation guard,
-       e.g. FFmpegBuildIn!=True or MediaFoundation's non-built-in Choose arm) immediately before the
-       import. AssemblyName is already resolved at body-time, so the per-package folder is correct. -->
+  <!-- Mirrors the package into ~/.beutl/sideloads/<AssemblyName> so a local dev build is picked up
+       by the running app. Imported from the consuming project's body (not Directory.Build.targets)
+       because OutputPath must be set before OutDir is derived. Guarded by SideloadOutput. -->
   <PropertyGroup Condition="'$(SideloadOutput)' == 'true' And '$(Configuration)'=='Debug' And '$(CI)'!='true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/build/props/SideloadOutput.props
+++ b/build/props/SideloadOutput.props
@@ -1,0 +1,20 @@
+<Project>
+  <!-- Sideload output layout for dynamically loaded extension packages. Mirrors the package into
+       the user's ~/.beutl/sideloads/<AssemblyName> folder so a local dev build is picked up by
+       the running app.
+
+       This is IMPORTED from the consuming project's body (props-time) rather than hoisted into
+       Directory.Build.targets: OutputPath must be set before Microsoft.Common.CurrentVersion.targets
+       derives OutDir/TargetDir from it. A Directory.Build.targets PropertyGroup runs after that
+       derivation, so the build output would land in bin/ instead of ~/.beutl/sideloads.
+
+       Guarded by SideloadOutput, which the importing project sets (inside its own activation guard,
+       e.g. FFmpegBuildIn!=True or MediaFoundation's non-built-in Choose arm) immediately before the
+       import. AssemblyName is already resolved at body-time, so the per-package folder is correct. -->
+  <PropertyGroup Condition="'$(SideloadOutput)' == 'true' And '$(Configuration)'=='Debug' And '$(CI)'!='true'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/Beutl.Controls/Beutl.Controls.csproj
+++ b/src/Beutl.Controls/Beutl.Controls.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <Nullable>disable</Nullable>
     <NoWarn>AVP1002</NoWarn>
   </PropertyGroup>

--- a/src/Beutl.Controls/Beutl.Controls.csproj
+++ b/src/Beutl.Controls/Beutl.Controls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <Nullable>disable</Nullable>
     <NoWarn>AVP1002</NoWarn>

--- a/src/Beutl.Controls/Beutl.Controls.csproj
+++ b/src/Beutl.Controls/Beutl.Controls.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <Nullable>disable</Nullable>
     <NoWarn>AVP1002</NoWarn>

--- a/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
+++ b/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <NeutralLanguage>en</NeutralLanguage>
     <SelfContained>false</SelfContained>

--- a/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
+++ b/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
+++ b/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
@@ -5,16 +5,10 @@
     <NeutralLanguage>en</NeutralLanguage>
     <SelfContained>false</SelfContained>
     <DefineConstants>$(DefineConstants);Beutl_ExceptionHandler</DefineConstants>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <DesktopExeRids>true</DesktopExeRids>
+    <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aigamo.ResXGenerator">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />

--- a/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
+++ b/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/Beutl.Extensions.AVFoundation/build/BeutlAVF.targets
+++ b/src/Beutl.Extensions.AVFoundation/build/BeutlAVF.targets
@@ -7,10 +7,8 @@
     <SwiftBuildConfig Condition="'$(SwiftBuildConfig)' == ''">release</SwiftBuildConfig>
     <SkipSwiftBuild Condition="'$(SkipSwiftBuild)' == ''">false</SkipSwiftBuild>
 
-    <!-- Owner switch: the AVFoundation project itself imports this file without setting any
-         property, so the Swift build + packaging pipeline below defaults on. Consumers that only
-         need the mirror-to-output target (the app and the AVF test project) import this file with
-         BeutlAVFOwnsSwiftBuild=false, leaving just CopyBeutlAVFDylibsToConsumerOutput active. -->
+    <!-- The AVF project imports this with the Swift build pipeline on; consumers that only need the
+         mirror target (the app, the AVF test project) import with BeutlAVFOwnsSwiftBuild=false. -->
     <BeutlAVFOwnsSwiftBuild Condition="'$(BeutlAVFOwnsSwiftBuild)' == ''">true</BeutlAVFOwnsSwiftBuild>
   </PropertyGroup>
 
@@ -81,12 +79,9 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Reusable mirror target for consumers that ProjectReference the AVF assembly but do not
-       own the Swift build (the app and the AVF test project). ProjectReferences don't
-       transitively copy native runtime assets (runtimes/<rid>/native), so each consumer mirrors
-       the committed dylibs from the AVF project's runtimes/ folder into its own $(OutDir).
-       Opt in with <CopyBeutlAVFDylibsToOutput>true</CopyBeutlAVFDylibsToOutput>; the consumer
-       keeps its own activation guard (the app gates on AVFBuildIn, the tests gate on macOS). -->
+  <!-- Mirror target for consumers that ProjectReference the AVF assembly but don't own the Swift
+       build. ProjectReferences don't copy native runtimes/<rid>/native assets, so each consumer
+       copies the committed dylibs into its own $(OutDir). Opt in with CopyBeutlAVFDylibsToOutput. -->
   <Target Name="CopyBeutlAVFDylibsToConsumerOutput"
           AfterTargets="Build"
           Condition="'$(CopyBeutlAVFDylibsToOutput)' == 'true'">

--- a/src/Beutl.Extensions.AVFoundation/build/BeutlAVF.targets
+++ b/src/Beutl.Extensions.AVFoundation/build/BeutlAVF.targets
@@ -6,9 +6,15 @@
     <SwiftDylibName>libBeutlAVF.dylib</SwiftDylibName>
     <SwiftBuildConfig Condition="'$(SwiftBuildConfig)' == ''">release</SwiftBuildConfig>
     <SkipSwiftBuild Condition="'$(SkipSwiftBuild)' == ''">false</SkipSwiftBuild>
+
+    <!-- Owner switch: the AVFoundation project itself imports this file without setting any
+         property, so the Swift build + packaging pipeline below defaults on. Consumers that only
+         need the mirror-to-output target (the app and the AVF test project) import this file with
+         BeutlAVFOwnsSwiftBuild=false, leaving just CopyBeutlAVFDylibsToConsumerOutput active. -->
+    <BeutlAVFOwnsSwiftBuild Condition="'$(BeutlAVFOwnsSwiftBuild)' == ''">true</BeutlAVFOwnsSwiftBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BeutlAVFOwnsSwiftBuild)' == 'true'">
     <SwiftSourceFile Include="$(SwiftPackageRoot)/Package.swift" />
     <SwiftSourceFile Include="$(SwiftPackageRoot)/Sources/**/*.swift" />
     <!-- Track the C shim (headers, modulemap, translation units) so ABI-relevant edits also
@@ -25,7 +31,7 @@
        NuGet package. That way package consumers on macOS get the native library regardless of
        which OS built the nupkg. The same <None> also drives CopyToOutputDirectory in the
        owning project for incremental dev builds. -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(BeutlAVFOwnsSwiftBuild)' == 'true'">
     <None Include="$(SwiftRuntimesRoot)/**/*.dylib">
       <Link>runtimes/%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -38,7 +44,7 @@
   <!-- Build the Swift package (incremental on source changes) and publish the dylib into the
        per-rid runtimes folder. Only runs on macOS; elsewhere the committed dylib is reused. -->
   <Target Name="BuildSwiftDylib"
-          Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true' and '$(SkipSwiftBuild)' != 'true'"
+          Condition="'$(BeutlAVFOwnsSwiftBuild)' == 'true' and '$([MSBuild]::IsOSPlatform(OSX))' == 'true' and '$(SkipSwiftBuild)' != 'true'"
           Inputs="@(SwiftSourceFile)"
           Outputs="$(SwiftRuntimesRoot)/osx-arm64/native/$(SwiftDylibName);$(SwiftRuntimesRoot)/osx-x64/native/$(SwiftDylibName)">
 
@@ -66,12 +72,29 @@
   <Target Name="CopyBeutlAVFDylibToOutput"
           AfterTargets="Build"
           DependsOnTargets="BuildSwiftDylib"
-          Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
+          Condition="'$(BeutlAVFOwnsSwiftBuild)' == 'true' and '$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
     <ItemGroup>
       <_BeutlAVFDylib Include="$(SwiftRuntimesRoot)/**/*.dylib" />
     </ItemGroup>
     <Copy SourceFiles="@(_BeutlAVFDylib)"
           DestinationFiles="@(_BeutlAVFDylib->'$(OutDir)runtimes/%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Reusable mirror target for consumers that ProjectReference the AVF assembly but do not
+       own the Swift build (the app and the AVF test project). ProjectReferences don't
+       transitively copy native runtime assets (runtimes/<rid>/native), so each consumer mirrors
+       the committed dylibs from the AVF project's runtimes/ folder into its own $(OutDir).
+       Opt in with <CopyBeutlAVFDylibsToOutput>true</CopyBeutlAVFDylibsToOutput>; the consumer
+       keeps its own activation guard (the app gates on AVFBuildIn, the tests gate on macOS). -->
+  <Target Name="CopyBeutlAVFDylibsToConsumerOutput"
+          AfterTargets="Build"
+          Condition="'$(CopyBeutlAVFDylibsToOutput)' == 'true'">
+    <ItemGroup>
+      <_BeutlAVFConsumerDylib Include="$(SwiftRuntimesRoot)/**/*.dylib" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_BeutlAVFConsumerDylib)"
+          DestinationFiles="@(_BeutlAVFConsumerDylib->'$(OutDir)runtimes/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 

--- a/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
+++ b/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
@@ -17,8 +17,7 @@
     <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 
-  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
-       SideloadOutput property set above. -->
+  <!-- Sideload output layout; see build/props/SideloadOutput.props. -->
   <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
 
   <ItemGroup>

--- a/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
+++ b/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
@@ -17,6 +17,10 @@
     <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 
+  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
+       SideloadOutput property set above. -->
+  <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
+
   <ItemGroup>
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="ReactiveProperty" />

--- a/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
+++ b/src/Beutl.Extensions.FFmpeg/Beutl.Extensions.FFmpeg.csproj
@@ -7,18 +7,17 @@
     <Authors>b-editor</Authors>
 
     <FFmpegBuildIn Condition="'$(FFmpegBuildIn)' == ''">True</FFmpegBuildIn>
+    <SideloadOutput Condition="'$(FFmpegBuildIn)'!='True'">true</SideloadOutput>
     <DefineConstants Condition="'$(FFmpegBuildIn)'=='True'">$(DefineConstants);FFMPEG_BUILD_IN</DefineConstants>
 
     <!-- The FFmpeg-calling code lives in the GPL Beutl.FFmpegWorker (separate process); this
          extension only hosts the MIT-licensed IPC proxy + UI, so it is unconditionally MIT. -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aigamo.ResXGenerator">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="ReactiveProperty" />
   </ItemGroup>
@@ -40,12 +39,5 @@
       <LogicalName>askpass.js</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(FFmpegBuildIn)'!='True' And '$(Configuration)'=='Debug' And '$(CI)'!='true'">
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <EnableDynamicLoading>true</EnableDynamicLoading>
-    <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
-  </PropertyGroup>
 
 </Project>

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -51,8 +51,7 @@
     </Otherwise>
   </Choose>
 
-  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
-       SideloadOutput property set in the non-built-in Choose arm above. -->
+  <!-- Sideload output layout; see build/props/SideloadOutput.props. -->
   <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
 
 </Project>

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -51,4 +51,8 @@
     </Otherwise>
   </Choose>
 
+  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
+       SideloadOutput property set in the non-built-in Choose arm above. -->
+  <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
+
 </Project>

--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -8,13 +8,10 @@
     <DefineConstants>$(DefineConstants);DESKTOP_APP</DefineConstants>
     <DefineConstants Condition="'$(MFBuildIn)'=='True'">$(DefineConstants);MF_BUILD_IN</DefineConstants>
     <PlatformTarget>x64</PlatformTarget>
+    <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aigamo.ResXGenerator">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -49,13 +46,7 @@
         <AssemblyName>Beutl.Extensions.MediaFoundation</AssemblyName>
         <PackageId>Beutl.Extensions.MediaFoundation</PackageId>
         <Title>Beutl.Extensions.MediaFoundation</Title>
-      </PropertyGroup>
-
-      <PropertyGroup Condition="'$(Configuration)'=='Debug' And '$(CI)'!='true'">
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-        <EnableDynamicLoading>true</EnableDynamicLoading>
-        <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
+        <SideloadOutput>true</SideloadOutput>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -7,11 +7,7 @@
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>$(DefineConstants);FFMPEG_BUILD_IN;BEUTL_FFMPEG_WORKER</DefineConstants>
     <SelfContained>false</SelfContained>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <DesktopExeRids>true</DesktopExeRids>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/src/Beutl.Language/Beutl.Language.csproj
+++ b/src/Beutl.Language/Beutl.Language.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <NeutralLanguage>en</NeutralLanguage>
+    <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aigamo.ResXGenerator">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Update="CommandNames.resx" />

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -8,18 +8,11 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <DefineConstants>$(DefineConstants);Beutl_PackageTools</DefineConstants>
     <ApplicationIcon>..\Beutl.Controls\Assets\logo.ico</ApplicationIcon>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <DesktopExeRids>true</DesktopExeRids>
+    <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aigamo.ResXGenerator">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -4,11 +4,7 @@
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <SelfContained>false</SelfContained>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <DesktopExeRids>true</DesktopExeRids>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <FFmpegBuildIn Condition="'$(FFmpegBuildIn)' == ''">True</FFmpegBuildIn>

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <DesktopExeRids>true</DesktopExeRids>
     <FFmpegBuildIn Condition="'$(FFmpegBuildIn)' == ''">True</FFmpegBuildIn>
     <MFBuildIn Condition="'$(MFBuildIn)' == '' And $(TargetFramework.Contains('windows'))">True</MFBuildIn>
     <!-- AVFoundationはmacOS専用。osx-* RID向けpublish時、または非Windows TFMの開発ビルド
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('windows'))">
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
@@ -148,21 +147,15 @@
 
   <!-- ProjectReferences don't transitively copy native runtime assets (runtimes/<rid>/native),
        so mirror the Swift dylib from the referenced project's runtimes/ folder into this
-       project's output. Gated on AVFBuildIn so Linux/Windows publishes don't pick up the
-       macOS-only dylibs. -->
-  <Target Name="CopyBeutlAVFDylibsForApp"
-          AfterTargets="Build"
-          Condition="'$(AVFBuildIn)'=='True'">
-    <PropertyGroup>
-      <_BeutlAVFSourceRuntimes>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Beutl.Extensions.AVFoundation/runtimes'))</_BeutlAVFSourceRuntimes>
-    </PropertyGroup>
-    <ItemGroup>
-      <_BeutlAVFDylib Include="$(_BeutlAVFSourceRuntimes)/**/*.dylib" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_BeutlAVFDylib)"
-          DestinationFiles="@(_BeutlAVFDylib->'$(OutDir)runtimes/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-  </Target>
+       project's output via the AVF package's shared CopyBeutlAVFDylibsToConsumerOutput target.
+       BeutlAVFOwnsSwiftBuild=false keeps the Swift build/packaging pipeline off in this import;
+       the mirror is gated on AVFBuildIn so Linux/Windows publishes don't pick up the macOS-only
+       dylibs. -->
+  <PropertyGroup>
+    <BeutlAVFOwnsSwiftBuild>false</BeutlAVFOwnsSwiftBuild>
+    <CopyBeutlAVFDylibsToOutput Condition="'$(AVFBuildIn)'=='True'">true</CopyBeutlAVFDylibsToOutput>
+  </PropertyGroup>
+  <Import Project="..\Beutl.Extensions.AVFoundation\build\BeutlAVF.targets" />
 
   <Target Name="CopyBeutlAVFDylibForPublish"
           AfterTargets="Publish"
@@ -176,7 +169,7 @@
           Condition="Exists('$(_BeutlAVFPublishSource)')" />
 
     <!-- Sweep every libBeutlAVF.dylib that Build mirrored into runtimes/, then
-         drop any folders left empty by the cleanup. CopyBeutlAVFDylibsForApp
+         drop any folders left empty by the cleanup. CopyBeutlAVFDylibsToConsumerOutput
          intentionally seeds runtimes/<rid>/native for all RIDs so non-macOS
          pipelines can reuse them, but those copies are redundant once we have
          the dylib in the publish root, so we strip them here. -->

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <DesktopExeRids>true</DesktopExeRids>

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework></TargetFramework><!-- clear inherited default so the TFMs below cross-target -->
+    <TargetFramework></TargetFramework><!-- empty so the TFMs below cross-target -->
     <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <DesktopExeRids>true</DesktopExeRids>

--- a/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
@@ -30,7 +30,7 @@
   <!-- The Swift dylib lives under the referenced project's runtimes/ folder. ProjectReferences
        don't transitively copy native runtime assets the way NuGet packages do, so mirror them
        into this project's output via the AVF package's shared CopyBeutlAVFDylibsToConsumerOutput
-       target so the test host can resolve `BeutlAVF.dylib`. BeutlAVFOwnsSwiftBuild=false keeps the
+       target so the test host can resolve `libBeutlAVF.dylib`. BeutlAVFOwnsSwiftBuild=false keeps the
        Swift build/packaging pipeline off in this import; the mirror is gated on macOS because the
        dylib only loads there. -->
   <PropertyGroup>

--- a/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
@@ -27,12 +27,9 @@
     <None Include="Fixtures\**\*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <!-- The Swift dylib lives under the referenced project's runtimes/ folder. ProjectReferences
-       don't transitively copy native runtime assets the way NuGet packages do, so mirror them
-       into this project's output via the AVF package's shared CopyBeutlAVFDylibsToConsumerOutput
-       target so the test host can resolve `libBeutlAVF.dylib`. BeutlAVFOwnsSwiftBuild=false keeps the
-       Swift build/packaging pipeline off in this import; the mirror is gated on macOS because the
-       dylib only loads there. -->
+  <!-- Mirror the AVF dylib into this project's output (ProjectReferences don't copy native
+       runtimes/ assets) so the test host can resolve libBeutlAVF.dylib. BeutlAVFOwnsSwiftBuild=false
+       imports only the mirror target; gated on macOS where the dylib loads. -->
   <PropertyGroup>
     <BeutlAVFOwnsSwiftBuild>false</BeutlAVFOwnsSwiftBuild>
     <CopyBeutlAVFDylibsToOutput Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">true</CopyBeutlAVFDylibsToOutput>

--- a/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/Beutl.Extensions.AVFoundation.Tests.csproj
@@ -29,19 +29,14 @@
 
   <!-- The Swift dylib lives under the referenced project's runtimes/ folder. ProjectReferences
        don't transitively copy native runtime assets the way NuGet packages do, so mirror them
-       into this project's output so the test host can resolve `BeutlAVF.dylib`. -->
-  <Target Name="CopyBeutlAVFDylibsForTests"
-          AfterTargets="Build"
-          Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
-    <PropertyGroup>
-      <_BeutlAVFSourceRuntimes>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../src/Beutl.Extensions.AVFoundation/runtimes'))</_BeutlAVFSourceRuntimes>
-    </PropertyGroup>
-    <ItemGroup>
-      <_BeutlAVFDylib Include="$(_BeutlAVFSourceRuntimes)/**/*.dylib" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_BeutlAVFDylib)"
-          DestinationFiles="@(_BeutlAVFDylib->'$(OutDir)runtimes/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-  </Target>
+       into this project's output via the AVF package's shared CopyBeutlAVFDylibsToConsumerOutput
+       target so the test host can resolve `BeutlAVF.dylib`. BeutlAVFOwnsSwiftBuild=false keeps the
+       Swift build/packaging pipeline off in this import; the mirror is gated on macOS because the
+       dylib only loads there. -->
+  <PropertyGroup>
+    <BeutlAVFOwnsSwiftBuild>false</BeutlAVFOwnsSwiftBuild>
+    <CopyBeutlAVFDylibsToOutput Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">true</CopyBeutlAVFDylibsToOutput>
+  </PropertyGroup>
+  <Import Project="..\..\src\Beutl.Extensions.AVFoundation\build\BeutlAVF.targets" />
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,4 +11,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)\ArtifactProvider.cs" />
   </ItemGroup>
 
+  <!-- Coverlet collection is shared across every real test project under tests/ (gated on
+       IsTestProject so benchmark/playground executables that lack Microsoft.NET.Test.Sdk don't
+       pull in the collector), so coverage is collected uniformly. Beutl.UnitTests already declares
+       its own coverlet.collector PackageReference, so it is excluded here to avoid a
+       duplicate-PackageReference error under central package management. The version is pinned
+       centrally in Directory.Packages.props. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' And '$(MSBuildProjectName)' != 'Beutl.UnitTests'">
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,12 +11,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)\ArtifactProvider.cs" />
   </ItemGroup>
 
-  <!-- Coverlet collection is shared across every real test project under tests/ (gated on
-       IsTestProject so benchmark/playground executables that lack Microsoft.NET.Test.Sdk don't
-       pull in the collector), so coverage is collected uniformly. Beutl.UnitTests already declares
-       its own coverlet.collector PackageReference, so it is excluded here to avoid a
-       duplicate-PackageReference error under central package management. The version is pinned
-       centrally in Directory.Packages.props. -->
+  <!-- coverlet.collector shared across every real test project (gated on IsTestProject so non-test
+       executables skip it). Beutl.UnitTests declares its own, so it is excluded here to avoid a
+       duplicate under central package management. -->
   <ItemGroup Condition="'$(IsTestProject)' == 'true' And '$(MSBuildProjectName)' != 'Beutl.UnitTests'">
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PackageSample/PackageSample.csproj
+++ b/tests/PackageSample/PackageSample.csproj
@@ -12,13 +12,7 @@
     <Authors>b-editor</Authors>
     <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <EnableAvaloniaXamlCompilation>false</EnableAvaloniaXamlCompilation>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug' And '$(CI)'!='true'">
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <EnableDynamicLoading>true</EnableDynamicLoading>
-    <OutputPath>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.beutl\sideloads\$(AssemblyName)</OutputPath>
+    <SideloadOutput>true</SideloadOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/PackageSample/PackageSample.csproj
+++ b/tests/PackageSample/PackageSample.csproj
@@ -15,8 +15,7 @@
     <SideloadOutput>true</SideloadOutput>
   </PropertyGroup>
 
-  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
-       SideloadOutput property set above. -->
+  <!-- Sideload output layout; see build/props/SideloadOutput.props. -->
   <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
 
   <ItemGroup>

--- a/tests/PackageSample/PackageSample.csproj
+++ b/tests/PackageSample/PackageSample.csproj
@@ -15,6 +15,10 @@
     <SideloadOutput>true</SideloadOutput>
   </PropertyGroup>
 
+  <!-- Sideload output layout (props-time; see build/props/SideloadOutput.props). Guarded by the
+       SideloadOutput property set above. -->
+  <Import Project="$(RootDirectory)build\props\SideloadOutput.props" />
+
   <ItemGroup>
     <Compile Remove="$(MSBuildThisFileDirectory)\..\ArtifactProvider.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Phase 2 — Build foundation (PR 1 of 4)

Part of the **refactoring Phase 2: Build & test foundation** (`docs/refactoring-plan.md`, board item #199667883). This PR makes the build cheaper and de-duplicates the MSBuild plumbing.

### Changes
- **Drop the blanket dual-TFM default.** `Directory.Build.props` defaulted every project to `net10.0;net10.0-windows`; flip it to a single `net10.0` and opt exactly the 6 projects that need a Windows surface back into the dual set: `Beutl`, `Beutl.Controls` (both carry `#if WINDOWS` code), plus `Beutl.ExceptionHandler` / `Beutl.PackageTools.UI` / `Beutl.WaitingDialog` / `Beutl.FFmpegWorker` (win-x64 RID narrowing + the Nuke `win_x64` publish path). `EnableWindowsTargeting=true` is kept so MediaFoundation (CsWin32/Vortice) still compiles cross-platform. **33 projects stop double-compiling** (the plan's "~24" undercounted; the test projects were also double-targeting because the singular `<TargetFramework>` in `tests/Directory.Build.props` is ignored while multi-targeting). `nukebuild/Build.cs` is unchanged — `GetTFM()` already reads the first TFM, and the 5 published projects keep `-windows`.
- **Hoist duplicated MSBuild block families**, each behind an opt-in guard property so behaviour is byte-preserved: `DesktopExeRids` (win-RID narrowing + base RID list, ×5) and `UseResXGenerator` (Aigamo.ResXGenerator PackageReference, ×5) into `Directory.Build.targets`; the two byte-identical AVF dylib-copy targets folded into one reusable target in `BeutlAVF.targets`. The publish-time `CopyBeutlAVFDylibForPublish` (bespoke stale-dylib sweep) is intentionally left per-project. The sideload output-layout block (×3) is shared via `build/props/SideloadOutput.props` **imported from each consuming project's body** rather than hoisted into `Directory.Build.targets`: it sets `OutputPath`, which must be evaluated before `Microsoft.Common.CurrentVersion.targets` derives `OutDir`/`TargetDir` (props-time), and a `Directory.Build.targets` property runs too late.
- **Unify coverlet collection.** `coverlet.collector` now comes from `tests/Directory.Build.props` for every real test project (gated on `IsTestProject` so benchmark/playground executables don't pull it in), excluding `Beutl.UnitTests` which already declares its own.
- **Merge coverage reports in CI** (`.github/workflows/dotnet.yml`). Because every test project now emits its own cobertura file, the old `CodeCoverageSummary` glob listed each package once per test assembly (duplicated table, deflated overall rate). Add a `reportgenerator` step that merges `tests/**/coverage.cobertura.xml` into a single `coveragereport/Cobertura.xml` (+ HTML) before summarizing, so packages are de-duplicated and coverage is unioned across suites; also drops the brittle `head -1` hardcode in the HTML report step. _(Workflow edit approved by the maintainer.)_

### Testing
`dotnet build Beutl.slnx` → 0 errors, building both legs (the ~27 single-target projects compile once; the 6 Windows-surface projects still cross-target `net10.0` + `net10.0-windows`). Verified via `dotnet msbuild -getProperty:...` that the 6 opt-ins resolve `IsCrossTargetingBuild=true`, RID narrowing yields `win-x64` on the `-windows` inner leg, the sideload `OutputPath`/`TargetDir` both land in `~/.beutl/sideloads/<AssemblyName>` for Debug non-CI extension builds, the AVF dylib still lands in `runtimes/`, and `coverlet.collector` resolves (`IsTestProject=true`, no duplicate-PackageReference). Validated the `reportgenerator` merge de-duplicates multiple cobertura inputs. Confirmed green inside the full 4-PR integration (`dotnet build Beutl.slnx` + UnitTests/AVFoundation/Graphics3D/FFmpegIpc/SourceGenerator suites pass; the MediaFoundation.Tests assembly only loads on x64, a pre-existing arm64 limitation also present on `main`).

### Follow-ups
- Optionally add an explicit `IsOSPlatform(OSX)` guard to the shared AVF dylib-copy target as defence-in-depth (behaviour-neutral today).
- CI coverage **threshold** is deliberately left at `0` this round; re-enabling a real `60/80` gate is a separate decision now that the merged report shows an accurate rate.

### Review responses
- **P1 — cleared inherited `TargetFramework`** (566cbd901). The global single `<TargetFramework>net10.0</TargetFramework>` left the property non-empty in the 6 opt-in projects, so the SDK never entered cross-targeting and only the `net10.0` leg built (the `#if WINDOWS` code was silently skipped). Each opt-in now clears `TargetFramework` next to its `TargetFrameworks`; verified `IsCrossTargetingBuild=true` for all 6.
- **P2 — sideload `OutputPath` evaluated at props-time** (0becec195). Hoisting the block into `Directory.Build.targets` set `OutputPath` after `OutDir`/`TargetDir` were derived, so Debug extension builds landed in `bin/` instead of `~/.beutl/sideloads`. Moved to `build/props/SideloadOutput.props`, imported from each project body.
- **P2 — coverlet condition** (no change): verified non-reproducing — `IsTestProject` is set by the test SDK's project-extension props before this ItemGroup evaluates, so `coverlet.collector` is added to every test project as intended.
- **Workflow change** (no change): the `dotnet.yml` coverage-merge step is the approved fix for the broken coverage table on this PR.
- **Comment fix** (06f43a21f): AVFoundation.Tests comment now references `libBeutlAVF.dylib`.

### Stack
PR 1/4 → base `main`. Merge this first; PRs 2–4 stack on top in order.

https://claude.ai/code/session_01RCEWT3SuoG84FZmmaHsiPj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated projects to target .NET 10.0 (including Windows variants) and refined desktop runtime packaging behavior.
  * Switched ResX generation to the SDK’s built-in generator.
  * Improved AVFoundation native dylib build/copy behavior, including optional mirroring into app/test outputs.
  * Enhanced local non-CI Debug “sideload” output layout to use a user profile directory.
* **Tests**
  * Improved test coverage reporting by merging per-project results into a single Cobertura report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
