### PR TITLE
cleanup(player): remove dead DrawFrame()

### DIFF
--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1709,40 +1709,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         });
     }
 
-    public async Task<Bitmap> DrawFrame()
-    {
-        await Pause();
-
-        return await RenderThread.Dispatcher.InvokeAsync(() =>
-        {
-            if (Scene == null) throw new Exception("Scene is null.");
-            SceneRenderer renderer = EditViewModel.Renderer.Value;
-
-            RenderCacheOptions restoreCacheOptions = renderer.CacheOptions;
-            renderer.CacheOptions = RenderCacheOptions.Disabled;
-
-            try
-            {
-                var compositionFrame = renderer.Compositor.EvaluateGraphics(CurrentFrame.Value);
-                renderer.Render(compositionFrame);
-
-                // Normalize snapshot to logical FrameSize (no-op when OutputScale == 1).
-                Bitmap snapshot = renderer.Snapshot();
-                Bitmap normalized = SupersampleDownscaler.ToFrameSize(snapshot, renderer.FrameSize, renderer.OutputScale);
-                if (!ReferenceEquals(normalized, snapshot))
-                {
-                    snapshot.Dispose();
-                }
-
-                return normalized;
-            }
-            finally
-            {
-                renderer.CacheOptions = restoreCacheOptions;
-            }
-        });
-    }
-
     /// <summary>
     /// Renders the current frame at full scale on a throwaway renderer, ignoring preview quality.
     /// </summary>


### PR DESCRIPTION
## Description
- Removes the parameterless `PlayerViewModel.DrawFrame()`, which has **zero callers**: every former call site moved to `DrawFrameAtFullScale` / `DrawFrameAtScale` during the 003 resolution-independent-pipeline work (commit `e322d3587`).
- It was also misleading: unlike the `*AtScale` variants (which render on a throwaway renderer at the requested scale), `DrawFrame()` rendered on the **live preview renderer** then downsampled via `SupersampleDownscaler.ToFrameSize`, baking in reduced preview quality. Deleting it prevents accidental reuse.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`) — app-shell player ViewModel
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. The removed method is an app-internal ViewModel member (not a plugin/library API in `Beutl.Engine` / `Beutl.Extensibility` / `Beutl.NodeGraph` / `Beutl.FFmpegIpc`) with no in-repo callers.

## Test plan
- Pure deletion of uncalled code — no new logic, so no new unit test is applicable (AGENTS.md rule #3 covers *new logic*).
- Safety verified by a repo-wide `\bDrawFrame\b` grep (word-boundary, excluding `DrawFrameAtFullScale` / `DrawFrameAtScale`) returning **only the definition itself**; the method is not part of `IPreviewPlayer` or any other interface, not `virtual`/`override`, and has no reflection / string-literal / XAML references.
- `dotnet build Beutl.slnx` is green (a stray caller would fail to compile here) — `1 file changed, 34 deletions`.
- `dotnet format Beutl.slnx --include src/Beutl/ViewModels/PlayerViewModel.cs --verify-no-changes` passes on the touched file.
- `SupersampleDownscaler.ToFrameSize` (the only non-trivial call inside the method) stays live via `src/Beutl/Models/FrameProviderImpl.cs`, so no helper is stranded.

## Fixed issues / References
- Project board: b-editor/projects/9 ("cleanup(player): remove dead PlayerViewModel.DrawFrame()")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an internal frame-rendering method. Existing frame-rendering capabilities remain available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->