### PR TITLE
fix(engine): guard audio/media sample-index conversions against Int32 overflow

### DIFF
--- a/src/Beutl.Engine/Audio/Graph/AudioMath.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioMath.cs
@@ -20,6 +20,21 @@ public static class AudioMath
         return linear > 0f ? 20f * MathF.Log10(linear) : -100f;
     }
 
+    /// <summary>
+    /// Converts an absolute time position to a sample index, using <see cref="long"/> to avoid the
+    /// Int32 overflow of <c>(int)(time.TotalSeconds * sampleRate)</c>. Once the product exceeds
+    /// <see cref="int.MaxValue"/> (~12.4 h at 48 kHz, ~3.1 h at 192 kHz) an unchecked <c>(int)</c>
+    /// cast silently yields <see cref="int.MinValue"/>; callers that need a bounded int must clamp
+    /// or guard the returned <see cref="long"/> themselves.
+    /// </summary>
+    public static long TimeToSampleIndex(TimeSpan time, int sampleRate)
+    {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+
+        return (long)(time.TotalSeconds * sampleRate);
+    }
+
     public static float CalculateRms(ReadOnlySpan<float> samples)
     {
         if (samples.Length == 0)

--- a/src/Beutl.Engine/Audio/Graph/AudioMath.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioMath.cs
@@ -21,11 +21,9 @@ public static class AudioMath
     }
 
     /// <summary>
-    /// Converts an absolute time position to a sample index, using <see cref="long"/> to avoid the
-    /// Int32 overflow of <c>(int)(time.TotalSeconds * sampleRate)</c>. Once the product exceeds
-    /// <see cref="int.MaxValue"/> (~12.4 h at 48 kHz, ~3.1 h at 192 kHz) an unchecked <c>(int)</c>
-    /// cast silently yields <see cref="int.MinValue"/>; callers that need a bounded int must clamp
-    /// or guard the returned <see cref="long"/> themselves.
+    /// Converts an absolute time position to a sample index as <see cref="long"/>, avoiding the Int32
+    /// overflow of <c>(int)(time.TotalSeconds * sampleRate)</c> on long timelines. Callers that need a
+    /// bounded int must clamp or guard the result.
     /// </summary>
     public static long TimeToSampleIndex(TimeSpan time, int sampleRate)
     {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
@@ -43,6 +43,8 @@ public class ClipNode : AudioNode
         {
             // padBefore (truncated) and buffer.SampleCount (from Math.Ceiling) can each drift by ±1,
             // so clamp the copy to newBuffer's capacity; the overflow is out-of-range padding.
+            // padBefore is one-clip-relative (bounded by [0, TimeRange.Duration], itself capped by
+            // GetSampleCount), so it never reaches the Int32 overflow regime — kept as int.
             int offset = (int)(padBefore.TotalSeconds * context.SampleRate);
             if (offset < 0) offset = 0;
             int copyCount = Math.Min(buffer.SampleCount, newBuffer.SampleCount - offset);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/ClipNode.cs
@@ -43,8 +43,7 @@ public class ClipNode : AudioNode
         {
             // padBefore (truncated) and buffer.SampleCount (from Math.Ceiling) can each drift by ±1,
             // so clamp the copy to newBuffer's capacity; the overflow is out-of-range padding.
-            // padBefore is one-clip-relative (bounded by [0, TimeRange.Duration], itself capped by
-            // GetSampleCount), so it never reaches the Int32 overflow regime — kept as int.
+            // padBefore is clip-relative and bounded by the clip duration, so it cannot overflow int.
             int offset = (int)(padBefore.TotalSeconds * context.SampleRate);
             if (offset < 0) offset = 0;
             int copyCount = Math.Min(buffer.SampleCount, newBuffer.SampleCount - offset);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
@@ -18,6 +18,16 @@ public sealed class SourceNode : AudioNode
         var resource = Source.Value.Resource;
         var sampleCount = context.GetSampleCount();
         var buffer = new AudioBuffer(context.SampleRate, 2, sampleCount);
+
+        // An unloaded or failed-to-open source keeps SampleRate == 0 (its MediaReader never opened — e.g.
+        // a moved / deleted / unsupported file). Such a source is unreadable, so return silence: feeding 0
+        // into TimeToSampleIndex below would throw (non-positive rate) and leak this buffer before the try
+        // block, regressing the prior "missing audio file -> silence" behavior into a render-pipeline throw.
+        if (resource.SampleRate <= 0)
+        {
+            return buffer;
+        }
+
         long start = AudioMath.TimeToSampleIndex(context.TimeRange.Start, resource.SampleRate);
         long length = (long)Math.Ceiling(context.TimeRange.Duration.TotalSeconds * resource.SampleRate);
 

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
@@ -18,13 +18,22 @@ public sealed class SourceNode : AudioNode
         var resource = Source.Value.Resource;
         var sampleCount = context.GetSampleCount();
         var buffer = new AudioBuffer(context.SampleRate, 2, sampleCount);
-        var start = (int)(context.TimeRange.Start.TotalSeconds * resource.SampleRate);
-        var length = (int)Math.Ceiling(context.TimeRange.Duration.TotalSeconds * resource.SampleRate);
+        long start = AudioMath.TimeToSampleIndex(context.TimeRange.Start, resource.SampleRate);
+        long length = (long)Math.Ceiling(context.TimeRange.Duration.TotalSeconds * resource.SampleRate);
+
+        // Resource.Read (and downstream decoders) take int sample offsets, so a source whose start
+        // exceeds int.MaxValue samples is unreadable regardless. Treat an out-of-int-range offset
+        // as silence instead of letting the unchecked (int) cast wrap to int.MinValue (wrong seek /
+        // audio on long timelines at high sample rates).
+        if (start < 0 || length < 0 || start > int.MaxValue || length > int.MaxValue)
+        {
+            return buffer;
+        }
 
         try
         {
             // Read PCM data from source
-            if (resource.Read(start, length, out var pcmRef))
+            if (resource.Read((int)start, (int)length, out var pcmRef))
             {
                 using (pcmRef)
                 {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SourceNode.cs
@@ -19,10 +19,8 @@ public sealed class SourceNode : AudioNode
         var sampleCount = context.GetSampleCount();
         var buffer = new AudioBuffer(context.SampleRate, 2, sampleCount);
 
-        // An unloaded or failed-to-open source keeps SampleRate == 0 (its MediaReader never opened — e.g.
-        // a moved / deleted / unsupported file). Such a source is unreadable, so return silence: feeding 0
-        // into TimeToSampleIndex below would throw (non-positive rate) and leak this buffer before the try
-        // block, regressing the prior "missing audio file -> silence" behavior into a render-pipeline throw.
+        // An unloaded or failed-to-open source has SampleRate == 0 and is unreadable — return silence
+        // (this also avoids TimeToSampleIndex throwing on the non-positive rate below).
         if (resource.SampleRate <= 0)
         {
             return buffer;
@@ -31,10 +29,8 @@ public sealed class SourceNode : AudioNode
         long start = AudioMath.TimeToSampleIndex(context.TimeRange.Start, resource.SampleRate);
         long length = (long)Math.Ceiling(context.TimeRange.Duration.TotalSeconds * resource.SampleRate);
 
-        // Resource.Read (and downstream decoders) take int sample offsets, so a source whose start
-        // exceeds int.MaxValue samples is unreadable regardless. Treat an out-of-int-range offset
-        // as silence instead of letting the unchecked (int) cast wrap to int.MinValue (wrong seek /
-        // audio on long timelines at high sample rates).
+        // Resource.Read takes int sample offsets, so an out-of-int-range start/length is unreadable —
+        // return silence rather than wrapping the cast to a negative offset.
         if (start < 0 || length < 0 || start > int.MaxValue || length > int.MaxValue)
         {
             return buffer;

--- a/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/SpeedNode.cs
@@ -95,7 +95,7 @@ public sealed class SpeedNode : AudioNode
         // Per-sample speed buffer, sized to expectedOutputSampleCount and allocated every render —
         // rent from ArrayPool to avoid hot-path GC pressure. ProcessBufferWithVariableSpeed consumes
         // the span synchronously without retaining it, so the array is safe to return afterwards.
-        var startInSamples = (int)(context.TimeRange.Start.TotalSeconds * context.SampleRate);
+        var startInSamples = AudioMath.TimeToSampleIndex(context.TimeRange.Start, context.SampleRate);
         double[] speedsArray = ArrayPool<double>.Shared.Rent(expectedOutputSampleCount);
         try
         {

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Beutl.Audio.Graph;
 using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Media.Decoding;
@@ -98,7 +99,11 @@ public sealed class SoundSource : MediaSource
 
         private int ToSamples(TimeSpan timeSpan)
         {
-            return (int)(timeSpan.TotalSeconds * SampleRate);
+            // Compute in long and clamp: an unchecked (int) cast wraps past int.MaxValue to
+            // int.MinValue, which ReadAudio would treat as a negative offset (latent today since no
+            // caller passes an absolute start, but same bug shape as the node-level conversions).
+            long samples = AudioMath.TimeToSampleIndex(timeSpan, SampleRate);
+            return (int)Math.Clamp(samples, 0, int.MaxValue);
         }
 
         public override void Update(EngineObject obj, CompositionContext context, ref bool updateOnly)

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -99,9 +99,8 @@ public sealed class SoundSource : MediaSource
 
         private int ToSamples(TimeSpan timeSpan)
         {
-            // Compute in long and clamp: an unchecked (int) cast wraps past int.MaxValue to
-            // int.MinValue, which ReadAudio would treat as a negative offset (latent today since no
-            // caller passes an absolute start, but same bug shape as the node-level conversions).
+            // Compute in long and clamp to a valid int offset, so a time past int.MaxValue samples
+            // does not wrap to a negative offset.
             long samples = AudioMath.TimeToSampleIndex(timeSpan, SampleRate);
             return (int)Math.Clamp(samples, 0, int.MaxValue);
         }

--- a/src/Beutl.Engine/Media/SpeedIntegrator.cs
+++ b/src/Beutl.Engine/Media/SpeedIntegrator.cs
@@ -117,11 +117,14 @@ public sealed class SpeedIntegrator : IDisposable
             _integralCache![sec + 1] = sum;
         }
 
-        // Integrate the remainder from the target second to the exact target time
-        int targetInSamples = (int)(timeSpan.TotalSeconds * _sampleRate);
-        int secStartInSamples = targetSec * _sampleRate;
+        // Integrate the remainder from the target second to the exact target time. Sample-domain
+        // math uses long: an absolute global time past int.MaxValue samples (long timelines at high
+        // sample rates) would wrap an unchecked (int) cast to a negative index and silently return
+        // a wrong (too-small) source start. targetSec stays int — it is in seconds (~68 yr ceiling).
+        long targetInSamples = (long)(timeSpan.TotalSeconds * _sampleRate);
+        long secStartInSamples = (long)targetSec * _sampleRate;
 
-        for (int i = secStartInSamples; i < targetInSamples; i++)
+        for (long i = secStartInSamples; i < targetInSamples; i++)
         {
             double t = i / (double)_sampleRate;
             float speed = animation.Interpolate(TimeSpan.FromSeconds(t));

--- a/src/Beutl.Engine/Media/SpeedIntegrator.cs
+++ b/src/Beutl.Engine/Media/SpeedIntegrator.cs
@@ -117,10 +117,8 @@ public sealed class SpeedIntegrator : IDisposable
             _integralCache![sec + 1] = sum;
         }
 
-        // Integrate the remainder from the target second to the exact target time. Sample-domain
-        // math uses long: an absolute global time past int.MaxValue samples (long timelines at high
-        // sample rates) would wrap an unchecked (int) cast to a negative index and silently return
-        // a wrong (too-small) source start. targetSec stays int — it is in seconds (~68 yr ceiling).
+        // Integrate the remainder from the target second to the exact target time. Sample-domain math
+        // uses long to avoid Int32 overflow on long timelines; targetSec stays int (seconds).
         long targetInSamples = (long)(timeSpan.TotalSeconds * _sampleRate);
         long secStartInSamples = (long)targetSec * _sampleRate;
 

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioMathTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioMathTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Beutl.Audio.Graph;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class AudioMathTests
+{
+    [TestCase(0.0, 44100, ExpectedResult = 0L)]
+    [TestCase(1.0, 44100, ExpectedResult = 44100L)]
+    [TestCase(0.5, 48000, ExpectedResult = 24000L)]
+    [TestCase(2.0, 192000, ExpectedResult = 384000L)]
+    public long TimeToSampleIndex_NormalTimes(double seconds, int sampleRate)
+    {
+        return AudioMath.TimeToSampleIndex(TimeSpan.FromSeconds(seconds), sampleRate);
+    }
+
+    // Regression for the audio-graph Int32 overflow: past int.MaxValue samples an unchecked (int)
+    // cast would silently wrap to int.MinValue and feed a negative offset / wrong seek. The helper
+    // must return the exact long value instead.
+    [Test]
+    public void TimeToSampleIndex_LongTimelineReturnsExactLongNotWrappedNegative()
+    {
+        // 7 h @ 192 kHz = 4,838,400,000 samples (> int.MaxValue = 2,147,483,647). Reaches the
+        // overflow regime at ~3.1 h at this rate.
+        long result = AudioMath.TimeToSampleIndex(TimeSpan.FromHours(7), 192000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(7L * 3600 * 192000));
+            Assert.That(result, Is.GreaterThan((long)int.MaxValue));
+        });
+    }
+
+    [Test]
+    public void TimeToSampleIndex_NegativeTimeReturnsNegativeLong()
+    {
+        // Callers that need a non-negative index clamp/guard themselves; the helper reports the
+        // true (negative) sample position for a time before zero.
+        Assert.That(
+            AudioMath.TimeToSampleIndex(TimeSpan.FromSeconds(-1.5), 48000),
+            Is.EqualTo(-72000L));
+    }
+
+    [Test]
+    public void TimeToSampleIndex_NonPositiveSampleRateThrows()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => AudioMath.TimeToSampleIndex(TimeSpan.Zero, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => AudioMath.TimeToSampleIndex(TimeSpan.Zero, -1));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioMathTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioMathTests.cs
@@ -16,14 +16,12 @@ public class AudioMathTests
         return AudioMath.TimeToSampleIndex(TimeSpan.FromSeconds(seconds), sampleRate);
     }
 
-    // Regression for the audio-graph Int32 overflow: past int.MaxValue samples an unchecked (int)
-    // cast would silently wrap to int.MinValue and feed a negative offset / wrong seek. The helper
-    // must return the exact long value instead.
+    // Regression: past int.MaxValue samples an (int) cast would wrap negative; the helper must
+    // return the exact long value.
     [Test]
     public void TimeToSampleIndex_LongTimelineReturnsExactLongNotWrappedNegative()
     {
-        // 7 h @ 192 kHz = 4,838,400,000 samples (> int.MaxValue = 2,147,483,647). Reaches the
-        // overflow regime at ~3.1 h at this rate.
+        // 7 h @ 192 kHz = 4,838,400,000 samples, well past int.MaxValue (2,147,483,647).
         long result = AudioMath.TimeToSampleIndex(TimeSpan.FromHours(7), 192000);
 
         Assert.Multiple(() =>
@@ -36,8 +34,7 @@ public class AudioMathTests
     [Test]
     public void TimeToSampleIndex_NegativeTimeReturnsNegativeLong()
     {
-        // Callers that need a non-negative index clamp/guard themselves; the helper reports the
-        // true (negative) sample position for a time before zero.
+        // The helper reports the true (negative) position for a time before zero; callers clamp if needed.
         Assert.That(
             AudioMath.TimeToSampleIndex(TimeSpan.FromSeconds(-1.5), 48000),
             Is.EqualTo(-72000L));

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceNodeTests.cs
@@ -1,0 +1,46 @@
+﻿using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Media;
+using Beutl.Media.Source;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class SourceNodeTests
+{
+    // Regression: a SoundSource whose media failed to open (moved / deleted / unsupported file) keeps
+    // SampleRate == 0 because the MediaReader never opened. SourceNode must return a silent buffer for it,
+    // not throw from AudioMath.TimeToSampleIndex(.., 0) and leak the rented buffer allocated before the
+    // try block. Pre-fix this regressed the prior "missing audio file -> silence" behavior into an uncaught
+    // render-pipeline exception plus a pooled-buffer leak.
+    [Test]
+    public void Process_UnloadedSourceWithZeroSampleRate_ReturnsSilenceInsteadOfThrowing()
+    {
+        var resource = new SoundSource.Resource();
+        Assume.That(resource.SampleRate, Is.Zero, "precondition: an unloaded resource has SampleRate 0");
+
+        var node = new SourceNode { Source = (resource, 0) };
+        var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        var context = new AudioProcessContext(range, 44100, new AnimationSampler(), null);
+
+        AudioBuffer? buffer = null;
+        Assert.DoesNotThrow(() => buffer = node.Process(context));
+
+        using (buffer)
+        {
+            Assert.That(buffer, Is.Not.Null);
+            Assert.That(buffer!.SampleCount, Is.EqualTo(context.GetSampleCount()));
+
+            float[] left = buffer.GetChannelData(0).ToArray();
+            float[] right = buffer.GetChannelData(1).ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(left, Is.All.EqualTo(0f), "left channel must be silent");
+                Assert.That(right, Is.All.EqualTo(0f), "right channel must be silent");
+            });
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceNodeTests.cs
@@ -11,11 +11,8 @@ namespace Beutl.UnitTests.Engine.Audio;
 [TestFixture]
 public class SourceNodeTests
 {
-    // Regression: a SoundSource whose media failed to open (moved / deleted / unsupported file) keeps
-    // SampleRate == 0 because the MediaReader never opened. SourceNode must return a silent buffer for it,
-    // not throw from AudioMath.TimeToSampleIndex(.., 0) and leak the rented buffer allocated before the
-    // try block. Pre-fix this regressed the prior "missing audio file -> silence" behavior into an uncaught
-    // render-pipeline exception plus a pooled-buffer leak.
+    // Regression: a source whose media failed to open has SampleRate == 0. SourceNode must return a
+    // silent buffer for it, not throw from TimeToSampleIndex on the zero rate.
     [Test]
     public void Process_UnloadedSourceWithZeroSampleRate_ReturnsSilenceInsteadOfThrowing()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SpeedNodeTests.cs
@@ -27,7 +27,7 @@ public class SpeedNodeTests
             var buffer = new AudioBuffer(_sampleRate, 2, count);
             Span<float> left = buffer.GetChannelData(0);
             Span<float> right = buffer.GetChannelData(1);
-            int startIndex = (int)(context.TimeRange.Start.TotalSeconds * _sampleRate);
+            long startIndex = AudioMath.TimeToSampleIndex(context.TimeRange.Start, _sampleRate);
             for (int i = 0; i < count; i++)
             {
                 float v = (startIndex + i) * 0.01f;
@@ -207,10 +207,10 @@ public class SpeedNodeTests
             var buffer = new AudioBuffer(_sampleRate, 2, count);
             Span<float> left = buffer.GetChannelData(0);
             Span<float> right = buffer.GetChannelData(1);
-            int startIndex = (int)(context.TimeRange.Start.TotalSeconds * _sampleRate);
+            long startIndex = AudioMath.TimeToSampleIndex(context.TimeRange.Start, _sampleRate);
             for (int i = 0; i < count; i++)
             {
-                int idx = startIndex + i;
+                long idx = startIndex + i;
                 float v = idx >= 0 && idx < _length ? idx * 0.01f : 0f;
                 left[i] = v;
                 right[i] = -v;


### PR DESCRIPTION
## Description
Several audio paths computed a sample index with `(int)(absoluteTime.TotalSeconds * sampleRate)`. The unchecked `double -> int` cast silently yields `int.MinValue` once the product exceeds `int.MaxValue` (~12.4 h @ 48 kHz, ~6.2 h @ 96 kHz, ~3.1 h @ 192 kHz). On the render/export path this fed a **wrong audio offset** (`SourceNode`) and a **wrong animated-speed time evaluation** (`SpeedNode` + `SpeedIntegrator`) with no warning -- audio glitch / desync on long timelines at high sample rates.

- Adds `AudioMath.TimeToSampleIndex(TimeSpan, int) -> long` (the existing stateless audio-math home) and routes the reachable conversions through it.
- `SourceNode`: long `start`/`length`; out-of-int-range returns the already-allocated silence buffer (`Read`/`ReadAudio` are int-bounded regardless).
- `SpeedNode`: long `startInSamples` (downstream is `double` division).
- `SpeedIntegrator.Integrate`: sample-domain math in `long`; seconds + cache stay `int`.
- `SoundSource.ToSamples`: long + clamp (latent -- same bug shape behind the `Read(TimeSpan)` overloads).
- `ClipNode` / `DelayNode` / `LimiterNode` / `AudioProcessContext.GetSampleForTime` are bounded -> left as `int` (invariant note on `ClipNode`).

Verified not a false positive against current code; a design-validation pass re-grepped `Audio/` and traced the downstream decoders.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None. Behavior is unchanged outside the overflow regime; inside it, a previously-silently-wrong offset/seek becomes silence (`SourceNode`) or correct (`SpeedNode` / `SpeedIntegrator`). Only a new public helper (`AudioMath.TimeToSampleIndex`) is added.

## Test plan
- Baseline-first: existing `SpeedNode` / `DelayNode` tests run green **before** the change.
- New `tests/Beutl.UnitTests/Engine/Audio/AudioMathTests.cs` covers `TimeToSampleIndex` incl. the overflow regime (`7 h @ 192 kHz == 4,838,400,000L`, `> int.MaxValue`, **not** a wrapped negative).
- Post-change `SpeedNode|DelayNode|AudioMath` filter: **26 passed / 0 failed**.
- `dotnet format --verify-no-changes` clean on all changed files.

## Follow-ups
- `SourceSound.Thumbnails.cs:103` (waveform thumbnail of multi-hour sources) is reachable but a separate UI path whose complete fix also touches the `Read(int)` boundary -- to be filed as a board draft.
- A SpeedNode large-start **slope** regression test was not added: `SpeedIntegrator.Integrate` runs `O(seconds x sampleRate)` (~2.7B iterations at 7 h @ 192 kHz), so an end-to-end overflow-range test is impractical until that is addressed. `AudioMath.TimeToSampleIndex` unit tests + the mechanical `long` routing (code review) cover conversion correctness.
- `AudioProcessContext.GetSampleForTime` returns `int` (safe today, bounded) -- candidate for a future orthogonality pass.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Audio nodes: unchecked int overflow in time->sample conversion")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public utility to convert time ranges to sample indices with safer handling of extreme values.

* **Bug Fixes**
  * Prevented integer overflow/wraparound in sample-index calculations across audio playback and speed processing, returning silence instead of incorrect offsets (including when a source has an invalid/zero sample rate).
  * Improved stability for very long timelines and high sample rates.

* **Tests**
  * Added/expanded unit tests for time-to-sample conversion, edge cases (long and negative times), invalid sample rates, and silence behavior for unloaded sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->