### PR TITLE
perf(ffmpeg): share FFmpegOptionsCache across editor instances to dedupe worker IPC

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -23,7 +23,6 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
     private readonly IPropertyAdapter<AudioFormat> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
-    private readonly FFmpegOptionsCache<AudioFormat> _cache = new();
     private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegAudioEncoderSettings? _settings;
@@ -104,7 +103,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
 
         QueryParams query = CreateQueryParams(_settings);
         string key = BuildCacheKey(query);
-        if (_cache.TryGetCached(key, out AudioFormat[]? cached))
+        if (FFmpegOptionsCaches.AudioFormats.TryGetCached(key, out AudioFormat[]? cached))
         {
             _refresh.Supersede();
             ApplyFormats(cached);
@@ -120,7 +119,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         OptionsQueryResult<AudioFormat> result;
         try
         {
-            result = await _cache
+            result = await FFmpegOptionsCaches.AudioFormats
                 .GetOrQueryAsync(key, () => QueryAudioFormatsAsync(query))
                 .ConfigureAwait(false);
         }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -14,15 +14,10 @@ internal readonly record struct OptionsQueryResult<T>(T[] Items, bool Degraded);
 /// Concurrent requests for the same key share a single in-flight query (single-flight).
 /// </summary>
 /// <remarks>
-/// <para>
 /// The shared query is not tied to any caller's <see cref="CancellationToken"/>, so abandoning one
-/// request never faults the result for others that joined the same query. Degraded results are
-/// surfaced to every awaiter but never cached, so the next visit re-queries.
-/// </para>
-/// <para>
+/// request never faults the result for others that joined it. Degraded results are never cached.
 /// Cached entries are bounded by a least-recently-used cap so a process-shared cache cannot grow
-/// without limit as keys (which embed the output file path) accumulate over a long editing session.
-/// </para>
+/// without limit as keys accumulate over a long editing session.
 /// </remarks>
 internal sealed class FFmpegOptionsCache<T>
 {
@@ -31,17 +26,16 @@ internal sealed class FFmpegOptionsCache<T>
     private readonly Dictionary<string, LinkedListNode<(string Key, T[] Items)>> _cache = [];
     private readonly LinkedList<(string Key, T[] Items)> _recency = new();
 
-    // Each in-flight query carries a monotonic token. Clear() drops the bookkeeping mid-flight, so a
-    // superseded query must not, when it finally completes, cache its now-stale result or remove the
-    // registration of the newer query that took over its key — the token tells the two apart.
+    // The token distinguishes a query from one that superseded it after a mid-flight Clear(), so the
+    // older query won't cache a stale result or evict the newer registration when it completes.
     private readonly Dictionary<string, (Task<OptionsQueryResult<T>> Task, long Token)> _inflight = [];
     private readonly object _gate = new();
     private readonly int _maxCachedEntries;
     private long _nextToken;
 
     /// <param name="maxCachedEntries">
-    /// Upper bound on retained authoritative entries; the least-recently-used entry is evicted once the
-    /// bound is exceeded. An evicted key is simply re-queried on its next visit.
+    /// Upper bound on retained entries; the least-recently-used one is evicted past the bound and
+    /// simply re-queried on its next visit.
     /// </param>
     public FFmpegOptionsCache(int maxCachedEntries = DefaultMaxCachedEntries)
     {
@@ -67,12 +61,10 @@ internal sealed class FFmpegOptionsCache<T>
     }
 
     /// <summary>
-    /// Drops every cached entry and abandons single-flight tracking for keys whose factory has not
-    /// completed yet. In-flight tasks are not cancelled (their awaiters still observe the result);
-    /// only the bookkeeping that dedupes <em>new</em> callers is cleared, so a caller that arrives
-    /// after <see cref="Clear"/> may launch a fresh query even while a previous one is still running.
-    /// Such a superseded query neither caches its result nor disturbs the newer query's registration.
-    /// Used to reset a process-shared cache (e.g. after the FFmpeg worker restarts).
+    /// Drops every cached entry and the single-flight bookkeeping. In-flight tasks keep running (their
+    /// awaiters still get the result), but a caller arriving after <see cref="Clear"/> may launch a
+    /// fresh query; that superseded query neither caches its result nor disturbs the newer one.
+    /// Used to reset a process-shared cache, e.g. after the FFmpeg worker restarts.
     /// </summary>
     public void Clear()
     {
@@ -122,8 +114,8 @@ internal sealed class FFmpegOptionsCache<T>
             {
                 lock (_gate)
                 {
-                    // Skip the write if Clear() (or a later query) superseded us: our token no longer
-                    // owns the key, so caching here would resurrect a stale result.
+                    // Skip the write if a Clear() or later query superseded us; caching now would
+                    // resurrect a stale result.
                     if (IsCurrent(key, token))
                         Store(key, result.Items);
                 }
@@ -135,8 +127,7 @@ internal sealed class FFmpegOptionsCache<T>
         {
             lock (_gate)
             {
-                // Remove only our own registration; after Clear() a newer query may own this key and
-                // must not be evicted by a superseded predecessor.
+                // Remove only our own registration; a newer query may now own this key.
                 if (IsCurrent(key, token))
                     _inflight.Remove(key);
             }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -34,6 +34,22 @@ internal sealed class FFmpegOptionsCache<T>
     }
 
     /// <summary>
+    /// Drops every cached entry and abandons single-flight tracking for keys whose factory has not
+    /// completed yet. In-flight tasks are not cancelled (their awaiters still observe the result);
+    /// only the bookkeeping that dedupes <em>new</em> callers is cleared, so a caller that arrives
+    /// after <see cref="Clear"/> may launch a fresh query even while a previous one is still running.
+    /// Used to reset a process-shared cache (e.g. after the FFmpeg worker restarts).
+    /// </summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _cache.Clear();
+            _inflight.Clear();
+        }
+    }
+
+    /// <summary>
     /// Returns the cached result for <paramref name="key"/>, or runs <paramref name="factory"/> once
     /// and caches its items unless the result is degraded. Concurrent calls for the same uncached key
     /// share one task and all receive the same <see cref="OptionsQueryResult{T}"/>.

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCache.cs
@@ -14,22 +14,55 @@ internal readonly record struct OptionsQueryResult<T>(T[] Items, bool Degraded);
 /// Concurrent requests for the same key share a single in-flight query (single-flight).
 /// </summary>
 /// <remarks>
+/// <para>
 /// The shared query is not tied to any caller's <see cref="CancellationToken"/>, so abandoning one
 /// request never faults the result for others that joined the same query. Degraded results are
 /// surfaced to every awaiter but never cached, so the next visit re-queries.
+/// </para>
+/// <para>
+/// Cached entries are bounded by a least-recently-used cap so a process-shared cache cannot grow
+/// without limit as keys (which embed the output file path) accumulate over a long editing session.
+/// </para>
 /// </remarks>
 internal sealed class FFmpegOptionsCache<T>
 {
-    private readonly Dictionary<string, T[]> _cache = [];
-    private readonly Dictionary<string, Task<OptionsQueryResult<T>>> _inflight = [];
+    private const int DefaultMaxCachedEntries = 128;
+
+    private readonly Dictionary<string, LinkedListNode<(string Key, T[] Items)>> _cache = [];
+    private readonly LinkedList<(string Key, T[] Items)> _recency = new();
+
+    // Each in-flight query carries a monotonic token. Clear() drops the bookkeeping mid-flight, so a
+    // superseded query must not, when it finally completes, cache its now-stale result or remove the
+    // registration of the newer query that took over its key — the token tells the two apart.
+    private readonly Dictionary<string, (Task<OptionsQueryResult<T>> Task, long Token)> _inflight = [];
     private readonly object _gate = new();
+    private readonly int _maxCachedEntries;
+    private long _nextToken;
+
+    /// <param name="maxCachedEntries">
+    /// Upper bound on retained authoritative entries; the least-recently-used entry is evicted once the
+    /// bound is exceeded. An evicted key is simply re-queried on its next visit.
+    /// </param>
+    public FFmpegOptionsCache(int maxCachedEntries = DefaultMaxCachedEntries)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxCachedEntries, 1);
+        _maxCachedEntries = maxCachedEntries;
+    }
 
     /// <summary>Returns the cached result for <paramref name="key"/> without querying the worker.</summary>
     public bool TryGetCached(string key, [MaybeNullWhen(false)] out T[] value)
     {
         lock (_gate)
         {
-            return _cache.TryGetValue(key, out value);
+            if (_cache.TryGetValue(key, out LinkedListNode<(string Key, T[] Items)>? node))
+            {
+                Touch(node);
+                value = node.Value.Items;
+                return true;
+            }
+
+            value = null;
+            return false;
         }
     }
 
@@ -38,6 +71,7 @@ internal sealed class FFmpegOptionsCache<T>
     /// completed yet. In-flight tasks are not cancelled (their awaiters still observe the result);
     /// only the bookkeeping that dedupes <em>new</em> callers is cleared, so a caller that arrives
     /// after <see cref="Clear"/> may launch a fresh query even while a previous one is still running.
+    /// Such a superseded query neither caches its result nor disturbs the newer query's registration.
     /// Used to reset a process-shared cache (e.g. after the FFmpeg worker restarts).
     /// </summary>
     public void Clear()
@@ -45,6 +79,7 @@ internal sealed class FFmpegOptionsCache<T>
         lock (_gate)
         {
             _cache.Clear();
+            _recency.Clear();
             _inflight.Clear();
         }
     }
@@ -59,18 +94,23 @@ internal sealed class FFmpegOptionsCache<T>
         lock (_gate)
         {
             // A cached entry is authoritative by construction (degraded results are never stored).
-            if (_cache.TryGetValue(key, out var cached))
-                return Task.FromResult(new OptionsQueryResult<T>(cached, Degraded: false));
+            if (_cache.TryGetValue(key, out LinkedListNode<(string Key, T[] Items)>? node))
+            {
+                Touch(node);
+                return Task.FromResult(new OptionsQueryResult<T>(node.Value.Items, Degraded: false));
+            }
             if (_inflight.TryGetValue(key, out var running))
-                return running;
+                return running.Task;
 
-            Task<OptionsQueryResult<T>> task = RunAsync(key, factory);
-            _inflight[key] = task;
+            long token = ++_nextToken;
+            Task<OptionsQueryResult<T>> task = RunAsync(key, token, factory);
+            _inflight[key] = (task, token);
             return task;
         }
     }
 
-    private async Task<OptionsQueryResult<T>> RunAsync(string key, Func<Task<OptionsQueryResult<T>>> factory)
+    private async Task<OptionsQueryResult<T>> RunAsync(
+        string key, long token, Func<Task<OptionsQueryResult<T>>> factory)
     {
         try
         {
@@ -82,7 +122,10 @@ internal sealed class FFmpegOptionsCache<T>
             {
                 lock (_gate)
                 {
-                    _cache[key] = result.Items;
+                    // Skip the write if Clear() (or a later query) superseded us: our token no longer
+                    // owns the key, so caching here would resurrect a stale result.
+                    if (IsCurrent(key, token))
+                        Store(key, result.Items);
                 }
             }
 
@@ -92,8 +135,37 @@ internal sealed class FFmpegOptionsCache<T>
         {
             lock (_gate)
             {
-                _inflight.Remove(key);
+                // Remove only our own registration; after Clear() a newer query may own this key and
+                // must not be evicted by a superseded predecessor.
+                if (IsCurrent(key, token))
+                    _inflight.Remove(key);
             }
         }
+    }
+
+    private bool IsCurrent(string key, long token)
+        => _inflight.TryGetValue(key, out var entry) && entry.Token == token;
+
+    private void Store(string key, T[] items)
+    {
+        if (_cache.TryGetValue(key, out LinkedListNode<(string Key, T[] Items)>? existing))
+        {
+            existing.Value = (key, items);
+            Touch(existing);
+            return;
+        }
+
+        _cache[key] = _recency.AddFirst((key, items));
+        if (_cache.Count > _maxCachedEntries && _recency.Last is { } lru)
+        {
+            _recency.RemoveLast();
+            _cache.Remove(lru.Value.Key);
+        }
+    }
+
+    private void Touch(LinkedListNode<(string Key, T[] Items)> node)
+    {
+        _recency.Remove(node);
+        _recency.AddFirst(node);
     }
 }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
@@ -4,18 +4,11 @@ using Beutl.FFmpegIpc.Protocol.Messages;
 namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 /// <summary>
-/// The three per-option-type caches shared across every codec property editor instance, so that
-/// concurrent editors using the same codec reuse one IPC query to the FFmpeg worker instead of each
-/// issuing their own. The generic type arguments differ, so each cache is naturally independent.
+/// Per-option-type caches shared across every codec property editor instance, so concurrent editors
+/// using the same codec reuse one IPC query to the FFmpeg worker. Sharing is safe because
+/// <see cref="FFmpegOptionsCache{T}"/> is thread-safe and each editor's refresh tracker stays
+/// instance-local. Call <see cref="ClearAll"/> if the worker binary may have changed.
 /// </summary>
-/// <remarks>
-/// Sharing is safe because <see cref="FFmpegOptionsCache{T}"/> is thread-safe (single-flight + lock)
-/// and each editor's <c>LatestRefreshTracker</c> stays instance-local. A cached option list is
-/// FFmpeg-build-determined, so it remains valid across worker restarts; call <see cref="ClearAll"/>
-/// defensively if the worker binary may have changed. Because these caches live for the process,
-/// each <see cref="FFmpegOptionsCache{T}"/> bounds its own entries with a least-recently-used cap so
-/// keys accumulated across many exports (the key embeds the output file path) cannot grow without limit.
-/// </remarks>
 internal static class FFmpegOptionsCaches
 {
     public static FFmpegOptionsCache<FFmpegAudioEncoderSettings.AudioFormat> AudioFormats { get; } = new();
@@ -24,7 +17,7 @@ internal static class FFmpegOptionsCaches
 
     public static FFmpegOptionsCache<int> SampleRates { get; } = new();
 
-    /// <summary>Clears all three caches. Intended for tests and, eventually, a worker-restart hook.</summary>
+    /// <summary>Clears all caches. Used by tests and, eventually, a worker-restart hook.</summary>
     public static void ClearAll()
     {
         AudioFormats.Clear();

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
@@ -12,7 +12,9 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 /// Sharing is safe because <see cref="FFmpegOptionsCache{T}"/> is thread-safe (single-flight + lock)
 /// and each editor's <c>LatestRefreshTracker</c> stays instance-local. A cached option list is
 /// FFmpeg-build-determined, so it remains valid across worker restarts; call <see cref="ClearAll"/>
-/// defensively if the worker binary may have changed.
+/// defensively if the worker binary may have changed. Because these caches live for the process,
+/// each <see cref="FFmpegOptionsCache{T}"/> bounds its own entries with a least-recently-used cap so
+/// keys accumulated across many exports (the key embeds the output file path) cannot grow without limit.
 /// </remarks>
 internal static class FFmpegOptionsCaches
 {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/FFmpegOptionsCaches.cs
@@ -1,0 +1,32 @@
+﻿using Beutl.Extensions.FFmpeg.Encoding;
+using Beutl.FFmpegIpc.Protocol.Messages;
+
+namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>
+/// The three per-option-type caches shared across every codec property editor instance, so that
+/// concurrent editors using the same codec reuse one IPC query to the FFmpeg worker instead of each
+/// issuing their own. The generic type arguments differ, so each cache is naturally independent.
+/// </summary>
+/// <remarks>
+/// Sharing is safe because <see cref="FFmpegOptionsCache{T}"/> is thread-safe (single-flight + lock)
+/// and each editor's <c>LatestRefreshTracker</c> stays instance-local. A cached option list is
+/// FFmpeg-build-determined, so it remains valid across worker restarts; call <see cref="ClearAll"/>
+/// defensively if the worker binary may have changed.
+/// </remarks>
+internal static class FFmpegOptionsCaches
+{
+    public static FFmpegOptionsCache<FFmpegAudioEncoderSettings.AudioFormat> AudioFormats { get; } = new();
+
+    public static FFmpegOptionsCache<PixelFormatInfo> PixelFormats { get; } = new();
+
+    public static FFmpegOptionsCache<int> SampleRates { get; } = new();
+
+    /// <summary>Clears all three caches. Intended for tests and, eventually, a worker-restart hook.</summary>
+    public static void ClearAll()
+    {
+        AudioFormats.Clear();
+        PixelFormats.Clear();
+        SampleRates.Clear();
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -23,7 +23,6 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<int> _selectedIndex;
-    private readonly FFmpegOptionsCache<PixelFormatInfo> _cache = new();
     private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegVideoEncoderSettings? _settings;
@@ -104,7 +103,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
 
         QueryParams query = CreateQueryParams(_settings);
         string key = BuildCacheKey(query);
-        if (_cache.TryGetCached(key, out PixelFormatInfo[]? cached))
+        if (FFmpegOptionsCaches.PixelFormats.TryGetCached(key, out PixelFormatInfo[]? cached))
         {
             _refresh.Supersede();
             ApplyFormats(cached);
@@ -120,7 +119,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         OptionsQueryResult<PixelFormatInfo> result;
         try
         {
-            result = await _cache
+            result = await FFmpegOptionsCaches.PixelFormats
                 .GetOrQueryAsync(key, () => QueryPixelFormatsAsync(query))
                 .ConfigureAwait(false);
         }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -22,7 +22,6 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
     private readonly IPropertyAdapter<int> _property;
     private readonly CompositeDisposable _disposables = [];
     private readonly ReactivePropertySlim<string> _text;
-    private readonly FFmpegOptionsCache<int> _cache = new();
     private readonly LatestRefreshTracker _refresh = new();
 
     private FFmpegAudioEncoderSettings? _settings;
@@ -102,7 +101,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
 
         QueryParams query = CreateQueryParams(_settings);
         string key = BuildCacheKey(query);
-        if (_cache.TryGetCached(key, out int[]? cached))
+        if (FFmpegOptionsCaches.SampleRates.TryGetCached(key, out int[]? cached))
         {
             _refresh.Supersede();
             ApplySuggestions(cached);
@@ -118,7 +117,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         OptionsQueryResult<int> result;
         try
         {
-            result = await _cache
+            result = await FFmpegOptionsCaches.SampleRates
                 .GetOrQueryAsync(key, () => QuerySampleRatesAsync(query))
                 .ConfigureAwait(false);
         }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -199,4 +199,45 @@ public class FFmpegOptionsCacheTests
 
         Assert.That((await joiner).Items, Is.EqualTo(new[] { 48000 }));
     }
+
+    [Test]
+    public async Task Clear_OnEmptyCache_IsNoOp()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+
+        cache.Clear();
+
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
+    }
+
+    [Test]
+    public async Task Clear_AfterPopulate_RemovesEntry()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        await cache.GetOrQueryAsync("aac", () => Ok(48000));
+        Assert.That(cache.TryGetCached("aac", out _), Is.True);
+
+        cache.Clear();
+
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
+    }
+
+    [Test]
+    public async Task Clear_ForcesNextCallToReQuery()
+    {
+        var cache = new FFmpegOptionsCache<int>();
+        int calls = 0;
+        await cache.GetOrQueryAsync("aac", () => { calls++; return Ok(48000); });
+
+        cache.Clear();
+
+        OptionsQueryResult<int> again = await cache.GetOrQueryAsync(
+            "aac", () => { calls++; return Ok(44100); });
+
+        // After Clear the cached entry is gone, so the factory runs again.
+        Assert.That(calls, Is.EqualTo(2));
+        Assert.That(again.Items, Is.EqualTo(new[] { 44100 }));
+        Assert.That(cache.TryGetCached("aac", out int[]? cached), Is.True);
+        Assert.That(cached, Is.EqualTo(new[] { 44100 }));
+    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -244,8 +244,7 @@ public class FFmpegOptionsCacheTests
     [Test]
     public async Task Clear_WhileQueryInFlight_StaleResultIsNotCached()
     {
-        // A query that started before Clear() must not write its (now stale) result into the cache
-        // after the reset — otherwise a worker-restart reset is silently undone by the old answer.
+        // A query started before Clear() must not write its stale result back after the reset.
         var cache = new FFmpegOptionsCache<int>();
         var stale = new TaskCompletionSource<OptionsQueryResult<int>>();
         var fresh = new TaskCompletionSource<OptionsQueryResult<int>>();
@@ -269,9 +268,8 @@ public class FFmpegOptionsCacheTests
     [Test]
     public async Task Clear_WhileQueryInFlight_StaleCompletionKeepsNewerInFlightEntry()
     {
-        // The pre-Clear query's cleanup removes its in-flight bookkeeping by key; it must not evict the
-        // newer query that took over the key after Clear(), or single-flight breaks and a later caller
-        // would launch a duplicate worker query instead of joining the running one.
+        // The pre-Clear query's cleanup must not evict the newer query that took over the key after
+        // Clear(), or single-flight breaks and a later caller would re-query instead of joining.
         var cache = new FFmpegOptionsCache<int>();
         var stale = new TaskCompletionSource<OptionsQueryResult<int>>();
         var fresh = new TaskCompletionSource<OptionsQueryResult<int>>();
@@ -285,9 +283,8 @@ public class FFmpegOptionsCacheTests
         await before;
 
         // The post-Clear query is still in flight, so a new caller must join it without re-querying.
-        // The joiner returns a distinct value, so a single-flight regression (joining failing and the
-        // joiner running its own query) is caught by both the unused-factory count and the result below
-        // rather than being masked by the two queries happening to share the same gate.
+        // The joiner's factory returns a distinct value, so a single-flight regression shows up in both
+        // the unused-factory count and the result below.
         int extraCalls = 0;
         Task<OptionsQueryResult<int>> joiner = cache.GetOrQueryAsync(
             "aac", () => { extraCalls++; return Ok(-1); });

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -201,7 +201,7 @@ public class FFmpegOptionsCacheTests
     }
 
     [Test]
-    public async Task Clear_OnEmptyCache_IsNoOp()
+    public void Clear_OnEmptyCache_IsNoOp()
     {
         var cache = new FFmpegOptionsCache<int>();
 
@@ -239,5 +239,78 @@ public class FFmpegOptionsCacheTests
         Assert.That(again.Items, Is.EqualTo(new[] { 44100 }));
         Assert.That(cache.TryGetCached("aac", out int[]? cached), Is.True);
         Assert.That(cached, Is.EqualTo(new[] { 44100 }));
+    }
+
+    [Test]
+    public async Task Clear_WhileQueryInFlight_StaleResultIsNotCached()
+    {
+        // A query that started before Clear() must not write its (now stale) result into the cache
+        // after the reset — otherwise a worker-restart reset is silently undone by the old answer.
+        var cache = new FFmpegOptionsCache<int>();
+        var stale = new TaskCompletionSource<OptionsQueryResult<int>>();
+        var fresh = new TaskCompletionSource<OptionsQueryResult<int>>();
+
+        Task<OptionsQueryResult<int>> before = cache.GetOrQueryAsync("aac", () => stale.Task);
+        cache.Clear();
+        Task<OptionsQueryResult<int>> after = cache.GetOrQueryAsync("aac", () => fresh.Task);
+
+        // The pre-Clear query completes first, but its result belongs to the discarded generation.
+        stale.SetResult(new OptionsQueryResult<int>([11025], Degraded: false));
+        await before;
+        Assert.That(cache.TryGetCached("aac", out _), Is.False);
+
+        // The post-Clear query is the one that populates the cache.
+        fresh.SetResult(new OptionsQueryResult<int>([48000], Degraded: false));
+        await after;
+        Assert.That(cache.TryGetCached("aac", out int[]? cached), Is.True);
+        Assert.That(cached, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task Clear_WhileQueryInFlight_StaleCompletionKeepsNewerInFlightEntry()
+    {
+        // The pre-Clear query's cleanup removes its in-flight bookkeeping by key; it must not evict the
+        // newer query that took over the key after Clear(), or single-flight breaks and a later caller
+        // would launch a duplicate worker query instead of joining the running one.
+        var cache = new FFmpegOptionsCache<int>();
+        var stale = new TaskCompletionSource<OptionsQueryResult<int>>();
+        var fresh = new TaskCompletionSource<OptionsQueryResult<int>>();
+
+        Task<OptionsQueryResult<int>> before = cache.GetOrQueryAsync("aac", () => stale.Task);
+        cache.Clear();
+        Task<OptionsQueryResult<int>> after = cache.GetOrQueryAsync("aac", () => fresh.Task);
+
+        // The pre-Clear query completes (degraded, so it never caches) and runs its cleanup.
+        stale.SetResult(new OptionsQueryResult<int>([], Degraded: true));
+        await before;
+
+        // The post-Clear query is still in flight, so a new caller must join it without re-querying.
+        int extraCalls = 0;
+        Task<OptionsQueryResult<int>> joiner = cache.GetOrQueryAsync(
+            "aac", () => { extraCalls++; return fresh.Task; });
+        Assert.That(extraCalls, Is.EqualTo(0));
+
+        fresh.SetResult(new OptionsQueryResult<int>([48000], Degraded: false));
+        OptionsQueryResult<int>[] results = await Task.WhenAll(after, joiner);
+        Assert.That(results[0].Items, Is.EqualTo(new[] { 48000 }));
+        Assert.That(results[1].Items, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task Cache_EvictsLeastRecentlyUsed_WhenOverCapacity()
+    {
+        var cache = new FFmpegOptionsCache<int>(maxCachedEntries: 2);
+        await cache.GetOrQueryAsync("a", () => Ok(1));
+        await cache.GetOrQueryAsync("b", () => Ok(2));
+
+        // Touch "a" so "b" is now the least-recently-used entry.
+        Assert.That(cache.TryGetCached("a", out _), Is.True);
+
+        // Inserting a third key exceeds the cap of 2 and evicts the LRU entry ("b").
+        await cache.GetOrQueryAsync("c", () => Ok(3));
+
+        Assert.That(cache.TryGetCached("a", out _), Is.True);
+        Assert.That(cache.TryGetCached("c", out _), Is.True);
+        Assert.That(cache.TryGetCached("b", out _), Is.False);
     }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs
@@ -285,13 +285,16 @@ public class FFmpegOptionsCacheTests
         await before;
 
         // The post-Clear query is still in flight, so a new caller must join it without re-querying.
+        // The joiner returns a distinct value, so a single-flight regression (joining failing and the
+        // joiner running its own query) is caught by both the unused-factory count and the result below
+        // rather than being masked by the two queries happening to share the same gate.
         int extraCalls = 0;
         Task<OptionsQueryResult<int>> joiner = cache.GetOrQueryAsync(
-            "aac", () => { extraCalls++; return fresh.Task; });
-        Assert.That(extraCalls, Is.EqualTo(0));
+            "aac", () => { extraCalls++; return Ok(-1); });
 
         fresh.SetResult(new OptionsQueryResult<int>([48000], Degraded: false));
         OptionsQueryResult<int>[] results = await Task.WhenAll(after, joiner);
+        Assert.That(extraCalls, Is.EqualTo(0));
         Assert.That(results[0].Items, Is.EqualTo(new[] { 48000 }));
         Assert.That(results[1].Items, Is.EqualTo(new[] { 48000 }));
     }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCachesTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCachesTests.cs
@@ -5,9 +5,7 @@ using NUnit.Framework;
 
 namespace Beutl.UnitTests.Extensions.FFmpeg;
 
-// Exercises the process-shared caches. Because the holder exposes static singletons, every test must
-// clear them in TearDown so a populated entry can't leak into a sibling test (the per-option-type
-// caches are independent, but all three are reset together for simplicity).
+// The holder exposes static singletons, so each test clears them around itself to avoid cross-test leakage.
 [TestFixture]
 public class FFmpegOptionsCachesTests
 {
@@ -29,9 +27,7 @@ public class FFmpegOptionsCachesTests
     [Test]
     public void EachCache_ReturnsSameInstanceAcrossAccesses()
     {
-        // The whole point of the holder is that every editor instance sees the same cache, so a codec
-        // queried by one editor is served from cache to the next. A property returning a new instance
-        // each call would silently defeat that sharing.
+        // Each property must return the same instance every time, or editors wouldn't share a cache.
         Assert.That(ReferenceEquals(FFmpegOptionsCaches.AudioFormats, FFmpegOptionsCaches.AudioFormats), Is.True);
         Assert.That(ReferenceEquals(FFmpegOptionsCaches.PixelFormats, FFmpegOptionsCaches.PixelFormats), Is.True);
         Assert.That(ReferenceEquals(FFmpegOptionsCaches.SampleRates, FFmpegOptionsCaches.SampleRates), Is.True);
@@ -40,8 +36,8 @@ public class FFmpegOptionsCachesTests
     [Test]
     public async Task AudioFormats_SharedAcrossLogicalEditors_DedupesWorkerQuery()
     {
-        // Two independent "editor" code paths that both ask for the same codec must share one factory
-        // invocation — single-flight is now cross-instance, which is the fix for the finding.
+        // Two editor code paths asking for the same codec must share one factory invocation
+        // (single-flight is now cross-instance).
         int calls = 0;
         var gate = new TaskCompletionSource<OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>>();
 

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCachesTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCachesTests.cs
@@ -1,0 +1,102 @@
+﻿using Beutl.Extensions.FFmpeg.Encoding;
+using Beutl.Extensions.FFmpeg.PropertyEditors;
+using Beutl.FFmpegIpc.Protocol.Messages;
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+// Exercises the process-shared caches. Because the holder exposes static singletons, every test must
+// clear them in TearDown so a populated entry can't leak into a sibling test (the per-option-type
+// caches are independent, but all three are reset together for simplicity).
+[TestFixture]
+public class FFmpegOptionsCachesTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        FFmpegOptionsCaches.ClearAll();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        FFmpegOptionsCaches.ClearAll();
+    }
+
+    private static Task<OptionsQueryResult<T>> Ok<T>(params T[] items)
+        => Task.FromResult(new OptionsQueryResult<T>(items, Degraded: false));
+
+    [Test]
+    public void EachCache_ReturnsSameInstanceAcrossAccesses()
+    {
+        // The whole point of the holder is that every editor instance sees the same cache, so a codec
+        // queried by one editor is served from cache to the next. A property returning a new instance
+        // each call would silently defeat that sharing.
+        Assert.That(ReferenceEquals(FFmpegOptionsCaches.AudioFormats, FFmpegOptionsCaches.AudioFormats), Is.True);
+        Assert.That(ReferenceEquals(FFmpegOptionsCaches.PixelFormats, FFmpegOptionsCaches.PixelFormats), Is.True);
+        Assert.That(ReferenceEquals(FFmpegOptionsCaches.SampleRates, FFmpegOptionsCaches.SampleRates), Is.True);
+    }
+
+    [Test]
+    public async Task AudioFormats_SharedAcrossLogicalEditors_DedupesWorkerQuery()
+    {
+        // Two independent "editor" code paths that both ask for the same codec must share one factory
+        // invocation — single-flight is now cross-instance, which is the fix for the finding.
+        int calls = 0;
+        var gate = new TaskCompletionSource<OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>>();
+
+        Task<OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>> first =
+            FFmpegOptionsCaches.AudioFormats.GetOrQueryAsync(
+                "aac\0out.mp4", () => { calls++; return gate.Task; });
+        Task<OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>> second =
+            FFmpegOptionsCaches.AudioFormats.GetOrQueryAsync(
+                "aac\0out.mp4", () => { calls++; return Ok(FFmpegAudioEncoderSettings.AudioFormat.Default); });
+
+        gate.SetResult(new OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>(
+            [FFmpegAudioEncoderSettings.AudioFormat.Default], Degraded: false));
+        OptionsQueryResult<FFmpegAudioEncoderSettings.AudioFormat>[] results =
+            await Task.WhenAll(first, second);
+
+        Assert.That(calls, Is.EqualTo(1));
+        Assert.That(results[0].Items, Is.EquivalentTo(results[1].Items));
+    }
+
+    [Test]
+    public async Task PixelFormats_PopulatedEntry_IsServedByTryGetCached()
+    {
+        await FFmpegOptionsCaches.PixelFormats.GetOrQueryAsync(
+            "h264\0out.mp4", () => Ok(new PixelFormatInfo()));
+
+        Assert.That(
+            FFmpegOptionsCaches.PixelFormats.TryGetCached("h264\0out.mp4", out PixelFormatInfo[]? cached),
+            Is.True);
+        Assert.That(cached, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SampleRates_PopulatedEntry_IsServedByTryGetCached()
+    {
+        await FFmpegOptionsCaches.SampleRates.GetOrQueryAsync("aac\0out.mp4", () => Ok(48000));
+
+        Assert.That(
+            FFmpegOptionsCaches.SampleRates.TryGetCached("aac\0out.mp4", out int[]? cached),
+            Is.True);
+        Assert.That(cached, Is.EqualTo(new[] { 48000 }));
+    }
+
+    [Test]
+    public async Task ClearAll_EmptiesAllThreeCaches()
+    {
+        await FFmpegOptionsCaches.AudioFormats.GetOrQueryAsync(
+            "aac\0out.mp4", () => Ok(FFmpegAudioEncoderSettings.AudioFormat.Default));
+        await FFmpegOptionsCaches.PixelFormats.GetOrQueryAsync(
+            "h264\0out.mp4", () => Ok(new PixelFormatInfo()));
+        await FFmpegOptionsCaches.SampleRates.GetOrQueryAsync("aac\0out.mp4", () => Ok(48000));
+
+        FFmpegOptionsCaches.ClearAll();
+
+        Assert.That(FFmpegOptionsCaches.AudioFormats.TryGetCached("aac\0out.mp4", out _), Is.False);
+        Assert.That(FFmpegOptionsCaches.PixelFormats.TryGetCached("h264\0out.mp4", out _), Is.False);
+        Assert.That(FFmpegOptionsCaches.SampleRates.TryGetCached("aac\0out.mp4", out _), Is.False);
+    }
+}


### PR DESCRIPTION
## Description
- `AudioFormatEditorViewModel`, `PixelFormatEditorViewModel`, and `SampleRateEditorViewModel` each held a **per-instance** `FFmpegOptionsCache<T>`, so the single-flight guarantee was scoped to one editor. Two clips using the same codec each fired a **separate IPC query** to the FFmpeg worker for the same codec/output-file key.
- Introduce a shared static holder `FFmpegOptionsCaches` (one cache per option type) and reference it from all three editors, so concurrent editors reuse **one in-flight query and one cached result per key**. The differing generic type arguments keep the three caches naturally independent.
- Add `FFmpegOptionsCache<T>.Clear()` + `FFmpegOptionsCaches.ClearAll()` as a hook for tests and a future worker-restart reset.
- **Why safe to share:** `FFmpegOptionsCache<T>` is already thread-safe (lock + single-flight), and each editor's `LatestRefreshTracker` stays instance-local, so no cross-instance supersede interference. Cached option lists are FFmpeg-build-determined (stable across worker restarts), so staleness risk is low today; `ClearAll()` provides the reset hook once a restart event exists.
- **Behavior-preserving** for the user-visible selection: the existing per-instance cache contract is unchanged (all prior cache tests stay green).

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary) — change lives in `Beutl.Extensions.FFmpeg` (the FFmpeg property-editor extension) and directly reduces worker IPC traffic.
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. `FFmpegOptionsCache<T>` and `FFmpegOptionsCaches` are `internal`; the editor ViewModels are `internal sealed`. No public API changed.

## Test plan
- `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCacheTests.cs` — the 11 pre-existing characterization tests (single-flight, cache-hit, degraded-not-cached, factory-throws-not-cached, concurrent joiner semantics) stay **green unchanged**, proving the cache's internal contract is preserved. Added 3 new tests for `Clear()`: empty no-op, removes populated entry, forces next call to re-query.
- `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegOptionsCachesTests.cs` (new) — 5 tests: each cache returns the same instance across accesses (pins the static-sharing behavior the finding asks for), cross-"editor" single-flight dedup, per-cache populate/TryGetCached, and `ClearAll` empties all three. `[SetUp]`/`[TearDown]` call `ClearAll()` for static-state isolation.
- Scoped run: `dotnet test ... --filter "FullyQualifiedName~FFmpegOptionsCache|FullyQualifiedName~FFmpegOptionsCaches"` → **19/19 passed** (exit 0).
- Broader regression: `dotnet test ... --filter "FullyQualifiedName~Extensions.FFmpeg"` → **39/39 passed** (exit 0).
- `dotnet format Beutl.slnx --verify-no-changes --include <touched files>` → clean (exit 0).
- VM-level "two VM instances share one cache" is guaranteed by construction (VMs reference `FFmpegOptionsCaches.*`, a static singleton) and verified by reading the diff; a runtime VM-instances-share integration test is deferred (VMs need the Avalonia dispatcher + `IPropertyAdapter`) — see Follow-ups.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-20][diff][medium] FFmpegOptionsCache is per-editor-instance; concurrent editors query worker redundantly")

## Follow-ups
- Wire `FFmpegOptionsCaches.ClearAll()` to a worker-restart/exit event once `FFmpegWorkerProcess` exposes one (defensive against FFmpeg binary changes across restarts).
- The three editor ViewModels share ~90% structure (`RequestUpdate`/`UpdateAsync`/`ApplyOnUiThreadAsync`/`QueryParams`/`BuildCacheKey`); extract a shared generic base `FFmpegOptionsEditorViewModel<T>` — larger diff, separate PR.
- Add a VM-instances-share integration test once a UI-less `IPropertyAdapter<T>` fixture is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process-wide cache clearing for FFmpeg-backed option lists (audio formats, pixel formats, sample rates).

* **Refactor**
  * Updated audio, pixel, and sample rate editors to reuse shared cached option lists instead of per-instance caches.
  * Enhanced the shared cache with LRU eviction and more robust concurrency handling for in-flight queries, ensuring only the latest results are cached.

* **Tests**
  * Expanded unit tests to cover cache clearing (including race conditions with in-flight requests), LRU eviction, and shared-cache deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->