### PR TITLE
fix: bound dotnet session-start hook operations

### DIFF
--- a/.claude/hooks/install-dotnet.sh
+++ b/.claude/hooks/install-dotnet.sh
@@ -60,7 +60,7 @@ sha256_of() {
 }
 
 run_with_timeout() {
-  timeout_seconds="$1"
+  local timeout_seconds="$1"
   shift
 
   if command -v timeout >/dev/null 2>&1; then

--- a/.claude/hooks/install-dotnet.sh
+++ b/.claude/hooks/install-dotnet.sh
@@ -47,7 +47,7 @@ dotnet_install_sha256="082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c
 dotnet_install_url="https://raw.githubusercontent.com/dotnet/install-scripts/${dotnet_install_commit}/src/dotnet-install.sh"
 download_timeout_seconds=60
 install_timeout_seconds=300
-restore_timeout_seconds=180
+restore_timeout_seconds=210
 
 # Print the SHA-256 of "$1" using whichever tool is available; print nothing if
 # neither exists (the caller treats an empty result as "cannot verify").
@@ -64,7 +64,7 @@ run_with_timeout() {
   shift
 
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$timeout_seconds" "$@"
+    timeout -k 10 "$timeout_seconds" "$@"
   else
     "$@"
   fi

--- a/.claude/hooks/install-dotnet.sh
+++ b/.claude/hooks/install-dotnet.sh
@@ -45,6 +45,9 @@ export DOTNET_NOLOGO=1
 dotnet_install_commit="6f559c420847ded38591392dafe785ad511f39f5"
 dotnet_install_sha256="082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e"
 dotnet_install_url="https://raw.githubusercontent.com/dotnet/install-scripts/${dotnet_install_commit}/src/dotnet-install.sh"
+download_timeout_seconds=60
+install_timeout_seconds=300
+restore_timeout_seconds=180
 
 # Print the SHA-256 of "$1" using whichever tool is available; print nothing if
 # neither exists (the caller treats an empty result as "cannot verify").
@@ -53,6 +56,17 @@ sha256_of() {
     sha256sum "$1" | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+run_with_timeout() {
+  timeout_seconds="$1"
+  shift
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_seconds" "$@"
+  else
+    "$@"
   fi
 }
 
@@ -68,7 +82,7 @@ if [ ! -x "$dotnet_dir/dotnet" ] \
 
   # Download, then verify the checksum before granting execute / running it.
   actual_sha=""
-  if curl -fsSL "$dotnet_install_url" -o "$installer"; then
+  if curl --connect-timeout 15 --max-time "$download_timeout_seconds" -fsSL "$dotnet_install_url" -o "$installer"; then
     actual_sha=$(sha256_of "$installer")
   fi
 
@@ -84,7 +98,7 @@ if [ ! -x "$dotnet_dir/dotnet" ] \
   fi
 
   if chmod +x "$installer" \
-     && "$installer" \
+     && run_with_timeout "$install_timeout_seconds" "$installer" \
           --jsonfile "$project_dir/global.json" \
           --install-dir "$dotnet_dir" \
           --no-path; then
@@ -109,7 +123,7 @@ echo "[install-dotnet] dotnet $("$dotnet_dir/dotnet" --version 2>/dev/null) read
 # performs an implicit restore lazily — running it unconditionally here would
 # add several seconds to every resume and can hang on slow NuGet feeds.
 if [ "$installed_now" -eq 1 ]; then
-  (cd "$project_dir" && "$dotnet_dir/dotnet" restore Beutl.slnx) >&2 \
+  (cd "$project_dir" && run_with_timeout "$restore_timeout_seconds" "$dotnet_dir/dotnet" restore Beutl.slnx) >&2 \
     || echo "[install-dotnet] dotnet restore failed; rerun manually if needed." >&2
 else
   echo "[install-dotnet] SDK already installed; skipping restore warmup." >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
             "type": "command",
             "command": "bash",
             "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/install-dotnet.sh"],
-            "timeout": 1800
+            "timeout": 600
           }
         ]
       }


### PR DESCRIPTION
## Description
- Add per-operation bounds to the Claude web .NET bootstrap hook:
  - `curl` now has a 15s connect timeout and 60s total download timeout.
  - `dotnet-install.sh` runs under a 300s timeout when `timeout` is available.
  - `dotnet restore Beutl.slnx` runs under a 180s timeout when `timeout` is available.
- Reduce the outer SessionStart hook timeout from 1800s to 600s now that the network/install/restore operations are individually bounded.
- Keep the hook best-effort: environments without `timeout` fall back to the previous direct command execution path.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `bash -n .claude/hooks/install-dotnet.sh`
- `python3 -m json.tool .claude/settings.json`
- `git diff --check`
- `env CLAUDE_CODE_REMOTE=false bash .claude/hooks/install-dotnet.sh`
- Ran the remote install path with stubbed `curl`, `timeout`, installer, and `dotnet`; verified the hook passes `--max-time 60`, wraps installer execution with `timeout 300`, wraps restore with `timeout 180`, and exits 0.
- NUnit not run: this change touches only Claude hook/config files, with no product C#/XAML logic.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-21][diff][medium] install-dotnet.sh: no per-op timeouts, session can freeze up to 30 min")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of remote web session setup by adding explicit timeout controls around the .NET SDK download, installation, and dependency restore steps to prevent indefinite hangs.
  * Reduced the maximum allowed runtime for a session startup hook, helping sessions reach a ready state faster and fail more predictably when setup exceeds the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->