### PR TITLE
docs: document shader uniform migration

### DIFF
--- a/docs/ai-workflow/resolution-independent-rendering.md
+++ b/docs/ai-workflow/resolution-independent-rendering.md
@@ -69,6 +69,38 @@ the CTM handles it, and a manual `× w` would double-scale and regress the resul
   exceed the per-buffer dimension budget. So 3D content is crisp under supersampled export instead of being
   upscaled by the root CTM.
 
+## Migrating pre-003 SKSL / GLSL shaders
+
+Before feature 003, custom shader target pixels and logical pixels were effectively the same because the
+render target was always allocated at scale `1.0`. After 003, SKSL `width` / `height` / `iResolution`
+and GLSL `pc.width` / `pc.height` report the scaled target size in device pixels. At `w = 1.0` the values
+are unchanged; at reduced preview, supersampled export, or a mixed-density effect boundary they change
+with the working scale.
+
+If a shader intentionally works in normalized coordinates, no migration is usually needed:
+`fragCoord / iResolution` in SKSL and the default GLSL `fragCoord` input already track the target. If a
+shader used those resolution values as logical project pixels, convert device pixels back to logical pixels
+with the scale uniform:
+
+```skia
+uniform float2 iResolution;  // device px
+uniform float iScale;        // device px per logical px
+
+float2 logicalSize = iResolution / iScale;
+float2 logicalCoord = fragCoord / iScale;
+```
+
+```glsl
+vec2 deviceSize = vec2(pc.width, pc.height);
+vec2 logicalSize = deviceSize / pc.scale;
+vec2 logicalCoord = (fragCoord * deviceSize) / pc.scale;
+```
+
+For the opposite direction, keep authored logical pixel literals stable by multiplying them by the working
+scale before using them in device-pixel shader math: `10.0 * iScale` in SKSL or `10.0 * pc.scale` in GLSL.
+See `docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md` for the full uniform
+contract.
+
 ## The scale-1.0 guarantee
 
 At `s_out = 1.0` with unit-scale inputs, the **golden content set** — vector geometry, text, Skia-filter

--- a/docs/ai-workflow/resolution-independent-rendering.md
+++ b/docs/ai-workflow/resolution-independent-rendering.md
@@ -79,22 +79,29 @@ with the working scale.
 
 If a shader intentionally works in normalized coordinates, no migration is usually needed:
 `fragCoord / iResolution` in SKSL and the default GLSL `fragCoord` input already track the target. If a
-shader used those resolution values as logical project pixels, convert device pixels back to logical pixels
-with the scale uniform:
+shader used those resolution values as logical project pixels, convert device pixels back to the shader
+grid's logical coordinates with the scale uniform:
 
 ```skia
 uniform float2 iResolution;  // device px
 uniform float iScale;        // device px per logical px
 
-float2 logicalSize = iResolution / iScale;
-float2 logicalCoord = fragCoord / iScale;
+float2 shaderGridLogicalSize = iResolution / iScale;
+float2 shaderGridLogicalCoord = fragCoord / iScale;
 ```
 
 ```glsl
 vec2 deviceSize = vec2(pc.width, pc.height);
-vec2 logicalSize = deviceSize / pc.scale;
-vec2 logicalCoord = (fragCoord * deviceSize) / pc.scale;
+vec2 shaderGridLogicalSize = deviceSize / pc.scale;
+vec2 shaderGridLogicalCoord = (fragCoord * deviceSize) / pc.scale;
 ```
+
+These values are the rounded shader-grid extent, not necessarily the exact project logical bounds:
+Beutl allocates device buffers as `ceil(bounds * scale)`, so a 101 logical px target at `0.5` scale
+reports 51 device px, and `51 / 0.5` is 102 logical px. For center or edge math that must stay tied to
+the exact authored bounds, keep the math normalized (`fragCoord / iResolution`, or GLSL's normalized
+`fragCoord`); the built-in script uniforms do not expose exact logical bounds, and they cannot be
+recovered from rounded device size alone.
 
 For the opposite direction, keep authored logical pixel literals stable by multiplying them by the working
 scale before using them in device-pixel shader math: `10.0 * iScale` in SKSL or `10.0 * pc.scale` in GLSL.

--- a/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
+++ b/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
@@ -20,13 +20,19 @@ Existing uniforms **keep their device-pixel meaning** = the size of the *scaled*
 Author rule: a UV-normalized shader (`fragCoord / iResolution`) auto-corrects across scales; a shader with an absolute pixel literal multiplies it by `iScale`, e.g. `float radius = 10.0 * iScale;`. Per-texel kernels (blur/edge/sharpen) are inherently resolution-sensitive (FR-013): reduced-scale preview is best-effort, full fidelity at export (`w=1`, i.e. `s_out=1.0` over a unit-scale input).
 
 Migration rule for existing SKSL scripts: if pre-003 code treated `width`, `height`, `iResolution`, or
-`fragCoord` as logical-pixel values, divide those device-pixel values by `iScale` before using them in
-logical-space math:
+`fragCoord` as logical-pixel values, divide those device-pixel values by `iScale` before using them in the
+shader grid's logical coordinate space:
 
 ```skia
-float2 logicalSize = iResolution / iScale;
-float2 logicalCoord = fragCoord / iScale;
+float2 shaderGridLogicalSize = iResolution / iScale;
+float2 shaderGridLogicalCoord = fragCoord / iScale;
 ```
+
+This does **not** recover the exact project logical bounds. Buffer dimensions are rounded with
+`ceil(bounds * iScale)`, so a 101 logical px target at `iScale = 0.5` reports 51 device px and converts
+back to a 102 logical px shader-grid extent. If center or edge math needs the exact authored bounds, keep
+that math normalized (`fragCoord / iResolution`); the built-in SKSL script uniforms do not expose exact
+logical bounds, and they cannot be recovered from rounded device size alone.
 
 Do not divide normalized-UV code (`fragCoord / iResolution`), and do not divide authored logical lengths
 that are about to be used as device-pixel shader literals; multiply those lengths by `iScale` instead.
@@ -43,14 +49,20 @@ GLSL carries the working scale in a dedicated **`scale`** push constant, mirrori
 `scale` is the **clamped buffer density** — `ResolveTargetDensity(bounds)` = `ClampWorkingScaleToBufferBudget(bounds, WorkingScale)`, the density the `ceil(bounds × w)` device buffer is allocated at — so it agrees with the buffer the shader iterates, identical to the value SKSL binds to `iScale`. A GLSL author multiplies an absolute-pixel literal by `scale`, e.g. `float border = 10.0 * pc.scale;`, instead of recovering `w` from `Width`/`Height` — a shader cannot do that without the logical bounds, and the recovery breaks across clips and under scale animation.
 
 Migration rule for existing GLSL scripts: `pc.width` and `pc.height` are device-pixel target dimensions.
-The default `fragCoord` input is normalized, so reconstruct a logical-pixel coordinate only when the shader
-needs one:
+The default `fragCoord` input is normalized, so reconstruct a shader-grid logical-pixel coordinate only
+when the shader needs one:
 
 ```glsl
 vec2 deviceSize = vec2(pc.width, pc.height);
-vec2 logicalSize = deviceSize / pc.scale;
-vec2 logicalCoord = (fragCoord * deviceSize) / pc.scale;
+vec2 shaderGridLogicalSize = deviceSize / pc.scale;
+vec2 shaderGridLogicalCoord = (fragCoord * deviceSize) / pc.scale;
 ```
+
+As with SKSL, this is a rounded shader-grid extent, not exact project bounds. `pc.width` / `pc.height` come
+from `ceil(bounds * pc.scale)`, so `deviceSize / pc.scale` can be larger than the authored logical target.
+Use normalized `fragCoord` for center or edge math that should track the actual target edges; the built-in
+GLSL script push constants do not expose exact logical bounds, and they cannot be recovered from rounded
+device size alone.
 
 Normalized-UV shaders can keep using `fragCoord` directly. Authored logical lengths that are used in
 device-pixel shader math should be multiplied by `pc.scale`, not divided.

--- a/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
+++ b/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
@@ -8,7 +8,7 @@ Existing uniforms **keep their device-pixel meaning** = the size of the *scaled*
 
 > **`w` is the CLAMPED buffer density (FR-037(b)).** The `w` bound into `iScale` / `width` / `height` / `Width` / `Height` is the density the target buffer was actually **allocated** at — `ClampWorkingScaleToBufferBudget(bounds, WorkingScale)` — which drops **below** the nominal working scale when `ceil(bounds × WorkingScale)` would exceed the 16384-px GPU axis limit. On a very large target `iScale` and the resolution uniforms shrink to keep the buffer allocatable, always agreeing with the buffer the shader iterates. In the common (unclamped) case the bound equals the working scale.
 
-## SKSL (`SKSLScriptEffect.cs:99-104`)
+## SKSL (`SKSLScriptEffect.cs:100-112`)
 
 | Uniform | Meaning | Under working scale `w` |
 |---|---|---|

--- a/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
+++ b/docs/specs/003-resolution-independent-pipeline/contracts/shader-uniforms.md
@@ -19,6 +19,18 @@ Existing uniforms **keep their device-pixel meaning** = the size of the *scaled*
 
 Author rule: a UV-normalized shader (`fragCoord / iResolution`) auto-corrects across scales; a shader with an absolute pixel literal multiplies it by `iScale`, e.g. `float radius = 10.0 * iScale;`. Per-texel kernels (blur/edge/sharpen) are inherently resolution-sensitive (FR-013): reduced-scale preview is best-effort, full fidelity at export (`w=1`, i.e. `s_out=1.0` over a unit-scale input).
 
+Migration rule for existing SKSL scripts: if pre-003 code treated `width`, `height`, `iResolution`, or
+`fragCoord` as logical-pixel values, divide those device-pixel values by `iScale` before using them in
+logical-space math:
+
+```skia
+float2 logicalSize = iResolution / iScale;
+float2 logicalCoord = fragCoord / iScale;
+```
+
+Do not divide normalized-UV code (`fragCoord / iResolution`), and do not divide authored logical lengths
+that are about to be used as device-pixel shader literals; multiply those lengths by `iScale` instead.
+
 ## GLSL (`GLSLScriptEffect.cs`)
 
 GLSL carries the working scale in a dedicated **`scale`** push constant, mirroring SKSL's `iScale`. The private `PushConstants` struct is `Progress`/`Duration`/`Time`/`Width`/`Height`/`Scale` and the default-template `layout(push_constant)` block declares the matching `float scale;` member.
@@ -29,6 +41,19 @@ GLSL carries the working scale in a dedicated **`scale`** push constant, mirrori
 | **`scale`** | working scale `w` | `w` (default `1.0`) |
 
 `scale` is the **clamped buffer density** — `ResolveTargetDensity(bounds)` = `ClampWorkingScaleToBufferBudget(bounds, WorkingScale)`, the density the `ceil(bounds × w)` device buffer is allocated at — so it agrees with the buffer the shader iterates, identical to the value SKSL binds to `iScale`. A GLSL author multiplies an absolute-pixel literal by `scale`, e.g. `float border = 10.0 * pc.scale;`, instead of recovering `w` from `Width`/`Height` — a shader cannot do that without the logical bounds, and the recovery breaks across clips and under scale animation.
+
+Migration rule for existing GLSL scripts: `pc.width` and `pc.height` are device-pixel target dimensions.
+The default `fragCoord` input is normalized, so reconstruct a logical-pixel coordinate only when the shader
+needs one:
+
+```glsl
+vec2 deviceSize = vec2(pc.width, pc.height);
+vec2 logicalSize = deviceSize / pc.scale;
+vec2 logicalCoord = (fragCoord * deviceSize) / pc.scale;
+```
+
+Normalized-UV shaders can keep using `fragCoord` directly. Authored logical lengths that are used in
+device-pixel shader math should be multiplied by `pc.scale`, not divided.
 
 Adding the field is **purely additive and within the existing 128-byte push-constant budget**: `VulkanPipeline3D` hard-codes a 128-byte push-constant range and sizes the upload dynamically from `sizeof(T)`; the 6-float struct is 24 bytes, and `PushConstants` is private so there is no public ABI surface. GLSL effects run in-process via the engine's Vulkan/SkSL pipeline, NOT the FFmpeg GPL worker, so the MIT/GPL boundary is unaffected.
 


### PR DESCRIPTION
## Description
- Documents how pre-003 SKSL / GLSL shader authors should migrate code that treated resolution uniforms as logical pixels.
- Adds concrete device-to-logical conversion snippets for SKSL `iScale` and GLSL `pc.scale`.
- Clarifies that normalized-UV shaders usually do not need migration, while authored logical pixel literals should be multiplied by the working scale before device-pixel shader math.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `git diff --check`
- Not run: docs-only change.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-18][diff][medium] SKSLScriptEffect/GLSLScriptEffect: width/height uniforms silently changed to device px — migration guide missing")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an author migration guide for resolution-independent shaders, covering **pre-003 SKSL** and **pre-003 GLSL** changes
  * Clarifies how to interpret shader target size and fragment coordinates (`width`/`height`/`iResolution`, `fragCoord`, and `pc.*`) under working scale (`iScale`/`pc.scale`)
  * Includes migration rules, worked examples for converting device-pixel vs logical-pixel math, and exceptions (e.g., normalized-UV usage and scaling authored logical-length literals)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->