### PR TITLE
fix(mediafoundation): dispose MFReader resources on init failure

### DIFF
--- a/src/Beutl.Extensions.MediaFoundation/Decoding/IMediaFoundationVideoDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/IMediaFoundationVideoDecoder.cs
@@ -1,0 +1,12 @@
+﻿#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Decoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Decoding;
+#endif
+
+internal interface IMediaFoundationVideoDecoder : IDisposable
+{
+    MFMediaInfo GetMediaInfo();
+
+    int ReadFrame(int frame, nint buf);
+}

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -22,7 +22,7 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 
 #pragma warning disable CA1416 // プラットフォームの互換性を検証
 
-internal sealed class MFDecoder : IDisposable
+internal sealed class MFDecoder : IMediaFoundationVideoDecoder
 {
     private readonly ILogger _logger = Log.CreateLogger<MFDecoder>();
     private readonly IMFSourceReader? _videoSourceReader;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -2,12 +2,15 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
+using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
 using Beutl.Media.Pixel;
 using Beutl.Media.Source;
+
+using Microsoft.Extensions.Logging;
 
 using NAudio.Wave;
 
@@ -21,6 +24,7 @@ namespace Beutl.Extensions.MediaFoundation.Decoding;
 
 public class MFReader : MediaReader
 {
+    private readonly ILogger _logger = Log.CreateLogger<MFReader>();
     private readonly string _file;
     private readonly MediaOptions _options;
 
@@ -89,6 +93,9 @@ public class MFReader : MediaReader
         }
         catch
         {
+            // Best-effort cleanup of any partially-initialized resources. Dispose() is
+            // non-throwing (see Dispose(bool)), so this cannot replace the original
+            // initialization exception that we rethrow below.
             Dispose();
             throw;
         }
@@ -226,7 +233,26 @@ public class MFReader : MediaReader
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        _decoder?.Dispose();
-        _audioReader?.Dispose();
+
+        // Release each resource independently and never throw: a failure disposing one
+        // must not leak the other, and this also runs from the constructor's
+        // init-failure path where it must not mask the original exception.
+        try
+        {
+            _decoder?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to dispose the Media Foundation video decoder.");
+        }
+
+        try
+        {
+            _audioReader?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to dispose the Media Foundation audio reader.");
+        }
     }
 }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -48,6 +48,9 @@ public class MFReader : MediaReader
         Func<string, MediaOptions, MFDecodingExtension, IMediaFoundationVideoDecoder> createVideoDecoder,
         Func<string, MediaFoundationReaderSettings, MediaFoundationReader> createAudioReader)
     {
+        ArgumentNullException.ThrowIfNull(createVideoDecoder);
+        ArgumentNullException.ThrowIfNull(createAudioReader);
+
         _file = file;
         _options = options;
         try

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -24,7 +24,7 @@ public class MFReader : MediaReader
     private readonly string _file;
     private readonly MediaOptions _options;
 
-    private readonly MFDecoder? _decoder;
+    private readonly IMediaFoundationVideoDecoder? _decoder;
     private readonly VideoStreamInfo? _videoInfo;
 
     private readonly AudioStreamInfo? _audioInfo;
@@ -33,6 +33,16 @@ public class MFReader : MediaReader
     private readonly ISampleProvider? _provider;
 
     public MFReader(string file, MediaOptions options, MFDecodingExtension extension)
+        : this(file, options, extension, CreateVideoDecoder, CreateAudioReader)
+    {
+    }
+
+    internal MFReader(
+        string file,
+        MediaOptions options,
+        MFDecodingExtension extension,
+        Func<string, MediaOptions, MFDecodingExtension, IMediaFoundationVideoDecoder> createVideoDecoder,
+        Func<string, MediaFoundationReaderSettings, MediaFoundationReader> createAudioReader)
     {
         _file = file;
         _options = options;
@@ -42,9 +52,8 @@ public class MFReader : MediaReader
             {
                 try
                 {
-                    var decoder = new MFDecoder(file, new MediaOptions(MediaMode.Video), extension);
-                    MFMediaInfo info = decoder.GetMediaInfo();
-                    _decoder = decoder;
+                    _decoder = createVideoDecoder(file, new MediaOptions(MediaMode.Video), extension);
+                    MFMediaInfo info = _decoder.GetMediaInfo();
                     _videoInfo = new VideoStreamInfo(
                         info.VideoFormatName ?? "Unknown",
                         info.TotalFrameCount,
@@ -62,7 +71,7 @@ public class MFReader : MediaReader
 
             if (options.StreamsToLoad.HasFlag(MediaMode.Audio))
             {
-                _audioReader = new MediaFoundationReader(_file, new MediaFoundationReaderSettings
+                _audioReader = createAudioReader(_file, new MediaFoundationReaderSettings
                 {
                     RequestFloatOutput = true
                 });
@@ -78,10 +87,21 @@ public class MFReader : MediaReader
                 HasAudio = true;
             }
         }
-        finally
+        catch
         {
+            Dispose();
+            throw;
         }
     }
+
+    private static IMediaFoundationVideoDecoder CreateVideoDecoder(
+        string file,
+        MediaOptions options,
+        MFDecodingExtension extension)
+        => new MFDecoder(file, options, extension);
+
+    private static MediaFoundationReader CreateAudioReader(string file, MediaFoundationReaderSettings settings)
+        => new(file, settings);
 
     public override VideoStreamInfo VideoInfo => _videoInfo ?? throw new NotSupportedException();
 

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
@@ -1,0 +1,75 @@
+﻿using Beutl.Embedding.MediaFoundation.Decoding;
+using Beutl.Media.Decoding;
+
+using Vortice.Win32;
+
+using Windows.Win32.Media.MediaFoundation;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+[TestFixture]
+public class MFReaderTests
+{
+    [Test]
+    public void Constructor_WhenAudioReaderFactoryThrowsAfterVideoDecoderCreation_DisposesVideoDecoder()
+    {
+        var decoder = new FakeVideoDecoder();
+
+        Assert.Throws<InvalidOperationException>(() => new MFReader(
+            "sample.mp4",
+            new MediaOptions(MediaMode.AudioVideo),
+            new MFDecodingExtension(),
+            (_, _, _) => decoder,
+            static (_, _) => throw new InvalidOperationException("audio initialization failed")));
+
+        Assert.That(decoder.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Constructor_WhenVideoMediaInfoThrows_DisposesVideoDecoder()
+    {
+        var decoder = new FakeVideoDecoder
+        {
+            GetMediaInfoException = new InvalidOperationException("media info failed"),
+        };
+
+        Assert.Throws<InvalidOperationException>(() => new MFReader(
+            "sample.mp4",
+            new MediaOptions(MediaMode.Video),
+            new MFDecodingExtension(),
+            (_, _, _) => decoder,
+            static (_, _) => throw new NotSupportedException()));
+
+        Assert.That(decoder.DisposeCount, Is.EqualTo(1));
+    }
+
+    private sealed class FakeVideoDecoder : IMediaFoundationVideoDecoder
+    {
+        public Exception? GetMediaInfoException { get; init; }
+
+        public int DisposeCount { get; private set; }
+
+        public MFMediaInfo GetMediaInfo()
+        {
+            if (GetMediaInfoException != null)
+            {
+                throw GetMediaInfoException;
+            }
+
+            return new()
+            {
+                VideoStreamIndex = 0,
+                Fps = new MFRatio { Numerator = 30, Denominator = 1 },
+                TotalFrameCount = 1,
+                ImageFormat = new BitmapInfoHeader { Width = 16, Height = 16 },
+                VideoFormatName = "YUY2",
+            };
+        }
+
+        public int ReadFrame(int frame, nint buf)
+            => throw new NotSupportedException();
+
+        public void Dispose()
+            => DisposeCount++;
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
@@ -43,6 +43,27 @@ public class MFReaderTests
         Assert.That(decoder.DisposeCount, Is.EqualTo(1));
     }
 
+    [Test]
+    public void Constructor_WhenVideoStreamSucceeds_DoesNotDisposeVideoDecoder()
+    {
+        var decoder = new FakeVideoDecoder();
+
+        // MediaMode.Video skips the audio branch, so the throwing audio factory is never invoked.
+        using var reader = new MFReader(
+            "sample.mp4",
+            new MediaOptions(MediaMode.Video),
+            new MFDecodingExtension(),
+            (_, _, _) => decoder,
+            static (_, _) => throw new NotSupportedException());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.HasVideo, Is.True);
+            Assert.That(reader.HasAudio, Is.False);
+            Assert.That(decoder.DisposeCount, Is.EqualTo(0));
+        });
+    }
+
     private sealed class FakeVideoDecoder : IMediaFoundationVideoDecoder
     {
         public Exception? GetMediaInfoException { get; init; }


### PR DESCRIPTION
## Description
- Dispose partially initialized `MFReader` resources before rethrowing constructor failures.
- Store the created video decoder before reading media info so both media-info failures and later audio initialization failures go through the same cleanup path.
- Add focused coverage for the two partial-construction failure paths.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only
- [x] Other: `Beutl.Extensions.MediaFoundation`

## Breaking changes
None.

## Test plan
- Added `tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs` for constructor cleanup when:
  - audio reader initialization throws after video decoder creation;
  - video media-info extraction throws after video decoder creation.
- `dotnet format Beutl.slnx --include src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs src/Beutl.Extensions.MediaFoundation/Decoding/IMediaFoundationVideoDecoder.cs tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs --verify-no-changes`
- `dotnet build tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --no-restore`
- `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --filter "FullyQualifiedName~MFReaderTests" --no-restore` was attempted on macOS ARM64, but NUnit discovered 0 matching tests because the MediaFoundation assembly is built as x64 (`PlatformTarget=x64`) and cannot be loaded by the ARM64 runtime in this environment.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[Bug] MFReader コンストラクタの部分構築失敗時に MFDecoder がリークする")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved media reader/decoder wiring to use dependency injection via factory delegates, enhancing initialization flow and testability.
  * Strengthened resource cleanup so disposal errors are handled independently and do not prevent other cleanup.
  * Updated video decoder contract usage to align with the new abstraction.
* **Tests**
  * Added unit tests validating disposal behavior when audio initialization fails after video decoder creation and when video media info retrieval throws.
  * Added coverage for successful video-only initialization without disposing the decoder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->