### PR TITLE
fix(engine): guard waveform thumbnail sample math overflow

### DIFF
--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -100,6 +100,11 @@ public sealed partial class SourceSound : IThumbnailsProvider
 
         var duration = TimeRange.Duration;
 
+        // TimeRange.Duration is unnormalized; a non-positive span has no waveform and would drive
+        // totalSamples negative (GetWaveformChunkSamplePosition then throws). Bail out instead.
+        if (duration <= TimeSpan.Zero)
+            yield break;
+
         int sampleRate = resource.Source.SampleRate;
         long totalSamples = AudioMath.TimeToSampleIndex(duration, sampleRate);
 

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Nodes;
 using Beutl.Audio.Composing;
+using Beutl.Audio.Graph;
 using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Media;
@@ -100,7 +101,7 @@ public sealed partial class SourceSound : IThumbnailsProvider
         var duration = TimeRange.Duration;
 
         int sampleRate = resource.Source.SampleRate;
-        int totalSamples = (int)(duration.TotalSeconds * sampleRate);
+        long totalSamples = AudioMath.TimeToSampleIndex(duration, sampleRate);
 
         string? cacheKey = cacheService != null ? GetThumbnailsCacheKey() : null;
         double chunkDurationSecs = duration.TotalSeconds / chunkCount;
@@ -114,15 +115,15 @@ public sealed partial class SourceSound : IThumbnailsProvider
             if (cancellationToken.IsCancellationRequested)
                 yield break;
 
-            int startSample = (int)((long)chunkIndex * totalSamples / chunkCount);
-            int endSample = (int)((long)(chunkIndex + 1) * totalSamples / chunkCount);
-            int fullSpan = endSample - startSample;
+            long startSample = chunkIndex * totalSamples / chunkCount;
+            long endSample = (chunkIndex + 1L) * totalSamples / chunkCount;
+            long fullSpan = endSample - startSample;
             // samplesPerChunk caps the work per chunk. Compose ranges stay tick-contiguous — so a
             // stateful effect like the limiter carries state across the strip — only when
             // fullSpan <= samplesPerChunk (short or zoomed-in clips). For longer clips the waveform
             // is a sparse approximation and the effect restarts per chunk: a deliberate quality
             // trade-off for bounded per-chunk cost, not a correctness guarantee.
-            int sampleCount = Math.Min(fullSpan, samplesPerChunk);
+            int sampleCount = (int)Math.Min(fullSpan, samplesPerChunk);
             var chunkTime = TimeSpan.FromSeconds((double)startSample / sampleRate);
             TimeSpan startTime = TimeRange.Start + chunkTime;
             TimeSpan durationTime = GetWaveformChunkDuration(sampleCount, sampleRate);

--- a/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
+++ b/src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs
@@ -115,8 +115,8 @@ public sealed partial class SourceSound : IThumbnailsProvider
             if (cancellationToken.IsCancellationRequested)
                 yield break;
 
-            long startSample = chunkIndex * totalSamples / chunkCount;
-            long endSample = (chunkIndex + 1L) * totalSamples / chunkCount;
+            long startSample = GetWaveformChunkSamplePosition(chunkIndex, totalSamples, chunkCount);
+            long endSample = GetWaveformChunkSamplePosition(chunkIndex + 1, totalSamples, chunkCount);
             long fullSpan = endSample - startSample;
             // samplesPerChunk caps the work per chunk. Compose ranges stay tick-contiguous — so a
             // stateful effect like the limiter carries state across the strip — only when
@@ -178,6 +178,22 @@ public sealed partial class SourceSound : IThumbnailsProvider
                 yield return chunk.Value;
             }
         }
+    }
+
+    internal static long GetWaveformChunkSamplePosition(int chunkIndex, long totalSamples, int chunkCount)
+    {
+        if (chunkIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(chunkIndex));
+        if (totalSamples < 0)
+            throw new ArgumentOutOfRangeException(nameof(totalSamples));
+        if (chunkCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(chunkCount));
+        if (chunkIndex > chunkCount)
+            throw new ArgumentOutOfRangeException(nameof(chunkIndex));
+
+        long quotient = totalSamples / chunkCount;
+        long remainder = totalSamples % chunkCount;
+        return chunkIndex * quotient + chunkIndex * remainder / chunkCount;
     }
 
     internal static TimeSpan GetWaveformChunkDuration(int sampleCount, int sampleRate)

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Audio;
+﻿using System.Numerics;
+using Beutl.Audio;
 using Beutl.Audio.Graph;
 using Beutl.Engine;
 using Beutl.Media;
@@ -119,7 +120,10 @@ public class SourceSoundThumbnailTests
         const int chunkCount = 4;
         const int samplesPerChunk = 4096;
         var duration = TimeSpan.FromHours(5);
-        string path = TestMediaHelper.CreateTestAudioFile(sampleRate: sampleRate, channels: 2, duration.TotalSeconds);
+        string path = TestMediaHelper.CreateTestAudioFile(
+            sampleRate: sampleRate,
+            channels: 2,
+            durationSeconds: duration.TotalSeconds);
         var soundSource = new SoundSource();
         soundSource.ReadFrom(new Uri(path));
 
@@ -134,6 +138,22 @@ public class SourceSoundThumbnailTests
         Assert.That(chunks.Select(c => c.Index), Is.EqualTo(Enumerable.Range(0, chunkCount)));
         Assert.That(chunks[^1].MinValue, Is.Zero);
         Assert.That(chunks[^1].MaxValue, Is.Zero);
+    }
+
+    [Test]
+    public void GetWaveformChunkSamplePosition_DoesNotOverflowIntermediateProduct()
+    {
+        const int chunkIndex = 2;
+        const int chunkCount = 3;
+        const long totalSamples = long.MaxValue;
+        long expected = (long)((BigInteger)chunkIndex * totalSamples / chunkCount);
+
+        long actual = SourceSound.GetWaveformChunkSamplePosition(chunkIndex, totalSamples, chunkCount);
+
+        Assert.That(actual, Is.EqualTo(expected));
+        Assert.That(
+            SourceSound.GetWaveformChunkSamplePosition(chunkCount, totalSamples, chunkCount),
+            Is.EqualTo(totalSamples));
     }
 
     private static async Task<List<WaveformChunk>> CollectAsync(

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -136,6 +136,10 @@ public class SourceSoundThumbnailTests
         var chunks = await CollectAsync(sound, chunkCount, samplesPerChunk, new FakeWaveformCache());
 
         Assert.That(chunks.Select(c => c.Index), Is.EqualTo(Enumerable.Range(0, chunkCount)));
+
+        // The final chunk starts past sample index int.MaxValue: 5h @ 192kHz is 3,456,000,000 samples
+        // and the last of 4 chunks begins at 2,592,000,000. SourceNode's int-range read guard then
+        // composes it as silence instead of wrapping the offset to a wrong position.
         Assert.That(chunks[^1].MinValue, Is.Zero);
         Assert.That(chunks[^1].MaxValue, Is.Zero);
     }

--- a/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs
@@ -112,6 +112,30 @@ public class SourceSoundThumbnailTests
             "a cache hit must return the cached min/max verbatim");
     }
 
+    [Test]
+    public async Task GetWaveformChunks_LongDurationAboveIntSampleBoundary_ProducesAllChunks()
+    {
+        const int sampleRate = 192000;
+        const int chunkCount = 4;
+        const int samplesPerChunk = 4096;
+        var duration = TimeSpan.FromHours(5);
+        string path = TestMediaHelper.CreateTestAudioFile(sampleRate: sampleRate, channels: 2, duration.TotalSeconds);
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource },
+            TimeRange = new TimeRange(TimeSpan.Zero, duration),
+        };
+
+        var chunks = await CollectAsync(sound, chunkCount, samplesPerChunk, new FakeWaveformCache());
+
+        Assert.That(chunks.Select(c => c.Index), Is.EqualTo(Enumerable.Range(0, chunkCount)));
+        Assert.That(chunks[^1].MinValue, Is.Zero);
+        Assert.That(chunks[^1].MaxValue, Is.Zero);
+    }
+
     private static async Task<List<WaveformChunk>> CollectAsync(
         SourceSound sound, int chunkCount, int samplesPerChunk, IThumbnailCacheService cache)
     {


### PR DESCRIPTION
## Description
- Fix SourceSound waveform thumbnail chunk math to keep total and per-chunk sample positions as long values.
- Prevent multi-hour high-sample-rate sources from wrapping Int32 and reading from the wrong audio position; chunks beyond the int-based read boundary compose as silence through the existing SourceNode guard.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Added `tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs` regression coverage for a 5-hour, 192 kHz source whose final waveform chunk crosses the int-based read boundary.
- Baseline-first check: the new regression failed before the production fix because the overflowed sample math read non-silent audio from the wrong position.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SourceSoundThumbnailTests.GetWaveformChunks_LongDurationAboveIntSampleBoundary_ProducesAllChunks"` (passed after fix)
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SourceSoundThumbnailTests"` (9 passed)
- `dotnet format Beutl.slnx --include src/Beutl.Engine/Audio/SourceSound.Thumbnails.cs tests/Beutl.UnitTests/Engine/Audio/SourceSoundThumbnailTests.cs --verify-no-changes`

## Fixed issues / References
- Project board: b-editor/projects/9 ("fix(engine): SourceSound.Thumbnails totalSamples Int32 overflow for multi-hour sources (PR #1960 follow-up)")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved waveform chunking for very long audio by using safer arithmetic for sample-position and chunk-boundary calculations.
  * Added an early bailout for invalid (non-positive) waveform duration ranges to prevent incorrect chunk computations.

* **Tests**
  * Added long-duration waveform chunking coverage to verify chunk indexing and end-of-range values.
  * Added an overflow-regression test to validate sample-position calculations against big-integer expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->