### PR TITLE
fix(editor): pause playback before history mutations

### DIFF
--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -74,6 +74,20 @@ public sealed class HistoryManager : IDisposable
     }
 
     /// <summary>
+    /// Returns <see langword="true"/> if <see cref="JumpTo"/> with <paramref name="index"/>
+    /// would move the current position — i.e. the index is in range and differs from
+    /// <see cref="CurrentIndex"/>. Evaluated under the internal lock.
+    /// </summary>
+    public bool WouldJumpToMove(int index)
+    {
+        ThrowIfDisposed();
+        lock (_lock)
+        {
+            return index >= 0 && index < _entries.Count && index != _undoStack.Count;
+        }
+    }
+
+    /// <summary>
     /// Atomically takes an initial snapshot and subscribes to subsequent
     /// <see cref="INotifyCollectionChanged.CollectionChanged"/> events on
     /// <see cref="Entries"/>. Use this when the consumer needs to mirror the

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -54,6 +54,21 @@ public sealed class HistoryManager : IDisposable
     // 自前で Commit を流し切るためのフック。
     public IObservable<System.Reactive.Unit> BeforeMutation => _beforeMutation.AsObservable();
 
+    /// <summary>
+    /// Fires <see cref="BeforeMutation"/> so subscribers (e.g. a debounced nudge service)
+    /// flush any pending work into history now. Call this before deciding whether a
+    /// following <see cref="Undo"/> / <see cref="Redo"/> / <see cref="JumpTo"/> will change
+    /// scene state: those operations fire <see cref="BeforeMutation"/> themselves, so a
+    /// still-pending edit is otherwise invisible to that decision yet gets committed — and
+    /// possibly reverted — once the operation runs. The operation's own notification then
+    /// finds nothing left to flush, so the flush stays single-effect for idempotent subscribers.
+    /// </summary>
+    public void FlushPendingMutations()
+    {
+        ThrowIfDisposed();
+        FireBeforeMutation();
+    }
+
     public ReadOnlyObservableCollection<HistoryEntry> Entries => _readOnlyEntries;
 
     public int CurrentIndex => _undoStack.Count;

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -59,6 +59,23 @@ public sealed class HistoryManager : IDisposable
     public int CurrentIndex => _undoStack.Count;
 
     /// <summary>
+    /// Whether the current uncommitted transaction holds operations — meaning a
+    /// history mutation can still change scene state (via the <see cref="BeforeMutation"/>
+    /// flush) even when <see cref="CanUndo"/> / <see cref="CanRedo"/> are false.
+    /// </summary>
+    public bool HasPendingOperations
+    {
+        get
+        {
+            ThrowIfDisposed();
+            lock (_lock)
+            {
+                return _currentTransaction.HasOperations;
+            }
+        }
+    }
+
+    /// <summary>
     /// Returns a thread-safe snapshot of the current entries taken under the
     /// internal lock. Use this from threads other than the writer to avoid
     /// racing with concurrent <see cref="Commit"/>, <see cref="Clear"/>, or
@@ -75,15 +92,21 @@ public sealed class HistoryManager : IDisposable
 
     /// <summary>
     /// Returns <see langword="true"/> if <see cref="JumpTo"/> with <paramref name="index"/>
-    /// would move the current position — i.e. the index is in range and differs from
-    /// <see cref="CurrentIndex"/>. Evaluated under the internal lock.
+    /// would mutate state — the index is in range and either differs from
+    /// <see cref="CurrentIndex"/> or a pending transaction would be rolled back.
+    /// Evaluated under the internal lock.
     /// </summary>
     public bool WouldJumpToMove(int index)
     {
         ThrowIfDisposed();
         lock (_lock)
         {
-            return index >= 0 && index < _entries.Count && index != _undoStack.Count;
+            if (index < 0 || index >= _entries.Count)
+            {
+                return false;
+            }
+
+            return index != _undoStack.Count || _currentTransaction.HasOperations;
         }
     }
 

--- a/src/Beutl.Editor/HistoryManager.cs
+++ b/src/Beutl.Editor/HistoryManager.cs
@@ -59,9 +59,8 @@ public sealed class HistoryManager : IDisposable
     public int CurrentIndex => _undoStack.Count;
 
     /// <summary>
-    /// Whether the current uncommitted transaction holds operations — meaning a
-    /// history mutation can still change scene state (via the <see cref="BeforeMutation"/>
-    /// flush) even when <see cref="CanUndo"/> / <see cref="CanRedo"/> are false.
+    /// Whether the current uncommitted transaction holds operations, so a mutation can still
+    /// change scene state even when <see cref="CanUndo"/> / <see cref="CanRedo"/> are false.
     /// </summary>
     public bool HasPendingOperations
     {
@@ -94,7 +93,6 @@ public sealed class HistoryManager : IDisposable
     /// Returns <see langword="true"/> if <see cref="JumpTo"/> with <paramref name="index"/>
     /// would mutate state — the index is in range and either differs from
     /// <see cref="CurrentIndex"/> or a pending transaction would be rolled back.
-    /// Evaluated under the internal lock.
     /// </summary>
     public bool WouldJumpToMove(int index)
     {

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -6,20 +6,41 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    internal async ValueTask<bool> RunAsync(IPreviewPlayer? player, Func<bool> shouldPause, Func<bool> mutate)
+    internal async ValueTask<bool> RunAsync(
+        IPreviewPlayer? player,
+        Action drainPendingMutations,
+        Func<bool> shouldPause,
+        Func<bool> mutate)
     {
+        ArgumentNullException.ThrowIfNull(drainPendingMutations);
         ArgumentNullException.ThrowIfNull(shouldPause);
         ArgumentNullException.ThrowIfNull(mutate);
 
         await _gate.WaitAsync();
         try
         {
+            // Flush debounced work (e.g. a pending nudge) before the pause decision: mutate()
+            // fires the same flush hook, so a still-pending edit would be invisible to
+            // shouldPause() yet get committed-then-reverted while playback is still live.
+            // Draining first makes shouldPause() reflect the real post-flush state.
+            drainPendingMutations();
+
             if (shouldPause() && player is not null)
             {
                 // Pause() is a no-op when nothing is playing, but still awaits any
                 // in-flight drain, so call it whenever a mutation is pending rather
                 // than gating on IsPlaying (which a mid-drain pause has already cleared).
                 await player.Pause();
+
+                // A Play() that slipped in while that Pause was draining only checks
+                // IsPlaying (already cleared), so it can restart the preview before we
+                // mutate. Re-pause until the player stays stopped; the final check and
+                // mutate() run on one synchronous turn (callers invoke the guard on the
+                // UI thread), so no restart can interleave between them.
+                while (player.IsPlaying.Value)
+                {
+                    await player.Pause();
+                }
             }
 
             return mutate();

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -2,13 +2,60 @@
 
 namespace Beutl.Helpers;
 
-internal static class HistoryMutationPlaybackGuard
+internal sealed class HistoryMutationPlaybackGuard : IDisposable
 {
-    internal static async ValueTask PauseIfPlayingAsync(IPreviewPlayer? player)
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private Task? _pauseTask;
+
+    internal async ValueTask<bool> RunAsync(IPreviewPlayer? player, Func<bool> shouldPause, Func<bool> mutate)
+    {
+        ArgumentNullException.ThrowIfNull(shouldPause);
+        ArgumentNullException.ThrowIfNull(mutate);
+
+        await _gate.WaitAsync();
+        try
+        {
+            if (shouldPause())
+            {
+                await PauseIfNeededAsync(player);
+            }
+
+            return mutate();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async ValueTask PauseIfNeededAsync(IPreviewPlayer? player)
     {
         if (player?.IsPlaying.Value == true)
         {
-            await player.Pause();
+            _pauseTask = player.Pause();
         }
+
+        Task? pauseTask = _pauseTask;
+        if (pauseTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await pauseTask;
+        }
+        finally
+        {
+            if (ReferenceEquals(_pauseTask, pauseTask) && pauseTask.IsCompleted)
+            {
+                _pauseTask = null;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _gate.Dispose();
     }
 }

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -1,11 +1,10 @@
-﻿using Beutl.Editor.Services;
+using Beutl.Editor.Services;
 
 namespace Beutl.Helpers;
 
 internal sealed class HistoryMutationPlaybackGuard : IDisposable
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private Task? _pauseTask;
 
     internal async ValueTask<bool> RunAsync(IPreviewPlayer? player, Func<bool> shouldPause, Func<bool> mutate)
     {
@@ -15,9 +14,9 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         await _gate.WaitAsync();
         try
         {
-            if (shouldPause())
+            if (shouldPause() && player?.IsPlaying.Value == true)
             {
-                await PauseIfNeededAsync(player);
+                await player.Pause();
             }
 
             return mutate();
@@ -28,34 +27,13 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         }
     }
 
-    private async ValueTask PauseIfNeededAsync(IPreviewPlayer? player)
-    {
-        if (player?.IsPlaying.Value == true)
-        {
-            _pauseTask = player.Pause();
-        }
-
-        Task? pauseTask = _pauseTask;
-        if (pauseTask is null)
-        {
-            return;
-        }
-
-        try
-        {
-            await pauseTask;
-        }
-        finally
-        {
-            if (ReferenceEquals(_pauseTask, pauseTask) && pauseTask.IsCompleted)
-            {
-                _pauseTask = null;
-            }
-        }
-    }
-
     public void Dispose()
     {
-        _gate.Dispose();
+        // Disposing a SemaphoreSlim with a pending WaitAsync is undefined, so skip it
+        // while the gate is held and let the GC reclaim it (no unmanaged handle is held).
+        if (_gate.Wait(0))
+        {
+            _gate.Dispose();
+        }
     }
 }

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -14,8 +14,11 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         await _gate.WaitAsync();
         try
         {
-            if (shouldPause() && player?.IsPlaying.Value == true)
+            if (shouldPause() && player is not null)
             {
+                // Pause() is a no-op when nothing is playing, but still awaits any
+                // in-flight drain, so call it whenever a mutation is pending rather
+                // than gating on IsPlaying (which a mid-drain pause has already cleared).
                 await player.Pause();
             }
 

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -1,4 +1,4 @@
-using Beutl.Editor.Services;
+﻿using Beutl.Editor.Services;
 
 namespace Beutl.Helpers;
 

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -19,12 +19,11 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         await _gate.WaitAsync();
         try
         {
-            // Flush debounced work (e.g. a pending nudge) before the pause decision: mutate()
-            // fires the same flush hook, so a still-pending edit would be invisible to
-            // shouldPause() yet get committed-then-reverted while playback is still live.
-            // Draining first makes shouldPause() reflect the real post-flush state.
-            drainPendingMutations();
-
+            // shouldPause() reflects whether this operation will change scene state, including
+            // any pending transaction the drain below will commit (callers' predicates check
+            // HasPendingOperations). Evaluate it before draining so the pause can bracket the
+            // drain: a flush that commits pending work (e.g. a nudge) schedules frame-cache
+            // rebuilds, which must not race a live player.
             if (shouldPause() && player is not null)
             {
                 // Pause() is a no-op when nothing is playing, but still awaits any
@@ -34,15 +33,17 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
 
                 // A Play() that slipped in while that Pause was draining only checks
                 // IsPlaying (already cleared), so it can restart the preview before we
-                // mutate. Re-pause until the player stays stopped; the final check and
-                // mutate() run on one synchronous turn (callers invoke the guard on the
-                // UI thread), so no restart can interleave between them.
+                // mutate. Re-pause until the player stays stopped.
                 while (player.IsPlaying.Value)
                 {
                     await player.Pause();
                 }
             }
 
+            // Drain debounced work (e.g. a pending nudge) and mutate only after the player is
+            // confirmed stopped. Both run on one synchronous turn after the last Pause await
+            // (callers invoke the guard on the UI thread), so no restart can interleave here.
+            drainPendingMutations();
             return mutate();
         }
         finally

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -1,0 +1,14 @@
+﻿using Beutl.Editor.Services;
+
+namespace Beutl.Helpers;
+
+internal static class HistoryMutationPlaybackGuard
+{
+    internal static async ValueTask PauseIfPlayingAsync(IPreviewPlayer? player)
+    {
+        if (player?.IsPlaying.Value == true)
+        {
+            await player.Pause();
+        }
+    }
+}

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -818,16 +818,8 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             $"JumpTo({index})",
             null,
             null,
-            () => ShouldPauseBeforeJumpTo(index),
+            () => HistoryManager.WouldJumpToMove(index),
             () => HistoryManager.JumpTo(index));
-    }
-
-    private bool ShouldPauseBeforeJumpTo(int index)
-    {
-        HistoryManager historyManager = HistoryManager;
-        return index >= 0
-            && index < historyManager.GetEntriesSnapshot().Length
-            && index != historyManager.CurrentIndex;
     }
 
     private async ValueTask<bool> ExecuteHistoryMutationAsync(

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -840,7 +840,8 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
                 _logger.LogInformation("{Message}", startMessage);
             }
 
-            bool changed = await _historyMutationPlaybackGuard.RunAsync(Player, shouldPause, mutate);
+            bool changed = await _historyMutationPlaybackGuard.RunAsync(
+                Player, HistoryManager.FlushPendingMutations, shouldPause, mutate);
             if (changed && completedMessage is not null)
             {
                 _logger.LogInformation("{Message}", completedMessage);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -798,7 +798,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             "Undo",
             "Undoing last command.",
             "Undo completed.",
-            () => HistoryManager.CanUndo,
+            // A pending transaction is flushed onto the undo stack by BeforeMutation
+            // before Undo() runs, so it can revert scene state even when CanUndo is false.
+            () => HistoryManager.CanUndo || HistoryManager.HasPendingOperations,
             HistoryManager.Undo);
     }
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -28,6 +28,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 {
     private readonly ILogger _logger = Log.CreateLogger<EditViewModel>();
     private readonly AutoSaveService _autoSaveService = new();
+    private readonly HistoryMutationPlaybackGuard _historyMutationPlaybackGuard = new();
 
     private readonly CompositeDisposable _disposables = [];
     private readonly TimelineOptionsProviderImpl _timelineOptionsProvider;
@@ -381,6 +382,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         DisposeCommandStateNotifier();
         await Player.DisposeAsync();
         _elementNudgeService?.Dispose();
+        _historyMutationPlaybackGuard.Dispose();
         _disposables.Dispose();
         IsEnabled.Dispose();
         Player = null!;
@@ -790,6 +792,79 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
         return nudge;
     }
 
+    internal ValueTask<bool> UndoHistoryAsync()
+    {
+        return ExecuteHistoryMutationAsync(
+            "Undo",
+            "Undoing last command.",
+            "Undo completed.",
+            () => HistoryManager.CanUndo,
+            HistoryManager.Undo);
+    }
+
+    internal ValueTask<bool> RedoHistoryAsync()
+    {
+        return ExecuteHistoryMutationAsync(
+            "Redo",
+            "Redoing last undone command.",
+            "Redo completed.",
+            () => HistoryManager.CanRedo,
+            HistoryManager.Redo);
+    }
+
+    internal ValueTask<bool> JumpToHistoryAsync(int index)
+    {
+        return ExecuteHistoryMutationAsync(
+            $"JumpTo({index})",
+            null,
+            null,
+            () => ShouldPauseBeforeJumpTo(index),
+            () => HistoryManager.JumpTo(index));
+    }
+
+    private bool ShouldPauseBeforeJumpTo(int index)
+    {
+        HistoryManager historyManager = HistoryManager;
+        return index >= 0
+            && index < historyManager.GetEntriesSnapshot().Length
+            && index != historyManager.CurrentIndex;
+    }
+
+    private async ValueTask<bool> ExecuteHistoryMutationAsync(
+        string operationName,
+        string? startMessage,
+        string? completedMessage,
+        Func<bool> shouldPause,
+        Func<bool> mutate)
+    {
+        try
+        {
+            if (startMessage is not null)
+            {
+                _logger.LogInformation("{Message}", startMessage);
+            }
+
+            bool changed = await _historyMutationPlaybackGuard.RunAsync(Player, shouldPause, mutate);
+            if (changed && completedMessage is not null)
+            {
+                _logger.LogInformation("{Message}", completedMessage);
+            }
+
+            return changed;
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogDebug(ex, "{OperationName} skipped because the editor is disposed.", operationName);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{OperationName} failed.", operationName);
+            NotificationService.ShowError(Strings.History, Strings.History_OperationFailed);
+            return false;
+        }
+    }
+
     private sealed class KnownCommandsImpl(Scene scene, EditViewModel viewModel) : IKnownEditorCommands
     {
         public ValueTask<bool> OnSave()
@@ -805,22 +880,12 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         public async ValueTask<bool> OnUndo()
         {
-            viewModel._logger.LogInformation("Undoing last command.");
-            await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(viewModel.Player);
-            viewModel.HistoryManager.Undo();
-            viewModel._logger.LogInformation("Undo completed.");
-
-            return true;
+            return await viewModel.UndoHistoryAsync();
         }
 
         public async ValueTask<bool> OnRedo()
         {
-            viewModel._logger.LogInformation("Redoing last undone command.");
-            await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(viewModel.Player);
-            viewModel.HistoryManager.Redo();
-            viewModel._logger.LogInformation("Redo completed.");
-
-            return true;
+            return await viewModel.RedoHistoryAsync();
         }
     }
 }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -9,6 +9,7 @@ using Beutl.Editor;
 using Beutl.Editor.Observers;
 using Beutl.Editor.Operations;
 using Beutl.Graphics.Rendering.Cache;
+using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Models;
@@ -802,22 +803,24 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             return ValueTask.FromResult(true);
         }
 
-        public ValueTask<bool> OnUndo()
+        public async ValueTask<bool> OnUndo()
         {
             viewModel._logger.LogInformation("Undoing last command.");
+            await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(viewModel.Player);
             viewModel.HistoryManager.Undo();
             viewModel._logger.LogInformation("Undo completed.");
 
-            return ValueTask.FromResult(true);
+            return true;
         }
 
-        public ValueTask<bool> OnRedo()
+        public async ValueTask<bool> OnRedo()
         {
             viewModel._logger.LogInformation("Redoing last undone command.");
+            await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(viewModel.Player);
             viewModel.HistoryManager.Redo();
             viewModel._logger.LogInformation("Redo completed.");
 
-            return ValueTask.FromResult(true);
+            return true;
         }
     }
 }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -810,7 +810,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             "Redo",
             "Redoing last undone command.",
             "Redo completed.",
-            () => HistoryManager.CanRedo,
+            // Redo() rolls back a pending transaction before checking the redo stack,
+            // so it can revert scene state even when CanRedo is false.
+            () => HistoryManager.CanRedo || HistoryManager.HasPendingOperations,
             HistoryManager.Redo);
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -57,9 +57,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
 
-    // Set by Pause(), cleared by Play(): tells the loop-playback task not to re-arm for
-    // another PlayInternal iteration when a pause lands in the brief IsPlaying=false
-    // window at a loop boundary, where gating on IsPlaying alone would miss the request.
+    // Set by Pause(), cleared by Play(): stops the loop-playback task from re-arming when
+    // a pause lands in the brief IsPlaying=false window at a loop boundary that gating on
+    // IsPlaying alone would miss.
     private volatile bool _stopRequested;
     // Published snapshots carry the start time of the buffer that was just *queued*
     // to the audio backend, which is ahead of the current playhead. Replay several
@@ -487,9 +487,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         PlaybackSpeed.Value = 1.0f;
         PlaybackDirection.Value = ViewModels.PlaybackDirection.Forward;
-        // Mark playing before publishing _playbackTask so a Pause() arriving in the
-        // startup window (before PlayInternal sets IsPlaying) sees it and signals the
-        // loop to stop, instead of awaiting a task that never received a stop signal.
+        // Mark playing before publishing _playbackTask so a Pause() in the startup window
+        // (before PlayInternal runs) signals the loop to stop instead of awaiting forever.
         _stopRequested = false;
         IsPlaying.Value = true;
 
@@ -502,9 +501,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             do
             {
                 restart = await PlayInternal();
-                // A pause that landed in the IsPlaying=false boundary window set
-                // _stopRequested without flipping IsPlaying; honor it here so the loop
-                // does not restart and leave Pause()'s awaiter hanging until end-of-loop.
+                // A boundary-window pause set _stopRequested without flipping IsPlaying;
+                // honor it so the loop does not restart and leave Pause()'s awaiter hanging.
                 if (restart && _stopRequested)
                 {
                     restart = false;
@@ -512,8 +510,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
                 if (restart)
                 {
-                    // Loop restart: re-arm IsPlaying for the next PlayInternal, which
-                    // no longer sets it itself. A user Pause yields restart == false.
+                    // Re-arm IsPlaying for the next PlayInternal, which no longer sets it.
                     IsPlaying.Value = true;
                 }
             } while (restart);
@@ -1336,9 +1333,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public async Task Pause()
     {
-        // Always record the stop request, even when IsPlaying is already false: at a
-        // loop boundary the playback task clears IsPlaying before re-arming it, and a
-        // pause arriving in that window must still cancel the pending restart.
+        // Record the stop request even when IsPlaying is already false: at a loop boundary
+        // the task clears IsPlaying before re-arming, and a pause in that window must still
+        // cancel the pending restart.
         _stopRequested = true;
         if (IsPlaying.Value)
         {
@@ -1349,12 +1346,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
         }
 
-        // Await the playback task even when already stopped, so a pause arriving while a
-        // previous pause is still draining still blocks until the pipeline finishes
-        // before the caller mutates frame-size-sensitive state. A faulted playback task
-        // must not veto that mutation — the drain is already over — so observe and log
-        // the fault here instead of letting it bubble up as a history-operation failure,
-        // and drop the faulted task so later pauses don't replay the same stale exception.
+        // Await even when already stopped so a pause overlapping a still-draining previous
+        // pause blocks until the pipeline finishes. Observe a faulted task here instead of
+        // letting it surface as a history-operation failure, and drop it so later pauses
+        // don't replay the same stale exception.
         Task playbackTask = _playbackTask;
         try
         {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -1308,13 +1308,18 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public async Task Pause()
     {
-        if (!IsPlaying.Value) return;
+        if (IsPlaying.Value)
+        {
+            _logger.LogInformation("Pause the playback. ({SceneId})", _editViewModel.SceneId);
+            _isShuttling = false;
+            IsPlaying.Value = false;
+            PlaybackSpeed.Value = 1.0f;
+            PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
+        }
 
-        _logger.LogInformation("Pause the playback. ({SceneId})", _editViewModel.SceneId);
-        _isShuttling = false;
-        IsPlaying.Value = false;
-        PlaybackSpeed.Value = 1.0f;
-        PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
+        // Await the playback task even when already stopped, so a pause arriving
+        // while a previous pause is still draining still blocks until the pipeline
+        // finishes before the caller mutates frame-size-sensitive state.
         await _playbackTask;
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -861,6 +861,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private void StartShuttle()
     {
         if (_isShuttling || Scene == null) return;
+        // Clear a stop request left by a prior Pause() so the flag's "true until the next
+        // playback start" invariant holds across shuttle too, not just Play().
+        _stopRequested = false;
         _isShuttling = true;
         IsPlaying.Value = true;
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -478,9 +478,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     public void Play()
     {
         if (IsPlaying.Value) return;
+        if (!_isEnabled.Value || Scene == null) return;
 
         PlaybackSpeed.Value = 1.0f;
         PlaybackDirection.Value = ViewModels.PlaybackDirection.Forward;
+        // Mark playing before publishing _playbackTask so a Pause() arriving in the
+        // startup window (before PlayInternal sets IsPlaying) sees it and signals the
+        // loop to stop, instead of awaiting a task that never received a stop signal.
+        IsPlaying.Value = true;
 
         _playbackTask = Task.Run(async () =>
         {
@@ -491,6 +496,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             do
             {
                 restart = await PlayInternal();
+                if (restart)
+                {
+                    // Loop restart: re-arm IsPlaying for the next PlayInternal, which
+                    // no longer sets it itself. A user Pause yields restart == false.
+                    IsPlaying.Value = true;
+                }
             } while (restart);
         });
     }
@@ -498,14 +509,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private async Task<bool> PlayInternal()
     {
         if (!_isEnabled.Value || Scene == null)
+        {
+            IsPlaying.Value = false;
             return false;
+        }
 
         BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
         FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
         Scene.Edited -= OnSceneEdited;
         _currentFrameSubscription?.Dispose();
 
-        IsPlaying.Value = true;
         int rate = GetFrameRate();
 
         TimeSpan tick = TimeSpan.FromSeconds(1d / rate);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -56,6 +56,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private Size _maxFrameSize;
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
+
+    // Set by Pause(), cleared by Play(): tells the loop-playback task not to re-arm for
+    // another PlayInternal iteration when a pause lands in the brief IsPlaying=false
+    // window at a loop boundary, where gating on IsPlaying alone would miss the request.
+    private volatile bool _stopRequested;
     // Published snapshots carry the start time of the buffer that was just *queued*
     // to the audio backend, which is ahead of the current playhead. Replay several
     // recent snapshots so a visualizer tab opened mid-playback also receives the
@@ -485,6 +490,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         // Mark playing before publishing _playbackTask so a Pause() arriving in the
         // startup window (before PlayInternal sets IsPlaying) sees it and signals the
         // loop to stop, instead of awaiting a task that never received a stop signal.
+        _stopRequested = false;
         IsPlaying.Value = true;
 
         _playbackTask = Task.Run(async () =>
@@ -496,6 +502,14 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             do
             {
                 restart = await PlayInternal();
+                // A pause that landed in the IsPlaying=false boundary window set
+                // _stopRequested without flipping IsPlaying; honor it here so the loop
+                // does not restart and leave Pause()'s awaiter hanging until end-of-loop.
+                if (restart && _stopRequested)
+                {
+                    restart = false;
+                }
+
                 if (restart)
                 {
                     // Loop restart: re-arm IsPlaying for the next PlayInternal, which
@@ -570,10 +584,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             try
             {
                 var expectFrame = ComputeExpectFrame();
-                if (!IsPlaying.Value || expectFrame >= endFrame)
+                if (_stopRequested || !IsPlaying.Value || expectFrame >= endFrame)
                 {
-                    // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える
-                    if (IsLoopEnabled.Value && expectFrame >= endFrame)
+                    // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える。
+                    // ただし停止要求中はループの自然終端とみなさず、再開させない。
+                    if (!_stopRequested && IsLoopEnabled.Value && expectFrame >= endFrame)
                     {
                         reachedNaturalEnd = true;
                         IsPlaying.Value = false;
@@ -1321,6 +1336,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public async Task Pause()
     {
+        // Always record the stop request, even when IsPlaying is already false: at a
+        // loop boundary the playback task clears IsPlaying before re-arming it, and a
+        // pause arriving in that window must still cancel the pending restart.
+        _stopRequested = true;
         if (IsPlaying.Value)
         {
             _logger.LogInformation("Pause the playback. ({SceneId})", _editViewModel.SceneId);
@@ -1330,10 +1349,25 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
         }
 
-        // Await the playback task even when already stopped, so a pause arriving
-        // while a previous pause is still draining still blocks until the pipeline
-        // finishes before the caller mutates frame-size-sensitive state.
-        await _playbackTask;
+        // Await the playback task even when already stopped, so a pause arriving while a
+        // previous pause is still draining still blocks until the pipeline finishes
+        // before the caller mutates frame-size-sensitive state. A faulted playback task
+        // must not veto that mutation — the drain is already over — so observe and log
+        // the fault here instead of letting it bubble up as a history-operation failure,
+        // and drop the faulted task so later pauses don't replay the same stale exception.
+        Task playbackTask = _playbackTask;
+        try
+        {
+            await playbackTask;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Playback task faulted before pause. ({SceneId})", _editViewModel.SceneId);
+            if (_playbackTask == playbackTask)
+            {
+                _playbackTask = Task.CompletedTask;
+            }
+        }
     }
 
     private void UpdateImage(Ref<Bitmap> source)

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -545,122 +545,136 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         };
 
         frameCacheManager.CurrentFrame = startFrame;
-        using var playerImpl = new BufferedPlayer(EditViewModel, Scene, IsPlaying, rate);
-        _logger.LogInformation("Start the playback. ({SceneId}, {Rate}, {Start}, {Duration})",
-            _editViewModel.SceneId, rate, startFrame, durationFrame);
-        playerImpl.Start();
-
-        var clock = new AudioPlaybackClock();
-        var audioTask = PlayAudio(Scene, clock, startTime);
-
-        // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
-        // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
-        // 音声側が再生を開始（または音声なしと判明して終了）するまで待ってから
-        // ウォールクロックの基準点を取得する。
-        await clock.StartedTask;
-
-        DateTime startDateTime = DateTime.UtcNow;
-        var tcs = new TaskCompletionSource<bool>();
-        int nextExpectedFrame = startFrame + 1;
-        int processing = 0;
         bool reachedNaturalEnd = false;
-
-        int ComputeExpectFrame()
+        try
         {
-            TimeSpan elapsed = clock.GetTime() is { } audioTime
-                ? audioTime - startTime
-                : DateTime.UtcNow - startDateTime;
-            if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
-            return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
-        }
+            using var playerImpl = new BufferedPlayer(EditViewModel, Scene, IsPlaying, rate);
+            _logger.LogInformation("Start the playback. ({SceneId}, {Rate}, {Start}, {Duration})",
+                _editViewModel.SceneId, rate, startFrame, durationFrame);
+            playerImpl.Start();
 
-        await using var timer = new Timer(_ =>
-        {
-            if (Interlocked.Exchange(ref processing, 1) != 0) return;
-            try
+            var clock = new AudioPlaybackClock();
+            var audioTask = PlayAudio(Scene, clock, startTime);
+
+            // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
+            // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
+            // 音声側が再生を開始（または音声なしと判明して終了）するまで待ってから
+            // ウォールクロックの基準点を取得する。
+            await clock.StartedTask;
+
+            DateTime startDateTime = DateTime.UtcNow;
+            var tcs = new TaskCompletionSource<bool>();
+            int nextExpectedFrame = startFrame + 1;
+            int processing = 0;
+
+            int ComputeExpectFrame()
             {
-                var expectFrame = ComputeExpectFrame();
-                if (_stopRequested || !IsPlaying.Value || expectFrame >= endFrame)
+                TimeSpan elapsed = clock.GetTime() is { } audioTime
+                    ? audioTime - startTime
+                    : DateTime.UtcNow - startDateTime;
+                if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+                return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
+            }
+
+            await using var timer = new Timer(_ =>
+            {
+                if (Interlocked.Exchange(ref processing, 1) != 0) return;
+                try
                 {
-                    // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える。
-                    // ただし停止要求中はループの自然終端とみなさず、再開させない。
-                    if (!_stopRequested && IsLoopEnabled.Value && expectFrame >= endFrame)
+                    var expectFrame = ComputeExpectFrame();
+                    if (_stopRequested || !IsPlaying.Value || expectFrame >= endFrame)
                     {
-                        reachedNaturalEnd = true;
-                        IsPlaying.Value = false;
-                    }
-                    else if (_stopRequested)
-                    {
-                        // A pause that raced the loop re-arm leaves IsPlaying=true; clear it so the
-                        // audio task stops here instead of running to the scene's natural end.
-                        IsPlaying.Value = false;
-                    }
-
-                    tcs.TrySetResult(true);
-                    return;
-                }
-
-                if (expectFrame < nextExpectedFrame)
-                {
-                    return;
-                }
-
-                bool dequeued = false;
-                while (playerImpl.TryDequeue(out IPlayer.Frame frame))
-                {
-                    dequeued = true;
-                    using (frame.Bitmap)
-                    {
-                        UpdateImage(frame.Bitmap.Clone());
-
-                        if (Scene != null)
+                        // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える。
+                        // ただし停止要求中はループの自然終端とみなさず、再開させない。
+                        if (!_stopRequested && IsLoopEnabled.Value && expectFrame >= endFrame)
                         {
-                            _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
-                            EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
+                            reachedNaturalEnd = true;
+                            IsPlaying.Value = false;
                         }
+                        else if (_stopRequested)
+                        {
+                            // A pause that raced the loop re-arm leaves IsPlaying=true; clear it so the
+                            // audio task stops here instead of running to the scene's natural end.
+                            IsPlaying.Value = false;
+                        }
+
+                        tcs.TrySetResult(true);
+                        return;
                     }
 
-                    // タイマーが正確じゃないから、だんだんとフレームがずれてくる
-                    // そのため、フレームを消費しすぎたら、そのフレーム番号とexpectFrameが一致するまでスキップする
-                    // 逆に、フレームを消費しすぎない場合は、そのまま次のフレームを取得する
-                    if (expectFrame <= frame.Time)
+                    if (expectFrame < nextExpectedFrame)
                     {
-                        nextExpectedFrame = frame.Time + 1;
-                        break;
+                        return;
                     }
 
-                    // 期待していたフレームよりも前のフレームが来た場合
-                }
+                    bool dequeued = false;
+                    while (playerImpl.TryDequeue(out IPlayer.Frame frame))
+                    {
+                        dequeued = true;
+                        using (frame.Bitmap)
+                        {
+                            UpdateImage(frame.Bitmap.Clone());
 
-                if (!dequeued && playerImpl.ProducerStopped)
+                            if (Scene != null)
+                            {
+                                _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
+                                EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
+                            }
+                        }
+
+                        // タイマーが正確じゃないから、だんだんとフレームがずれてくる
+                        // そのため、フレームを消費しすぎたら、そのフレーム番号とexpectFrameが一致するまでスキップする
+                        // 逆に、フレームを消費しすぎない場合は、そのまま次のフレームを取得する
+                        if (expectFrame <= frame.Time)
+                        {
+                            nextExpectedFrame = frame.Time + 1;
+                            break;
+                        }
+
+                        // 期待していたフレームよりも前のフレームが来た場合
+                    }
+
+                    if (!dequeued && playerImpl.ProducerStopped)
+                    {
+                        IsPlaying.Value = false;
+                        tcs.TrySetResult(true);
+                        return;
+                    }
+
+                    playerImpl.Skipped(ComputeExpectFrame() + 1);
+                }
+                finally
                 {
-                    IsPlaying.Value = false;
-                    tcs.TrySetResult(true);
-                    return;
+                    Interlocked.Exchange(ref processing, 0);
                 }
+            }, null, tick, tick);
 
-                playerImpl.Skipped(ComputeExpectFrame() + 1);
-            }
-            finally
-            {
-                Interlocked.Exchange(ref processing, 0);
-            }
-        }, null, tick, tick);
+            await Task.WhenAll(tcs.Task, audioTask);
 
-        await Task.WhenAll(tcs.Task, audioTask);
-
-        IsPlaying.Value = false;
-        frameCacheManager.UpdateBlocks();
-        bufferStatus.StartTime.Value = TimeSpan.Zero;
-        bufferStatus.EndTime.Value = TimeSpan.Zero;
-        frameCacheManager.Options = frameCacheManager.Options with
+            frameCacheManager.UpdateBlocks();
+        }
+        finally
         {
-            DeletionStrategy = FrameCacheDeletionStrategy.Old
-        };
+            // Restore the scene/frame subscriptions PlayInternal detached on entry, even if
+            // playback faulted mid-run. A leaked detach would leave the editor unsubscribed,
+            // and Pause() swallows the fault, so a guarded history mutation could otherwise
+            // run against a detached editor.
+            IsPlaying.Value = false;
+            bufferStatus.StartTime.Value = TimeSpan.Zero;
+            bufferStatus.EndTime.Value = TimeSpan.Zero;
+            frameCacheManager.Options = frameCacheManager.Options with
+            {
+                DeletionStrategy = FrameCacheDeletionStrategy.Old
+            };
 
-        _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
-        Scene.Edited += OnSceneEdited;
-        _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
+            _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
+            if (Scene != null)
+            {
+                Scene.Edited += OnSceneEdited;
+            }
+
+            _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
+        }
 
         // ループが有効でユーザーによる停止ではない場合、ループ先頭に戻して再開を要求。
         // loopStart は購読で最新化されているため、再生中の In/Out 変更にも追従する。

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -57,9 +57,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
 
-    // Set by Pause(), cleared by Play(): stops the loop-playback task from re-arming when
-    // a pause lands in the brief IsPlaying=false window at a loop boundary that gating on
-    // IsPlaying alone would miss.
+    // Set by Pause(), cleared by Play(). Cancels a loop re-arm when a pause lands in the
+    // brief IsPlaying=false window at a loop boundary that gating on IsPlaying would miss.
     private volatile bool _stopRequested;
     // Published snapshots carry the start time of the buffer that was just *queued*
     // to the audio backend, which is ahead of the current playhead. Replay several
@@ -590,6 +589,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         reachedNaturalEnd = true;
                         IsPlaying.Value = false;
                     }
+                    else if (_stopRequested)
+                    {
+                        // A pause that raced the loop re-arm leaves IsPlaying=true; clear it so the
+                        // audio task stops here instead of running to the scene's natural end.
+                        IsPlaying.Value = false;
+                    }
+
                     tcs.TrySetResult(true);
                     return;
                 }
@@ -1346,10 +1352,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
         }
 
-        // Await even when already stopped so a pause overlapping a still-draining previous
-        // pause blocks until the pipeline finishes. Observe a faulted task here instead of
-        // letting it surface as a history-operation failure, and drop it so later pauses
-        // don't replay the same stale exception.
+        // Await even when already stopped so an overlapping pause blocks until the prior
+        // drain finishes. Catch a faulted task and drop it, so it neither surfaces as a
+        // history-operation failure nor replays on later pauses.
         Task playbackTask = _playbackTask;
         try
         {

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -4,7 +4,6 @@ using System.Reactive.Disposables;
 using System.Text.Json.Nodes;
 using Avalonia.Threading;
 using Beutl.Editor;
-using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
@@ -74,53 +73,17 @@ public sealed class HistoryViewModel : IToolContext
 
     public async Task JumpTo(int index)
     {
-        try
-        {
-            await PauseBeforeHistoryMutationAsync();
-            _historyManager.JumpTo(index);
-        }
-        catch (ObjectDisposedException ex)
-        {
-            _logger.LogDebug(ex, "JumpTo({Index}) skipped — manager is disposed", index);
-        }
-        catch (Exception ex)
-        {
-            ReportFailure(ex, $"Failed to jump to history index {index}");
-        }
+        await _editViewModel.JumpToHistoryAsync(index);
     }
 
     public async Task Undo()
     {
-        try
-        {
-            await PauseBeforeHistoryMutationAsync();
-            _historyManager.Undo();
-        }
-        catch (ObjectDisposedException ex)
-        {
-            _logger.LogDebug(ex, "Undo skipped — manager is disposed");
-        }
-        catch (Exception ex)
-        {
-            ReportFailure(ex, "Failed to undo");
-        }
+        await _editViewModel.UndoHistoryAsync();
     }
 
     public async Task Redo()
     {
-        try
-        {
-            await PauseBeforeHistoryMutationAsync();
-            _historyManager.Redo();
-        }
-        catch (ObjectDisposedException ex)
-        {
-            _logger.LogDebug(ex, "Redo skipped — manager is disposed");
-        }
-        catch (Exception ex)
-        {
-            ReportFailure(ex, "Failed to redo");
-        }
+        await _editViewModel.RedoHistoryAsync();
     }
 
     public void Dispose()
@@ -131,11 +94,6 @@ public sealed class HistoryViewModel : IToolContext
     public object? GetService(Type serviceType)
     {
         return _editViewModel.GetService(serviceType);
-    }
-
-    private ValueTask PauseBeforeHistoryMutationAsync()
-    {
-        return HistoryMutationPlaybackGuard.PauseIfPlayingAsync(_editViewModel.Player);
     }
 
     public void ReadFromJson(JsonObject json)
@@ -295,11 +253,5 @@ public sealed class HistoryViewModel : IToolContext
         {
             Dispatcher.UIThread.Post(RunGuarded);
         }
-    }
-
-    private void ReportFailure(Exception ex, string context)
-    {
-        _logger.LogError(ex, "{Context}", context);
-        NotificationService.ShowError(Strings.History, Strings.History_OperationFailed);
     }
 }

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive.Disposables;
 using System.Text.Json.Nodes;
 using Avalonia.Threading;
 using Beutl.Editor;
+using Beutl.Helpers;
 using Beutl.Logging;
 using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
@@ -71,10 +72,11 @@ public sealed class HistoryViewModel : IToolContext
 
     public IReadOnlyReactiveProperty<int> CurrentIndex { get; }
 
-    public void JumpTo(int index)
+    public async Task JumpTo(int index)
     {
         try
         {
+            await PauseBeforeHistoryMutationAsync();
             _historyManager.JumpTo(index);
         }
         catch (ObjectDisposedException ex)
@@ -87,10 +89,11 @@ public sealed class HistoryViewModel : IToolContext
         }
     }
 
-    public void Undo()
+    public async Task Undo()
     {
         try
         {
+            await PauseBeforeHistoryMutationAsync();
             _historyManager.Undo();
         }
         catch (ObjectDisposedException ex)
@@ -103,10 +106,11 @@ public sealed class HistoryViewModel : IToolContext
         }
     }
 
-    public void Redo()
+    public async Task Redo()
     {
         try
         {
+            await PauseBeforeHistoryMutationAsync();
             _historyManager.Redo();
         }
         catch (ObjectDisposedException ex)
@@ -127,6 +131,11 @@ public sealed class HistoryViewModel : IToolContext
     public object? GetService(Type serviceType)
     {
         return _editViewModel.GetService(serviceType);
+    }
+
+    private ValueTask PauseBeforeHistoryMutationAsync()
+    {
+        return HistoryMutationPlaybackGuard.PauseIfPlayingAsync(_editViewModel.Player);
     }
 
     public void ReadFromJson(JsonObject json)

--- a/src/Beutl/Views/Tools/HistoryView.axaml.cs
+++ b/src/Beutl/Views/Tools/HistoryView.axaml.cs
@@ -142,21 +142,23 @@ public partial class HistoryView : UserControl
         item.Classes.Set("future", index > currentIndex);
     }
 
-    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    private async void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (_suppressSelectionChanged) return;
         if (_currentViewModel is null || HistoryList is null) return;
 
+        HistoryViewModel viewModel = _currentViewModel;
         int index = HistoryList.SelectedIndex;
         if (index < 0) return;
 
-        _currentViewModel.JumpTo(index);
+        await viewModel.JumpTo(index);
+        if (_currentViewModel != viewModel || HistoryList is null) return;
 
         // If JumpTo did not actually move (failure, no-op, or same index),
         // StateChanged may not have fired and the selected row would otherwise
         // remain on the clicked index, drifting from the real CurrentIndex.
         // Re-sync so a subsequent click on the same row re-issues JumpTo.
-        if (_currentViewModel.CurrentIndex.Value != index)
+        if (viewModel.CurrentIndex.Value != index)
         {
             SyncSelection();
         }
@@ -166,13 +168,19 @@ public partial class HistoryView : UserControl
         }
     }
 
-    private void OnUndoClick(object? sender, RoutedEventArgs e)
+    private async void OnUndoClick(object? sender, RoutedEventArgs e)
     {
-        _currentViewModel?.Undo();
+        if (_currentViewModel is { } viewModel)
+        {
+            await viewModel.Undo();
+        }
     }
 
-    private void OnRedoClick(object? sender, RoutedEventArgs e)
+    private async void OnRedoClick(object? sender, RoutedEventArgs e)
     {
-        _currentViewModel?.Redo();
+        if (_currentViewModel is { } viewModel)
+        {
+            await viewModel.Redo();
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -39,6 +39,7 @@
          pure helpers are compiled directly into the test assembly (same pattern as Beutl.FFmpegBenchmarks). -->
     <Compile Include="..\..\src\Beutl\Helpers\ExportSupersampling.cs" Link="Editor\Linked\ExportSupersampling.cs" />
     <Compile Include="..\..\src\Beutl\Helpers\CancellationTokenSourceHelper.cs" Link="Helpers\Linked\CancellationTokenSourceHelper.cs" />
+    <Compile Include="..\..\src\Beutl\Helpers\HistoryMutationPlaybackGuard.cs" Link="Helpers\Linked\HistoryMutationPlaybackGuard.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1969,5 +1969,31 @@ public class HistoryManagerTests
         Assert.That(completed, Is.True);
     }
 
+    [TestCase(0, ExpectedResult = true)]
+    [TestCase(1, ExpectedResult = true)]
+    [TestCase(2, ExpectedResult = false)]
+    [TestCase(3, ExpectedResult = false)]
+    [TestCase(-1, ExpectedResult = false)]
+    public bool WouldJumpToMove_ReflectsWhetherJumpWouldMove(int index)
+    {
+        // Two commits: entries [initial, First, Second] (Count 3), CurrentIndex 2.
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("First");
+        manager.Record(CreateTestOperation());
+        manager.Commit("Second");
+
+        return manager.WouldJumpToMove(index);
+    }
+
+    [Test]
+    public void WouldJumpToMove_ShouldThrowObjectDisposedException_WhenDisposed()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.WouldJumpToMove(0));
+    }
+
     #endregion
 }

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -1995,5 +1995,46 @@ public class HistoryManagerTests
         Assert.Throws<ObjectDisposedException>(() => manager.WouldJumpToMove(0));
     }
 
+    [Test]
+    public void WouldJumpToMove_ShouldReturnTrue_ForCurrentIndexWithPendingTransaction()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Record(CreateTestOperation());
+        manager.Commit("First");
+        // CurrentIndex == 1. An uncommitted operation makes JumpTo(1) still mutate
+        // (it rolls the pending transaction back) even though the index matches.
+        manager.Record(CreateTestOperation());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(manager.WouldJumpToMove(manager.CurrentIndex), Is.True);
+            // Out-of-range stays false even with a pending transaction.
+            Assert.That(manager.WouldJumpToMove(99), Is.False);
+        });
+    }
+
+    [Test]
+    public void HasPendingOperations_ShouldTrackUncommittedRecord()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+
+        Assert.That(manager.HasPendingOperations, Is.False);
+
+        manager.Record(CreateTestOperation());
+        Assert.That(manager.HasPendingOperations, Is.True);
+
+        manager.Commit("Commit");
+        Assert.That(manager.HasPendingOperations, Is.False);
+    }
+
+    [Test]
+    public void HasPendingOperations_ShouldThrowObjectDisposedException_WhenDisposed()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = manager.HasPendingOperations);
+    }
+
     #endregion
 }

--- a/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryManagerTests.cs
@@ -2036,5 +2036,26 @@ public class HistoryManagerTests
         Assert.Throws<ObjectDisposedException>(() => _ = manager.HasPendingOperations);
     }
 
+    [Test]
+    public void FlushPendingMutations_ShouldFireBeforeMutation()
+    {
+        using var manager = new HistoryManager(_root, _sequenceGenerator);
+        int fired = 0;
+        using var subscription = manager.BeforeMutation.Subscribe(_ => fired++);
+
+        manager.FlushPendingMutations();
+
+        Assert.That(fired, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FlushPendingMutations_ShouldThrowObjectDisposedException_WhenDisposed()
+    {
+        var manager = new HistoryManager(_root, _sequenceGenerator);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.FlushPendingMutations());
+    }
+
     #endregion
 }

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -18,7 +18,7 @@ public class HistoryMutationPlaybackGuardTests
         using var player = new PreviewPlayerStub(isPlaying: true);
         bool mutatedAfterPause = false;
 
-        bool result = await guard.RunAsync(player, () => true, () =>
+        bool result = await guard.RunAsync(player, () => { }, () => true, () =>
         {
             mutatedAfterPause = !player.IsPlaying.Value;
             return true;
@@ -40,7 +40,7 @@ public class HistoryMutationPlaybackGuardTests
         using var player = new PreviewPlayerStub(isPlaying: false);
         bool mutated = false;
 
-        bool result = await guard.RunAsync(player, () => true, () =>
+        bool result = await guard.RunAsync(player, () => { }, () => true, () =>
         {
             mutated = true;
             return true;
@@ -60,7 +60,7 @@ public class HistoryMutationPlaybackGuardTests
         using var guard = new HistoryMutationPlaybackGuard();
         bool mutated = false;
 
-        bool result = await guard.RunAsync(null, () => true, () =>
+        bool result = await guard.RunAsync(null, () => { }, () => true, () =>
         {
             mutated = true;
             return true;
@@ -80,7 +80,7 @@ public class HistoryMutationPlaybackGuardTests
         using var player = new PreviewPlayerStub(isPlaying: true);
         bool mutated = false;
 
-        bool result = await guard.RunAsync(player, () => false, () =>
+        bool result = await guard.RunAsync(player, () => { }, () => false, () =>
         {
             mutated = true;
             return false;
@@ -96,6 +96,62 @@ public class HistoryMutationPlaybackGuardTests
     }
 
     [Test]
+    public async Task RunAsync_DrainsPendingMutationsBeforeShouldPauseDecision()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true);
+        bool drained = false;
+        bool shouldPauseSawDrain = false;
+
+        // The drain simulates a BeforeMutation flush that commits a pending nudge, turning
+        // an otherwise no-op-looking mutation into a real one. shouldPause must observe the
+        // post-drain state, so the guard pauses before mutating.
+        bool result = await guard.RunAsync(
+            player,
+            () => drained = true,
+            () =>
+            {
+                shouldPauseSawDrain = drained;
+                return drained;
+            },
+            () => true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(drained, Is.True);
+            Assert.That(shouldPauseSawDrain, Is.True, "drain must run before shouldPause so the pause decision sees flushed work");
+            Assert.That(player.StopCount, Is.EqualTo(1), "a mutation revealed by the drain must pause playback");
+            Assert.That(player.IsPlaying.Value, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task RunAsync_WhenPlaybackRestartsDuringPause_RePausesBeforeMutation()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true)
+        {
+            SimulateRestartOnce = true
+        };
+        bool mutatedWhileStopped = false;
+
+        bool result = await guard.RunAsync(player, () => { }, () => true, () =>
+        {
+            mutatedWhileStopped = !player.IsPlaying.Value;
+            return true;
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(mutatedWhileStopped, Is.True, "the mutation must run only after the restarted playback is paused again");
+            Assert.That(player.StopCount, Is.EqualTo(2), "the guard must re-pause the playback that restarted mid-drain");
+            Assert.That(player.IsPlaying.Value, Is.False);
+        });
+    }
+
+    [Test]
     public async Task RunAsync_WhenPauseIsInFlight_SecondMutationWaitsAndDoesNotStopTwice()
     {
         using var guard = new HistoryMutationPlaybackGuard();
@@ -105,14 +161,14 @@ public class HistoryMutationPlaybackGuardTests
         };
         int mutationCount = 0;
 
-        Task<bool> first = guard.RunAsync(player, () => true, () =>
+        Task<bool> first = guard.RunAsync(player, () => { }, () => true, () =>
         {
             mutationCount++;
             return true;
         }).AsTask();
         await player.WaitForPauseStartedAsync();
 
-        Task<bool> second = guard.RunAsync(player, () => true, () =>
+        Task<bool> second = guard.RunAsync(player, () => { }, () => true, () =>
         {
             mutationCount++;
             return true;
@@ -150,7 +206,7 @@ public class HistoryMutationPlaybackGuardTests
         player.BeginExternalDrain();
         bool mutatedBeforeDrain = false;
 
-        Task<bool> run = guard.RunAsync(player, () => true, () =>
+        Task<bool> run = guard.RunAsync(player, () => { }, () => true, () =>
         {
             mutatedBeforeDrain = !player.DrainCompleted;
             return true;
@@ -178,6 +234,7 @@ public class HistoryMutationPlaybackGuardTests
         // Mirrors PlayerViewModel._playbackTask: incomplete while a drain is in
         // flight, already complete when nothing is playing.
         private readonly TaskCompletionSource _drain = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _restartedOnce;
 
         public PreviewPlayerStub(bool isPlaying)
         {
@@ -189,6 +246,11 @@ public class HistoryMutationPlaybackGuardTests
         }
 
         public bool CompletePauseManually { get; init; }
+
+        // When set, the first Pause() that stops playback re-arms IsPlaying afterwards,
+        // simulating a Play() that restarted the preview during the drain. The guard's
+        // re-pause loop must then stop it a second time before mutating.
+        public bool SimulateRestartOnce { get; init; }
 
         public int PauseCallCount { get; private set; }
 
@@ -214,6 +276,12 @@ public class HistoryMutationPlaybackGuardTests
                 {
                     _drain.TrySetResult();
                 }
+            }
+
+            if (SimulateRestartOnce && !_restartedOnce)
+            {
+                _restartedOnce = true;
+                _isPlaying.Value = true;
             }
 
             return _drain.Task;

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive;
+﻿using System.Reactive;
 using System.Reactive.Linq;
 using Beutl.Editor.Services;
 using Beutl.Helpers;

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -96,32 +96,32 @@ public class HistoryMutationPlaybackGuardTests
     }
 
     [Test]
-    public async Task RunAsync_DrainsPendingMutationsBeforeShouldPauseDecision()
+    public async Task RunAsync_PausesBeforeDrainingPendingMutations()
     {
         using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: true);
-        bool drained = false;
-        bool shouldPauseSawDrain = false;
+        bool drainedWhileStopped = false;
+        bool mutatedWhileStopped = false;
 
-        // The drain simulates a BeforeMutation flush that commits a pending nudge, turning
-        // an otherwise no-op-looking mutation into a real one. shouldPause must observe the
-        // post-drain state, so the guard pauses before mutating.
+        // shouldPause() reflects the pending work the drain will commit (callers' predicates
+        // check HasPendingOperations). The guard must pause before draining: a flush that
+        // commits a pending nudge schedules frame-cache rebuilds that must not race a live player.
         bool result = await guard.RunAsync(
             player,
-            () => drained = true,
+            () => drainedWhileStopped = !player.IsPlaying.Value,
+            () => true,
             () =>
             {
-                shouldPauseSawDrain = drained;
-                return drained;
-            },
-            () => true);
+                mutatedWhileStopped = !player.IsPlaying.Value;
+                return true;
+            });
 
         Assert.Multiple(() =>
         {
             Assert.That(result, Is.True);
-            Assert.That(drained, Is.True);
-            Assert.That(shouldPauseSawDrain, Is.True, "drain must run before shouldPause so the pause decision sees flushed work");
-            Assert.That(player.StopCount, Is.EqualTo(1), "a mutation revealed by the drain must pause playback");
+            Assert.That(drainedWhileStopped, Is.True, "the drain must run only after playback is paused");
+            Assert.That(mutatedWhileStopped, Is.True);
+            Assert.That(player.StopCount, Is.EqualTo(1), "a mutation that needs a pause must stop playback once");
             Assert.That(player.IsPlaying.Value, Is.False);
         });
     }

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -12,44 +12,144 @@ namespace Beutl.UnitTests.Editor;
 public class HistoryMutationPlaybackGuardTests
 {
     [Test]
-    public async Task PauseIfPlayingAsync_WhenPlayerIsPlaying_AwaitsPause()
+    public async Task RunAsync_WhenPlayerIsPlaying_AwaitsPauseBeforeMutation()
     {
+        using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: true);
+        bool mutatedAfterPause = false;
 
-        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(player);
+        bool result = await guard.RunAsync(player, () => true, () =>
+        {
+            mutatedAfterPause = !player.IsPlaying.Value;
+            return true;
+        });
 
         Assert.Multiple(() =>
         {
+            Assert.That(result, Is.True);
+            Assert.That(mutatedAfterPause, Is.True);
             Assert.That(player.PauseCallCount, Is.EqualTo(1));
             Assert.That(player.IsPlaying.Value, Is.False);
         });
     }
 
     [Test]
-    public async Task PauseIfPlayingAsync_WhenPlayerIsStopped_DoesNotPause()
+    public async Task RunAsync_WhenPlayerIsStopped_MutatesWithoutPause()
     {
+        using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: false);
+        bool mutated = false;
 
-        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(player);
+        bool result = await guard.RunAsync(player, () => true, () =>
+        {
+            mutated = true;
+            return true;
+        });
 
-        Assert.That(player.PauseCallCount, Is.Zero);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(mutated, Is.True);
+            Assert.That(player.PauseCallCount, Is.Zero);
+        });
     }
 
     [Test]
-    public async Task PauseIfPlayingAsync_WhenPlayerIsNull_DoesNotThrow()
+    public async Task RunAsync_WhenPlayerIsNull_DoesNotThrow()
     {
-        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(null);
+        using var guard = new HistoryMutationPlaybackGuard();
+        bool mutated = false;
+
+        bool result = await guard.RunAsync(null, () => true, () =>
+        {
+            mutated = true;
+            return true;
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(mutated, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task RunAsync_WhenMutationDoesNotNeedPause_DoesNotPausePlayingPlayer()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true);
+        bool mutated = false;
+
+        bool result = await guard.RunAsync(player, () => false, () =>
+        {
+            mutated = true;
+            return false;
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(mutated, Is.True);
+            Assert.That(player.PauseCallCount, Is.Zero);
+            Assert.That(player.IsPlaying.Value, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task RunAsync_WhenPauseIsInFlight_SecondMutationWaitsAndDoesNotPauseTwice()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true)
+        {
+            CompletePauseManually = true
+        };
+        int mutationCount = 0;
+
+        Task<bool> first = guard.RunAsync(player, () => true, () =>
+        {
+            mutationCount++;
+            return true;
+        }).AsTask();
+        await player.WaitForPauseStartedAsync();
+
+        Task<bool> second = guard.RunAsync(player, () => true, () =>
+        {
+            mutationCount++;
+            return true;
+        }).AsTask();
+        await Task.Yield();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.IsCompleted, Is.False);
+            Assert.That(mutationCount, Is.Zero);
+            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+        });
+
+        player.CompletePause();
+        bool[] results = await Task.WhenAll(first, second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results, Is.All.True);
+            Assert.That(mutationCount, Is.EqualTo(2));
+            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+        });
     }
 
     private sealed class PreviewPlayerStub : IPreviewPlayer, IDisposable
     {
         private readonly ReactivePropertySlim<Ref<Bitmap>?> _previewImage = new();
         private readonly ReactivePropertySlim<bool> _isPlaying;
+        private readonly TaskCompletionSource _pauseStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource? _pauseCompletion;
 
         public PreviewPlayerStub(bool isPlaying)
         {
             _isPlaying = new ReactivePropertySlim<bool>(isPlaying);
         }
+
+        public bool CompletePauseManually { get; init; }
 
         public int PauseCallCount { get; private set; }
 
@@ -63,7 +163,25 @@ public class HistoryMutationPlaybackGuardTests
         {
             PauseCallCount++;
             _isPlaying.Value = false;
-            return Task.CompletedTask;
+            _pauseStarted.TrySetResult();
+
+            if (!CompletePauseManually)
+            {
+                return Task.CompletedTask;
+            }
+
+            _pauseCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return _pauseCompletion.Task;
+        }
+
+        public Task WaitForPauseStartedAsync()
+        {
+            return _pauseStarted.Task;
+        }
+
+        public void CompletePause()
+        {
+            _pauseCompletion?.SetResult();
         }
 
         public void Dispose()

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Reactive;
+using System.Reactive.Linq;
+using Beutl.Editor.Services;
+using Beutl.Helpers;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class HistoryMutationPlaybackGuardTests
+{
+    [Test]
+    public async Task PauseIfPlayingAsync_WhenPlayerIsPlaying_AwaitsPause()
+    {
+        using var player = new PreviewPlayerStub(isPlaying: true);
+
+        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(player);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+            Assert.That(player.IsPlaying.Value, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task PauseIfPlayingAsync_WhenPlayerIsStopped_DoesNotPause()
+    {
+        using var player = new PreviewPlayerStub(isPlaying: false);
+
+        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(player);
+
+        Assert.That(player.PauseCallCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task PauseIfPlayingAsync_WhenPlayerIsNull_DoesNotThrow()
+    {
+        await HistoryMutationPlaybackGuard.PauseIfPlayingAsync(null);
+    }
+
+    private sealed class PreviewPlayerStub : IPreviewPlayer, IDisposable
+    {
+        private readonly ReactivePropertySlim<Ref<Bitmap>?> _previewImage = new();
+        private readonly ReactivePropertySlim<bool> _isPlaying;
+
+        public PreviewPlayerStub(bool isPlaying)
+        {
+            _isPlaying = new ReactivePropertySlim<bool>(isPlaying);
+        }
+
+        public int PauseCallCount { get; private set; }
+
+        public IReadOnlyReactiveProperty<Ref<Bitmap>?> PreviewImage => _previewImage;
+
+        public IObservable<Unit> AfterRendered => Observable.Empty<Unit>();
+
+        public IReadOnlyReactiveProperty<bool> IsPlaying => _isPlaying;
+
+        public Task Pause()
+        {
+            PauseCallCount++;
+            _isPlaying.Value = false;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _previewImage.Dispose();
+            _isPlaying.Dispose();
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reactive;
+using System.Reactive;
 using System.Reactive.Linq;
 using Beutl.Editor.Services;
 using Beutl.Helpers;
@@ -12,7 +12,7 @@ namespace Beutl.UnitTests.Editor;
 public class HistoryMutationPlaybackGuardTests
 {
     [Test]
-    public async Task RunAsync_WhenPlayerIsPlaying_AwaitsPauseBeforeMutation()
+    public async Task RunAsync_WhenPlayerIsPlaying_StopsAndAwaitsBeforeMutation()
     {
         using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: true);
@@ -28,13 +28,13 @@ public class HistoryMutationPlaybackGuardTests
         {
             Assert.That(result, Is.True);
             Assert.That(mutatedAfterPause, Is.True);
-            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+            Assert.That(player.StopCount, Is.EqualTo(1));
             Assert.That(player.IsPlaying.Value, Is.False);
         });
     }
 
     [Test]
-    public async Task RunAsync_WhenPlayerIsStopped_MutatesWithoutPause()
+    public async Task RunAsync_WhenPlayerIsStopped_MutatesWithoutStopping()
     {
         using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: false);
@@ -50,7 +50,7 @@ public class HistoryMutationPlaybackGuardTests
         {
             Assert.That(result, Is.True);
             Assert.That(mutated, Is.True);
-            Assert.That(player.PauseCallCount, Is.Zero);
+            Assert.That(player.StopCount, Is.Zero);
         });
     }
 
@@ -74,7 +74,7 @@ public class HistoryMutationPlaybackGuardTests
     }
 
     [Test]
-    public async Task RunAsync_WhenMutationDoesNotNeedPause_DoesNotPausePlayingPlayer()
+    public async Task RunAsync_WhenMutationDoesNotNeedPause_DoesNotCallPause()
     {
         using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: true);
@@ -96,7 +96,7 @@ public class HistoryMutationPlaybackGuardTests
     }
 
     [Test]
-    public async Task RunAsync_WhenPauseIsInFlight_SecondMutationWaitsAndDoesNotPauseTwice()
+    public async Task RunAsync_WhenPauseIsInFlight_SecondMutationWaitsAndDoesNotStopTwice()
     {
         using var guard = new HistoryMutationPlaybackGuard();
         using var player = new PreviewPlayerStub(isPlaying: true)
@@ -123,17 +123,50 @@ public class HistoryMutationPlaybackGuardTests
         {
             Assert.That(second.IsCompleted, Is.False);
             Assert.That(mutationCount, Is.Zero);
-            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+            Assert.That(player.StopCount, Is.EqualTo(1));
         });
 
-        player.CompletePause();
+        player.CompleteDrain();
         bool[] results = await Task.WhenAll(first, second);
 
         Assert.Multiple(() =>
         {
             Assert.That(results, Is.All.True);
             Assert.That(mutationCount, Is.EqualTo(2));
-            Assert.That(player.PauseCallCount, Is.EqualTo(1));
+            Assert.That(player.StopCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task RunAsync_WhenPlayerStoppedMidDrain_AwaitsDrainBeforeMutation()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true)
+        {
+            CompletePauseManually = true
+        };
+        // An external Pause() has already cleared IsPlaying but the pipeline is still
+        // draining; the guard must await that in-flight drain rather than skip it.
+        player.BeginExternalDrain();
+        bool mutatedBeforeDrain = false;
+
+        Task<bool> run = guard.RunAsync(player, () => true, () =>
+        {
+            mutatedBeforeDrain = !player.DrainCompleted;
+            return true;
+        }).AsTask();
+        await Task.Yield();
+
+        Assert.That(run.IsCompleted, Is.False);
+
+        player.CompleteDrain();
+        bool result = await run;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(mutatedBeforeDrain, Is.False);
+            Assert.That(player.StopCount, Is.Zero);
         });
     }
 
@@ -142,16 +175,26 @@ public class HistoryMutationPlaybackGuardTests
         private readonly ReactivePropertySlim<Ref<Bitmap>?> _previewImage = new();
         private readonly ReactivePropertySlim<bool> _isPlaying;
         private readonly TaskCompletionSource _pauseStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private TaskCompletionSource? _pauseCompletion;
+        // Mirrors PlayerViewModel._playbackTask: incomplete while a drain is in
+        // flight, already complete when nothing is playing.
+        private readonly TaskCompletionSource _drain = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public PreviewPlayerStub(bool isPlaying)
         {
             _isPlaying = new ReactivePropertySlim<bool>(isPlaying);
+            if (!isPlaying)
+            {
+                _drain.SetResult();
+            }
         }
 
         public bool CompletePauseManually { get; init; }
 
         public int PauseCallCount { get; private set; }
+
+        public int StopCount { get; private set; }
+
+        public bool DrainCompleted => _drain.Task.IsCompleted;
 
         public IReadOnlyReactiveProperty<Ref<Bitmap>?> PreviewImage => _previewImage;
 
@@ -162,16 +205,24 @@ public class HistoryMutationPlaybackGuardTests
         public Task Pause()
         {
             PauseCallCount++;
-            _isPlaying.Value = false;
-            _pauseStarted.TrySetResult();
-
-            if (!CompletePauseManually)
+            if (_isPlaying.Value)
             {
-                return Task.CompletedTask;
+                StopCount++;
+                _isPlaying.Value = false;
+                _pauseStarted.TrySetResult();
+                if (!CompletePauseManually)
+                {
+                    _drain.TrySetResult();
+                }
             }
 
-            _pauseCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            return _pauseCompletion.Task;
+            return _drain.Task;
+        }
+
+        // Simulate an external pause that cleared IsPlaying but is still draining.
+        public void BeginExternalDrain()
+        {
+            _isPlaying.Value = false;
         }
 
         public Task WaitForPauseStartedAsync()
@@ -179,9 +230,9 @@ public class HistoryMutationPlaybackGuardTests
             return _pauseStarted.Task;
         }
 
-        public void CompletePause()
+        public void CompleteDrain()
         {
-            _pauseCompletion?.SetResult();
+            _drain.TrySetResult();
         }
 
         public void Dispose()

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -103,9 +103,8 @@ public class HistoryMutationPlaybackGuardTests
         bool drainedWhileStopped = false;
         bool mutatedWhileStopped = false;
 
-        // shouldPause() reflects the pending work the drain will commit (callers' predicates
-        // check HasPendingOperations). The guard must pause before draining: a flush that
-        // commits a pending nudge schedules frame-cache rebuilds that must not race a live player.
+        // The drain commits pending work (e.g. a nudge) that schedules frame-cache rebuilds,
+        // so it must run only after the player is paused — never against a live player.
         bool result = await guard.RunAsync(
             player,
             () => drainedWhileStopped = !player.IsPlaying.Value,


### PR DESCRIPTION
## Description
- Pause active preview playback before history Undo, Redo, and JumpTo mutations.
- This lets the playback pipeline drain before history replay can restore scene settings that rebuild the renderer/frame-cache pair.
- Add a linked helper test that verifies the pause guard only calls `IPreviewPlayer.Pause()` while playback is active.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~HistoryMutationPlaybackGuardTests"`
- `dotnet build src/Beutl/Beutl.csproj -f net10.0`
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --no-build --filter "FullyQualifiedName~HistoryMutationPlaybackGuardTests|FullyQualifiedName~SceneSettingsServiceTests"`
- `dotnet format Beutl.slnx --include src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs src/Beutl/ViewModels/EditViewModel.cs src/Beutl/ViewModels/Tools/HistoryViewModel.cs src/Beutl/Views/Tools/HistoryView.axaml.cs tests/Beutl.UnitTests/Beutl.UnitTests.csproj tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs --verify-no-changes`
- `git diff --check`

## Fixed issues / References
- Project board: b-editor/projects/9 ("Guard scene-settings undo/redo during playback against the renderer-rebuild freeze (003)")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Undo, Redo, and Jump now run asynchronously and coordinate safely with playback, pausing only when required and waiting for any in-progress pause/drain to finish.
  * History navigation has safer UI sync after rapid selection changes, reducing stale updates.
  * History now exposes helpers to report pending operations and to indicate whether a Jump would actually change state.
  * Playback pause now consistently waits for any in-flight playback work to complete.

* **Tests**
  * Added and expanded tests for coordinated pause/stop behavior, concurrency, null player handling, and pending-operation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->