### PR TITLE
test(nodegraph): cover NodeGraphFilterEffectRenderNode scale forwarding

### DIFF
--- a/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
@@ -9,16 +9,12 @@ using Beutl.NodeGraph.Nodes;
 
 namespace Beutl.UnitTests.NodeGraph;
 
-// NodeGraphFilterEffectRenderNode.Process forwards context.OutputScale / MaxWorkingScale into the
-// inner RenderNodeProcessor that walks the graph's output subtree. These tests build a real
-// FilterEffectInputNode -> FilterEffectNode -> OutputNode graph and assert the forwarded scales
-// reach the effect inside the graph, where they drive RenderNodeContext.ResolveWorkingScale.
+// NodeGraphFilterEffectRenderNode.Process forwards OutputScale / MaxWorkingScale into the inner
+// processor that walks the graph. These tests assert those scales reach the effect inside the graph.
 [TestFixture]
 public class NodeGraphFilterEffectRenderNodeTests
 {
-    // Graph: FilterEffectInputNode --> FilterEffectNode<ScaleProbeEffect> --> OutputNode.
-    // The probe effect's render node stamps the resolved working scale onto its output ops, making
-    // the scale forwarded by NodeGraphFilterEffectRenderNode observable without touching the GPU.
+    // Graph: FilterEffectInputNode -> FilterEffectNode<ScaleProbeEffect> -> OutputNode.
     private static NodeGraphFilterEffect.Resource BuildGraphResource()
     {
         var effect = new NodeGraphFilterEffect();
@@ -31,9 +27,8 @@ public class NodeGraphFilterEffectRenderNodeTests
         model.Nodes.Add(probeNode);
         model.Nodes.Add(outputNode);
 
-        // ConfigureNode's base ctor adds Items[0] = Output port and Items[1] = list Input port
-        // (FilterEffectNode<T>'s per-property value inputs, if any, follow at Items[2+]). Neither typed
-        // port is exposed publicly, so the render-chain ports are reached by index and named here.
+        // The render-chain ports are not exposed publicly: Items[0] = Output, Items[1] = list Input
+        // (per-property value inputs follow at Items[2+]). Reach them by index.
         var probeChainInput = (IInputPort)probeNode.Items[1];
         var probeChainOutput = (IOutputPort)probeNode.Items[0];
         model.Connect(probeChainInput, inputNode.Output);
@@ -49,8 +44,7 @@ public class NodeGraphFilterEffectRenderNodeTests
             hitTest: _ => false,
             effectiveScale: EffectiveScale.At(density));
 
-    // An At(1) source lets OutputScale drive the working scale: w = max(s_out, 1). A regression that
-    // seeds the inner processor with a hardcoded s_out = 1 would resolve every case to 1.
+    // An At(1) source lets OutputScale drive the working scale: w = max(s_out, 1).
     [TestCase(1.0f, 1.0f)]
     [TestCase(2.0f, 2.0f)]
     [TestCase(4.0f, 4.0f)]
@@ -69,7 +63,6 @@ public class NodeGraphFilterEffectRenderNodeTests
     }
 
     // An At(4) source pushes supply above s_out, so only the forwarded MaxWorkingScale can cap it.
-    // A regression that seeds the inner processor with +Inf would never cap the 4.0 supply.
     [TestCase(float.PositiveInfinity, 4.0f)]
     [TestCase(2.0f, 2.0f)]
     public void Process_ForwardsMaxWorkingScale_IntoGraphOutputSubtree(float maxWorkingScale, float expectedW)
@@ -95,9 +88,8 @@ public class NodeGraphFilterEffectRenderNodeTests
     }
 }
 
-// A GPU-free FilterEffect whose render node resolves the supply-driven working scale and stamps it
-// onto passthrough ops, exposing the scale that NodeGraphFilterEffectRenderNode forwarded. Mirrors
-// the manual-Resource + SuppressResourceClassGeneration pattern used by NodeGraphFilterEffect.
+// A GPU-free FilterEffect whose render node stamps the resolved working scale onto passthrough ops,
+// exposing the scale that NodeGraphFilterEffectRenderNode forwarded.
 [SuppressResourceClassGeneration]
 internal sealed partial class ScaleProbeEffect : FilterEffect
 {
@@ -123,10 +115,8 @@ internal sealed class ScaleProbeRenderNode(FilterEffect.Resource fe) : FilterEff
 {
     public override RenderNodeOperation[] Process(RenderNodeContext context)
     {
-        // Resolve w from the forwarded scales exactly as FilterEffectRenderNode.Process would, but skip
-        // the rest of its real path: ClampWorkingScaleToBufferBudget (a no-op at these test bounds) and
-        // the FilterEffectContext / SkiaSharp filter-build + rasterize that need a GPU device. So w here
-        // is the supply-driven scale that was forwarded, not a real effect's final working scale.
+        // Resolve w as FilterEffectRenderNode.Process would, but skip its GPU path (buffer-budget clamp +
+        // SkiaSharp build/rasterize). So w is the forwarded supply-driven scale, not a real final scale.
         EffectiveScale[] scales = context.Input.Select(i => i.EffectiveScale).ToArray();
         float w = RenderNodeContext.ResolveWorkingScale(scales, context.OutputScale, context.MaxWorkingScale);
         return context.Input.Select(input => RenderNodeOperation.CreateLambda(

--- a/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
@@ -1,0 +1,132 @@
+﻿using System.Linq;
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using Beutl.NodeGraph;
+using Beutl.NodeGraph.Nodes;
+
+namespace Beutl.UnitTests.NodeGraph;
+
+// NodeGraphFilterEffectRenderNode.Process forwards context.OutputScale / MaxWorkingScale into the
+// inner RenderNodeProcessor that walks the graph's output subtree. These tests build a real
+// FilterEffectInputNode -> FilterEffectNode -> OutputNode graph and assert the forwarded scales
+// reach the effect inside the graph, where they drive RenderNodeContext.ResolveWorkingScale.
+[TestFixture]
+public class NodeGraphFilterEffectRenderNodeTests
+{
+    // Graph: FilterEffectInputNode --> FilterEffectNode<ScaleProbeEffect> --> OutputNode.
+    // The probe effect's render node stamps the resolved working scale onto its output ops, making
+    // the scale forwarded by NodeGraphFilterEffectRenderNode observable without touching the GPU.
+    private static NodeGraphFilterEffect.Resource BuildGraphResource()
+    {
+        var effect = new NodeGraphFilterEffect();
+        GraphModel model = effect.Model.CurrentValue!;
+
+        var inputNode = new FilterEffectInputNode();
+        var probeNode = new FilterEffectNode<ScaleProbeEffect>();
+        var outputNode = new OutputNode();
+        model.Nodes.Add(inputNode);
+        model.Nodes.Add(probeNode);
+        model.Nodes.Add(outputNode);
+
+        // ConfigureNode ctor adds Items[0] = Output port, Items[1] = list Input port.
+        model.Connect((IInputPort)probeNode.Items[1], inputNode.Output);
+        model.Connect(outputNode.InputPort, (IOutputPort)probeNode.Items[0]);
+
+        return effect.ToResource(CompositionContext.Default);
+    }
+
+    private static RenderNodeOperation SourceOp(float density)
+        => RenderNodeOperation.CreateLambda(
+            new Rect(0, 0, 120, 90),
+            _ => { },
+            hitTest: _ => false,
+            effectiveScale: EffectiveScale.At(density));
+
+    // An At(1) source lets OutputScale drive the working scale: w = max(s_out, 1). A regression that
+    // seeds the inner processor with a hardcoded s_out = 1 would resolve every case to 1.
+    [TestCase(1.0f, 1.0f)]
+    [TestCase(2.0f, 2.0f)]
+    [TestCase(4.0f, 4.0f)]
+    public void Process_ForwardsOutputScale_IntoGraphOutputSubtree(float outputScale, float expectedW)
+    {
+        using NodeGraphFilterEffect.Resource resource = BuildGraphResource();
+        using FilterEffectRenderNode node = resource.CreateRenderNode();
+        var context = new RenderNodeContext([SourceOp(1.0f)], outputScale: outputScale);
+
+        RenderNodeOperation[] ops = node.Process(context);
+
+        Assert.That(ops, Is.Not.Empty, "the graph dropped the input op");
+        Assert.That(ops[0].EffectiveScale.Value, Is.EqualTo(expectedW).Within(1e-4),
+            "the forwarded OutputScale did not drive the working scale inside the graph");
+        DisposeAll(ops);
+    }
+
+    // An At(4) source pushes supply above s_out, so only the forwarded MaxWorkingScale can cap it.
+    // A regression that seeds the inner processor with +Inf would never cap the 4.0 supply.
+    [TestCase(float.PositiveInfinity, 4.0f)]
+    [TestCase(2.0f, 2.0f)]
+    public void Process_ForwardsMaxWorkingScale_IntoGraphOutputSubtree(float maxWorkingScale, float expectedW)
+    {
+        using NodeGraphFilterEffect.Resource resource = BuildGraphResource();
+        using FilterEffectRenderNode node = resource.CreateRenderNode();
+        var context = new RenderNodeContext([SourceOp(4.0f)], outputScale: 1.0f, maxWorkingScale: maxWorkingScale);
+
+        RenderNodeOperation[] ops = node.Process(context);
+
+        Assert.That(ops, Is.Not.Empty, "the graph dropped the input op");
+        Assert.That(ops[0].EffectiveScale.Value, Is.EqualTo(expectedW).Within(1e-4),
+            "the forwarded MaxWorkingScale did not cap the working scale inside the graph");
+        DisposeAll(ops);
+    }
+
+    private static void DisposeAll(RenderNodeOperation[] ops)
+    {
+        foreach (RenderNodeOperation op in ops)
+        {
+            op.Dispose();
+        }
+    }
+}
+
+// A GPU-free FilterEffect whose render node resolves the supply-driven working scale and stamps it
+// onto passthrough ops, exposing the scale that NodeGraphFilterEffectRenderNode forwarded. Mirrors
+// the manual-Resource + SuppressResourceClassGeneration pattern used by NodeGraphFilterEffect.
+[SuppressResourceClassGeneration]
+internal sealed partial class ScaleProbeEffect : FilterEffect
+{
+    public override void ApplyTo(FilterEffectContext context, FilterEffect.Resource resource)
+    {
+    }
+
+    public override Resource ToResource(CompositionContext context)
+    {
+        var resource = new Resource();
+        bool updateOnly = false;
+        resource.Update(this, context, ref updateOnly);
+        return resource;
+    }
+
+    public new sealed class Resource : FilterEffect.Resource
+    {
+        public override FilterEffectRenderNode CreateRenderNode() => new ScaleProbeRenderNode(this);
+    }
+}
+
+internal sealed class ScaleProbeRenderNode(FilterEffect.Resource fe) : FilterEffectRenderNode(fe)
+{
+    public override RenderNodeOperation[] Process(RenderNodeContext context)
+    {
+        EffectiveScale[] scales = context.Input.Select(i => i.EffectiveScale).ToArray();
+        float w = RenderNodeContext.ResolveWorkingScale(scales, context.OutputScale, context.MaxWorkingScale);
+        return context.Input.Select(input => RenderNodeOperation.CreateLambda(
+                input.Bounds,
+                input.Render,
+                hitTest: input.HitTest,
+                onDispose: input.Dispose,
+                effectiveScale: EffectiveScale.At(w)))
+            .ToArray();
+    }
+}

--- a/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
+++ b/tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs
@@ -31,9 +31,13 @@ public class NodeGraphFilterEffectRenderNodeTests
         model.Nodes.Add(probeNode);
         model.Nodes.Add(outputNode);
 
-        // ConfigureNode ctor adds Items[0] = Output port, Items[1] = list Input port.
-        model.Connect((IInputPort)probeNode.Items[1], inputNode.Output);
-        model.Connect(outputNode.InputPort, (IOutputPort)probeNode.Items[0]);
+        // ConfigureNode's base ctor adds Items[0] = Output port and Items[1] = list Input port
+        // (FilterEffectNode<T>'s per-property value inputs, if any, follow at Items[2+]). Neither typed
+        // port is exposed publicly, so the render-chain ports are reached by index and named here.
+        var probeChainInput = (IInputPort)probeNode.Items[1];
+        var probeChainOutput = (IOutputPort)probeNode.Items[0];
+        model.Connect(probeChainInput, inputNode.Output);
+        model.Connect(outputNode.InputPort, probeChainOutput);
 
         return effect.ToResource(CompositionContext.Default);
     }
@@ -119,6 +123,10 @@ internal sealed class ScaleProbeRenderNode(FilterEffect.Resource fe) : FilterEff
 {
     public override RenderNodeOperation[] Process(RenderNodeContext context)
     {
+        // Resolve w from the forwarded scales exactly as FilterEffectRenderNode.Process would, but skip
+        // the rest of its real path: ClampWorkingScaleToBufferBudget (a no-op at these test bounds) and
+        // the FilterEffectContext / SkiaSharp filter-build + rasterize that need a GPU device. So w here
+        // is the supply-driven scale that was forwarded, not a real effect's final working scale.
         EffectiveScale[] scales = context.Input.Select(i => i.EffectiveScale).ToArray();
         float w = RenderNodeContext.ResolveWorkingScale(scales, context.OutputScale, context.MaxWorkingScale);
         return context.Input.Select(input => RenderNodeOperation.CreateLambda(


### PR DESCRIPTION
## Description
`NodeGraphFilterEffectRenderNode.Process` forwards `context.OutputScale` and `context.MaxWorkingScale` into the inner `RenderNodeProcessor` that walks the graph's output subtree (`src/Beutl.NodeGraph/NodeGraphFilterEffectRenderNode.cs:43`), but nothing exercised that forwarding — a grep for `NodeGraphFilterEffect` in `tests/` only hit a comment in `SourceEffectiveScaleFlowTests` that *mirrors* the pattern, never the real type.

- Adds a GPU-free test that builds a real `FilterEffectInputNode -> FilterEffectNode -> OutputNode` graph and drives it through the public `FilterEffectRenderNode.Process`.
- A lightweight probe effect (`FilterEffectNode<ScaleProbeEffect>`) resolves the supply-driven working scale via `RenderNodeContext.ResolveWorkingScale` and stamps it onto its passthrough ops, so the scale forwarded by `NodeGraphFilterEffectRenderNode` is observable without touching the GPU.
- Asserts the forwarded **OutputScale** floors the working scale (`At(1)` source at `s_out` 2/4 → `w` 2/4) and the forwarded **MaxWorkingScale** caps it (`At(4)` source capped to 2).

## Affected areas
- [x] `Beutl.NodeGraph` (node editor)

## Breaking changes
None — test-only change. No production code touched.

## Test plan
- New fixture `tests/Beutl.UnitTests/NodeGraph/NodeGraphFilterEffectRenderNodeTests.cs` (5 cases across 2 `[TestCase]` methods).
- Baseline: all 5 pass against the current code; the wider `FullyQualifiedName~NodeGraph` filter is green (22/22).
- Mutation check: replacing the forwarded scales with hardcoded `1f` / `+Inf` turns the suite red (3 failed / 2 passed — the 2 survivors are the no-discrimination baselines `s_out=1→1` and `max=+Inf→4`), confirming the test actually guards the forwarding. Reverted before committing.
- `dotnet format` verified clean on the changed file.

## Fixed issues / References
- Project board: b-editor/projects/9 ("test(nodegraph): cover NodeGraphFilterEffectRenderNode scale forwarding")

https://claude.ai/code/session_01AgTwKnyYSUv8odY3YzAVy5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify the filter-effect render node pipeline forwards `OutputScale` and correctly applies `MaxWorkingScale` when resolving and stamping effective working scale in the graph output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->