### PR TITLE
docs: fix Graphics3D NUnit test routing across guidance docs

### DIFF
--- a/.claude/skills/beutl-test/SKILL.md
+++ b/.claude/skills/beutl-test/SKILL.md
@@ -38,7 +38,7 @@ If `$ARGUMENTS` is provided, treat it as the FQN substring and skip the prompt.
 
 - Framework `net10.0` matches `.github/workflows/dotnet.yml`. There is also a `net10.0-windows` target for Windows-specific tests; do not switch without reason.
 - Coverlet settings live in `coverlet.runsettings`.
-- Test framework: **NUnit + Moq**. Tests live under `tests/` in per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/Beutl.Graphics3DTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`).
+- Test framework: **NUnit + Moq**. Tests live under `tests/` in per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`). Note `tests/Beutl.Graphics3DTests/` is an executable visual harness, not an NUnit project — Graphics3D NUnit tests live under `tests/Beutl.UnitTests/Engine/Graphics3D/`.
 - Benchmark projects (`tests/Beutl.Benchmarks`, `tests/Beutl.FFmpegBenchmarks`) use BenchmarkDotNet; exclude them by selecting a single test project rather than the whole solution when iterating.
 - For deeper debugging without polluting the working tree, prefer the `beutl-test-runner` subagent (it runs in an isolated worktree).
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -22,7 +22,7 @@ Beutl targets `net10.0` and `net10.0-windows`. Both targets must keep building. 
 
 ### III. Test-First with NUnit
 
-- Test framework is NUnit + Moq. Tests are organized under `tests/` in per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/Beutl.Graphics3DTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`).
+- Test framework is NUnit + Moq. Tests are organized under `tests/` in per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`). `tests/Beutl.Graphics3DTests/` is an executable visual harness, not an NUnit project.
 - New logic in `src/` is incomplete without an accompanying test.
 - Benchmarks (`tests/Beutl.Benchmarks`, `tests/Beutl.FFmpegBenchmarks`) use BenchmarkDotNet and are excluded from regular `dotnet test` runs.
 - CI quality gate: `dotnet test Beutl.slnx -f net10.0 --settings coverlet.runsettings` must pass, with the coverage threshold configured in [`.github/workflows/dotnet.yml`](../../.github/workflows/dotnet.yml) honored.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Beutl is a cross-platform video editing / compositing application built on Avalo
 
 - License: the main app is **MIT**; `Beutl.FFmpegWorker` alone is **GPL-3.0-or-later** (a separate process)
 - UI: Avalonia (XAML + ViewModel)
-- Tests: NUnit + Moq under `tests/` (per-area projects, e.g. `tests/Beutl.UnitTests/`, `tests/Beutl.Graphics3DTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`)
+- Tests: NUnit + Moq under `tests/` (per-area projects, e.g. `tests/Beutl.UnitTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`). `tests/Beutl.Graphics3DTests/` is an executable visual harness, not an NUnit project — see `tests/CLAUDE.md`
 - Build: Nuke (`nukebuild/`) or `dotnet` directly
 
 ## Build / test / format

--- a/docs/ai-workflow/coding-guidelines-for-ai.md
+++ b/docs/ai-workflow/coding-guidelines-for-ai.md
@@ -33,7 +33,7 @@ The `beutl-design-reviewer` subagent audits public-surface diffs against these r
 
 ## Tests
 
-- **NUnit + Moq** under `tests/`. Tests are split across per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/Beutl.Graphics3DTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`); add new tests to the one that matches the code you changed. Do not introduce another test framework.
+- **NUnit + Moq** under `tests/`. Tests are split across per-area projects (e.g. `tests/Beutl.UnitTests/`, `tests/SourceGeneratorTest/`, `tests/Beutl.FFmpegIpc.Tests/`); add new tests to the one that matches the code you changed. Do not introduce another test framework. (`tests/Beutl.Graphics3DTests/` is an executable visual harness, not an NUnit project — Graphics3D NUnit tests live under `tests/Beutl.UnitTests/Engine/Graphics3D/`.)
 - **New logic ships with a test.** A PR without a corresponding test is incomplete.
 - **`isolation: worktree`** — the `beutl-test-runner` subagent lets you try fixes against a worktree copy of the repo without polluting your real branch.
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,7 +7,7 @@ All test projects are NUnit (+ Moq where needed). Use this index when picking th
 | Production code under… | Test project |
 |---|---|
 | `src/Beutl.Engine/Graphics/`, `Animation/`, `Audio/`, `Composition/`, etc. (non-3D) | `tests/Beutl.UnitTests/` |
-| `src/Beutl.Engine/Graphics3D/` | `tests/Beutl.Graphics3DTests/` |
+| `src/Beutl.Engine/Graphics3D/` | `tests/Beutl.UnitTests/Engine/Graphics3D/` |
 | `src/Beutl.Engine.SourceGenerators/` | `tests/SourceGeneratorTest/` |
 | `src/Beutl.FFmpegIpc/` and IPC-level contract tests against `Beutl.FFmpegWorker` | `tests/Beutl.FFmpegIpc.Tests/` |
 | `src/Beutl.Editor*/` | `tests/Beutl.UnitTests/Editor*/` |
@@ -15,6 +15,8 @@ All test projects are NUnit (+ Moq where needed). Use this index when picking th
 | `src/Beutl.Extensions.AVFoundation/` (macOS only) | `tests/Beutl.Extensions.AVFoundation.Tests/` |
 
 `tests/Beutl.Benchmarks/` and `tests/Beutl.FFmpegBenchmarks/` are BenchmarkDotNet projects, not NUnit — do not add unit tests there.
+
+`tests/Beutl.Graphics3DTests/` is an executable visual harness for manual Graphics3D checks, not an NUnit test project. Graphics3D NUnit tests live under `tests/Beutl.UnitTests/Engine/Graphics3D/`.
 
 `tests/DirectoryViewTest/`, `tests/PackageSample/`, `tests/TextFormattingPlayground/`, `tests/PropertyEditorViewTests/`, `tests/EnumerateFontFamilies/`, `tests/XamlPreview/` are interactive Avalonia previewers, not test harnesses — running them launches a window.
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # tests/ — local context
 
-All test projects are NUnit (+ Moq where needed). Use this index when picking the right project for a new test.
+The unit-test suites here are NUnit (+ Moq where needed) — but not every project under `tests/` is an NUnit suite (some are BenchmarkDotNet benchmarks, manual visual harnesses, or interactive previewers; see the notes below the table). Use this index when picking the right project for a new test.
 
 ## Where new tests go
 


### PR DESCRIPTION
## Description
- Correct `tests/CLAUDE.md` so Graphics3D NUnit tests route to `tests/Beutl.UnitTests/Engine/Graphics3D/`, and clarify that `tests/Beutl.Graphics3DTests/` is an executable visual harness, not an NUnit test project.
- Remove the same mis-classification from the other guidance docs that listed `tests/Beutl.Graphics3DTests/` among the NUnit + Moq per-area test projects, adding the same clarification to each:
  - `AGENTS.md` (loaded into every agent's context via `CLAUDE.md`)
  - `.claude/skills/beutl-test/SKILL.md`
  - `docs/ai-workflow/coding-guidelines-for-ai.md` (which also instructs agents to add new tests to the project that matches the changed code)
  - `.specify/memory/constitution.md`
- Verified the AI Review item is not a false positive: `tests/Beutl.Graphics3DTests.csproj` has `OutputType=Exe` and no NUnit packages (521-line console `Program.cs`, zero `[Test]`/`[TestFixture]`), while existing Graphics3D `[TestFixture]` files live under `tests/Beutl.UnitTests/Engine/Graphics3D/`.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `git diff --check`
- No NUnit run: documentation-only routing fix.

## Fixed issues / References
- Project board: b-editor/projects/9 ("docs(tests): tests/CLAUDE.md mis-routes Graphics3D NUnit tests")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified where NUnit + Moq unit tests should be added and run within the per-area `tests/` structure.
  * Updated guidance to state that `tests/Beutl.Graphics3DTests/` is an executable visual harness (not an NUnit test project), and that the Graphics3D NUnit tests are located in a different `tests/` folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
