### PR TITLE
refactor(editor): extract encoder settings JSON handling

### DIFF
--- a/src/Beutl.Editor/Services/EncoderSettingsJson.cs
+++ b/src/Beutl.Editor/Services/EncoderSettingsJson.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Media;
 using Beutl.Media.Encoding;
 using Beutl.Serialization;
@@ -17,6 +17,13 @@ public static class EncoderSettingsJson
         if (settings == null) return;
 
         CoreSerializer.PopulateFromJsonObject(settings, settings.GetType(), json);
+    }
+
+    public static void CopyTo(MediaEncoderSettings? source, MediaEncoderSettings? destination)
+    {
+        if (source == null || destination == null) return;
+
+        Populate(destination, CoreSerializer.SerializeToJsonObject(source));
     }
 
     public static void PopulateVideoPreset(VideoEncoderSettings settings, JsonObject json)

--- a/src/Beutl.Editor/Services/EncoderSettingsJson.cs
+++ b/src/Beutl.Editor/Services/EncoderSettingsJson.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Nodes;
+using Beutl.Media;
+using Beutl.Media.Encoding;
+using Beutl.Serialization;
+
+namespace Beutl.Editor.Services;
+
+public static class EncoderSettingsJson
+{
+    public static JsonObject? Serialize(MediaEncoderSettings? settings)
+    {
+        return settings == null ? null : CoreSerializer.SerializeToJsonObject(settings);
+    }
+
+    public static void Populate(MediaEncoderSettings? settings, JsonObject json)
+    {
+        if (settings == null) return;
+
+        CoreSerializer.PopulateFromJsonObject(settings, settings.GetType(), json);
+    }
+
+    public static void PopulateVideoPreset(VideoEncoderSettings settings, JsonObject json)
+    {
+        PixelSize sourceSize = settings.SourceSize;
+        PixelSize destinationSize = settings.DestinationSize;
+        Rational frameRate = settings.FrameRate;
+
+        try
+        {
+            Populate(settings, json);
+        }
+        finally
+        {
+            settings.SourceSize = sourceSize;
+            settings.DestinationSize = destinationSize;
+            settings.FrameRate = frameRate;
+        }
+    }
+
+    public static void PopulateAudioPreset(AudioEncoderSettings settings, JsonObject json)
+    {
+        int sampleRate = settings.SampleRate;
+
+        try
+        {
+            Populate(settings, json);
+        }
+        finally
+        {
+            settings.SampleRate = sampleRate;
+        }
+    }
+}

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -13,7 +13,6 @@ using Beutl.Media;
 using Beutl.Media.Encoding;
 using Beutl.Models;
 using Beutl.ProjectSystem;
-using Beutl.Serialization;
 using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
 using DynamicData;
@@ -53,10 +52,8 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                     && Controller?.Value != null)
                 {
                     var newController = newEncoder.CreateController(newFile);
-                    var videoSettings = CoreSerializer.SerializeToJsonObject(Controller.Value.VideoSettings);
-                    CoreSerializer.PopulateFromJsonObject(newController.VideoSettings, videoSettings);
-                    var audioSettings = CoreSerializer.SerializeToJsonObject(Controller.Value.AudioSettings);
-                    CoreSerializer.PopulateFromJsonObject(newController.AudioSettings, audioSettings);
+                    EncoderSettingsJson.CopyTo(Controller.Value.VideoSettings, newController.VideoSettings);
+                    EncoderSettingsJson.CopyTo(Controller.Value.AudioSettings, newController.AudioSettings);
                     return newController;
                 }
 

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive.Subjects;
 using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
+using Beutl.Editor.Services;
 using Beutl.Graphics.Rendering;
 using Beutl.Graphics.Rendering.Cache;
 using Beutl.Helpers;
@@ -576,15 +577,50 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
     private JsonObject? SerializeEncoderSettings(MediaEncoderSettings? settings)
     {
-        if (settings == null) return null;
         try
         {
-            return CoreSerializer.SerializeToJsonObject(settings);
+            return EncoderSettingsJson.Serialize(settings);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "An exception occurred during serialization.");
             return null;
+        }
+    }
+
+    private void PopulateEncoderSettings(MediaEncoderSettings? settings, JsonObject json)
+    {
+        try
+        {
+            EncoderSettingsJson.Populate(settings, json);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An exception occurred during deserialization.");
+        }
+    }
+
+    private void PopulateVideoPreset(VideoEncoderSettings settings, JsonObject json)
+    {
+        try
+        {
+            EncoderSettingsJson.PopulateVideoPreset(settings, json);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An exception occurred during deserialization.");
+        }
+    }
+
+    private void PopulateAudioPreset(AudioEncoderSettings settings, JsonObject json)
+    {
+        try
+        {
+            EncoderSettingsJson.PopulateAudioPreset(settings, json);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An exception occurred during deserialization.");
         }
     }
 
@@ -612,19 +648,6 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
     private void ReadFromJsonCore(JsonObject json, bool applyingPreset)
     {
-        void Deserialize(MediaEncoderSettings? settings, JsonObject json)
-        {
-            if (settings == null) return;
-            try
-            {
-                CoreSerializer.PopulateFromJsonObject(settings, settings.GetType(), json);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "An exception occurred during deserialization.");
-            }
-        }
-
         if (DestinationFile.Value == null && applyingPreset)
         {
             string path = Model.Uri!.LocalPath;
@@ -668,27 +691,18 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             SupersampleFactor.Value = ssFactor;
         }
 
-        // 上のSelectedEncoder.Value = encoder;でnull以外が指定された場合、VideoSettings, AudioSettingsもnullじゃなくなる。
+        // Selecting an encoder above also creates the current video/audio settings.
         if (json.TryGetPropertyValue(nameof(VideoSettings), out JsonNode? videoNode)
             && videoNode is JsonObject videoObj
             && VideoSettings.Value?.Settings is VideoEncoderSettings videoSettings)
         {
-            PixelSize srcSize = default;
-            PixelSize dstSize = default;
-            Rational framerate = default;
             if (applyingPreset)
             {
-                srcSize = videoSettings.SourceSize;
-                dstSize = videoSettings.DestinationSize;
-                framerate = videoSettings.FrameRate;
+                PopulateVideoPreset(videoSettings, videoObj);
             }
-
-            Deserialize(videoSettings, videoObj);
-            if (applyingPreset)
+            else
             {
-                videoSettings.SourceSize = srcSize;
-                videoSettings.DestinationSize = dstSize;
-                videoSettings.FrameRate = framerate;
+                PopulateEncoderSettings(videoSettings, videoObj);
             }
         }
 
@@ -696,16 +710,13 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             && audioNode is JsonObject audioObj
             && AudioSettings.Value?.Settings is AudioEncoderSettings audioSettings)
         {
-            int sampleRate = 0;
             if (applyingPreset)
             {
-                sampleRate = audioSettings.SampleRate;
+                PopulateAudioPreset(audioSettings, audioObj);
             }
-
-            Deserialize(AudioSettings.Value?.Settings, audioObj);
-            if (applyingPreset)
+            else
             {
-                audioSettings.SampleRate = sampleRate;
+                PopulateEncoderSettings(audioSettings, audioObj);
             }
         }
 

--- a/tests/Beutl.UnitTests/Editor/Services/EncoderSettingsJsonTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/EncoderSettingsJsonTests.cs
@@ -1,10 +1,11 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Beutl.Editor.Services;
 using Beutl.Media;
 using Beutl.Media.Encoding;
 
 namespace Beutl.UnitTests.Editor.Services;
 
+[TestFixture]
 public class EncoderSettingsJsonTests
 {
     [Test]
@@ -147,5 +148,43 @@ public class EncoderSettingsJsonTests
         Assert.That(() => EncoderSettingsJson.PopulateAudioPreset(target, json), Throws.Exception);
 
         Assert.That(target.SampleRate, Is.EqualTo(44100));
+    }
+
+    [Test]
+    public void CopyTo_CopiesAllSettings()
+    {
+        var source = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(1920, 1080),
+            DestinationSize = new PixelSize(1280, 720),
+            FrameRate = new Rational(60, 1),
+            Bitrate = 7_000_000,
+            KeyframeRate = 24
+        };
+        var destination = new VideoEncoderSettings();
+
+        EncoderSettingsJson.CopyTo(source, destination);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(destination.SourceSize, Is.EqualTo(source.SourceSize));
+            Assert.That(destination.DestinationSize, Is.EqualTo(source.DestinationSize));
+            Assert.That(destination.FrameRate, Is.EqualTo(source.FrameRate));
+            Assert.That(destination.Bitrate, Is.EqualTo(source.Bitrate));
+            Assert.That(destination.KeyframeRate, Is.EqualTo(source.KeyframeRate));
+        });
+    }
+
+    [Test]
+    public void CopyTo_NullArguments_DoNotThrow()
+    {
+        var settings = new VideoEncoderSettings { Bitrate = 7_000_000 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => EncoderSettingsJson.CopyTo(null, settings), Throws.Nothing);
+            Assert.That(() => EncoderSettingsJson.CopyTo(settings, null), Throws.Nothing);
+        });
+        Assert.That(settings.Bitrate, Is.EqualTo(7_000_000));
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/EncoderSettingsJsonTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/EncoderSettingsJsonTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json.Nodes;
+using Beutl.Editor.Services;
+using Beutl.Media;
+using Beutl.Media.Encoding;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+public class EncoderSettingsJsonTests
+{
+    [Test]
+    public void Serialize_NullSettings_ReturnsNull()
+    {
+        Assert.That(EncoderSettingsJson.Serialize(null), Is.Null);
+    }
+
+    [Test]
+    public void Populate_PopulatesVideoSettings()
+    {
+        var source = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(1920, 1080),
+            DestinationSize = new PixelSize(1280, 720),
+            FrameRate = new Rational(60, 1),
+            Bitrate = 7_000_000,
+            KeyframeRate = 24
+        };
+        var target = new VideoEncoderSettings();
+
+        EncoderSettingsJson.Populate(target, EncoderSettingsJson.Serialize(source)!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.SourceSize, Is.EqualTo(source.SourceSize));
+            Assert.That(target.DestinationSize, Is.EqualTo(source.DestinationSize));
+            Assert.That(target.FrameRate, Is.EqualTo(source.FrameRate));
+            Assert.That(target.Bitrate, Is.EqualTo(source.Bitrate));
+            Assert.That(target.KeyframeRate, Is.EqualTo(source.KeyframeRate));
+        });
+    }
+
+    [Test]
+    public void PopulateVideoPreset_PreservesTimelineOwnedSettings()
+    {
+        var preset = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(640, 360),
+            DestinationSize = new PixelSize(640, 360),
+            FrameRate = new Rational(24, 1),
+            Bitrate = 2_000_000,
+            KeyframeRate = 8
+        };
+        var target = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(3840, 2160),
+            DestinationSize = new PixelSize(1920, 1080),
+            FrameRate = new Rational(60, 1),
+            Bitrate = 5_000_000,
+            KeyframeRate = 12
+        };
+
+        EncoderSettingsJson.PopulateVideoPreset(target, EncoderSettingsJson.Serialize(preset)!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.SourceSize, Is.EqualTo(new PixelSize(3840, 2160)));
+            Assert.That(target.DestinationSize, Is.EqualTo(new PixelSize(1920, 1080)));
+            Assert.That(target.FrameRate, Is.EqualTo(new Rational(60, 1)));
+            Assert.That(target.Bitrate, Is.EqualTo(preset.Bitrate));
+            Assert.That(target.KeyframeRate, Is.EqualTo(preset.KeyframeRate));
+        });
+    }
+
+    [Test]
+    public void PopulateVideoPreset_WhenPopulateThrows_PreservesTimelineOwnedSettings()
+    {
+        var preset = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(640, 360),
+            DestinationSize = new PixelSize(640, 360),
+            FrameRate = new Rational(24, 1),
+            Bitrate = 2_000_000
+        };
+        JsonObject json = EncoderSettingsJson.Serialize(preset)!;
+        json[nameof(VideoEncoderSettings.Bitrate)] = JsonValue.Create("invalid");
+        var target = new VideoEncoderSettings
+        {
+            SourceSize = new PixelSize(3840, 2160),
+            DestinationSize = new PixelSize(1920, 1080),
+            FrameRate = new Rational(60, 1),
+            Bitrate = 5_000_000
+        };
+
+        Assert.That(() => EncoderSettingsJson.PopulateVideoPreset(target, json), Throws.Exception);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.SourceSize, Is.EqualTo(new PixelSize(3840, 2160)));
+            Assert.That(target.DestinationSize, Is.EqualTo(new PixelSize(1920, 1080)));
+            Assert.That(target.FrameRate, Is.EqualTo(new Rational(60, 1)));
+        });
+    }
+
+    [Test]
+    public void PopulateAudioPreset_PreservesSampleRate()
+    {
+        var preset = new AudioEncoderSettings
+        {
+            SampleRate = 48000,
+            Channels = 1,
+            Bitrate = 96_000
+        };
+        var target = new AudioEncoderSettings
+        {
+            SampleRate = 44100,
+            Channels = 2,
+            Bitrate = 128_000
+        };
+
+        EncoderSettingsJson.PopulateAudioPreset(target, EncoderSettingsJson.Serialize(preset)!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.SampleRate, Is.EqualTo(44100));
+            Assert.That(target.Channels, Is.EqualTo(preset.Channels));
+            Assert.That(target.Bitrate, Is.EqualTo(preset.Bitrate));
+        });
+    }
+
+    [Test]
+    public void PopulateAudioPreset_WhenPopulateThrows_PreservesSampleRate()
+    {
+        var preset = new AudioEncoderSettings
+        {
+            SampleRate = 48000,
+            Channels = 1,
+            Bitrate = 96_000
+        };
+        JsonObject json = EncoderSettingsJson.Serialize(preset)!;
+        json[nameof(AudioEncoderSettings.Channels)] = JsonValue.Create("invalid");
+        var target = new AudioEncoderSettings
+        {
+            SampleRate = 44100,
+            Channels = 2,
+            Bitrate = 128_000
+        };
+
+        Assert.That(() => EncoderSettingsJson.PopulateAudioPreset(target, json), Throws.Exception);
+
+        Assert.That(target.SampleRate, Is.EqualTo(44100));
+    }
+}


### PR DESCRIPTION
## Description
- Extract encoder settings JSON serialization/population and preset-preservation rules into `Beutl.Editor`.
- Keep `OutputViewModel` responsible for UI state and logging while delegating encoder settings JSON handling to the testable helper.
- Add NUnit coverage for roundtrip population, preset-owned video/audio setting preservation, and exception-path restoration.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~EncoderSettingsJsonTests|FullyQualifiedName~ControllableEncodingExtensionTests"` (14 passed)
- `dotnet build src/Beutl/Beutl.csproj -f net10.0` (passed, 0 warnings)
- `git diff --check` (passed)
- `dotnet format ... --verify-no-changes` was attempted for touched files, but did not complete locally and was interrupted after emitting no diagnostics.

## Fixed issues / References
- Project board: b-editor/projects/9 ("設計改善: テスト可能なコアと UI 統合部分をさらに分離する")

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encoder settings JSON operations, including safer copying and preset application.
  * Enhanced error handling for encoder settings serialization/deserialization, with centralized logging and clearer behavior on invalid preset data.

* **Tests**
  * Expanded unit tests to cover null-safe serialize/copy behavior and verify preset application preserves timeline-owned values and appropriately retains key settings when errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->