### PR TITLE
fix(engine): preserve rasterize cleanup exceptions

### DIFF
--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -100,10 +100,8 @@ public class RenderNodeProcessor(
         catch
         {
             // Clean up remaining ops (RasterizeAt already disposed the faulting one).
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
-            foreach (var item in list)
-                item.Item1.Dispose();
+            DisposeRemainingOperations(ops, consumed);
+            DisposeRenderTargets(list);
             throw;
         }
     }
@@ -129,10 +127,8 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
-            foreach (var bmp in list)
-                bmp.Dispose();
+            DisposeRemainingOperations(ops, consumed);
+            DisposeBitmaps(list);
             throw;
         }
     }
@@ -163,12 +159,47 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
+            DisposeRemainingOperations(ops, consumed);
             throw;
         }
 
         return renderTarget.Snapshot();
+    }
+
+    private static void DisposeRemainingOperations(RenderNodeOperation[] ops, int start)
+    {
+        for (int j = start; j < ops.Length; j++)
+        {
+            DisposeBestEffort(ops[j]);
+        }
+    }
+
+    private static void DisposeRenderTargets(List<(RenderTarget RenderTarget, Rect Bounds)> targets)
+    {
+        foreach (var item in targets)
+        {
+            DisposeBestEffort(item.RenderTarget);
+        }
+    }
+
+    private static void DisposeBitmaps(List<Bitmap> bitmaps)
+    {
+        foreach (var bmp in bitmaps)
+        {
+            DisposeBestEffort(bmp);
+        }
+    }
+
+    private static void DisposeBestEffort(IDisposable disposable)
+    {
+        try
+        {
+            disposable.Dispose();
+        }
+        catch
+        {
+            // Preserve the original render/rasterize failure while still sweeping the rest.
+        }
     }
 
     public RenderNodeOperation[] PullToRoot()

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -67,9 +67,11 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            renderTarget.Dispose();
+            // renderTarget.Dispose() is GPU-native teardown that can itself throw; swallow cleanup
+            // faults so the in-flight render exception propagates and the op is still disposed.
+            DisposeBestEffort(renderTarget);
             if (!opDisposeStarted)
-                op.Dispose();
+                DisposeBestEffort(op);
             throw;
         }
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -136,6 +136,42 @@ public class RenderNodeProcessorExceptionSafetyTests
         }));
     }
 
+    // RasterizeAt's own catch disposes the faulting op AND its render target. Both go through
+    // DisposeBestEffort, so a throwing op Dispose() there is swallowed and the original render
+    // exception still propagates. Only Rasterize/RasterizeToRenderTargets reach RasterizeAt;
+    // RasterizeAndConcat renders directly into a shared canvas and is covered above.
+    [Test]
+    public void RasterizeToRenderTargets_PreservesRenderException_WhenFaultingOpAlsoThrowsOnDispose()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("render-fault", disposed, throwOnRender: true, throwOnDispose: true, disposeFaultMessage: "dispose-fault"),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault", "remaining" }));
+    }
+
+    [Test]
+    public void Rasterize_PreservesRenderException_WhenFaultingOpAlsoThrowsOnDispose()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("render-fault", disposed, throwOnRender: true, throwOnDispose: true, disposeFaultMessage: "dispose-fault"),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault", "remaining" }));
+    }
+
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
     {
         return new StaticRenderNode(
@@ -150,7 +186,8 @@ public class RenderNodeProcessorExceptionSafetyTests
         string name,
         ICollection<string> disposed,
         bool throwOnRender = false,
-        bool throwOnDispose = false)
+        bool throwOnDispose = false,
+        string? disposeFaultMessage = null)
     {
         return RenderNodeOperation.CreateLambda(
             new Rect(0, 0, 4, 4),
@@ -166,7 +203,7 @@ public class RenderNodeProcessorExceptionSafetyTests
                 disposed.Add(name);
                 if (throwOnDispose)
                 {
-                    throw new InvalidOperationException(name);
+                    throw new InvalidOperationException(disposeFaultMessage ?? name);
                 }
             });
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -76,6 +76,76 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
     }
 
+    [Test]
+    public void RasterizeToRenderTargets_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[]
+        {
+            "first",
+            "render-fault",
+            "throwing-remaining-1",
+            "throwing-remaining-2",
+            "remaining"
+        }));
+    }
+
+    [Test]
+    public void Rasterize_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[]
+        {
+            "first",
+            "render-fault",
+            "throwing-remaining-1",
+            "throwing-remaining-2",
+            "remaining"
+        }));
+    }
+
+    [Test]
+    public void RasterizeAndConcat_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[]
+        {
+            "first",
+            "render-fault",
+            "throwing-remaining-1",
+            "throwing-remaining-2",
+            "remaining"
+        }));
+    }
+
+    private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
+    {
+        return new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("render-fault", disposed, throwOnRender: true),
+            CreateOperation("throwing-remaining-1", disposed, throwOnDispose: true),
+            CreateOperation("throwing-remaining-2", disposed, throwOnDispose: true),
+            CreateOperation("remaining", disposed));
+    }
+
     private static RenderNodeOperation CreateOperation(
         string name,
         ICollection<string> disposed,


### PR DESCRIPTION
## Description
- Make RenderNodeProcessor catch-block cleanup sweeps best-effort so a throwing cleanup Dispose does not mask the original render/rasterize exception.
- Continue sweeping later operations and already-created rasterized resources after one cleanup Dispose throws.
- Add regression coverage for RasterizeToRenderTargets, Rasterize, and RasterizeAndConcat with multiple throwing cleanup operations.
- Harden `RasterizeAt`'s own catch the same way: route both `renderTarget.Dispose()` and `op.Dispose()` through `DisposeBestEffort` so a throwing GPU-native render-target teardown there cannot mask the in-flight render exception or skip the op's disposal (review follow-up; the failure mode the outer catches fixed, left open one level down).

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Added regression tests in `tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs` for cleanup sweep exception safety.
- Confirmed the new tests failed before the production fix: 3 failed, 4 passed.
- Hardened `RasterizeAt`'s catch (commit `a20368bea`) and added 2 regression tests for a faulting op that also throws on dispose; confirmed both fail before the fix (`dispose-fault` masks `render-fault`) and pass after.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~RenderNodeProcessorExceptionSafetyTests"` (9 passed)
- `dotnet format src/Beutl.Engine/Beutl.Engine.csproj --include src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs --verify-no-changes --no-restore`
- `dotnet format tests/Beutl.UnitTests/Beutl.UnitTests.csproj --include tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs --verify-no-changes --no-restore`
- `git diff --check`

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-20][review][low] Catch-sweep Dispose throw aborts cleanup and masks original exception (Rasterize / RasterizeToRenderTargets / RasterizeAndConcat)")

## Follow-ups
- **Cover the render-target / built-resource Dispose-throw paths (needs a test seam).** Still untested after this PR: (1) `RasterizeAt`'s catch when the faulting op's **render target** `Dispose()` throws (`renderTarget.Dispose()`, the GPU-native teardown) — the current tests only drive the op's own `Dispose()` throwing there; (2) the outer `DisposeRenderTargets` / `DisposeBitmaps` best-effort branches when an **already-built** `RenderTarget` / `Bitmap` throws during the sweep (the tests only make *remaining ops* throw, so `list` only ever holds the clean first result). Both require substituting a `RenderTarget` / `Bitmap` whose `Dispose()` throws, but `RenderTarget` has a private constructor + non-virtual `Dispose()` and is created internally via `RenderTarget.Create()`, so it cannot be subclassed or injected today. Options: add an injectable `RenderTarget` factory to `RenderNodeProcessor`, or make `RenderTarget` test-substitutable. Low priority — the shared `DisposeBestEffort` body is already exercised, so the swallow logic itself is covered; this is about the specific entry points. Tracked on b-editor/projects/9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during rendering operations to ensure original error messages are preserved and all resources are properly cleaned up when failures occur.

* **Tests**
  * Added comprehensive exception safety tests to verify proper resource cleanup behavior during rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
