### PR TITLE
fix(mediafoundation): compile sideload timestamp utilities

### DIFF
--- a/src/Beutl.Extensions.MediaFoundation/TimestampUtilities.cs
+++ b/src/Beutl.Extensions.MediaFoundation/TimestampUtilities.cs
@@ -1,8 +1,8 @@
 ﻿// https://github.com/amate/MFVideoReader
 
-#if MF_BUILD_IN
 using Windows.Win32.Media.MediaFoundation;
 
+#if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;
 #else
 namespace Beutl.Extensions.MediaFoundation.Decoding;


### PR DESCRIPTION
## Description
- Fixes the `MFBuildIn=False` sideload build by making `TimestampUtilities` import `MFRatio` in both MediaFoundation extension configurations.
- Keeps the existing `MF_BUILD_IN` namespace split unchanged.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

MediaFoundation extension build configuration only.

## Breaking changes
None.

## Test plan
- Reproduced the original issue before the fix: `dotnet build src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj -f net10.0-windows -p:MFBuildIn=False --no-restore` failed with CS0246 for `MFRatio` in `TimestampUtilities.cs`.
- Passed: `dotnet build src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj -f net10.0 -p:MFBuildIn=False --no-restore`
- Passed: `dotnet build src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj -f net10.0 --no-restore`
- Passed: `git diff --check`
- Attempted: `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --filter "FullyQualifiedName~TimestampUtilitiesTests"`; this currently fails before exercising the change because the testhost cannot load `Beutl.Embedding.MediaFoundation, Version=2.99.99.0` even though the project output contains `Beutl.Embedding.MediaFoundation.dll`.
- Attempted: `dotnet format ... --include src/Beutl.Extensions.MediaFoundation/TimestampUtilities.cs --verify-no-changes`; both solution- and project-scoped invocations stayed running without output and were interrupted.

## Follow-ups
- Investigate `tests/Beutl.Extensions.MediaFoundation.Tests` runtime assembly loading for `Beutl.Embedding.MediaFoundation`; the filtered `TimestampUtilitiesTests` run currently fails before the assertions execute.

## Fixed issues / References
- Project board: b-editor/projects/9 ("MF: MFBuildIn=False sideload configuration does not compile")
