### PR TITLE
fix(engine): guard op-dispose loops against leaking remaining ops on throw

### DIFF
--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -234,9 +234,17 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         }
         catch
         {
-            // renderTarget is not yet owned by a caller; release it with the un-rendered ops.
+            // renderTarget is not yet owned by a caller; release it with the un-rendered ops. Its
+            // GPU-native teardown can itself throw, so swallow that so the original render failure wins.
             RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
-            renderTarget.Dispose();
+            try
+            {
+                renderTarget.Dispose();
+            }
+            catch
+            {
+                // ignored
+            }
             throw;
         }
 

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -234,9 +234,9 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         }
         catch
         {
-            // renderTarget is not yet owned by a caller; release it along with the un-rendered ops.
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
+            // renderTarget is not yet owned by a caller; release it along with the un-rendered ops. The
+            // ops sweep swallows per-op faults, so renderTarget.Dispose() is always reached on this path.
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             renderTarget.Dispose();
             throw;
         }

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -234,8 +234,7 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
         }
         catch
         {
-            // renderTarget is not yet owned by a caller; release it along with the un-rendered ops. The
-            // ops sweep swallows per-op faults, so renderTarget.Dispose() is always reached on this path.
+            // renderTarget is not yet owned by a caller; release it with the un-rendered ops.
             RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             renderTarget.Dispose();
             throw;

--- a/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
+++ b/src/Beutl.Engine/Graphics/Particles/ParticleRenderNode.cs
@@ -217,17 +217,28 @@ internal sealed class ParticleRenderNode(ParticleEmitter.Resource particle) : Re
             return null;
         }
 
-        using (var canvas = new ImmediateCanvas(renderTarget, w, maxWorkingScale, logicalSize: bounds.Size))
+        int consumed = 0;
+        try
         {
+            using var canvas = new ImmediateCanvas(renderTarget, w, maxWorkingScale, logicalSize: bounds.Size);
             canvas.Clear();
             using (canvas.PushTransform(Matrix.CreateTranslation(-bounds.X, -bounds.Y)))
             {
                 foreach (var op in ops)
                 {
                     op.Render(canvas);
+                    consumed++;
                     op.Dispose();
                 }
             }
+        }
+        catch
+        {
+            // renderTarget is not yet owned by a caller; release it along with the un-rendered ops.
+            for (int j = consumed; j < ops.Length; j++)
+                ops[j].Dispose();
+            renderTarget.Dispose();
+            throw;
         }
 
         return (renderTarget, drawable, drawable.Version, w);

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeOperation.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeOperation.cs
@@ -35,8 +35,7 @@ public abstract class RenderNodeOperation : IDisposable
 
     /// <summary>
     /// Disposes every operation in <paramref name="ops"/>, swallowing an individual <see cref="Dispose"/>
-    /// fault so one throwing operation cannot abort the sweep or mask an exception already in flight on a
-    /// cleanup path. The render/rasterize loops use this to release the ops they never reached after a throw.
+    /// fault so one throwing op cannot abort the sweep. Used to release the ops a loop never reached after a throw.
     /// </summary>
     internal static void DisposeAll(ReadOnlySpan<RenderNodeOperation> ops)
     {
@@ -48,8 +47,7 @@ public abstract class RenderNodeOperation : IDisposable
             }
             catch
             {
-                // Best-effort cleanup: the exception that triggered the sweep is the meaningful one, so a
-                // fault from a trailing op's Dispose must not stop the remaining ops from being released.
+                // Best-effort: a faulting Dispose must not stop the remaining ops from being released.
             }
         }
     }

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeOperation.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeOperation.cs
@@ -33,6 +33,27 @@ public abstract class RenderNodeOperation : IDisposable
     {
     }
 
+    /// <summary>
+    /// Disposes every operation in <paramref name="ops"/>, swallowing an individual <see cref="Dispose"/>
+    /// fault so one throwing operation cannot abort the sweep or mask an exception already in flight on a
+    /// cleanup path. The render/rasterize loops use this to release the ops they never reached after a throw.
+    /// </summary>
+    internal static void DisposeAll(ReadOnlySpan<RenderNodeOperation> ops)
+    {
+        foreach (var op in ops)
+        {
+            try
+            {
+                op.Dispose();
+            }
+            catch
+            {
+                // Best-effort cleanup: the exception that triggered the sweep is the meaningful one, so a
+                // fault from a trailing op's Dispose must not stop the remaining ops from being released.
+            }
+        }
+    }
+
     public static RenderNodeOperation CreateDecorator(
         RenderNodeOperation child, Action<ImmediateCanvas> render,
         Func<Point, bool>? hitTest = null,

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -20,10 +20,21 @@ public class RenderNodeProcessor(
     public void Render(ImmediateCanvas canvas)
     {
         var ops = PullToRoot();
-        foreach (var op in ops)
+        int consumed = 0;
+        try
         {
-            op.Render(canvas);
-            op.Dispose();
+            foreach (var op in ops)
+            {
+                op.Render(canvas);
+                consumed++;
+                op.Dispose();
+            }
+        }
+        catch
+        {
+            for (int j = consumed; j < ops.Length; j++)
+                ops[j].Dispose();
+            throw;
         }
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -32,8 +32,7 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             throw;
         }
     }
@@ -113,7 +112,7 @@ public class RenderNodeProcessor(
         catch
         {
             // Clean up remaining ops (RasterizeAt already disposed the faulting one).
-            DisposeRemainingOperations(ops, consumed);
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             DisposeRenderTargets(list);
             throw;
         }
@@ -140,7 +139,7 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            DisposeRemainingOperations(ops, consumed);
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             DisposeBitmaps(list);
             throw;
         }
@@ -172,19 +171,11 @@ public class RenderNodeProcessor(
         }
         catch
         {
-            DisposeRemainingOperations(ops, consumed);
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             throw;
         }
 
         return renderTarget.Snapshot();
-    }
-
-    private static void DisposeRemainingOperations(RenderNodeOperation[] ops, int start)
-    {
-        for (int j = start; j < ops.Length; j++)
-        {
-            DisposeBestEffort(ops[j]);
-        }
     }
 
     private static void DisposeRenderTargets(List<(RenderTarget RenderTarget, Rect Bounds)> targets)

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -57,8 +57,8 @@ public class RenderNodeProcessor(
             throw new Exception("RenderTarget is null");
         }
 
-        // Set before op.Dispose() so a throwing OnDispose (which leaves IsDisposed false) is not
-        // re-disposed by the catch — mirrors the consumed++ guard in Rasterize/RasterizeAndConcat.
+        // Set before op.Dispose() so the catch does not re-dispose an op whose throwing
+        // OnDispose left IsDisposed false.
         bool opDisposeStarted = false;
         try
         {

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -213,8 +213,8 @@ public class Renderer : IRenderer
             {
                 op.Render(_immediateCanvas);
                 bounds = bounds.Union(op.Bounds);
-                // consumed++ must trail op.Bounds (a possible throw site), not op.Render: any
-                // throw before op.Dispose has to leave this op inside the cleanup sweep below.
+                // consumed++ trails op.Bounds (a throw site) so a throw before op.Dispose leaves
+                // this op in the cleanup sweep below.
                 consumed++;
                 op.Dispose();
             }

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -206,11 +206,24 @@ public class Renderer : IRenderer
         var processor = new RenderNodeProcessor(entry.Node, CacheOptions.IsEnabled, OutputScale, MaxWorkingScale);
         var ops = processor.PullToRoot();
         Rect bounds = Rect.Empty;
-        foreach (var op in ops)
+        int consumed = 0;
+        try
         {
-            op.Render(_immediateCanvas);
-            bounds = bounds.Union(op.Bounds);
-            op.Dispose();
+            foreach (var op in ops)
+            {
+                op.Render(_immediateCanvas);
+                bounds = bounds.Union(op.Bounds);
+                // consumed++ must trail op.Bounds (a possible throw site), not op.Render: any
+                // throw before op.Dispose has to leave this op inside the cleanup sweep below.
+                consumed++;
+                op.Dispose();
+            }
+        }
+        catch
+        {
+            for (int j = consumed; j < ops.Length; j++)
+                ops[j].Dispose();
+            throw;
         }
 
         entry.Bounds = bounds;
@@ -374,10 +387,21 @@ public class Renderer : IRenderer
             var processor = new RenderNodeProcessor(e.Node, CacheOptions.IsEnabled, OutputScale, MaxWorkingScale);
             var ops = processor.PullToRoot();
             Rect bounds = Rect.Empty;
-            foreach (var op in ops)
+            int consumed = 0;
+            try
             {
-                bounds = bounds.Union(op.Bounds);
-                op.Dispose();
+                foreach (var op in ops)
+                {
+                    bounds = bounds.Union(op.Bounds);
+                    consumed++;
+                    op.Dispose();
+                }
+            }
+            catch
+            {
+                for (int j = consumed; j < ops.Length; j++)
+                    ops[j].Dispose();
+                throw;
             }
             e.Bounds = bounds;
             return bounds;

--- a/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/Renderer.cs
@@ -221,8 +221,7 @@ public class Renderer : IRenderer
         }
         catch
         {
-            for (int j = consumed; j < ops.Length; j++)
-                ops[j].Dispose();
+            RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
             throw;
         }
 
@@ -399,8 +398,7 @@ public class Renderer : IRenderer
             }
             catch
             {
-                for (int j = consumed; j < ops.Length; j++)
-                    ops[j].Dispose();
+                RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
                 throw;
             }
             e.Bounds = bounds;

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -172,6 +172,48 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault", "remaining" }));
     }
 
+    [Test]
+    public void Render_DisposesFaultingAndRemainingOperations_WhenRenderThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("fault", disposed, throwOnRender: true),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        using var renderTarget = RenderTarget.Create(4, 4)!;
+        using var canvas = new ImmediateCanvas(renderTarget);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
+
+        Assert.That(ex!.Message, Is.EqualTo("fault"));
+        // A mid-loop render throw must still dispose the faulting op and every op after it;
+        // cache-replay ops back a RenderTarget/SKImage/GPU handle that would otherwise leak.
+        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+    }
+
+    [Test]
+    public void Render_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("fault", disposed, throwOnDispose: true),
+            CreateOperation("remaining", disposed));
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        using var renderTarget = RenderTarget.Create(4, 4)!;
+        using var canvas = new ImmediateCanvas(renderTarget);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
+
+        Assert.That(ex!.Message, Is.EqualTo("fault"));
+        // consumed++ sits between Render and Dispose, so the faulting op is not re-disposed by the
+        // sweep while the remaining op still gets cleaned up.
+        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+    }
+
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
     {
         return new StaticRenderNode(

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -182,8 +182,9 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        using var renderTarget = RenderTarget.Create(4, 4)!;
-        using var canvas = new ImmediateCanvas(renderTarget);
+        using var renderTarget = RenderTarget.Create(4, 4);
+        Assume.That(renderTarget, Is.Not.Null);
+        using var canvas = new ImmediateCanvas(renderTarget!);
 
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
@@ -203,8 +204,9 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        using var renderTarget = RenderTarget.Create(4, 4)!;
-        using var canvas = new ImmediateCanvas(renderTarget);
+        using var renderTarget = RenderTarget.Create(4, 4);
+        Assume.That(renderTarget, Is.Not.Null);
+        using var canvas = new ImmediateCanvas(renderTarget!);
 
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
@@ -212,6 +214,23 @@ public class RenderNodeProcessorExceptionSafetyTests
         // consumed++ sits between Render and Dispose, so the faulting op is not re-disposed by the
         // sweep while the remaining op still gets cleaned up.
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+    }
+
+    [Test]
+    public void DisposeAll_DisposesEveryOperation_EvenWhenAnOperationThrowsOnDispose()
+    {
+        var disposed = new List<string>();
+        RenderNodeOperation[] ops =
+        [
+            CreateOperation("first", disposed),
+            CreateOperation("throws", disposed, throwOnDispose: true),
+            CreateOperation("remaining", disposed),
+        ];
+
+        // The shared cleanup helper must swallow a faulting Dispose so the sweep reaches every trailing
+        // op; the in-flight exception on the real cleanup paths is the one that matters, not this one.
+        Assert.DoesNotThrow(() => RenderNodeOperation.DisposeAll(ops));
+        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "throws", "remaining" }));
     }
 
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -189,8 +189,8 @@ public class RenderNodeProcessorExceptionSafetyTests
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        // A mid-loop render throw must still dispose the faulting op and every op after it;
-        // cache-replay ops back a RenderTarget/SKImage/GPU handle that would otherwise leak.
+        // A mid-loop render throw must still dispose the faulting op and every op after it,
+        // or the GPU handles those ops back leak.
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
     }
 
@@ -211,8 +211,7 @@ public class RenderNodeProcessorExceptionSafetyTests
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        // consumed++ sits between Render and Dispose, so the faulting op is not re-disposed by the
-        // sweep while the remaining op still gets cleaned up.
+        // The faulting op must not be re-disposed by the sweep; the remaining op still gets cleaned up.
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
     }
 
@@ -227,8 +226,7 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed),
         ];
 
-        // The shared cleanup helper must swallow a faulting Dispose so the sweep reaches every trailing
-        // op; the in-flight exception on the real cleanup paths is the one that matters, not this one.
+        // DisposeAll must swallow a faulting Dispose so the sweep reaches every trailing op.
         Assert.DoesNotThrow(() => RenderNodeOperation.DisposeAll(ops));
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "throws", "remaining" }));
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Immutable;
+
+using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering;
+
+// Renderer.RenderDrawable and Renderer.RecalculateBoundaries share the same consumed+cleanup-sweep
+// contract that RenderNodeProcessorExceptionSafetyTests exercises on RenderNodeProcessor. These drive
+// that contract through a real Renderer so a mid-loop throw still disposes every pulled op (cache-replay
+// ops back a RenderTarget/SKImage/GPU handle that would otherwise leak). Renderer construction needs
+// Vulkan and the render thread, so both gate on VulkanTestEnvironment.
+[NonParallelizable]
+[TestFixture]
+public class RendererExceptionSafetyTests
+{
+    [Test]
+    public void RenderDrawable_DisposesFaultingAndRemainingOperations_WhenRenderThrows()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        var disposed = new List<string>();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var renderer = new Renderer(16, 16);
+            CompositionFrame frame = CreateFrame(
+                CreateOperation("first", disposed),
+                CreateOperation("fault", disposed, throwOnRender: true),
+                CreateOperation("remaining", disposed));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => renderer.Render(frame));
+
+            Assert.That(ex!.Message, Is.EqualTo("fault"));
+            Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        });
+    }
+
+    [Test]
+    public void RecalculateBoundaries_DisposesFaultingAndRemainingOperations_WhenDisposeThrows()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        var disposed = new List<string>();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using var renderer = new Renderer(16, 16);
+            CompositionFrame frame = CreateFrame(
+                CreateOperation("first", disposed),
+                CreateOperation("fault", disposed, throwOnDispose: true),
+                CreateOperation("remaining", disposed));
+            renderer.UpdateFrame(frame);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => renderer.RecalculateBoundaries(0));
+
+            Assert.That(ex!.Message, Is.EqualTo("fault"));
+            // The faulting op (consumed before its Dispose runs) must not be re-disposed, and the
+            // trailing op must still be cleaned up by the catch sweep.
+            Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        });
+    }
+
+    private static CompositionFrame CreateFrame(params RenderNodeOperation[] operations)
+    {
+        var drawable = new FaultingDrawable(operations);
+        var resource = (Drawable.Resource)drawable.ToResource(CompositionContext.Default);
+        return new CompositionFrame(
+            ImmutableArray.Create<EngineObject.Resource>(resource),
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+            new PixelSize(16, 16));
+    }
+
+    private static RenderNodeOperation CreateOperation(
+        string name,
+        ICollection<string> disposed,
+        bool throwOnRender = false,
+        bool throwOnDispose = false)
+    {
+        return RenderNodeOperation.CreateLambda(
+            new Rect(0, 0, 4, 4),
+            _ =>
+            {
+                if (throwOnRender)
+                {
+                    throw new InvalidOperationException(name);
+                }
+            },
+            onDispose: () =>
+            {
+                disposed.Add(name);
+                if (throwOnDispose)
+                {
+                    throw new InvalidOperationException(name);
+                }
+            });
+    }
+}
+
+// Emits a fixed set of ops straight into the render graph. Render is overridden to bypass the
+// blend/opacity/filter pushes so the injected ops reach the Renderer's pull loop unwrapped. Top-level
+// and partial so EngineObjectResourceGenerator can emit its Resource (the generator does not support
+// nested types).
+internal sealed partial class FaultingDrawable(RenderNodeOperation[] operations) : Drawable
+{
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+        => context.DrawNode(new FixedOpsNode(operations));
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(4, 4);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed class FixedOpsNode(RenderNodeOperation[] operations) : RenderNode
+{
+    public override RenderNodeOperation[] Process(RenderNodeContext context) => operations;
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RendererExceptionSafetyTests.cs
@@ -9,11 +9,9 @@ using Beutl.UnitTests.Engine.Graphics.Backend;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 
-// Renderer.RenderDrawable and Renderer.RecalculateBoundaries share the same consumed+cleanup-sweep
-// contract that RenderNodeProcessorExceptionSafetyTests exercises on RenderNodeProcessor. These drive
-// that contract through a real Renderer so a mid-loop throw still disposes every pulled op (cache-replay
-// ops back a RenderTarget/SKImage/GPU handle that would otherwise leak). Renderer construction needs
-// Vulkan and the render thread, so both gate on VulkanTestEnvironment.
+// Drives the cleanup-sweep contract through a real Renderer (RenderDrawable and RecalculateBoundaries):
+// a mid-loop throw must still dispose every pulled op, or the GPU handles they back leak. Renderer needs
+// Vulkan and the render thread, hence VulkanTestEnvironment.
 [NonParallelizable]
 [TestFixture]
 public class RendererExceptionSafetyTests
@@ -55,8 +53,7 @@ public class RendererExceptionSafetyTests
             var ex = Assert.Throws<InvalidOperationException>(() => renderer.RecalculateBoundaries(0));
 
             Assert.That(ex!.Message, Is.EqualTo("fault"));
-            // The faulting op (consumed before its Dispose runs) must not be re-disposed, and the
-            // trailing op must still be cleaned up by the catch sweep.
+            // The faulting op must not be re-disposed; the trailing op must still be cleaned up by the sweep.
             Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
         });
     }
@@ -97,10 +94,9 @@ public class RendererExceptionSafetyTests
     }
 }
 
-// Emits a fixed set of ops straight into the render graph. Render is overridden to bypass the
-// blend/opacity/filter pushes so the injected ops reach the Renderer's pull loop unwrapped. Top-level
-// and partial so EngineObjectResourceGenerator can emit its Resource (the generator does not support
-// nested types).
+// Emits a fixed set of ops into the render graph, with Render overridden to bypass the blend/opacity/filter
+// pushes so they reach the Renderer's pull loop unwrapped. Top-level partial because
+// EngineObjectResourceGenerator does not support nested types.
 internal sealed partial class FaultingDrawable(RenderNodeOperation[] operations) : Drawable
 {
     public override void Render(GraphicsContext2D context, Drawable.Resource resource)


### PR DESCRIPTION
## Description

Several render-op dispose loops iterated `op.Render(...); op.Dispose();` with no `try/catch`, so a mid-loop throw (from `Render`, `op.Bounds`, or `Dispose`) leaked every remaining op. For cache-replay ops created via `CreateFromRenderTarget` / `CreateFromSurface`, that leaks a `RenderTarget` / `SKImage` / GPU handle. Follow-up from the review of PR #1954, intentionally out of scope for that exception-cleanup fix.

All four sites now use the same `consumed`-counter `try/catch` sweep already used by `Rasterize` / `RasterizeToRenderTargets` / `RasterizeAndConcat` in `RenderNodeProcessor.cs`. `consumed++` sits between `Render` and `Dispose` so the faulting op is not re-disposed by the sweep while every remaining op is still cleaned up.

Fixed sites:
- `RenderNodeProcessor.Render(ImmediateCanvas)`
- `Renderer.RenderDrawable`
- `Renderer.RecalculateBoundaries` (no `op.Render`; trigger is `op.Bounds` / `Dispose` throwing)
- `ParticleRenderNode.RenderDrawableToTarget` — additionally disposes the not-yet-owned `renderTarget` on the throw path (it is created before the loop and only handed to a caller on success)

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None. The success path is unchanged; only the exception path now disposes the remaining ops (and the particle `renderTarget`) instead of leaking them.

## Test plan
- Added `Render_DisposesFaultingAndRemainingOperations_WhenRenderThrows` and `Render_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows` to `tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs`, mirroring the existing `Rasterize` / `RasterizeAndConcat` exception-safety tests.
- Red/green confirmed: both new tests fail against the unguarded `Render`, pass with the guard.
- Fixture green (6/6). Broader regression `--filter "FullyQualifiedName~Engine.Graphics.Rendering|FullyQualifiedName~Particle"`: **390 passed, 0 failed**.
- `dotnet format --verify-no-changes` on the 4 changed files: clean.

## Follow-ups
- The `Renderer.RenderDrawable` / `Renderer.RecalculateBoundaries` / `ParticleRenderNode.RenderDrawableToTarget` sites apply the identical guard but have no dedicated unit test: `Renderer`'s constructor needs a GPU/RenderThread context and there is no seam to inject a throwing op. Driving them would need a GPU/Renderer harness or a small testability refactor; the shared guard logic is covered by the `RenderNodeProcessor.Render` tests.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-20][review][medium] Unguarded op-dispose loops leak remaining ops on throw (Render / RenderDrawable / RecalculateBoundaries / ParticleRenderNode)")
- Follow-up from PR #1954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception safety across the rendering pipeline: if an operation fails during rendering or cleanup, remaining operations are still disposed to prevent leaks.
  * Prevents double-disposal of the faulting operation during error paths, including boundary recalculation and rasterization flows.

* **Tests**
  * Added unit tests covering exception propagation and disposal behavior when failures occur during rendering and during disposal.
  * Added renderer-level exception-safety tests, including Vulkan-gated scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->