### PR TITLE
fix(engine): deterministically dispose FormattedText Skia handles

### DIFF
--- a/src/Beutl.Engine/Graphics/Shapes/TextBlock.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextBlock.cs
@@ -280,6 +280,8 @@ public partial class TextBlock : Drawable
         partial void PostDispose(bool disposing)
         {
             _pen?.Dispose();
+            _elements?.Dispose();
+            _elements = null;
         }
 
         partial void PreUpdate(TextBlock obj, CompositionContext context)
@@ -348,6 +350,7 @@ public partial class TextBlock : Drawable
             if (_isDirty)
             {
                 Version++;
+                _elements?.Dispose();
                 _elements = null;
                 _isDirty = false;
             }

--- a/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
@@ -28,6 +28,9 @@ public class TextElements : IReadOnlyList<TextElement>, IDisposable
 
     public bool IsDisposed { get; private set; }
 
+    /// <remarks>
+    /// Idempotent and one-shot; this instance and its <see cref="Lines"/> must not be used after disposal.
+    /// </remarks>
     public void Dispose()
     {
         if (IsDisposed) return;
@@ -57,6 +60,10 @@ public class TextElements : IReadOnlyList<TextElement>, IDisposable
 
         public bool IsDisposed { get; private set; }
 
+        /// <remarks>
+        /// Idempotent and one-shot; do not enumerate after disposal. <see cref="GetEnumerator"/> would
+        /// re-allocate <see cref="FormattedText"/> instances that a later <see cref="Dispose"/> will not release.
+        /// </remarks>
         public void Dispose()
         {
             if (IsDisposed) return;
@@ -82,6 +89,16 @@ public class TextElements : IReadOnlyList<TextElement>, IDisposable
 
             if (_formattedTexts?.Length != count)
             {
+                // The element count changed (TextElement is mutable): dispose the abandoned array's
+                // FormattedText handles before replacing it so they are released deterministically.
+                if (_formattedTexts is { } stale)
+                {
+                    foreach (FormattedText item in stale)
+                    {
+                        item.Dispose();
+                    }
+                }
+
                 _formattedTexts = new FormattedText[count];
                 foreach (ref FormattedText item in _formattedTexts.AsSpan())
                 {

--- a/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
@@ -5,7 +5,7 @@ using Beutl.Media.TextFormatting;
 
 namespace Beutl.Graphics.Shapes;
 
-public class TextElements : IReadOnlyList<TextElement>
+public class TextElements : IReadOnlyList<TextElement>, IDisposable
 {
     private readonly TextElement[] _array;
 
@@ -26,6 +26,15 @@ public class TextElements : IReadOnlyList<TextElement>
 
     public LineEnumerable Lines { get; }
 
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose()
+    {
+        if (IsDisposed) return;
+        Lines.Dispose();
+        IsDisposed = true;
+    }
+
     public IEnumerator<TextElement> GetEnumerator()
     {
         return ((IEnumerable<TextElement>)_array).GetEnumerator();
@@ -36,7 +45,7 @@ public class TextElements : IReadOnlyList<TextElement>
         return _array.GetEnumerator();
     }
 
-    public class LineEnumerable
+    public class LineEnumerable : IDisposable
     {
         private readonly TextElement[] _array;
         private FormattedText[]? _formattedTexts;
@@ -44,6 +53,23 @@ public class TextElements : IReadOnlyList<TextElement>
         internal LineEnumerable(TextElement[] array)
         {
             _array = array;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            if (_formattedTexts is { } texts)
+            {
+                foreach (FormattedText item in texts)
+                {
+                    item.Dispose();
+                }
+            }
+
+            _formattedTexts = null;
+            IsDisposed = true;
         }
 
         public LineEnumerator GetEnumerator()

--- a/src/Beutl.Engine/Media/Geometry/SKPathGeometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/SKPathGeometry.cs
@@ -4,10 +4,9 @@ using SkiaSharp;
 
 namespace Beutl.Media;
 
-internal sealed partial class SKPathGeometry : Geometry
+internal sealed partial class SKPathGeometry : Geometry, IDisposable
 {
     private SKPath? _path;
-    private bool _clone;
 
     public SKPathGeometry(SKPath path, bool clone)
     {
@@ -18,21 +17,27 @@ internal sealed partial class SKPathGeometry : Geometry
     {
     }
 
+    // Test hook: exposes the owned glyph path so deterministic disposal can be asserted.
+    internal SKPath? Path => _path;
+
+    // The geometry owns _path in both clone modes (clone: true copies and owns; clone: false takes
+    // ownership of the handed-off path), so it is always responsible for releasing it.
     public void SetSKPath(SKPath? path, bool clone)
     {
-        if (_clone && _path != null)
+        SKPath? newPath = path != null && clone ? new SKPath(path) : path;
+        if (!ReferenceEquals(_path, newPath))
         {
-            _path.Dispose();
-            _path = null;
+            _path?.Dispose();
         }
 
-        if (path != null)
-        {
-            _clone = clone;
-            _path = clone ? new SKPath(path) : path;
-        }
-
+        _path = newPath;
         RaiseEdited();
+    }
+
+    public void Dispose()
+    {
+        _path?.Dispose();
+        _path = null;
     }
 
     public override void ApplyTo(IGeometryContext context, Geometry.Resource resource)

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -61,6 +61,11 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
 
     public bool IsDisposed { get; private set; }
 
+    /// <remarks>
+    /// Disposal is idempotent and one-shot; the instance must not be used afterwards. Measuring members
+    /// (e.g. <see cref="Bounds"/> or the density-scaled blob/stroke accessors) would re-allocate Skia
+    /// handles that a later <see cref="Dispose"/> call will not release.
+    /// </remarks>
     // No finalizer: every owned field (SKTextBlob / SKPath / SKPathGeometry.Resource) is itself
     // finalizable via SkiaSharp, so deterministic Dispose only speeds up release. If a non-SkiaSharp
     // unmanaged field is ever added, add ~FormattedText() here.
@@ -72,6 +77,9 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         (_textBlob, _fillPath, _strokePath).DisposeAll();
         foreach (SKPathGeometry.Resource? resource in _pathList)
         {
+            // Dispose the geometry too: it owns the per-glyph SKPath (set via SetSKPath(..., clone: false)),
+            // which the resource's cached render path does not cover.
+            resource?.GetOriginal().Dispose();
             resource?.Dispose();
         }
 

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -10,7 +10,7 @@ using SkiaSharp.HarfBuzz;
 namespace Beutl.Media.TextFormatting;
 
 [DebuggerDisplay("{Text}")]
-public class FormattedText : IEquatable<FormattedText>
+public class FormattedText : IEquatable<FormattedText>, IDisposable
 {
     private FontWeight _weight = FontWeight.Regular;
     private FontStyle _style = FontStyle.Normal;
@@ -57,6 +57,29 @@ public class FormattedText : IEquatable<FormattedText>
 
     public FormattedText()
     {
+    }
+
+    public bool IsDisposed { get; private set; }
+
+    // No finalizer: every owned field (SKTextBlob / SKPath / SKPathGeometry.Resource) is itself
+    // finalizable via SkiaSharp, so deterministic Dispose only speeds up release. If a non-SkiaSharp
+    // unmanaged field is ever added, add ~FormattedText() here.
+    public void Dispose()
+    {
+        if (IsDisposed) return;
+
+        ClearScaledTextCache();
+        (_textBlob, _fillPath, _strokePath).DisposeAll();
+        foreach (SKPathGeometry.Resource? resource in _pathList)
+        {
+            resource?.Dispose();
+        }
+
+        _pathList = [];
+        _textBlob = null;
+        _fillPath = null;
+        _strokePath = null;
+        IsDisposed = true;
     }
 
     public FontWeight Weight

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -1,0 +1,199 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Shapes;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class FormattedTextDisposalTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
+        _ = TypefaceProvider.Typeface();
+    }
+
+    private static FormattedText CreateText(string text = "ABC", float size = 24f)
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        return new FormattedText
+        {
+            Font = typeface.FontFamily,
+            Style = typeface.Style,
+            Weight = typeface.Weight,
+            Size = size,
+            Spacing = 1f,
+            Text = text
+        };
+    }
+
+    [Test]
+    public void Dispose_MarksIsDisposed_True()
+    {
+        FormattedText ft = CreateText();
+        _ = ft.Bounds;
+
+        ft.Dispose();
+
+        Assert.That(ft.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void Dispose_IsIdempotent()
+    {
+        FormattedText ft = CreateText();
+        _ = ft.Bounds;
+
+        ft.Dispose();
+        Assert.DoesNotThrow(() => ft.Dispose());
+        Assert.That(ft.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void Dispose_ClearsMainSkiaHandleFields()
+    {
+        FormattedText ft = CreateText();
+        Assert.That(ft.GetTextBlob(), Is.Not.Null);
+        Assert.That(ft.GetFillPath(), Is.Not.Null);
+
+        ft.Dispose();
+
+        Assert.That(ft.GetTextBlob(), Is.Null, "TextBlob field should be cleared after Dispose.");
+        Assert.That(ft.GetFillPath(), Is.Null, "FillPath field should be cleared after Dispose.");
+        Assert.That(ft.GetStrokePath(), Is.Null, "StrokePath field should be cleared after Dispose.");
+    }
+
+    [Test]
+    public void Dispose_ClearsScaledTextCache()
+    {
+        FormattedText ft = CreateText();
+        SKTextBlob? before = ft.GetTextBlob(2f);
+        Assert.That(before, Is.Not.Null);
+
+        ft.Dispose();
+
+        SKTextBlob? after = ft.GetTextBlob(2f);
+        Assert.That(after, Is.Not.Null);
+        Assert.That(ReferenceEquals(before, after), Is.False,
+            "Scaled cache should have been cleared by Dispose; a fresh blob must be produced on re-access.");
+        ft.Dispose();
+    }
+
+    [Test]
+    public void Dispose_ReleasesPathListResources()
+    {
+        FormattedText ft = CreateText("AB");
+        IReadOnlyList<Geometry.Resource> geometries = ft.ToGeometies();
+        Assert.That(geometries.Count, Is.GreaterThan(0));
+
+        ft.Dispose();
+
+        foreach (Geometry.Resource? g in geometries)
+        {
+            if (g is not null)
+            {
+                Assert.That(g.IsDisposed, Is.True, "Path-list resource should be disposed.");
+            }
+        }
+    }
+
+    [Test]
+    public void LineEnumerable_Dispose_DisposesContainedFormattedTexts()
+    {
+        TextElements elements = new(
+        [
+            new TextElement { Size = 24, Text = "ABC" }
+        ]);
+
+        FormattedText captured = null!;
+        foreach (Span<FormattedText> line in elements.Lines)
+        {
+            captured = line[0];
+            _ = captured.Bounds;
+            break;
+        }
+
+        elements.Lines.Dispose();
+
+        Assert.That(captured.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void TextElements_Dispose_DisposesLineEnumerable()
+    {
+        TextElements elements = new(
+        [
+            new TextElement { Size = 24, Text = "ABC" }
+        ]);
+        _ = elements.Lines;
+
+        elements.Dispose();
+
+        Assert.That(elements.IsDisposed, Is.True);
+        Assert.That(elements.Lines.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void TextElements_Dispose_IsIdempotent()
+    {
+        TextElements elements = new(
+        [
+            new TextElement { Size = 24, Text = "ABC" }
+        ]);
+
+        elements.Dispose();
+        Assert.DoesNotThrow(() => elements.Dispose());
+    }
+
+    [Test]
+    public void TextBlock_Resource_Dispose_DisposesElements()
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        TextBlock tb = new();
+        tb.FontFamily.CurrentValue = typeface.FontFamily;
+        tb.Size.CurrentValue = 24;
+        tb.Text.CurrentValue = "ABC";
+        tb.Fill.CurrentValue = Brushes.White;
+
+        TextBlock.Resource resource = tb.ToResource(CompositionContext.Default);
+        TextElements elements = resource.GetTextElements();
+        foreach (Span<FormattedText> line in elements.Lines)
+        {
+            foreach (FormattedText ft in line)
+            {
+                _ = ft.Bounds;
+            }
+        }
+
+        resource.Dispose();
+
+        Assert.That(elements.IsDisposed, Is.True);
+    }
+
+    [Test]
+    public void TextBlock_Resource_Update_WithChangedText_DisposesOldElements()
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        TextBlock tb = new();
+        tb.FontFamily.CurrentValue = typeface.FontFamily;
+        tb.Size.CurrentValue = 24;
+        tb.Text.CurrentValue = "ABC";
+        tb.Fill.CurrentValue = Brushes.White;
+
+        TextBlock.Resource resource = tb.ToResource(CompositionContext.Default);
+        TextElements elements = resource.GetTextElements();
+
+        tb.Text.CurrentValue = "DEF";
+        bool updateOnly = false;
+        resource.Update(tb, CompositionContext.Default, ref updateOnly);
+
+        Assert.That(elements.IsDisposed, Is.True,
+            "Old TextElements must be disposed when text changes so FormattedText Skia handles are released deterministically.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -15,7 +15,13 @@ public class FormattedTextDisposalTests
     [SetUp]
     public void Setup()
     {
-        Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
+        // Log.LoggerFactory is write-once (??=); skip allocating a factory we would only discard
+        // when another fixture already set one.
+        if (Log.LoggerFactory is null)
+        {
+            Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
+        }
+
         _ = TypefaceProvider.Typeface();
     }
 
@@ -100,6 +106,31 @@ public class FormattedTextDisposalTests
             {
                 Assert.That(g.IsDisposed, Is.True, "Path-list resource should be disposed.");
             }
+        }
+    }
+
+    [Test]
+    public void Dispose_DisposesOwnedGlyphPaths()
+    {
+        FormattedText ft = CreateText("AB");
+        IReadOnlyList<Geometry.Resource> geometries = ft.ToGeometies();
+
+        // The per-glyph SKPath lives on the SKPathGeometry the resource wraps, not in the resource's
+        // cached render path; capture those handles so we can assert they were released by Dispose.
+        List<SKPath> glyphPaths = geometries
+            .OfType<SKPathGeometry.Resource>()
+            .Select(r => r.GetOriginal().Path)
+            .Where(p => p is not null)
+            .Select(p => p!)
+            .ToList();
+        Assert.That(glyphPaths, Is.Not.Empty, "Split-glyph paths should be populated before disposal.");
+
+        ft.Dispose();
+
+        foreach (SKPath path in glyphPaths)
+        {
+            Assert.That(path.Handle, Is.EqualTo(IntPtr.Zero),
+                "Owned glyph SKPath should be deterministically disposed.");
         }
     }
 


### PR DESCRIPTION
## Description

`FormattedText` did not implement `IDisposable`, so its Skia handles (`SKTextBlob` / `SKPath` / scaled-cache entries / path-list `Geometry.Resource`s) were released only by SkiaSharp finalizers. The leak surface spans the whole ownership chain: `TextBlock.Resource._elements` → `TextElements` → `LineEnumerable` → `FormattedText[]`.

**Hot leak path:** `TextBlock.Resource.PostUpdate` set `_elements = null` on every text change, abandoning the old `FormattedText` array to GC-dependent cleanup. `PostDispose` did not release `_elements` either.

### Fix
- `FormattedText : IDisposable` — `Dispose()` clears the scaled-text cache, releases the three main handles via `DisposeAll()`, and disposes each path-list `Geometry.Resource`. No finalizer (every owned field is itself finalizable via SkiaSharp).
- `TextElements.LineEnumerable : IDisposable` — disposes its `FormattedText[]`.
- `TextElements : IDisposable` — disposes its `LineEnumerable`.
- `TextBlock.Resource` — `PostUpdate` and `PostDispose` now dispose `_elements` before nulling.

Adding `IDisposable` to the three public types is **additive** — existing callers that do not call `Dispose` continue to work via SkiaSharp finalizers, same as before. No migration needed.

- Found via `scheduled-code-review.yml` — Project #9 "AI Review" item "[2026-06-19][diff][medium] FormattedText._scaledTextCache: non-deterministic Skia handle disposal on GC".

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None (behavior-preserving). Adding `IDisposable` to the public types `FormattedText`, `TextElements`, and `TextElements.LineEnumerable` is a source-compatible, additive interface implementation — callers are not required to call `Dispose` and no existing API signature changes.

## Test plan
- `tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs` (10 new tests):
  - `Dispose_MarksIsDisposed_True`, `Dispose_IsIdempotent`
  - `Dispose_ClearsMainSkiaHandleFields` — verifies `GetTextBlob`/`GetFillPath`/`GetStrokePath` return null after Dispose
  - `Dispose_ClearsScaledTextCache` — verifies the LRU scaled cache is cleared (fresh blob on re-access)
  - `Dispose_ReleasesPathListResources` — verifies each `Geometry.Resource.IsDisposed`
  - `LineEnumerable_Dispose_DisposesContainedFormattedTexts`
  - `TextElements_Dispose_DisposesLineEnumerable`, `TextElements_Dispose_IsIdempotent`
  - `TextBlock_Resource_Dispose_DisposesElements`
  - `TextBlock_Resource_Update_WithChangedText_DisposesOldElements` — verifies the hot-path leak is closed
- Existing regression suite (7 tests) confirmed green: `FormattedTextDeviceScaleTests` (3), `TextElementsTests` (1), `TextBlockTests` (3).
- `dotnet format --verify-no-changes` clean on all touched files.

All 17 tests pass (`dotnet test -f net10.0 --filter "FullyQualifiedName~FormattedText|FullyQualifiedName~TextElements|FullyQualifiedName~TextBlock"`).

## Follow-ups

Design review (`beutl-design-reviewer`) surfaced these items, intentionally out of scope for this fix:

1. **Post-dispose contract incoherence (medium):** `FormattedText` does not throw `ObjectDisposedException` on use-after-dispose — some accessors return null, others (`GetTextBlob(float density)`) resurrect via re-measure. The coherent fix is to add `ObjectDisposedException.ThrowIf(IsDisposed, this)` guards to `MeasureAndSetField` and the public accessors, matching the `TextBlock.Resource` / `LineEnumerator.MoveNext` convention. Requires verifying no render-graph path accesses a disposed `FormattedText`.
2. **`TextRenderNode` ownership gap (medium):** `TextRenderNode` holds a `FormattedText` reference but never disposes it in `OnDispose`. For `TextBlock` this is masked (the `Resource` owns the chain), but a plugin calling `GraphicsContext2D.DrawText` directly gets no deterministic disposal. Decision needed: framework-owns (add `TextRenderNode.OnDispose` + doc) vs caller-owns (doc only).
3. **Non-virtual `Dispose()` on unsealed public types (medium):** `FormattedText` / `TextElements` / `LineEnumerable` are unsealed but `Dispose()` is non-virtual. Either seal them or follow the `RenderNode` virtual-`OnDispose(bool)` pattern so subclasses can participate.
4. **`LineEnumerable`/`TextElements` disposal-guard consistency (low):** clusters with #1 — apply the terminal contract uniformly once decided.
5. **`_pathList` shrink-on-remeasure leak (medium):** `FormattedText.MeasureCore` calls `CollectionsMarshal.SetCount(_pathList, glyphCount)` on re-measure. When the glyph count shrinks (e.g. a cached `FormattedText` whose `Text` is shortened to fewer glyphs), the truncated trailing `SKPathGeometry.Resource` entries — and the glyph `SKPath` each owns (`SetSKPath(..., clone: false)`) — are dropped without being disposed, leaking to finalizers. Same class of leak as the per-glyph `SKPathGeometry._path` release added here for `Dispose()`, but on the shrink path. Fix: dispose the trailing resources (and their owned geometries) before the `SetCount` truncation. Surfaced while handling PR review comments.

## References
- Project board: b-editor/projects/9 ("[2026-06-19][diff][medium] FormattedText._scaledTextCache: non-deterministic Skia handle disposal on GC")
- Related: #1954 (the RasterizeAndConcat double-dispose fix from the same review batch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disposal and cache invalidation for text rendering resources, ensuring previously cached text/geometry data is deterministically released and objects become safely idempotent on repeated disposal.
  * Updated graphics path geometry handling so owned path resources are properly disposed when replaced or no longer needed.

* **Tests**
  * Added comprehensive unit tests validating `FormattedText`/text containers disposal behavior, including cache clearing, propagation through nested containers, and resource release after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
