### PR TITLE
fix(ci): select x64 debian release asset

### DIFF
--- a/.github/workflows/reflect-release.yml
+++ b/.github/workflows/reflect-release.yml
@@ -50,7 +50,7 @@ jobs:
 
           WIN_INSTALLER=$(url_of "beutl-setup.exe")
           WIN_STANDALONE=$(url_of "beutl-standalone-setup.exe")
-          LINUX_DEB=$(url_of_glob '\.deb$')
+          LINUX_DEB=$(url_of_glob '^beutl_.*_amd64\.deb$')
           LINUX_ZIP=$(url_of "Beutl-linux-x64-$VER.zip")
           LINUX_ZIP_STANDALONE=$(url_of "Beutl-linux-x64-standalone-$VER.zip")
           MAC_X64=$(url_of "Beutl.osx_x64.app.zip")
@@ -67,7 +67,7 @@ jobs:
           }
           check "beutl-setup.exe"                       "$WIN_INSTALLER"
           check "beutl-standalone-setup.exe"            "$WIN_STANDALONE"
-          check "*.deb"                                 "$LINUX_DEB"
+          check "beutl_*_amd64.deb"                     "$LINUX_DEB"
           check "Beutl-linux-x64-$VER.zip"              "$LINUX_ZIP"
           check "Beutl-linux-x64-standalone-$VER.zip"   "$LINUX_ZIP_STANDALONE"
           check "Beutl.osx_x64.app.zip"                 "$MAC_X64"


### PR DESCRIPTION
## Description
- Limit the reflected Debian release asset lookup to the amd64 package that matches the existing linux x64 payload entry.
- Prevent future multi-architecture Debian releases from registering whichever `.deb` asset appears first in the release asset list.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/reflect-release.yml'); puts 'yaml ok'"`
- Characterized the workflow's `jq test($pat) | head -n1` selection with an arm64 `.deb` before an amd64 `.deb`; the old `.deb$` glob selected `arm64-url`, while the new `^beutl_.*_amd64\.deb$` glob selected `amd64-url`.
- No .NET tests were run because this is a GitHub Actions workflow-only change.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-05-17][diff][medium] reflect-release.yml selects .deb asset by glob without architecture filter")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release workflow to improve asset selection precision for Linux Debian packages, ensuring more reliable and consistent build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->