### PR TITLE
fix(mediafoundation): guard frame buffer size overflow

### DIFF
--- a/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
+++ b/src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj
@@ -7,7 +7,7 @@
     <MFBuildIn Condition="'$(MFBuildIn)' == ''">True</MFBuildIn>
     <DefineConstants>$(DefineConstants);DESKTOP_APP</DefineConstants>
     <DefineConstants Condition="'$(MFBuildIn)'=='True'">$(DefineConstants);MF_BUILD_IN</DefineConstants>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformTarget)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">x64</PlatformTarget>
     <UseResXGenerator>true</UseResXGenerator>
   </PropertyGroup>
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -427,7 +427,10 @@ internal sealed class MFDecoder : IDisposable
             _mediaInfo.ImageFormat = bih;
             _mediaInfo.TotalFrameCount =
                 TimestampUtilities.ConvertFrameFromTimeStamp(_mediaInfo.HnsDuration, _mediaInfo.Fps);
-            _mediaInfo.OutImageBufferSize = bih.Width * bih.Height * (bih.BitCount / 8);
+            _mediaInfo.OutImageBufferSize = MFFrameBufferSize.Calculate(
+                bih.Width,
+                bih.Height,
+                bih.BitCount / 8);
             _mediaInfo.VideoFormatName = VideoFormatName.GetName(subType) ?? subType.ToString();
         }
 

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFFrameBufferSize.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFFrameBufferSize.cs
@@ -1,0 +1,53 @@
+using System.IO;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Decoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Decoding;
+#endif
+
+internal static class MFFrameBufferSize
+{
+    public const int Yuy2BytesPerPixel = 2;
+
+    public static int CalculateYuy2(int width, int height)
+        => Calculate(width, height, Yuy2BytesPerPixel);
+
+    public static int Calculate(int width, int height, int bytesPerPixel)
+    {
+        if (width <= 0)
+        {
+            throw CreateInvalidSizeException(width, height, bytesPerPixel);
+        }
+
+        if (height <= 0)
+        {
+            throw CreateInvalidSizeException(width, height, bytesPerPixel);
+        }
+
+        if (bytesPerPixel <= 0)
+        {
+            throw CreateInvalidSizeException(width, height, bytesPerPixel);
+        }
+
+        long size;
+        try
+        {
+            size = checked((long)width * height * bytesPerPixel);
+        }
+        catch (OverflowException)
+        {
+            throw CreateInvalidSizeException(width, height, bytesPerPixel);
+        }
+
+        if (size > Array.MaxLength)
+        {
+            throw CreateInvalidSizeException(width, height, bytesPerPixel);
+        }
+
+        return (int)size;
+    }
+
+    private static InvalidDataException CreateInvalidSizeException(int width, int height, int bytesPerPixel)
+        => new($"Decoded video frame buffer size is invalid: {width}x{height}x{bytesPerPixel} bytes.");
+}

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFFrameBufferSize.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFFrameBufferSize.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 #if MF_BUILD_IN
 namespace Beutl.Embedding.MediaFoundation.Decoding;

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -123,8 +123,7 @@ public class MFReader : MediaReader
         int w = info.ImageFormat.Width;
         int h = info.ImageFormat.Height;
 
-        // YUY2: 2 bytes per pixel
-        int yuy2Size = w * h * 2;
+        int yuy2Size = MFFrameBufferSize.CalculateYuy2(w, h);
         byte[] yuy2Buffer = ArrayPool<byte>.Shared.Rent(yuy2Size);
         try
         {

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFFrameBufferSizeTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFFrameBufferSizeTests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+
+using Beutl.Embedding.MediaFoundation.Decoding;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+[TestFixture]
+public class MFFrameBufferSizeTests
+{
+    [Test]
+    public void CalculateYuy2_WithValidDimensions_ReturnsByteCount()
+    {
+        int size = MFFrameBufferSize.CalculateYuy2(1920, 1080);
+
+        Assert.That(size, Is.EqualTo(1920 * 1080 * 2));
+    }
+
+    [TestCase(0, 1080, 2)]
+    [TestCase(1920, 0, 2)]
+    [TestCase(1920, 1080, 0)]
+    [TestCase(-1, 1080, 2)]
+    [TestCase(1920, -1, 2)]
+    [TestCase(1920, 1080, -1)]
+    public void Calculate_WithNonPositiveInput_ThrowsInvalidDataException(
+        int width,
+        int height,
+        int bytesPerPixel)
+    {
+        Assert.That(
+            () => MFFrameBufferSize.Calculate(width, height, bytesPerPixel),
+            Throws.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public void Calculate_WhenByteCountExceedsMaximumArrayLength_ThrowsInvalidDataException()
+    {
+        Assert.That(
+            () => MFFrameBufferSize.Calculate(int.MaxValue, int.MaxValue, 2),
+            Throws.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public void Calculate_WhenByteCountOverflowsInt64_ThrowsInvalidDataException()
+    {
+        Assert.That(
+            () => MFFrameBufferSize.Calculate(int.MaxValue, int.MaxValue, int.MaxValue),
+            Throws.TypeOf<InvalidDataException>());
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFFrameBufferSizeTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFFrameBufferSizeTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 using Beutl.Embedding.MediaFoundation.Decoding;
 
@@ -15,6 +15,14 @@ public class MFFrameBufferSizeTests
         Assert.That(size, Is.EqualTo(1920 * 1080 * 2));
     }
 
+    [Test]
+    public void Calculate_WithValidDimensions_ReturnsByteCount()
+    {
+        int size = MFFrameBufferSize.Calculate(1920, 1080, 4);
+
+        Assert.That(size, Is.EqualTo(1920 * 1080 * 4));
+    }
+
     [TestCase(0, 1080, 2)]
     [TestCase(1920, 0, 2)]
     [TestCase(1920, 1080, 0)]
@@ -28,6 +36,22 @@ public class MFFrameBufferSizeTests
     {
         Assert.That(
             () => MFFrameBufferSize.Calculate(width, height, bytesPerPixel),
+            Throws.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public void Calculate_WhenByteCountEqualsMaximumArrayLength_ReturnsByteCount()
+    {
+        int size = MFFrameBufferSize.Calculate(Array.MaxLength, 1, 1);
+
+        Assert.That(size, Is.EqualTo(Array.MaxLength));
+    }
+
+    [Test]
+    public void Calculate_WhenByteCountJustExceedsMaximumArrayLength_ThrowsInvalidDataException()
+    {
+        Assert.That(
+            () => MFFrameBufferSize.Calculate(Array.MaxLength, 1, 2),
             Throws.TypeOf<InvalidDataException>());
     }
 


### PR DESCRIPTION
## Description
- Guard Media Foundation decoded frame buffer size calculations against non-positive dimensions and integer overflow before renting arrays or entering the unsafe sample-copy path.
- Reuse the checked size helper from both `MFDecoder.CheckMediaInfo` and `MFReader.ReadVideoCore`.
- Keep Windows builds x64 by default while allowing non-Windows pure-logic tests to run as AnyCPU.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only
- [x] MediaFoundation extension (`Beutl.Extensions.MediaFoundation`)

## Breaking changes
None.

## Test plan
- `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --filter "FullyQualifiedName~MFFrameBufferSizeTests"` (9 passed)
- `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --artifacts-path /tmp/beutl-mf-artifacts` (47 passed; Windows-only tests skipped on macOS)
- `dotnet build src/Beutl.Extensions.MediaFoundation/Beutl.Extensions.MediaFoundation.csproj -f net10.0 -p:PlatformTarget=x64`
- `git diff --check HEAD~1 HEAD`

## Fixed issues / References
- Project board: b-editor/projects/9 ("MF: guard frame-buffer size math against int overflow")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MediaFoundation decoding by using a centralized frame buffer size calculation with stricter validation (including overflow and maximum-size checks) to ensure correct YUY2 buffer allocation.
  * Updated Windows build behavior to set the `PlatformTarget` to `x64` only when it isn’t already specified.

* **Tests**
  * Added NUnit coverage for frame buffer size calculations and validation, including boundary and overflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->