### PR TITLE
fix(editor): apply latest scene settings after pause

### DIFF
--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -68,11 +68,8 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Apply = new AsyncReactiveCommand(CanApply)
             .WithSubscribe(async () =>
             {
-                if (TimeSpan.TryParse(StartInput.Value, out TimeSpan start)
-                    && TimeSpan.TryParse(DurationInput.Value, out TimeSpan duration))
+                if (TryReadSceneSettings(out Media.PixelSize frameSize, out TimeSpan start, out TimeSpan duration))
                 {
-                    var frameSize = new Media.PixelSize(Width.Value, Height.Value);
-
                     // Pause playback before rebuilding the renderer to avoid UI freeze.
                     if ((frameSize != _scene.FrameSize
                             || start != _scene.Start
@@ -80,6 +77,11 @@ public sealed class SceneSettingsTabViewModel : IToolContext
                         && _editorContext.GetService<IPreviewPlayer>() is { IsPlaying.Value: true } player)
                     {
                         await player.Pause();
+
+                        if (!TryReadSceneSettings(out frameSize, out start, out duration))
+                        {
+                            return;
+                        }
                     }
 
                     _editorContext.GetRequiredService<ISceneSettingsService>().Apply(
@@ -171,6 +173,14 @@ public sealed class SceneSettingsTabViewModel : IToolContext
     private string? ValidateSize(int observable)
     {
         return observable <= 0 ? MessageStrings.ValueLessThanOrEqualToZero : null;
+    }
+
+    private bool TryReadSceneSettings(out Media.PixelSize frameSize, out TimeSpan start, out TimeSpan duration)
+    {
+        frameSize = new Media.PixelSize(Width.Value, Height.Value);
+        bool hasStart = TimeSpan.TryParse(StartInput.Value, out start);
+        bool hasDuration = TimeSpan.TryParse(DurationInput.Value, out duration);
+        return hasStart && hasDuration;
     }
 
     public void Dispose()

--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -180,7 +180,10 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         frameSize = new Media.PixelSize(Width.Value, Height.Value);
         bool hasStart = TimeSpan.TryParse(StartInput.Value, out start);
         bool hasDuration = TimeSpan.TryParse(DurationInput.Value, out duration);
-        return hasStart && hasDuration;
+        return Width.Value > 0
+            && Height.Value > 0
+            && hasStart && start >= TimeSpan.Zero
+            && hasDuration && duration > TimeSpan.Zero;
     }
 
     public void Dispose()

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -1,0 +1,181 @@
+﻿using System.Numerics;
+using System.Reactive;
+using System.Reactive.Linq;
+
+using Beutl.Editor.Components.SceneSettingsTab.ViewModels;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class SceneSettingsTabViewModelTests
+{
+    [Test]
+    public async Task Apply_WhenInputsChangeWhilePausing_CommitsLatestInputs()
+    {
+        var scene = new Scene(640, 480, string.Empty)
+        {
+            Start = TimeSpan.FromSeconds(1),
+            Duration = TimeSpan.FromSeconds(5),
+        };
+        var sceneSettingsService = new CaptureSceneSettingsService();
+        var timelineOptionsProvider = new TestTimelineOptionsProvider(scene);
+        var previewPlayer = new BlockingPreviewPlayer();
+        var editorContext = new TestEditorContext(scene);
+        editorContext.AddService(scene);
+        editorContext.AddService<ISceneSettingsService>(sceneSettingsService);
+        editorContext.AddService<ITimelineOptionsProvider>(timelineOptionsProvider);
+        editorContext.AddService<IPreviewPlayer>(previewPlayer);
+
+        using var viewModel = new SceneSettingsTabViewModel(editorContext)
+        {
+            Width =
+            {
+                Value = 800
+            },
+            Height =
+            {
+                Value = 600
+            },
+            StartInput =
+            {
+                Value = TimeSpan.FromSeconds(2).ToString()
+            },
+            DurationInput =
+            {
+                Value = TimeSpan.FromSeconds(10).ToString()
+            },
+        };
+
+        Task applyTask = viewModel.Apply.ExecuteAsync();
+        await previewPlayer.PauseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var latestFrameSize = new PixelSize(1280, 720);
+        TimeSpan latestStart = TimeSpan.FromSeconds(3);
+        TimeSpan latestDuration = TimeSpan.FromSeconds(12);
+        viewModel.Width.Value = latestFrameSize.Width;
+        viewModel.Height.Value = latestFrameSize.Height;
+        viewModel.StartInput.Value = latestStart.ToString();
+        viewModel.DurationInput.Value = latestDuration.ToString();
+
+        previewPlayer.CompletePause();
+        await applyTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sceneSettingsService.CallCount, Is.EqualTo(1));
+            Assert.That(sceneSettingsService.FrameSize, Is.EqualTo(latestFrameSize));
+            Assert.That(sceneSettingsService.Start, Is.EqualTo(latestStart));
+            Assert.That(sceneSettingsService.Duration, Is.EqualTo(latestDuration));
+        });
+    }
+
+    private sealed class TestEditorContext(CoreObject obj) : IEditorContext
+    {
+        private readonly Dictionary<Type, object> _services = [];
+
+        public CoreObject Object { get; } = obj;
+
+        public EditorExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public void AddService<T>(T service)
+            where T : notnull
+        {
+            _services[typeof(T)] = service;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            return _services.GetValueOrDefault(serviceType);
+        }
+
+        public T? FindToolTab<T>(Func<T, bool> condition)
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public T? FindToolTab<T>()
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public bool OpenToolTab(IToolContext item)
+        {
+            return false;
+        }
+
+        public void CloseToolTab(IToolContext item)
+        {
+        }
+    }
+
+    private sealed class TestTimelineOptionsProvider(Scene scene) : ITimelineOptionsProvider
+    {
+        public Scene Scene { get; } = scene;
+
+        public IReactiveProperty<TimelineOptions> Options { get; } = new ReactiveProperty<TimelineOptions>(
+            new TimelineOptions(1, Vector2.Zero, 4));
+
+        public IObservable<float> Scale => Options.Select(x => x.Scale);
+
+        public IObservable<Vector2> Offset => Options.Select(x => x.Offset);
+    }
+
+    private sealed class BlockingPreviewPlayer : IPreviewPlayer
+    {
+        private readonly TaskCompletionSource _pauseCompletion = new();
+
+        public TaskCompletionSource PauseStarted { get; } = new();
+
+        public IReadOnlyReactiveProperty<Ref<Bitmap>?> PreviewImage { get; } =
+            new ReactiveProperty<Ref<Bitmap>?>((Ref<Bitmap>?)null);
+
+        public IObservable<Unit> AfterRendered => Observable.Empty<Unit>();
+
+        public IReadOnlyReactiveProperty<bool> IsPlaying { get; } = new ReactiveProperty<bool>(true);
+
+        public async Task Pause()
+        {
+            PauseStarted.SetResult();
+            await _pauseCompletion.Task;
+        }
+
+        public void CompletePause()
+        {
+            _pauseCompletion.SetResult();
+        }
+    }
+
+    private sealed class CaptureSceneSettingsService : ISceneSettingsService
+    {
+        public int CallCount { get; private set; }
+
+        public PixelSize FrameSize { get; private set; }
+
+        public TimeSpan Start { get; private set; }
+
+        public TimeSpan Duration { get; private set; }
+
+        public bool Apply(Scene scene, PixelSize frameSize, TimeSpan start, TimeSpan duration)
+        {
+            CallCount++;
+            FrameSize = frameSize;
+            Start = start;
+            Duration = duration;
+            return true;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -77,6 +77,61 @@ public class SceneSettingsTabViewModelTests
         });
     }
 
+    [TestCase(0, 600, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommit_WhenWidthBecomesZeroWhilePausing")]
+    [TestCase(800, 0, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommit_WhenHeightBecomesZeroWhilePausing")]
+    [TestCase(800, 600, "-00:00:01", "00:00:12", TestName = "Apply_DoesNotCommit_WhenStartBecomesNegativeWhilePausing")]
+    [TestCase(800, 600, "00:00:03", "00:00:00", TestName = "Apply_DoesNotCommit_WhenDurationBecomesZeroWhilePausing")]
+    public async Task Apply_WhenInputsBecomeInvalidWhilePausing_DoesNotCommit(
+        int width, int height, string start, string duration)
+    {
+        var scene = new Scene(640, 480, string.Empty)
+        {
+            Start = TimeSpan.FromSeconds(1),
+            Duration = TimeSpan.FromSeconds(5),
+        };
+        var sceneSettingsService = new CaptureSceneSettingsService();
+        var timelineOptionsProvider = new TestTimelineOptionsProvider(scene);
+        var previewPlayer = new BlockingPreviewPlayer();
+        var editorContext = new TestEditorContext(scene);
+        editorContext.AddService(scene);
+        editorContext.AddService<ISceneSettingsService>(sceneSettingsService);
+        editorContext.AddService<ITimelineOptionsProvider>(timelineOptionsProvider);
+        editorContext.AddService<IPreviewPlayer>(previewPlayer);
+
+        using var viewModel = new SceneSettingsTabViewModel(editorContext)
+        {
+            Width =
+            {
+                Value = 800
+            },
+            Height =
+            {
+                Value = 600
+            },
+            StartInput =
+            {
+                Value = TimeSpan.FromSeconds(2).ToString()
+            },
+            DurationInput =
+            {
+                Value = TimeSpan.FromSeconds(10).ToString()
+            },
+        };
+
+        Task applyTask = viewModel.Apply.ExecuteAsync();
+        await previewPlayer.PauseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        viewModel.Width.Value = width;
+        viewModel.Height.Value = height;
+        viewModel.StartInput.Value = start;
+        viewModel.DurationInput.Value = duration;
+
+        previewPlayer.CompletePause();
+        await applyTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(sceneSettingsService.CallCount, Is.EqualTo(0));
+    }
+
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
         private readonly Dictionary<Type, object> _services = [];


### PR DESCRIPTION
## Description
- Re-read Scene Settings tab inputs after awaited playback pause completes.
- Prevent edits made during the pause drain window from being overwritten by the stale click-time snapshot.
- Add a regression test that blocks `IPreviewPlayer.Pause()`, changes pending inputs, and verifies `ISceneSettingsService.Apply` receives the latest values.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Baseline-first: `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SceneSettingsTabViewModelTests"` failed before the fix because `800x600 / 2s / 10s` was committed instead of the edited `1280x720 / 3s / 12s` values.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SceneSettingsTabViewModelTests|FullyQualifiedName~SceneSettingsServiceTests"` passed: 6 tests.
- `dotnet format whitespace src/Beutl.Editor.Components/Beutl.Editor.Components.csproj --include src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs --verify-no-changes --no-restore`
- `dotnet format whitespace tests/Beutl.UnitTests/Beutl.UnitTests.csproj --include tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs --verify-no-changes --no-restore`

## Fixed issues / References
- Project board: b-editor/projects/9 ("fix(editor): SceneSettingsTabViewModel.Apply commits stale values after await Pause")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for scene settings by enforcing positive width/height and valid start/duration timing before applying changes.
  * Prevents committing scene settings when inputs become invalid during a preview pause, avoiding incorrect or partial updates.
  * Updated behavior to re-validate after pausing and only proceed when parsed values are valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->