### PR TITLE
fix(engine): guard video thumbnail count against degenerate frame size

### DIFF
--- a/src/Beutl.Engine/Graphics/SourceVideo.Thumbnails.cs
+++ b/src/Beutl.Engine/Graphics/SourceVideo.Thumbnails.cs
@@ -99,9 +99,13 @@ public partial class SourceVideo : IThumbnailsProvider
             var duration = TimeRange.Duration;
 
             var frameSize = source.FrameSize;
-            float aspectRatio = (float)frameSize.Width / frameSize.Height;
-            float thumbWidth = maxHeight * aspectRatio;
-            int count = (int)MathF.Ceiling(maxWidth / thumbWidth);
+            int count = GetVideoThumbnailCount(frameSize, maxWidth, maxHeight);
+            // A degenerate frame size (e.g. corrupt metadata with Height == 0) makes the division below
+            // produce Infinity, which then overflows TimeSpan.FromSeconds. Bail out instead.
+            if (count <= 0)
+                yield break;
+            // count > 0 implies frameSize dimensions and maxHeight are positive, so this is finite.
+            float thumbWidth = maxHeight * (float)frameSize.Width / frameSize.Height;
             double interval = duration.TotalSeconds / count;
 
             string? cacheKey = cacheService != null ? GetThumbnailsCacheKey() : null;
@@ -174,5 +178,22 @@ public partial class SourceVideo : IThumbnailsProvider
     {
         await Task.CompletedTask;
         yield break;
+    }
+
+    internal static int GetVideoThumbnailCount(PixelSize frameSize, int maxWidth, int maxHeight)
+    {
+        if (frameSize.Width <= 0 || frameSize.Height <= 0 || maxWidth <= 0 || maxHeight <= 0)
+            return 0;
+
+        float aspectRatio = (float)frameSize.Width / frameSize.Height;
+        float thumbWidth = maxHeight * aspectRatio;
+        if (!float.IsFinite(thumbWidth) || thumbWidth <= 0)
+            return 0;
+
+        float raw = MathF.Ceiling(maxWidth / thumbWidth);
+        if (!float.IsFinite(raw) || raw <= 0 || raw > int.MaxValue)
+            return 0;
+
+        return (int)raw;
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Media;
 
 namespace Beutl.UnitTests.Engine.Graphics;

--- a/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs
@@ -1,0 +1,52 @@
+using Beutl.Graphics;
+using Beutl.Media;
+
+namespace Beutl.UnitTests.Engine.Graphics;
+
+[TestFixture]
+public class SourceVideoThumbnailTests
+{
+    // Regression for Project #9 item #240 (Grafana Loki 2026-06-14): a degenerate frame size
+    // (Height == 0, e.g. corrupt media metadata) made GetThumbnailStripAsync compute count = 0,
+    // interval = +Infinity, and TimeSpan.FromSeconds(interval * 0.5) threw OverflowException
+    // ("TimeSpan overflowed because the duration is too long"), crashing thumbnail generation.
+    // GetVideoThumbnailCount must return 0 so the caller bails out before that math runs.
+    [TestCase(1920, 0, TestName = "ZeroHeight")]
+    [TestCase(1920, -1, TestName = "NegativeHeight")]
+    [TestCase(0, 1080, TestName = "ZeroWidth")]
+    [TestCase(-1, 1080, TestName = "NegativeWidth")]
+    public void GetVideoThumbnailCount_ReturnsZero_ForDegenerateFrameSize(int width, int height)
+    {
+        int count = SourceVideo.GetVideoThumbnailCount(new PixelSize(width, height), maxWidth: 1920, maxHeight: 25);
+
+        Assert.That(count, Is.Zero);
+    }
+
+    [Test]
+    public void GetVideoThumbnailCount_ReturnsZero_ForNonPositiveMaxDimensions()
+    {
+        var frame = new PixelSize(1920, 1080);
+        Assert.That(SourceVideo.GetVideoThumbnailCount(frame, maxWidth: 0, maxHeight: 25), Is.Zero);
+        Assert.That(SourceVideo.GetVideoThumbnailCount(frame, maxWidth: 1920, maxHeight: 0), Is.Zero);
+    }
+
+    [Test]
+    public void GetVideoThumbnailCount_ComputesExpectedCount_ForValidFrameSize()
+    {
+        // 16:9 frame, maxWidth 1920, thumbnail height 25:
+        //   thumbWidth = 25 * (1920 / 1080) ≈ 44.44, count = ceil(1920 / 44.44) = 44.
+        int count = SourceVideo.GetVideoThumbnailCount(new PixelSize(1920, 1080), maxWidth: 1920, maxHeight: 25);
+
+        Assert.That(count, Is.EqualTo(44));
+    }
+
+    // Pins the failure mode the guard prevents: a zero count makes the interval +Infinity and
+    // TimeSpan.FromSeconds overflows. If this ever stops throwing, GetVideoThumbnailCount is no
+    // longer the only thing keeping Infinity out of the thumbnail time math.
+    [Test]
+    public void FromSeconds_OfInfinity_ThrowsOverflow()
+    {
+        // duration.TotalSeconds / count when count == 0 yields +Infinity.
+        Assert.Throws<OverflowException>(() => TimeSpan.FromSeconds(double.PositiveInfinity * 0.5));
+    }
+}


### PR DESCRIPTION
## Description
- `SourceVideo.GetThumbnailStripAsync` computed `aspectRatio = Width/Height` and `count = Ceil(maxWidth / thumbWidth)` without validating the frame size.
- A degenerate source reporting `FrameSize.Height == 0` (e.g. corrupt media metadata) produced `aspectRatio = +Infinity` → `count = 0` → `interval = +Infinity`, and `TimeSpan.FromSeconds(interval * 0.5)` threw `OverflowException` ("TimeSpan overflowed because the duration is too long").
- This surfaced in production as "Failed to update thumbnails" (Grafana Loki 2026-06-14; Project #9 item "サムネイル更新時のTimeSpanオーバーフロー").
- Extract the count math into `GetVideoThumbnailCount` (returns 0 for non-positive dimensions, non-finite thumbWidth, or int-overflowing ceiling); the caller bails on `count <= 0` so the interval is always finite.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None — the guard is a strict superset of the old preconditions; the count formula is unchanged for valid sources.

## Test plan
- New `tests/Beutl.UnitTests/Engine/Graphics/SourceVideoThumbnailTests.cs`:
  - `GetVideoThumbnailCount` returns 0 for degenerate frame sizes (zero/negative width & height) and non-positive max dimensions.
  - `GetVideoThumbnailCount` returns the expected count (44) for a valid 16:9 frame.
  - `FromSeconds_OfInfinity_ThrowsOverflow` pins the failure mode the guard prevents.
- Scoped run: `17 Passed, 0 Failed` (5 new + 12 existing `SourceSoundThumbnailTests` as regression).
- `dotnet build` clean; `dotnet format --verify-no-changes` clean on touched files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("サムネイル更新時のTimeSpanオーバーフロー")

## Follow-ups
- The audio waveform path (`SourceSound.GetWaveformChunksAsync`) is already guarded (`chunkCount = Math.Max(1, …)` ≥ 1), so it is not affected by this Infinity class of overflow.
- A separate, much less likely overflow remains if a source reports an absurd (multi-millennium) duration that overflows `time + TimeRange.Start` inside the render lambda; that needs pathological data and is out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of video thumbnail strip generation by validating frame and max dimensions, avoiding non-finite/overflow conditions, and ensuring invalid inputs produce no thumbnails instead of errors.

* **Tests**
  * Added unit tests covering degenerate frame sizes (zero/negative width/height), non-positive max dimensions, expected thumbnail count for a valid 16:9 frame, and a regression check that infinite `TimeSpan` inputs throw to confirm the guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->