### PR TITLE
fix(api): roll back failed extension loads

### DIFF
--- a/src/Beutl.Api/Beutl.Api.csproj
+++ b/src/Beutl.Api/Beutl.Api.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="..\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Allow package lifecycle tests to exercise internal load/rollback seams without
+         widening the extension API surface. -->
+    <InternalsVisibleTo Include="Beutl.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Beutl.Api/Services/ExtensionProvider.cs
+++ b/src/Beutl.Api/Services/ExtensionProvider.cs
@@ -122,7 +122,7 @@ public sealed class ExtensionProvider : IBeutlApiResource
         {
             if (!_allExtensions.TryAdd(id, extensions))
             {
-                throw new Exception("");
+                throw new InvalidOperationException($"Extensions for package (id: {id}) are already registered.");
             }
 
             _extensions.AddRange(extensions);

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -426,20 +426,39 @@ public sealed class PackageManager(
     {
         try
         {
-            var types = loadContext.Assemblies.SelectMany(a => a.GetTypes()).ToArray();
+            Type[] types = loadContext.Assemblies.SelectMany(GetLoadableTypes).ToArray();
             TypeUnloadNotifier.NotifyUnloading(types);
             AvaloniaPropertyRegistry.Instance.UnregisterByModule(types);
             foreach (string name in loadContext.Assemblies.Select(a => a.GetName().Name).OfType<string>())
             {
                 AssetLoader.InvalidateAssemblyCache(name);
             }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clean up type registrations for {PackageName}.", package.Name);
+        }
 
+        try
+        {
             loadContext.Unload();
             _logger.LogInformation("AssemblyLoadContext unloaded for {PackageName}.", package.Name);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to unload AssemblyLoadContext for {PackageName}.", package.Name);
+        }
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.OfType<Type>();
         }
     }
 

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -220,12 +220,15 @@ public sealed class PackageManager(
             activity?.AddEvent(new ActivityEvent("Assemblies loaded"));
             activity?.SetTag("AssemblyCount", result.Assemblies.Length);
 
+            // Strict on purpose: GetExportedTypes throws on an unresolvable type so a broken plugin
+            // fails the load and rolls back instead of registering with extensions silently skipped.
+            // Unload stays lenient (GetLoadableTypes) since cleanup must proceed regardless.
             return LoadExtensionsAndRegister(
                 activity,
                 package,
                 result.Assemblies,
                 result.LoadContext,
-                result.Assemblies.SelectMany(GetLoadableTypes).Where(type => type.IsVisible));
+                result.Assemblies.SelectMany(assembly => assembly.GetExportedTypes()));
         }
     }
 
@@ -339,8 +342,8 @@ public sealed class PackageManager(
                 ExtensionProvider.RemoveExtensions(package.LocalId);
             }
 
-            // extensions stays empty unless LoadPackageExtensions returned (it rolls itself back on
-            // failure), so this only unloads when a registration step below threw.
+            // LoadPackageExtensions already rolls back on failure, so extensions is non-empty
+            // only when a later registration step threw; this is not a double-unload.
             RollbackLoadedExtensions(extensions);
             if (loadContext is { })
             {

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -222,19 +222,35 @@ public sealed class PackageManager(
 
             var extensions = new List<Extension>();
 
-            foreach (Assembly assembly in result.Assemblies)
+            var addedToProvider = false;
+            try
             {
-                LoadExtensions(assembly, extensions);
+                LoadPackageExtensions(result.Assemblies.SelectMany(assembly => assembly.GetExportedTypes()), extensions);
+
+                activity?.AddEvent(new ActivityEvent("Extensions loaded"));
+                activity?.SetTag("ExtensionCount", extensions.Count);
+
+                ExtensionProvider.AddExtensions(package.LocalId, extensions.ToArray());
+                addedToProvider = true;
+
+                if (!_loadedPackages.TryAdd(package.LocalId, new LoadedPackageInfo(package, result.LoadContext)))
+                {
+                    throw new InvalidOperationException($"Package {package.Name} is already loaded.");
+                }
+
+                return result.Assemblies;
             }
+            catch
+            {
+                if (addedToProvider)
+                {
+                    ExtensionProvider.RemoveExtensions(package.LocalId);
+                }
 
-            activity?.AddEvent(new ActivityEvent("Extensions loaded"));
-            activity?.SetTag("ExtensionCount", extensions.Count);
-
-            ExtensionProvider.AddExtensions(package.LocalId, extensions.ToArray());
-
-            _loadedPackages.TryAdd(package.LocalId, new LoadedPackageInfo(package, result.LoadContext));
-
-            return result.Assemblies;
+                RollbackLoadedExtensions(extensions);
+                TryUnloadLoadContext(package, result.LoadContext);
+                throw;
+            }
         }
     }
 
@@ -300,23 +316,7 @@ public sealed class PackageManager(
 
         if (info.LoadContext is { } loadContext)
         {
-            try
-            {
-                var types = loadContext.Assemblies.SelectMany(a => a.GetTypes()).ToArray();
-                TypeUnloadNotifier.NotifyUnloading(types);
-                AvaloniaPropertyRegistry.Instance.UnregisterByModule(types);
-                foreach (string name in loadContext.Assemblies.Select(a => a.GetName().Name).OfType<string>())
-                {
-                    AssetLoader.InvalidateAssemblyCache(name);
-                }
-
-                loadContext.Unload();
-                _logger.LogInformation("AssemblyLoadContext unloaded for {PackageName}.", package.Name);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to unload AssemblyLoadContext for {PackageName}.", package.Name);
-            }
+            TryUnloadLoadContext(package, loadContext);
         }
 
         // https://learn.microsoft.com/ja-jp/dotnet/standard/assembly/unloadability#use-a-custom-collectible-assemblyloadcontext
@@ -331,26 +331,115 @@ public sealed class PackageManager(
             .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.Name, name))];
     }
 
-    private void LoadExtensions(Assembly assembly, List<Extension> extensions)
+    internal void LoadPackageExtensions(IEnumerable<Type> extensionTypes, List<Extension> extensions)
     {
-        foreach (Type type in assembly.GetExportedTypes())
+        try
         {
-            if (type.GetCustomAttribute<ExportAttribute>() is { })
+            foreach (Type type in extensionTypes)
             {
-                if (type.IsAssignableTo(typeof(Extension))
-                    && Activator.CreateInstance(type) is Extension extension)
-                {
-                    SetupExtensionSettings(extension);
-                    if (extension is ViewExtension viewExtension)
-                    {
-                        commandManager.Register(viewExtension);
-                    }
-                    extension.Load();
-
-                    extensions.Add(extension);
-                    _logger.LogInformation("Extension {ExtensionName} loaded from assembly {AssemblyName}", type.Name, assembly.GetName().Name);
-                }
+                LoadExtension(type, extensions);
             }
+        }
+        catch
+        {
+            RollbackLoadedExtensions(extensions);
+            throw;
+        }
+    }
+
+    private void LoadExtension(Type type, List<Extension> extensions)
+    {
+        if (type.GetCustomAttribute<ExportAttribute>() is { }
+            && type.IsAssignableTo(typeof(Extension))
+            && Activator.CreateInstance(type) is Extension extension)
+        {
+            var loadStarted = false;
+            try
+            {
+                SetupExtensionSettings(extension);
+                if (extension is ViewExtension viewExtension)
+                {
+                    commandManager.Register(viewExtension);
+                }
+
+                loadStarted = true;
+                extension.Load();
+
+                extensions.Add(extension);
+                _logger.LogInformation("Extension {ExtensionName} loaded from assembly {AssemblyName}", type.Name, type.Assembly.GetName().Name);
+            }
+            catch
+            {
+                RollbackExtensionLoad(extension, loadStarted);
+                throw;
+            }
+        }
+    }
+
+    private void RollbackLoadedExtensions(List<Extension> extensions)
+    {
+        for (int i = extensions.Count - 1; i >= 0; i--)
+        {
+            RollbackExtensionLoad(extensions[i], unload: true);
+        }
+
+        extensions.Clear();
+    }
+
+    private void RollbackExtensionLoad(Extension extension, bool unload)
+    {
+        if (extension is ViewExtension viewExtension)
+        {
+            try
+            {
+                commandManager.Unregister(viewExtension);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to unregister commands while rolling back extension {ExtensionName}.", extension.GetType().Name);
+            }
+        }
+
+        if (unload)
+        {
+            try
+            {
+                extension.Unload();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to unload extension {ExtensionName} while rolling back load.", extension.GetType().Name);
+            }
+        }
+
+        try
+        {
+            CleanupExtensionSettings(extension);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clean up settings while rolling back extension {ExtensionName}.", extension.GetType().Name);
+        }
+    }
+
+    private void TryUnloadLoadContext(LocalPackage package, PluginLoadContext loadContext)
+    {
+        try
+        {
+            var types = loadContext.Assemblies.SelectMany(a => a.GetTypes()).ToArray();
+            TypeUnloadNotifier.NotifyUnloading(types);
+            AvaloniaPropertyRegistry.Instance.UnregisterByModule(types);
+            foreach (string name in loadContext.Assemblies.Select(a => a.GetName().Name).OfType<string>())
+            {
+                AssetLoader.InvalidateAssemblyCache(name);
+            }
+
+            loadContext.Unload();
+            _logger.LogInformation("AssemblyLoadContext unloaded for {PackageName}.", package.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to unload AssemblyLoadContext for {PackageName}.", package.Name);
         }
     }
 

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -225,7 +225,7 @@ public sealed class PackageManager(
                 package,
                 result.Assemblies,
                 result.LoadContext,
-                result.Assemblies.SelectMany(assembly => assembly.GetExportedTypes()));
+                result.Assemblies.SelectMany(GetLoadableTypes).Where(type => type.IsVisible));
         }
     }
 
@@ -313,11 +313,11 @@ public sealed class PackageManager(
         PluginLoadContext? loadContext,
         IEnumerable<Type> extensionTypes)
     {
-        var extensions = new List<Extension>();
+        List<Extension> extensions = [];
         var addedToProvider = false;
         try
         {
-            LoadPackageExtensions(extensionTypes, extensions);
+            extensions = LoadPackageExtensions(extensionTypes);
 
             activity?.AddEvent(new ActivityEvent("Extensions loaded"));
             activity?.SetTag("ExtensionCount", extensions.Count);
@@ -339,8 +339,8 @@ public sealed class PackageManager(
                 ExtensionProvider.RemoveExtensions(package.LocalId);
             }
 
-            // No-op when LoadPackageExtensions already rolled back and cleared its list; this unloads
-            // the extensions only when registration below failed.
+            // extensions stays empty unless LoadPackageExtensions returned (it rolls itself back on
+            // failure), so this only unloads when a registration step below threw.
             RollbackLoadedExtensions(extensions);
             if (loadContext is { })
             {
@@ -351,14 +351,17 @@ public sealed class PackageManager(
         }
     }
 
-    internal void LoadPackageExtensions(IEnumerable<Type> extensionTypes, List<Extension> extensions)
+    internal List<Extension> LoadPackageExtensions(IEnumerable<Type> extensionTypes)
     {
+        var extensions = new List<Extension>();
         try
         {
             foreach (Type type in extensionTypes)
             {
                 LoadExtension(type, extensions);
             }
+
+            return extensions;
         }
         catch
         {

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -220,37 +220,12 @@ public sealed class PackageManager(
             activity?.AddEvent(new ActivityEvent("Assemblies loaded"));
             activity?.SetTag("AssemblyCount", result.Assemblies.Length);
 
-            var extensions = new List<Extension>();
-
-            var addedToProvider = false;
-            try
-            {
-                LoadPackageExtensions(result.Assemblies.SelectMany(assembly => assembly.GetExportedTypes()), extensions);
-
-                activity?.AddEvent(new ActivityEvent("Extensions loaded"));
-                activity?.SetTag("ExtensionCount", extensions.Count);
-
-                ExtensionProvider.AddExtensions(package.LocalId, extensions.ToArray());
-                addedToProvider = true;
-
-                if (!_loadedPackages.TryAdd(package.LocalId, new LoadedPackageInfo(package, result.LoadContext)))
-                {
-                    throw new InvalidOperationException($"Package {package.Name} is already loaded.");
-                }
-
-                return result.Assemblies;
-            }
-            catch
-            {
-                if (addedToProvider)
-                {
-                    ExtensionProvider.RemoveExtensions(package.LocalId);
-                }
-
-                RollbackLoadedExtensions(extensions);
-                TryUnloadLoadContext(package, result.LoadContext);
-                throw;
-            }
+            return LoadExtensionsAndRegister(
+                activity,
+                package,
+                result.Assemblies,
+                result.LoadContext,
+                result.Assemblies.SelectMany(assembly => assembly.GetExportedTypes()));
         }
     }
 
@@ -329,6 +304,51 @@ public sealed class PackageManager(
         return [.. _loadedPackages.Values
             .Select(x => x.Package)
             .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.Name, name))];
+    }
+
+    internal Assembly[] LoadExtensionsAndRegister(
+        Activity? activity,
+        LocalPackage package,
+        Assembly[] assemblies,
+        PluginLoadContext? loadContext,
+        IEnumerable<Type> extensionTypes)
+    {
+        var extensions = new List<Extension>();
+        var addedToProvider = false;
+        try
+        {
+            LoadPackageExtensions(extensionTypes, extensions);
+
+            activity?.AddEvent(new ActivityEvent("Extensions loaded"));
+            activity?.SetTag("ExtensionCount", extensions.Count);
+
+            ExtensionProvider.AddExtensions(package.LocalId, extensions.ToArray());
+            addedToProvider = true;
+
+            if (!_loadedPackages.TryAdd(package.LocalId, new LoadedPackageInfo(package, loadContext)))
+            {
+                throw new InvalidOperationException($"Package {package.Name} is already loaded.");
+            }
+
+            return assemblies;
+        }
+        catch
+        {
+            if (addedToProvider)
+            {
+                ExtensionProvider.RemoveExtensions(package.LocalId);
+            }
+
+            // No-op when LoadPackageExtensions already rolled back and cleared its list; this unloads
+            // the extensions only when registration below failed.
+            RollbackLoadedExtensions(extensions);
+            if (loadContext is { })
+            {
+                TryUnloadLoadContext(package, loadContext);
+            }
+
+            throw;
+        }
     }
 
     internal void LoadPackageExtensions(IEnumerable<Type> extensionTypes, List<Extension> extensions)

--- a/src/Beutl.Extensibility/Extension.cs
+++ b/src/Beutl.Extensibility/Extension.cs
@@ -13,6 +13,9 @@ public abstract class Extension
 
     /// <summary>
     /// Called once when the extension is loaded. Override to perform initialization.
+    /// If this method throws, <see cref="Unload"/> is called to roll back any partial
+    /// initialization, so write <see cref="Unload"/> to be idempotent and safe against
+    /// partially initialized state.
     /// </summary>
     public virtual void Load()
     {

--- a/src/Beutl.Extensibility/Extension.cs
+++ b/src/Beutl.Extensibility/Extension.cs
@@ -11,10 +11,18 @@ public abstract class Extension
 
     internal EventHandler? SettingsChangedHandler { get; set; }
 
+    /// <summary>
+    /// Called once when the extension is loaded. Override to perform initialization.
+    /// </summary>
     public virtual void Load()
     {
     }
 
+    /// <summary>
+    /// Called when the extension is unloaded. This may also be called to roll back a failed load —
+    /// including after <see cref="Load"/> itself has thrown — so implementations must be idempotent
+    /// and safe to run against partially initialized state.
+    /// </summary>
     public virtual void Unload()
     {
     }

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -1,0 +1,103 @@
+﻿using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Api;
+
+public class PackageManagerExtensionLifecycleTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        SuccessfulViewExtension.Reset();
+        FailingViewExtension.Reset();
+    }
+
+    [Test]
+    public void LoadPackageExtensions_RollsBackLoadedExtensions_WhenLaterExtensionFails()
+    {
+        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager);
+        var extensions = new List<Extension>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadPackageExtensions(
+                [typeof(SuccessfulViewExtension), typeof(FailingViewExtension)],
+                extensions));
+
+        Assert.That(exception!.Message, Is.EqualTo("boom"));
+        Assert.That(extensions, Is.Empty);
+        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
+        Assert.That(commandManager.GetDefinitions(typeof(FailingViewExtension)), Is.Empty);
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
+        Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(1));
+        Assert.That(FailingViewExtension.LoadCount, Is.EqualTo(1));
+        Assert.That(FailingViewExtension.UnloadCount, Is.EqualTo(1));
+    }
+
+    private static PackageManager CreatePackageManager(out ContextCommandManager commandManager)
+    {
+        commandManager = new ContextCommandManager(
+            new ContextCommandSettingsStore(),
+            new ContextCommandHandlerRegistry());
+
+        return new PackageManager(
+            new InstalledPackageRepository(),
+            new ExtensionProvider(),
+            commandManager,
+            apiApplication: null!);
+    }
+}
+
+[Export]
+public sealed class SuccessfulViewExtension : ViewExtension
+{
+    public static int LoadCount { get; private set; }
+
+    public static int UnloadCount { get; private set; }
+
+    public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+        [new("success-command")];
+
+    public static void Reset()
+    {
+        LoadCount = 0;
+        UnloadCount = 0;
+    }
+
+    public override void Load()
+    {
+        LoadCount++;
+    }
+
+    public override void Unload()
+    {
+        UnloadCount++;
+    }
+}
+
+[Export]
+public sealed class FailingViewExtension : ViewExtension
+{
+    public static int LoadCount { get; private set; }
+
+    public static int UnloadCount { get; private set; }
+
+    public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+        [new("failing-command")];
+
+    public static void Reset()
+    {
+        LoadCount = 0;
+        UnloadCount = 0;
+    }
+
+    public override void Load()
+    {
+        LoadCount++;
+        throw new InvalidOperationException("boom");
+    }
+
+    public override void Unload()
+    {
+        UnloadCount++;
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -3,6 +3,7 @@ using Beutl.Extensibility;
 
 namespace Beutl.UnitTests.Api;
 
+[TestFixture]
 public class PackageManagerExtensionLifecycleTests
 {
     [SetUp]

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -4,6 +4,7 @@ using Beutl.Extensibility;
 namespace Beutl.UnitTests.Api;
 
 [TestFixture]
+[NonParallelizable]
 public class PackageManagerExtensionLifecycleTests
 {
     [SetUp]
@@ -16,7 +17,7 @@ public class PackageManagerExtensionLifecycleTests
     [Test]
     public void LoadPackageExtensions_RollsBackLoadedExtensions_WhenLaterExtensionFails()
     {
-        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager);
+        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager, out _);
         var extensions = new List<Extension>();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -34,71 +35,120 @@ public class PackageManagerExtensionLifecycleTests
         Assert.That(FailingViewExtension.UnloadCount, Is.EqualTo(1));
     }
 
-    private static PackageManager CreatePackageManager(out ContextCommandManager commandManager)
+    [Test]
+    public void LoadExtensionsAndRegister_RegistersPackage_OnSuccess()
+    {
+        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "Successful" };
+
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(SuccessfulViewExtension)]);
+
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
+        Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(0));
+        Assert.That(provider.GetExtensions<SuccessfulViewExtension>(), Has.Length.EqualTo(1));
+        Assert.That(manager.LoadedPackage, Does.Contain(package));
+        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Not.Empty);
+    }
+
+    [Test]
+    public void LoadExtensionsAndRegister_RollsBackNewExtensions_WhenPackageIdAlreadyRegistered()
+    {
+        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "Duplicate" };
+
+        // Pre-register the package id so AddExtensions rejects the load as a duplicate.
+        provider.AddExtensions(package.LocalId, []);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(SuccessfulViewExtension)]));
+
+        Assert.That(exception!.Message, Does.Contain("already registered"));
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
+        Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(1));
+        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
+        Assert.That(manager.LoadedPackage, Is.Empty);
+    }
+
+    private static PackageManager CreatePackageManager(
+        out ContextCommandManager commandManager,
+        out ExtensionProvider extensionProvider)
     {
         commandManager = new ContextCommandManager(
             new ContextCommandSettingsStore(),
             new ContextCommandHandlerRegistry());
+        extensionProvider = new ExtensionProvider();
 
         return new PackageManager(
             new InstalledPackageRepository(),
-            new ExtensionProvider(),
+            extensionProvider,
             commandManager,
             apiApplication: null!);
     }
-}
 
-[Export]
-public sealed class SuccessfulViewExtension : ViewExtension
-{
-    public static int LoadCount { get; private set; }
-
-    public static int UnloadCount { get; private set; }
-
-    public override IEnumerable<ContextCommandDefinition> ContextCommands =>
-        [new("success-command")];
-
-    public static void Reset()
+    // Nested + private so the app's exported-type scan never picks these up; [Export] stays because
+    // LoadExtension filters candidate types on it.
+    [Export]
+    private sealed class SuccessfulViewExtension : ViewExtension
     {
-        LoadCount = 0;
-        UnloadCount = 0;
+        public static int LoadCount { get; private set; }
+
+        public static int UnloadCount { get; private set; }
+
+        public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+            [new("success-command")];
+
+        public static void Reset()
+        {
+            LoadCount = 0;
+            UnloadCount = 0;
+        }
+
+        public override void Load()
+        {
+            LoadCount++;
+        }
+
+        public override void Unload()
+        {
+            UnloadCount++;
+        }
     }
 
-    public override void Load()
+    [Export]
+    private sealed class FailingViewExtension : ViewExtension
     {
-        LoadCount++;
-    }
+        public static int LoadCount { get; private set; }
 
-    public override void Unload()
-    {
-        UnloadCount++;
-    }
-}
+        public static int UnloadCount { get; private set; }
 
-[Export]
-public sealed class FailingViewExtension : ViewExtension
-{
-    public static int LoadCount { get; private set; }
+        public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+            [new("failing-command")];
 
-    public static int UnloadCount { get; private set; }
+        public static void Reset()
+        {
+            LoadCount = 0;
+            UnloadCount = 0;
+        }
 
-    public override IEnumerable<ContextCommandDefinition> ContextCommands =>
-        [new("failing-command")];
+        public override void Load()
+        {
+            LoadCount++;
+            throw new InvalidOperationException("boom");
+        }
 
-    public static void Reset()
-    {
-        LoadCount = 0;
-        UnloadCount = 0;
-    }
-
-    public override void Load()
-    {
-        LoadCount++;
-        throw new InvalidOperationException("boom");
-    }
-
-    public override void Unload()
-    {
-        UnloadCount++;
+        public override void Unload()
+        {
+            UnloadCount++;
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -18,15 +18,12 @@ public class PackageManagerExtensionLifecycleTests
     public void LoadPackageExtensions_RollsBackLoadedExtensions_WhenLaterExtensionFails()
     {
         PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager, out _);
-        var extensions = new List<Extension>();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             manager.LoadPackageExtensions(
-                [typeof(SuccessfulViewExtension), typeof(FailingViewExtension)],
-                extensions));
+                [typeof(SuccessfulViewExtension), typeof(FailingViewExtension)]));
 
         Assert.That(exception!.Message, Is.EqualTo("boom"));
-        Assert.That(extensions, Is.Empty);
         Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
         Assert.That(commandManager.GetDefinitions(typeof(FailingViewExtension)), Is.Empty);
         Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
@@ -77,6 +74,39 @@ public class PackageManagerExtensionLifecycleTests
         Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(1));
         Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
         Assert.That(manager.LoadedPackage, Is.Empty);
+    }
+
+    [Test]
+    public void LoadExtensionsAndRegister_RollsBackNewExtensions_WhenPackageAlreadyTracked()
+    {
+        PackageManager manager = CreatePackageManager(out ContextCommandManager commandManager, out ExtensionProvider provider);
+        var package = new LocalPackage { Name = "Tracked" };
+
+        manager.LoadExtensionsAndRegister(
+            activity: null,
+            package,
+            assemblies: [],
+            loadContext: null,
+            [typeof(SuccessfulViewExtension)]);
+
+        // Drop only the provider entry so the second load passes AddExtensions but trips the
+        // _loadedPackages.TryAdd guard, exercising the "already loaded" rollback branch.
+        provider.RemoveExtensions(package.LocalId);
+        SuccessfulViewExtension.Reset();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            manager.LoadExtensionsAndRegister(
+                activity: null,
+                package,
+                assemblies: [],
+                loadContext: null,
+                [typeof(SuccessfulViewExtension)]));
+
+        Assert.That(exception!.Message, Does.Contain("already loaded"));
+        Assert.That(SuccessfulViewExtension.LoadCount, Is.EqualTo(1));
+        Assert.That(SuccessfulViewExtension.UnloadCount, Is.EqualTo(1));
+        Assert.That(provider.GetExtensions<SuccessfulViewExtension>(), Is.Empty);
+        Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
     }
 
     private static PackageManager CreatePackageManager(


### PR DESCRIPTION
## Description
- Roll back package extension load side effects when a later exported extension fails during `PackageManager.Load`.
- The rollback unregisters view commands, calls `Unload()` for extensions whose `Load()` started, cleans settings handlers, removes provider entries when needed, and unloads the plugin `AssemblyLoadContext` before rethrowing the original load failure.
- Confirmed the Project #9 finding is not a false positive: `LoadExtensions()` registered settings/commands and called `Extension.Load()` without a failure rollback path.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Added `tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs` to cover rollback of a successful `ViewExtension` plus a failing `ViewExtension` in the same package load.
- Baseline check: the new test failed before the rollback implementation because the successful extension remained in the loaded list.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~PackageManagerExtensionLifecycleTests|FullyQualifiedName~ContextCommandTests|FullyQualifiedName~ControllableEncodingExtensionTests"` (17 passed)
- `dotnet format Beutl.slnx --include src/Beutl.Api/Beutl.Api.csproj src/Beutl.Api/Services/PackageManager.cs tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs --verify-no-changes`

## Fixed issues / References
- Project board: b-editor/projects/9 ("設計改善: 拡張ロード/unload のライフサイクルを明示する")

## Follow-ups
- Define the extension resource ownership contract explicitly so plugin authors know what `Load()` may retain and what `Unload()` must release.
- Add diagnostics for remaining unload roots when a plugin `AssemblyLoadContext` does not become collectible after unload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package extension loading robustness: failures during extension load now trigger orderly rollback, including unloading and removal of any context command registrations tied to partially loaded extensions.
  * Enhanced duplicate package registration handling with a clearer `InvalidOperationException` message.
* **Documentation**
  * Documented expected `Extension.Load()`/`Unload()` behavior, including rollback after failed loads and idempotency requirements.
* **Tests**
  * Added coverage for extension lifecycle behavior, including success registration, rollback on later failure, and handling when packages are already registered/tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->