### PR TITLE
test(engine): cover SpeedIntegrator long-timeline sample index

### DIFF
--- a/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
+++ b/tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs
@@ -25,6 +25,44 @@ public class SpeedIntegratorTests
         return animation;
     }
 
+    private static KeyFrameAnimation<float> RampedSpeedForLongTimeline()
+    {
+        var animation = new KeyFrameAnimation<float>();
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.Zero,
+            Value = 100f,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromHours(7),
+            Value = 200f,
+            Easing = new LinearEasing()
+        });
+        animation.KeyFrames.Add(new KeyFrame<float>
+        {
+            KeyTime = TimeSpan.FromHours(8),
+            Value = 200f,
+            Easing = new LinearEasing()
+        });
+        return animation;
+    }
+
+    private static void SeedIntegralCache(SpeedIntegrator integrator, int second, double integralSeconds)
+    {
+        // Avoid billions of integration steps while exercising the long sample-domain remainder path.
+        System.Reflection.FieldInfo field = typeof(SpeedIntegrator).GetField(
+            "_integralCache",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("SpeedIntegrator cache field was not found.");
+
+        field.SetValue(integrator, new Dictionary<int, double>
+        {
+            [second] = integralSeconds
+        });
+    }
+
     [Test]
     public void SampleRate_Setter_InvalidatesCache()
     {
@@ -86,6 +124,29 @@ public class SpeedIntegratorTests
         var result = integrator.Integrate(TimeSpan.FromSeconds(2), animation);
 
         Assert.That(result.TotalSeconds, Is.EqualTo(0).Within(0.05));
+    }
+
+    [Test]
+    public void Integrate_LongTimelineRemainderUsesLongSampleIndex()
+    {
+        const int sampleRate = 100000;
+        TimeSpan start = TimeSpan.FromHours(7);
+        TimeSpan oneSample = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / sampleRate);
+        long startSampleIndex = 7L * 60 * 60 * sampleRate;
+        double cachedIntegralSeconds = 12345.0;
+
+        using var integrator = new SpeedIntegrator(sampleRate);
+        var animation = RampedSpeedForLongTimeline();
+        integrator.EnsureCache(animation);
+        SeedIntegralCache(integrator, (int)start.TotalSeconds, cachedIntegralSeconds);
+
+        TimeSpan result = integrator.Integrate(start + oneSample, animation);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(startSampleIndex, Is.GreaterThan((long)int.MaxValue));
+            Assert.That(result.TotalSeconds, Is.EqualTo(cachedIntegralSeconds + (2.0 / sampleRate)).Within(1e-9));
+        });
     }
 
     [Test]


### PR DESCRIPTION
## Description
- Adds a SpeedIntegrator regression test for the long-timeline sample-domain remainder path.
- Seeds the integral cache so the test exercises a sample index beyond `int.MaxValue` without doing billions of integration steps.
- Confirms the AI Review finding is not a false positive: existing SpeedIntegrator coverage did not assert the long sample-index boundary.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SpeedIntegratorTests"` (10 passed)
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~SpeedIntegratorTests|FullyQualifiedName~AudioMathTests"` (17 passed)
- `dotnet format Beutl.slnx --include tests/Beutl.UnitTests/Engine/SpeedIntegratorTests.cs --verify-no-changes`

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-21][diff][medium] SpeedIntegrator long-timeline overflow fix missing regression test")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for long timeline edge cases in the SpeedIntegrator component, ensuring robust handling of large sample rates and extended animation durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->