### PR TITLE
fix(player): prevent BufferedPlayer timer dispose hang

### DIFF
--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -22,11 +22,11 @@ public sealed class BufferedPlayer : IPlayer
     private readonly Scene _scene;
     private readonly IReadOnlyReactiveProperty<bool> _isPlaying;
     private readonly int _rate;
-    private volatile CancellationTokenSource? _waitRenderToken;
-    private volatile CancellationTokenSource? _waitTimerToken;
+    private readonly BufferedPlayerWaitGate _waitRenderGate;
+    private readonly BufferedPlayerWaitGate _waitTimerGate;
     private readonly IDisposable _disposable;
     private int? _requestedFrame;
-    private bool _isDisposed;
+    private volatile bool _isDisposed;
 
     // Set true whenever the producer (Start's dispatched loop) is no longer running. The consumer waits on a
     // per-wait token that only the producer cancels, so a producer that stops while no one is waiting (e.g. a
@@ -46,11 +46,13 @@ public sealed class BufferedPlayer : IPlayer
         _scene = scene;
         _isPlaying = isPlaying;
         _rate = rate;
+        _waitRenderGate = new(() => _isDisposed || _producerStopped);
+        _waitTimerGate = new(() => _isDisposed);
 
         _disposable = isPlaying.Where(v => !v).Subscribe(_ =>
         {
-            _waitRenderToken.CancelIgnoringDisposed();
-            _waitTimerToken.CancelIgnoringDisposed();
+            _waitRenderGate.Cancel();
+            _waitTimerGate.Cancel();
         });
     }
 
@@ -115,7 +117,7 @@ public sealed class BufferedPlayer : IPlayer
                         }
                     }
 
-                    _waitRenderToken.CancelIgnoringDisposed();
+                    _waitRenderGate.Cancel();
                     if (_isPlaying.Value)
                         _editViewModel.BufferStatus.EndTime.Value = time;
 
@@ -155,15 +157,15 @@ public sealed class BufferedPlayer : IPlayer
                 // instead of blocking forever on a wakeup that will never come (the lost-wakeup hang).
                 _producerStopped = true;
                 Interlocked.MemoryBarrier();
-                _waitRenderToken.CancelIgnoringDisposed();
-                _waitTimerToken.CancelIgnoringDisposed();
+                _waitRenderGate.Cancel();
+                _waitTimerGate.Cancel();
             }
         }, Threading.DispatchPriority.High);
     }
 
     public bool TryDequeue(out IPlayer.Frame frame)
     {
-        _waitTimerToken.CancelIgnoringDisposed();
+        _waitTimerGate.Cancel();
         if (_queue.TryDequeue(out IPlayer.Frame f))
         {
             frame = f;
@@ -179,33 +181,20 @@ public sealed class BufferedPlayer : IPlayer
     {
         if (_isDisposed || _producerStopped) return;
         using var cts = new CancellationTokenSource();
-        _waitRenderToken = cts;
+        if (!_waitRenderGate.Publish(cts)) return;
 
-        // Re-check after publishing the token. The producer's finally sets _producerStopped then cancels the
-        // current token; the full fence here pairs with the fence there so either the producer sees the token we
-        // just published (and cancels it, waking us) or we see the stop flag (and bail). Without this, a producer
-        // that stops while we are between publishing the token and WaitOne would leave us blocked forever.
-        Interlocked.MemoryBarrier();
-        if (_isDisposed || _producerStopped)
-        {
-            _waitRenderToken = null;
-            return;
-        }
-
-        _waitRenderToken.Token.WaitHandle.WaitOne();
-        _waitRenderToken = null;
+        cts.Token.WaitHandle.WaitOne();
+        _waitRenderGate.Clear(cts);
     }
 
-    // Sole waiter on _waitTimerToken (called only from the producer loop), so unlike WaitRender it needs no
-    // post-publish re-check.
     private void WaitTimer()
     {
         if (_isDisposed) return;
         using var cts = new CancellationTokenSource();
-        _waitTimerToken = cts;
+        if (!_waitTimerGate.Publish(cts)) return;
 
-        _waitTimerToken.Token.WaitHandle.WaitOne();
-        _waitTimerToken = null;
+        cts.Token.WaitHandle.WaitOne();
+        _waitTimerGate.Clear(cts);
     }
 
     public void Skipped(int requestedFrame)
@@ -220,8 +209,8 @@ public sealed class BufferedPlayer : IPlayer
             _logger.LogInformation("Disposing BufferedPlayer.");
 
             _isDisposed = true;
-            _waitRenderToken.CancelIgnoringDisposed();
-            _waitTimerToken.CancelIgnoringDisposed();
+            _waitRenderGate.Cancel();
+            _waitTimerGate.Cancel();
             _disposable.Dispose();
             while (_queue.TryDequeue(out var f))
             {

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -152,11 +152,10 @@ public sealed class BufferedPlayer : IPlayer
             finally
             {
                 // Whenever the producer thread exits — normal completion, mid-playback renderer rebuild, or an
-                // exception — record the stop and wake any current waiter. The full fence pairs with WaitRender's
-                // post-publish re-check so a consumer that reaches WaitRender after this point observes the stop
-                // instead of blocking forever on a wakeup that will never come (the lost-wakeup hang).
+                // exception — record the stop before waking any current waiter: setting _producerStopped first
+                // pairs with WaitRender's post-publish re-check (Cancel fences), so a consumer reaching WaitRender
+                // after this point observes the stop instead of blocking forever on a wakeup that never comes.
                 _producerStopped = true;
-                Interlocked.MemoryBarrier();
                 _waitRenderGate.Cancel();
                 _waitTimerGate.Cancel();
             }

--- a/src/Beutl/Models/BufferedPlayerWaitGate.cs
+++ b/src/Beutl/Models/BufferedPlayerWaitGate.cs
@@ -1,0 +1,43 @@
+﻿using Beutl.Helpers;
+
+namespace Beutl.Models;
+
+internal sealed class BufferedPlayerWaitGate
+{
+    private readonly Func<bool> _shouldStop;
+    private volatile CancellationTokenSource? _token;
+
+    public BufferedPlayerWaitGate(Func<bool> shouldStop)
+    {
+        _shouldStop = shouldStop;
+    }
+
+    public void Cancel()
+    {
+        _token.CancelIgnoringDisposed();
+    }
+
+    public bool Publish(CancellationTokenSource cts)
+    {
+        _token = cts;
+
+        // Re-check stop state after publishing the token. A stopping thread may have observed the old token slot
+        // before this publish; the fence ensures this waiter either sees the stop flag or the stopper sees this token.
+        Interlocked.MemoryBarrier();
+        if (!_shouldStop())
+        {
+            return true;
+        }
+
+        Clear(cts);
+        return false;
+    }
+
+    public void Clear(CancellationTokenSource cts)
+    {
+        if (ReferenceEquals(_token, cts))
+        {
+            _token = null;
+        }
+    }
+}

--- a/src/Beutl/Models/BufferedPlayerWaitGate.cs
+++ b/src/Beutl/Models/BufferedPlayerWaitGate.cs
@@ -14,6 +14,9 @@ internal sealed class BufferedPlayerWaitGate
 
     public void Cancel()
     {
+        // Full fence, not just the volatile read: it must order the caller's prior stop-flag store before this
+        // token read (mirroring Publish's fence), or a StoreLoad reorder revives the lost-wakeup / dispose hang.
+        Interlocked.MemoryBarrier();
         Volatile.Read(ref _token).CancelIgnoringDisposed();
     }
 
@@ -22,7 +25,8 @@ internal sealed class BufferedPlayerWaitGate
         Volatile.Write(ref _token, cts);
 
         // Re-check stop state after publishing the token. A stopping thread may have observed the old token slot
-        // before this publish; the fence ensures this waiter either sees the stop flag or the stopper sees this token.
+        // before this publish; this fence paired with Cancel's ensures this waiter either sees the stop flag or the
+        // stopper sees this token.
         Interlocked.MemoryBarrier();
         if (!_shouldStop())
         {

--- a/src/Beutl/Models/BufferedPlayerWaitGate.cs
+++ b/src/Beutl/Models/BufferedPlayerWaitGate.cs
@@ -5,7 +5,7 @@ namespace Beutl.Models;
 internal sealed class BufferedPlayerWaitGate
 {
     private readonly Func<bool> _shouldStop;
-    private volatile CancellationTokenSource? _token;
+    private CancellationTokenSource? _token;
 
     public BufferedPlayerWaitGate(Func<bool> shouldStop)
     {
@@ -14,12 +14,12 @@ internal sealed class BufferedPlayerWaitGate
 
     public void Cancel()
     {
-        _token.CancelIgnoringDisposed();
+        Volatile.Read(ref _token).CancelIgnoringDisposed();
     }
 
     public bool Publish(CancellationTokenSource cts)
     {
-        _token = cts;
+        Volatile.Write(ref _token, cts);
 
         // Re-check stop state after publishing the token. A stopping thread may have observed the old token slot
         // before this publish; the fence ensures this waiter either sees the stop flag or the stopper sees this token.
@@ -35,9 +35,7 @@ internal sealed class BufferedPlayerWaitGate
 
     public void Clear(CancellationTokenSource cts)
     {
-        if (ReferenceEquals(_token, cts))
-        {
-            _token = null;
-        }
+        // A plain check-then-clear could wipe a concurrently-published newer token and lose its wakeup.
+        Interlocked.CompareExchange(ref _token, null, cts);
     }
 }

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="..\..\src\Beutl\Helpers\ExportSupersampling.cs" Link="Editor\Linked\ExportSupersampling.cs" />
     <Compile Include="..\..\src\Beutl\Helpers\CancellationTokenSourceHelper.cs" Link="Helpers\Linked\CancellationTokenSourceHelper.cs" />
     <Compile Include="..\..\src\Beutl\Helpers\HistoryMutationPlaybackGuard.cs" Link="Helpers\Linked\HistoryMutationPlaybackGuard.cs" />
+    <Compile Include="..\..\src\Beutl\Models\BufferedPlayerWaitGate.cs" Link="Models\Linked\BufferedPlayerWaitGate.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.UnitTests/Models/BufferedPlayerWaitGateTests.cs
+++ b/tests/Beutl.UnitTests/Models/BufferedPlayerWaitGateTests.cs
@@ -1,0 +1,50 @@
+﻿using Beutl.Models;
+
+namespace Beutl.UnitTests.Models;
+
+[TestFixture]
+public class BufferedPlayerWaitGateTests
+{
+    [Test]
+    public void Publish_WhenStopRequestedAfterPublish_ClearsTokenAndSkipsWait()
+    {
+        using var cts = new CancellationTokenSource();
+        var gate = new BufferedPlayerWaitGate(() => true);
+
+        bool shouldWait = gate.Publish(cts);
+        gate.Cancel();
+
+        Assert.That(shouldWait, Is.False);
+        Assert.That(cts.IsCancellationRequested, Is.False);
+    }
+
+    [Test]
+    public void Clear_RemovesPublishedToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var gate = new BufferedPlayerWaitGate(() => false);
+
+        bool shouldWait = gate.Publish(cts);
+        gate.Clear(cts);
+        gate.Cancel();
+
+        Assert.That(shouldWait, Is.True);
+        Assert.That(cts.IsCancellationRequested, Is.False);
+    }
+
+    [Test]
+    public void Clear_DoesNotRemoveNewerPublishedToken()
+    {
+        using var oldCts = new CancellationTokenSource();
+        using var newCts = new CancellationTokenSource();
+        var gate = new BufferedPlayerWaitGate(() => false);
+
+        gate.Publish(oldCts);
+        gate.Publish(newCts);
+        gate.Clear(oldCts);
+        gate.Cancel();
+
+        Assert.That(oldCts.IsCancellationRequested, Is.False);
+        Assert.That(newCts.IsCancellationRequested, Is.True);
+    }
+}


### PR DESCRIPTION
## Description
- Fixes the AI Review finding where `BufferedPlayer.WaitTimer` could publish a wait token after `Dispose` had already observed the previous token slot, leaving the producer blocked on `WaitHandle.WaitOne()`.
- Adds `BufferedPlayerWaitGate` to centralize wait-token publication, post-publish stop-state re-checking, cancellation, and safe clearing.
- Uses the same gate for `WaitRender` and `WaitTimer`, and makes `_isDisposed` volatile because it is read across threads.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --settings coverlet.runsettings --logger "console;verbosity=normal" --filter "FullyQualifiedName~BufferedPlayerWaitGateTests"` (3 passed)
- `dotnet build src/Beutl/Beutl.csproj -f net10.0 -c Debug` (passed; existing nullable warnings only)
- `dotnet format Beutl.slnx --include src/Beutl/Models/BufferedPlayer.cs src/Beutl/Models/BufferedPlayerWaitGate.cs tests/Beutl.UnitTests/Beutl.UnitTests.csproj tests/Beutl.UnitTests/Models/BufferedPlayerWaitGateTests.cs --verify-no-changes --verbosity minimal` (passed; workspace load warnings only)

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-21][diff][medium] BufferedPlayer.WaitTimer lacks post-publish _isDisposed re-check")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked buffered player wait/cancel coordination by introducing a shared wait gate mechanism to improve responsiveness during stop and shutdown, helping avoid potential playback stalls caused by race timing.
  * Updated rendering/timer waiting and queue backpressure behavior to cancel and release waiters consistently when stopping.
* **Tests**
  * Added unit coverage for the new publish/clear/cancel synchronization semantics, including edge cases for stop requests and overlapping published tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->