### PR TITLE
refactor!: remove ProjectService/EditorService/ExtensionProvider singletons

### DIFF
--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -115,7 +115,7 @@ public sealed class SampleEditorExtension : EditorExtension
         return ext is ".txt" or ".scene";
     }
 
-    public override bool TryCreateContext(CoreObject obj, [NotNullWhen(true)] out IEditorContext? context)
+    public override bool TryCreateContext(CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
     {
         context = null;
         if (obj is Scene)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -54,6 +54,7 @@ public class BeutlApiApplication
 
     public BeutlApiApplication(HttpClient httpClient, ExtensionProvider extensionProvider)
     {
+        ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(extensionProvider);
 
         _httpClient = httpClient;

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -32,6 +32,7 @@ public class BeutlApiApplication
     public const string UserFileName = "user.json";
 #endif
     private readonly HttpClient _httpClient;
+    private readonly ExtensionProvider _extensionProvider;
     private readonly ReactivePropertySlim<AuthenticatedUser?> _authenticatedUser = new();
     private readonly Dictionary<Type, Lazy<object>> _services = [];
     private static readonly ILogger s_logger = Log.CreateLogger<BeutlApiApplication>();
@@ -51,9 +52,12 @@ public class BeutlApiApplication
         return metadata;
     });
 
-    public BeutlApiApplication(HttpClient httpClient)
+    public BeutlApiApplication(HttpClient httpClient, ExtensionProvider extensionProvider)
     {
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+
         _httpClient = httpClient;
+        _extensionProvider = extensionProvider;
         httpClient.BaseAddress = new Uri(BaseUrl);
         App = RestService.For<IAppClient>(httpClient);
         Packages = RestService.For<IPackagesClient>(httpClient);
@@ -137,7 +141,7 @@ public class BeutlApiApplication
     private void RegisterAll()
     {
         Register(() => new DiscoverService(this));
-        Register(() => ExtensionProvider.Current);
+        Register(() => _extensionProvider);
         Register(() => new ContextCommandSettingsStore());
         Register(() => new ContextCommandHandlerRegistry());
         Register(() => new ContextCommandManager(

--- a/src/Beutl.Api/Services/ExtensionProvider.cs
+++ b/src/Beutl.Api/Services/ExtensionProvider.cs
@@ -6,7 +6,7 @@ using static Beutl.Configuration.ExtensionConfig;
 
 namespace Beutl.Api.Services;
 
-public sealed class ExtensionProvider : IBeutlApiResource
+public sealed class ExtensionProvider : IBeutlApiResource, IExtensionProvider
 {
     private readonly Dictionary<int, Extension[]> _allExtensions = [];
     private readonly ExtensionConfig _config = GlobalConfiguration.Instance.ExtensionConfig;
@@ -18,8 +18,6 @@ public sealed class ExtensionProvider : IBeutlApiResource
     public ExtensionProvider()
     {
     }
-
-    public static ExtensionProvider Current { get; } = new();
 
     public ICoreReadOnlyList<Extension> AllExtensions => _extensions;
 

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -16,10 +16,23 @@ public abstract class EditorExtension : ViewExtension
         CoreObject obj,
         [NotNullWhen(true)] out Control? editor);
 
-    // NOTE: ここからProjectItemを取得する場合、
-    //       ProjectItemContainerから取得すればいい
+    /// <summary>
+    /// Creates the editor context for <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">The object to open in the editor.</param>
+    /// <param name="services">
+    /// Host services the created context may need — e.g. <see cref="IEditorContextServices.ExtensionProvider"/>
+    /// for querying other extensions. Owned by the composition root and passed in explicitly instead
+    /// of relying on global singletons. An extension that needs nothing from the host may ignore it.
+    /// </param>
+    /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
+    /// <returns><see langword="true"/> if a context was created for <paramref name="obj"/>.</returns>
+    /// <remarks>
+    /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer.
+    /// </remarks>
     public abstract bool TryCreateContext(
         CoreObject obj,
+        IEditorContextServices services,
         [NotNullWhen(true)] out IEditorContext? context);
 
     public virtual bool IsSupported(string? file)

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -22,8 +22,8 @@ public abstract class EditorExtension : ViewExtension
     /// <param name="obj">The object to open in the editor.</param>
     /// <param name="services">
     /// Host services the created context may need — e.g. <see cref="IEditorContextServices.ExtensionProvider"/>
-    /// for querying other extensions. Owned by the composition root and passed in explicitly instead
-    /// of relying on global singletons. An extension that needs nothing from the host may ignore it.
+    /// for querying other extensions. Owned by the composition root and passed in explicitly. An
+    /// extension that needs nothing from the host may ignore it.
     /// </param>
     /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
     /// <returns><see langword="true"/> if a context was created for <paramref name="obj"/>.</returns>

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -1,0 +1,13 @@
+﻿namespace Beutl.Extensibility;
+
+/// <summary>
+/// Host services supplied to <see cref="EditorExtension.TryCreateContext"/> so a created
+/// <see cref="IEditorContext"/> can reach host capabilities without relying on global singletons.
+/// The host owns the instance and passes it in explicitly; an extension that needs nothing from
+/// the host may ignore it.
+/// </summary>
+public interface IEditorContextServices
+{
+    /// <summary>Gets the host's extension provider, for querying other registered extensions.</summary>
+    IExtensionProvider ExtensionProvider { get; }
+}

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -2,9 +2,8 @@
 
 /// <summary>
 /// Host services supplied to <see cref="EditorExtension.TryCreateContext"/> so a created
-/// <see cref="IEditorContext"/> can reach host capabilities without relying on global singletons.
-/// The host owns the instance and passes it in explicitly; an extension that needs nothing from
-/// the host may ignore it.
+/// <see cref="IEditorContext"/> can reach host capabilities. The host owns the instance and
+/// passes it in explicitly; an extension that needs nothing from the host may ignore it.
 /// </summary>
 public interface IEditorContextServices
 {

--- a/src/Beutl.Extensibility/IExtensionProvider.cs
+++ b/src/Beutl.Extensibility/IExtensionProvider.cs
@@ -1,0 +1,21 @@
+﻿using Beutl.Collections;
+
+namespace Beutl.Extensibility;
+
+/// <summary>
+/// A read-only view over the registered extensions. Exposed to extension authors (for example
+/// through <see cref="IEditorContextServices"/>) so they can query other extensions without
+/// referencing the host's concrete extension provider implementation.
+/// </summary>
+public interface IExtensionProvider
+{
+    /// <summary>Gets every registered extension.</summary>
+    ICoreReadOnlyList<Extension> AllExtensions { get; }
+
+    /// <summary>Gets all registered extensions assignable to <typeparamref name="TExtension"/>.</summary>
+    TExtension[] GetExtensions<TExtension>()
+        where TExtension : Extension;
+
+    /// <summary>Finds the editor extension that supports <paramref name="file"/>, or <see langword="null"/>.</summary>
+    EditorExtension? MatchEditorExtension(string file);
+}

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -144,8 +144,6 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
         // プリフェッチが進行中だが要求と一致しない場合は、完了を待ってから結果を破棄する。
         // ホストへ非順次なリクエストが流出しないよう、参照を捨てるだけでなく必ず await する。
-        // フィールドを await 前にクリアするためプロバイダはピン留めされず、失敗したプリフェッチは
-        // この呼び出しで一度だけ伝播し、後続の要求は通常どおり処理できる（キャンセルや通信エラーも同様に伝播）。
         if (_prefetchTask != null)
         {
             Task<Pcm<Stereo32BitFloat>> staleTask = _prefetchTask;

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -23,7 +23,7 @@ public class MainViewModel
 
     public MainViewModel()
     {
-        _app = new BeutlApiApplication(new HttpClient());
+        _app = new BeutlApiApplication(new HttpClient(), ExtensionProvider.Current);
         _model = new ChangesModel();
 
         _beutlProcesses =

--- a/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/MainViewModel.cs
@@ -23,7 +23,9 @@ public class MainViewModel
 
     public MainViewModel()
     {
-        _app = new BeutlApiApplication(new HttpClient(), ExtensionProvider.Current);
+        // This standalone package-tools process owns its own extension provider; it never
+        // loads editor extensions, so a fresh instance is sufficient for the API resource graph.
+        _app = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
         _model = new ChangesModel();
 
         _beutlProcesses =

--- a/src/Beutl/App.axaml.cs
+++ b/src/Beutl/App.axaml.cs
@@ -13,6 +13,7 @@ using Beutl.Graphics.Backend;
 using Beutl.NodeGraph.Nodes;
 using Beutl.Pages;
 using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.Services.StartupTasks;
 using Beutl.Services.Tutorials;
 using Beutl.ViewModels;
@@ -33,6 +34,8 @@ public sealed class App : Application
 
     public override void Initialize()
     {
+        // The built-in tutorials receive their editor-session services when LoadPrimitiveExtensionTask
+        // (run by RunStartupTask) constructs DefaultTutorialExtension, so no tutorial wiring is needed here.
         _startUp = GetMainViewModel().RunStartupTask();
         _startUp.WaitAll().ContinueWith(_ => _startUp = null);
 

--- a/src/Beutl/App.axaml.cs
+++ b/src/Beutl/App.axaml.cs
@@ -34,8 +34,6 @@ public sealed class App : Application
 
     public override void Initialize()
     {
-        // The built-in tutorials receive their editor-session services when LoadPrimitiveExtensionTask
-        // (run by RunStartupTask) constructs DefaultTutorialExtension, so no tutorial wiring is needed here.
         _startUp = GetMainViewModel().RunStartupTask();
         _startUp.WaitAll().ContinueWith(_ => _startUp = null);
 

--- a/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
@@ -14,9 +14,6 @@
              d:DesignWidth="800"
              x:DataType="vm:ExtensionsSettingsPageViewModel"
              mc:Ignorable="d">
-    <UserControl.DataContext>
-        <vm:ExtensionsSettingsPageViewModel />
-    </UserControl.DataContext>
     <Grid Margin="18" RowDefinitions="Auto,*">
 
         <TextBlock Margin="10,8"

--- a/src/Beutl/Services/Adapters/PropertiesEditorFactoryImpl.cs
+++ b/src/Beutl/Services/Adapters/PropertiesEditorFactoryImpl.cs
@@ -1,14 +1,13 @@
-﻿using Beutl.Editor.Services;
+﻿using Beutl.Api.Services;
+using Beutl.Editor.Services;
 using Beutl.ViewModels.Editors;
 
 namespace Beutl.Services.Adapters;
 
-internal sealed class PropertiesEditorFactoryImpl : IPropertiesEditorFactory
+internal sealed class PropertiesEditorFactoryImpl(ExtensionProvider extensionProvider) : IPropertiesEditorFactory
 {
-    public static readonly PropertiesEditorFactoryImpl Instance = new();
-
     public IPropertiesEditorViewModel Create(ICoreObject obj)
     {
-        return new PropertiesEditorViewModel(obj);
+        return new PropertiesEditorViewModel(obj, extensionProvider);
     }
 }

--- a/src/Beutl/Services/Adapters/PropertyEditorFactoryAdapter.cs
+++ b/src/Beutl/Services/Adapters/PropertyEditorFactoryAdapter.cs
@@ -1,16 +1,15 @@
-﻿using Beutl.Editor.Services;
+﻿using Beutl.Api.Services;
+using Beutl.Editor.Services;
 using Beutl.ViewModels.Editors;
 using DynamicData;
 
 namespace Beutl.Services.Adapters;
 
-internal sealed class PropertyEditorFactoryAdapter : IPropertyEditorFactory
+internal sealed class PropertyEditorFactoryAdapter(ExtensionProvider extensionProvider) : IPropertyEditorFactory
 {
-    public static readonly PropertyEditorFactoryAdapter Instance = new();
-
     public IPropertyEditorContext? CreateEditor(IPropertyAdapter property)
     {
-        var (props, ext) = PropertyEditorService.MatchProperty([property]);
+        var (props, ext) = PropertyEditorService.MatchProperty([property], extensionProvider);
         if (props != null && ext != null && ext.TryCreateContext(props, out var ctx))
             return ctx;
         return null;
@@ -18,7 +17,7 @@ internal sealed class PropertyEditorFactoryAdapter : IPropertyEditorFactory
 
     public (IPropertyAdapter[]? Properties, PropertyEditorExtension? Extension) MatchProperty(IReadOnlyList<IPropertyAdapter> properties)
     {
-        return PropertyEditorService.MatchProperty(properties);
+        return PropertyEditorService.MatchProperty(properties, extensionProvider);
     }
 
     public IReadOnlyList<IPropertyEditorContext?> CreatePropertyEditorContexts(
@@ -32,7 +31,7 @@ internal sealed class PropertyEditorFactoryAdapter : IPropertyEditorFactory
 
         do
         {
-            (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+            (foundItems, extension) = PropertyEditorService.MatchProperty(props, extensionProvider);
             if (foundItems != null && extension != null)
             {
                 if (extension.TryCreateContext(foundItems, out IPropertyEditorContext? context))

--- a/src/Beutl/Services/CommandPaletteHandlerProvider.cs
+++ b/src/Beutl/Services/CommandPaletteHandlerProvider.cs
@@ -11,10 +11,12 @@ public interface ICommandPaletteHandlerProvider
 internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProvider
 {
     private readonly Func<MainViewModel?> _mainViewModelAccessor;
+    private readonly EditorService _editorService;
 
-    public CommandPaletteHandlerProvider(Func<MainViewModel?> mainViewModelAccessor)
+    public CommandPaletteHandlerProvider(Func<MainViewModel?> mainViewModelAccessor, EditorService editorService)
     {
         _mainViewModelAccessor = mainViewModelAccessor;
+        _editorService = editorService;
     }
 
     public IContextCommandHandler? Resolve(Type extensionType)
@@ -26,7 +28,7 @@ internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProv
 
         if (typeof(EditorExtension).IsAssignableFrom(extensionType))
         {
-            EditorTabItem? tab = EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? tab = _editorService.SelectedTabItem.Value;
             if (tab?.Extension.Value is { } extension && extension.GetType() == extensionType)
             {
                 return tab.Context.Value as IContextCommandHandler;
@@ -37,7 +39,7 @@ internal sealed class CommandPaletteHandlerProvider : ICommandPaletteHandlerProv
 
         if (typeof(ToolTabExtension).IsAssignableFrom(extensionType))
         {
-            EditorTabItem? tab = EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? tab = _editorService.SelectedTabItem.Value;
             if (tab?.Context.Value is EditViewModel editor)
             {
                 return editor.DockHost.FindToolContext(extensionType) as IContextCommandHandler;

--- a/src/Beutl/Services/CommandPaletteService.cs
+++ b/src/Beutl/Services/CommandPaletteService.cs
@@ -16,16 +16,22 @@ public sealed class CommandPaletteService
     private readonly ContextCommandManager? _commandManager;
     private readonly ICommandPaletteHandlerProvider _handlerProvider;
     private readonly Func<MenuBarViewModel?> _menuBarAccessor;
+    private readonly EditorService _editorService;
+    private readonly ExtensionProvider _extensionProvider;
     private readonly Dictionary<Type, string> _categoryNameCache = new();
 
     public CommandPaletteService(
         ContextCommandManager? commandManager,
         ICommandPaletteHandlerProvider handlerProvider,
-        Func<MenuBarViewModel?> menuBarAccessor)
+        Func<MenuBarViewModel?> menuBarAccessor,
+        EditorService editorService,
+        ExtensionProvider extensionProvider)
     {
         _commandManager = commandManager;
         _handlerProvider = handlerProvider;
         _menuBarAccessor = menuBarAccessor;
+        _editorService = editorService;
+        _extensionProvider = extensionProvider;
     }
 
     public IReadOnlyList<PaletteCommand> EnumerateCommands()
@@ -34,7 +40,7 @@ public sealed class CommandPaletteService
 
         if (_commandManager != null)
         {
-            EditorTabItem? activeTab = EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? activeTab = _editorService.SelectedTabItem.Value;
             Type? activeEditorExtensionType = activeTab?.Extension.Value?.GetType();
             EditViewModel? activeEditor = activeTab?.Context.Value as EditViewModel;
 
@@ -117,7 +123,7 @@ public sealed class CommandPaletteService
         }
 
         string name = extensionType.Name;
-        Extension? matched = ExtensionProvider.Current.AllExtensions
+        Extension? matched = _extensionProvider.AllExtensions
             .FirstOrDefault(i => i.GetType() == extensionType);
         if (matched != null && !string.IsNullOrEmpty(matched.DisplayName))
         {

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -4,9 +4,9 @@ using Beutl.Extensibility;
 namespace Beutl.Services;
 
 // Host services handed to EditorExtension.TryCreateContext so a created editor context can
-// receive the services it needs without reaching for global singletons. Plugins consume the
-// typed IEditorContextServices surface; in-tree extensions (e.g. SceneEditorExtension) cast to
-// this concrete type to also obtain the host-internal EditorService.
+// receive the services it needs. Plugins consume the typed IEditorContextServices surface;
+// in-tree extensions (e.g. SceneEditorExtension) cast to this concrete type to also obtain
+// the host-internal EditorService.
 internal sealed class EditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
     : IEditorContextServices
 {

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -1,0 +1,18 @@
+﻿using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.Services;
+
+// Host services handed to EditorExtension.TryCreateContext so a created editor context can
+// receive the services it needs without reaching for global singletons. Plugins consume the
+// typed IEditorContextServices surface; in-tree extensions (e.g. SceneEditorExtension) cast to
+// this concrete type to also obtain the host-internal EditorService.
+internal sealed class EditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
+    : IEditorContextServices
+{
+    public ExtensionProvider ExtensionProvider => extensionProvider;
+
+    public EditorService EditorService => editorService;
+
+    IExtensionProvider IEditorContextServices.ExtensionProvider => extensionProvider;
+}

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -70,13 +70,15 @@ public sealed class EditorTabItem : IAsyncDisposable
 public sealed class EditorService
 {
     private readonly CoreList<EditorTabItem> _tabItems;
+    private readonly ExtensionProvider _extensionProvider;
 
-    public EditorService()
+    public EditorService(ExtensionProvider extensionProvider)
     {
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+
+        _extensionProvider = extensionProvider;
         _tabItems = new() { ResetBehavior = ResetBehavior.Remove };
     }
-
-    public static EditorService Current { get; } = new();
 
     public ICoreList<EditorTabItem> TabItems => _tabItems;
 
@@ -102,9 +104,9 @@ public sealed class EditorService
         }
         else
         {
-            EditorExtension? ext = ExtensionProvider.Current.MatchEditorExtension(path);
+            EditorExtension? ext = _extensionProvider.MatchEditorExtension(path);
 
-            if (ext?.TryCreateContext(obj, out IEditorContext? context) == true)
+            if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
                 TabItems.Add(tabItem2);

--- a/src/Beutl/Services/OutputService.cs
+++ b/src/Beutl/Services/OutputService.cs
@@ -12,11 +12,13 @@ namespace Beutl.Services;
 public sealed class OutputProfileItem : IDisposable
 {
     private readonly ILogger<OutputProfileItem> _logger = Log.CreateLogger<OutputProfileItem>();
+    private readonly EditorService _editorService;
 
-    public OutputProfileItem(IOutputContext context, IEditorContext editorContext)
+    public OutputProfileItem(IOutputContext context, IEditorContext editorContext, EditorService editorService)
     {
         Context = context;
         EditorContext = editorContext;
+        _editorService = editorService;
 
         Context.Started += OnStarted;
         Context.Finished += OnFinished;
@@ -32,7 +34,7 @@ public sealed class OutputProfileItem : IDisposable
     {
         _logger.LogDebug("Output started for file: {File}", Context.Object.Uri);
 
-        if (EditorService.Current.TryGetTabItem(Context.Object, out EditorTabItem? tabItem))
+        if (_editorService.TryGetTabItem(Context.Object, out EditorTabItem? tabItem))
         {
             tabItem.Context.Value.IsEnabled.Value = false;
             _logger.LogDebug("Tab item disabled for file: {File}", Context.Object.Uri);
@@ -47,7 +49,7 @@ public sealed class OutputProfileItem : IDisposable
     {
         _logger.LogDebug("Output finished for file: {File}", Context.Object.Uri);
 
-        if (EditorService.Current.TryGetTabItem(Context.Object, out EditorTabItem? tabItem))
+        if (_editorService.TryGetTabItem(Context.Object, out EditorTabItem? tabItem))
         {
             tabItem.Context.Value.IsEnabled.Value = true;
             _logger.LogDebug("Tab item enabled for file: {File}", Context.Object.Uri);
@@ -78,7 +80,8 @@ public sealed class OutputProfileItem : IDisposable
         };
     }
 
-    public static OutputProfileItem? FromJson(IEditorContext editorContext, JsonNode json, ILogger logger)
+    public static OutputProfileItem? FromJson(IEditorContext editorContext, JsonNode json, ILogger logger,
+        ExtensionProvider extensionProvider, EditorService editorService)
     {
         try
         {
@@ -87,8 +90,7 @@ public sealed class OutputProfileItem : IDisposable
 
             string extensionStr = obj["Extension"]!.AsValue().GetValue<string>();
             Type? extensionType = TypeFormat.ToType(extensionStr);
-            ExtensionProvider provider = ExtensionProvider.Current;
-            OutputExtension? extension = Array.Find(provider.GetExtensions<OutputExtension>(),
+            OutputExtension? extension = Array.Find(extensionProvider.GetExtensions<OutputExtension>(),
                 x => x.GetType() == extensionType);
 
             string file = obj["File"]!.AsValue().GetValue<string>();
@@ -101,7 +103,7 @@ public sealed class OutputProfileItem : IDisposable
                 context.ReadFromJson(contextJson.AsObject());
                 logger.LogInformation("OutputProfileItem created from JSON. File: {File}, Context: {Context}", file,
                     context);
-                return new OutputProfileItem(context, editorContext);
+                return new OutputProfileItem(context, editorContext, editorService);
             }
             else
             {
@@ -122,6 +124,8 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
 {
     private readonly CoreList<OutputProfileItem> _items = [];
     private readonly ReactivePropertySlim<OutputProfileItem?> _selectedItem = new();
+    private readonly EditorService _editorService = editViewModel.EditorService;
+    private readonly ExtensionProvider _extensionProvider = editViewModel.ExtensionProvider;
 
     private readonly string _filePath = Path.Combine(
         Path.GetDirectoryName(editViewModel.Scene.Uri!.LocalPath)!,
@@ -143,15 +147,15 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
         }
 
         context.Name.Value = Items.Count == 0 ? "Default" : $"Profile {Items.Count}";
-        var item = new OutputProfileItem(context, editViewModel);
+        var item = new OutputProfileItem(context, editViewModel, _editorService);
         Items.Add(item);
         SelectedItem.Value = item;
         _logger.LogInformation("Added new OutputProfileItem. File: {File}, Context: {Context}", file, context);
     }
 
-    public static OutputExtension[] GetExtensions(Type type)
+    public OutputExtension[] GetExtensions(Type type)
     {
-        return ExtensionProvider.Current
+        return _extensionProvider
             .GetExtensions<OutputExtension>()
             .Where(x => x.IsSupported(type)).ToArray();
     }
@@ -207,7 +211,7 @@ public sealed class OutputService(EditViewModel editViewModel) : IDisposable
             {
                 if (jsonItem == null) continue;
 
-                var item = OutputProfileItem.FromJson(editViewModel, jsonItem, _logger);
+                var item = OutputProfileItem.FromJson(editViewModel, jsonItem, _logger, _extensionProvider, _editorService);
                 if (item != null)
                 {
                     _items.Add(item);

--- a/src/Beutl/Services/PrimitiveImpls/DefaultTutorialExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/DefaultTutorialExtension.cs
@@ -5,15 +5,29 @@ namespace Beutl.Services.PrimitiveImpls;
 [PrimitiveImpl]
 public class DefaultTutorialExtension : TutorialExtension
 {
-    public static readonly DefaultTutorialExtension Instance = new();
+    private readonly EditorService _editorService;
+    private readonly ProjectService _projectService;
+
+    // The editor-session services are constructor-injected from the composition root so the
+    // tutorial step bodies can drive the editor instead of the removed EditorService.Current /
+    // ProjectService.Current singletons. Unlike the other primitive extensions this one cannot
+    // be a service-free static singleton, so LoadPrimitiveExtensionTask constructs it.
+    public DefaultTutorialExtension(EditorService editorService, ProjectService projectService)
+    {
+        ArgumentNullException.ThrowIfNull(editorService);
+        ArgumentNullException.ThrowIfNull(projectService);
+
+        _editorService = editorService;
+        _projectService = projectService;
+    }
 
     public override IReadOnlyList<TutorialDefinition> GetTutorials()
     {
         return
         [
             WelcomeTutorial.Create(),
-            TimelineBasicsTutorial.Create(),
-            AnimationEditTutorial.Create()
+            TimelineBasicsTutorial.Create(_editorService, _projectService),
+            AnimationEditTutorial.Create(_editorService, _projectService)
         ];
     }
 }

--- a/src/Beutl/Services/PrimitiveImpls/DefaultTutorialExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/DefaultTutorialExtension.cs
@@ -9,9 +9,8 @@ public class DefaultTutorialExtension : TutorialExtension
     private readonly ProjectService _projectService;
 
     // The editor-session services are constructor-injected from the composition root so the
-    // tutorial step bodies can drive the editor instead of the removed EditorService.Current /
-    // ProjectService.Current singletons. Unlike the other primitive extensions this one cannot
-    // be a service-free static singleton, so LoadPrimitiveExtensionTask constructs it.
+    // tutorial step bodies can drive the editor. Unlike the other primitive extensions this one
+    // cannot be a service-free static singleton, so LoadPrimitiveExtensionTask constructs it.
     public DefaultTutorialExtension(EditorService editorService, ProjectService projectService)
     {
         ArgumentNullException.ThrowIfNull(editorService);

--- a/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
@@ -38,7 +38,7 @@ public sealed class ExtensionsToolWindowExtension : ToolWindowExtension
             return false;
         }
 
-        context = new ExtensionsPageViewModel(mainViewModel._beutlClients);
+        context = new ExtensionsPageViewModel(mainViewModel._beutlClients, mainViewModel.EditorService, mainViewModel.ProjectService);
         return true;
     }
 }

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -116,18 +116,19 @@ public sealed class SceneEditorExtension : EditorExtension
         }
     }
 
-    public override bool TryCreateContext(CoreObject obj, [NotNullWhen(true)] out IEditorContext? context)
+    public override bool TryCreateContext(
+        CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
     {
-        if (obj is Scene scene)
+        // TryCreate* must not throw: only build the context for the host-provided services we
+        // recognize, otherwise fail (return false) rather than pushing nulls into EditViewModel.
+        if (obj is Scene scene && services is EditorContextServices ctx)
         {
-            context = new EditViewModel(scene);
+            context = new EditViewModel(scene, ctx.ExtensionProvider, ctx.EditorService);
             return true;
         }
-        else
-        {
-            context = null;
-            return false;
-        }
+
+        context = null;
+        return false;
     }
 
     public override IconSource? GetIcon()

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -28,8 +28,6 @@ public sealed class ProjectService
         _isOpened = CurrentProject.Select(v => v != null).ToReadOnlyReactivePropertySlim();
     }
 
-    public static ProjectService Current { get; } = new();
-
     public IObservable<(Project? New, Project? Old)> ProjectObservable => _projectObservable;
 
     public IReadOnlyReactiveProperty<Project?> CurrentProject { get; }

--- a/src/Beutl/Services/PropertyEditorService.cs
+++ b/src/Beutl/Services/PropertyEditorService.cs
@@ -7,6 +7,7 @@ using Avalonia.Styling;
 using Beutl.Api.Services;
 using Beutl.Audio.Effects;
 using Beutl.Controls.PropertyEditors;
+using Beutl.Extensibility;
 using Beutl.Graphics;
 using Beutl.Graphics.Effects;
 using Beutl.Graphics.Transformation;
@@ -29,8 +30,10 @@ public static class PropertyEditorService
     }
 
     public static (IPropertyAdapter[]? Properties, PropertyEditorExtension? Extension) MatchProperty(
-        IReadOnlyList<IPropertyAdapter> properties, ExtensionProvider extensionProvider)
+        IReadOnlyList<IPropertyAdapter> properties, IExtensionProvider extensionProvider)
     {
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+
         PropertyEditorExtension[] items = extensionProvider.GetExtensions<PropertyEditorExtension>();
         for (int i = items.Length - 1; i >= 0; i--)
         {

--- a/src/Beutl/Services/PropertyEditorService.cs
+++ b/src/Beutl/Services/PropertyEditorService.cs
@@ -28,9 +28,10 @@ public static class PropertyEditorService
         return (IPropertyAdapter<T>)pi;
     }
 
-    public static (IPropertyAdapter[]? Properties, PropertyEditorExtension? Extension) MatchProperty(IReadOnlyList<IPropertyAdapter> properties)
+    public static (IPropertyAdapter[]? Properties, PropertyEditorExtension? Extension) MatchProperty(
+        IReadOnlyList<IPropertyAdapter> properties, ExtensionProvider extensionProvider)
     {
-        PropertyEditorExtension[] items = ExtensionProvider.Current.GetExtensions<PropertyEditorExtension>();
+        PropertyEditorExtension[] items = extensionProvider.GetExtensions<PropertyEditorExtension>();
         for (int i = items.Length - 1; i >= 0; i--)
         {
             PropertyEditorExtension item = items[i];

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -54,19 +54,22 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         EqualizerPropertiesExtension.Instance,
         ScriptEditorExtension.Instance,
         FileBrowserTabExtension.Instance,
-        HistoryTabExtension.Instance,
-        DefaultTutorialExtension.Instance
+        HistoryTabExtension.Instance
     ];
 
-    public LoadPrimitiveExtensionTask(PackageManager manager)
+    public LoadPrimitiveExtensionTask(PackageManager manager, ExtensionProvider provider,
+        EditorService editorService, ProjectService projectService)
     {
         _manager = manager;
+        // DefaultTutorialExtension needs the editor-session services, so unlike the other
+        // primitive extensions it is not a service-free static singleton; build the full set here.
+        Extension[] allExtensions =
+            [.. PrimitiveExtensions, new DefaultTutorialExtension(editorService, projectService)];
         Task = Task.Run(async () =>
         {
             using (Activity? activity = Telemetry.StartActivity("LoadPrimitiveExtensionTask"))
             {
-                ExtensionProvider provider = ExtensionProvider.Current;
-                foreach (Extension item in PrimitiveExtensions)
+                foreach (Extension item in allExtensions)
                 {
                     _manager.SetupExtensionSettings(item);
                     if (item is ViewExtension viewExtension)
@@ -76,7 +79,7 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
                     item.Load();
                 }
 
-                provider.AddExtensions(LocalPackage.Reserved0, PrimitiveExtensions);
+                provider.AddExtensions(LocalPackage.Reserved0, allExtensions);
                 activity?.AddEvent(new("Loaded_Extensions"));
 
                 await Task.Yield();

--- a/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
+++ b/src/Beutl/Services/StartupTasks/RestoreLastProjectTask.cs
@@ -10,7 +10,7 @@ public sealed class RestoreLastProjectTask : StartupTask
 {
     private readonly ILogger<RestoreLastProjectTask> _logger = Log.CreateLogger<RestoreLastProjectTask>();
 
-    public RestoreLastProjectTask(Startup startup)
+    public RestoreLastProjectTask(Startup startup, ProjectService projectService)
     {
         Task = Task.Run(async () =>
         {
@@ -34,7 +34,7 @@ public sealed class RestoreLastProjectTask : StartupTask
                 return;
             }
 
-            if (ProjectService.Current.CurrentProject.Value is not null)
+            if (projectService.CurrentProject.Value is not null)
             {
                 return;
             }
@@ -44,7 +44,7 @@ public sealed class RestoreLastProjectTask : StartupTask
                 return;
             }
 
-            await Dispatcher.UIThread.InvokeAsync(() => ProjectService.Current.OpenProject(file));
+            await Dispatcher.UIThread.InvokeAsync(() => projectService.OpenProject(file));
         });
     }
 

--- a/src/Beutl/Services/StartupTasks/Startup.cs
+++ b/src/Beutl/Services/StartupTasks/Startup.cs
@@ -7,10 +7,14 @@ public sealed class Startup
 {
     private readonly Dictionary<Type, Lazy<StartupTask>> _tasks = [];
     private readonly BeutlApiApplication _apiApp;
+    private readonly ProjectService _projectService;
+    private readonly EditorService _editorService;
 
-    public Startup(BeutlApiApplication apiApp)
+    public Startup(BeutlApiApplication apiApp, ProjectService projectService, EditorService editorService)
     {
         _apiApp = apiApp;
+        _projectService = projectService;
+        _editorService = editorService;
         Initialize();
     }
 
@@ -64,10 +68,12 @@ public sealed class Startup
         Register(() => new CrashRecoveryPromptTask());
         Register(() => new LoadInstalledExtensionTask(
             _apiApp.GetResource<PackageManager>(), this));
-        Register(() => new LoadPrimitiveExtensionTask(_apiApp.GetResource<PackageManager>()));
+        Register(() => new LoadPrimitiveExtensionTask(
+            _apiApp.GetResource<PackageManager>(), _apiApp.GetResource<ExtensionProvider>(),
+            _editorService, _projectService));
         Register(() => new LoadSideloadExtensionTask(_apiApp.GetResource<PackageManager>()));
         Register(() => new AfterLoadingExtensionsTask(this));
-        Register(() => new RestoreLastProjectTask(this));
+        Register(() => new RestoreLastProjectTask(this, _projectService));
         Register(() => new CheckForUpdatesTask(_apiApp));
         Register(() => new CheckForPackageUpdatesTask(this, _apiApp.GetResource<PackageManager>()));
     }

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Beutl.Animation;

--- a/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
+++ b/src/Beutl/Services/Tutorials/AnimationEditTutorial.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Beutl.Animation;
@@ -24,7 +24,7 @@ public static class AnimationEditTutorial
 {
     public const string TutorialId = "animation-edit";
 
-    public static TutorialDefinition Create()
+    public static TutorialDefinition Create(EditorService editorService, ProjectService projectService)
     {
         IDisposable? step1Subscription = null;
         IDisposable? step2Subscription = null;
@@ -41,14 +41,14 @@ public static class AnimationEditTutorial
             Description = TutorialStrings.Tutorial_AnimationEdit_Description,
             Priority = 20,
             Category = "advanced",
-            CanStart = TutorialHelpers.OpenLibraryTabIfNeeded,
+            CanStart = () => TutorialHelpers.OpenLibraryTabIfNeeded(editorService),
             FulfillPrerequisites = async () =>
             {
                 // プロジェクトを準備（シーンを開くまで）
-                bool result = await TutorialHelpers.EnsureProjectAsync("AnimationTutorial");
+                bool result = await TutorialHelpers.EnsureProjectAsync(projectService, editorService, "AnimationTutorial");
                 if (!result) return false;
 
-                EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                 var adder = editVm?.GetService<IElementAdder>();
                 if (adder == null) return false;
 
@@ -75,7 +75,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         step1Subscription = TutorialHelpers.SubscribeToElementSelection(
                             editVm,
                             () => TutorialService.Current.AdvanceStep());
@@ -99,7 +99,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         Drawable? drawable = TutorialHelpers.GetDrawable(editVm);
@@ -151,7 +151,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         TranslateTransform? translateTransform = TutorialHelpers.GetTranslateTransform(
@@ -186,7 +186,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         var editorClock = editVm.GetService<IEditorClock>();
@@ -238,7 +238,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         // Set LibraryTab to Easings tab via View's TabStrip
@@ -304,7 +304,7 @@ public static class AnimationEditTutorial
                     PreferredPlacement = TutorialStepPlacement.Bottom,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm?.Scene);
                         TutorialHelpers.PrepareForPlayback(editVm, element);
                     },
@@ -340,7 +340,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         TranslateTransform? translateTransform = TutorialHelpers.GetTranslateTransform(
@@ -372,7 +372,7 @@ public static class AnimationEditTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         TranslateTransform? translateTransform = TutorialHelpers.GetTranslateTransform(
@@ -402,7 +402,7 @@ public static class AnimationEditTutorial
                     PreferredPlacement = TutorialStepPlacement.Bottom,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm?.Scene);
                         var clock = editVm?.GetService<IEditorClock>();
                         if (editVm != null && element != null && clock != null)

--- a/src/Beutl/Services/Tutorials/TimelineBasicsTutorial.cs
+++ b/src/Beutl/Services/Tutorials/TimelineBasicsTutorial.cs
@@ -20,7 +20,7 @@ public static class TimelineBasicsTutorial
 {
     public const string TutorialId = "timeline-basics";
 
-    public static TutorialDefinition Create()
+    public static TutorialDefinition Create(EditorService editorService, ProjectService projectService)
     {
         IDisposable? step1Subscription = null;
         IDisposable? step2Subscription = null;
@@ -34,8 +34,8 @@ public static class TimelineBasicsTutorial
             Description = TutorialStrings.Tutorial_SceneEdit_Description,
             Priority = 10,
             Category = "basics",
-            CanStart = TutorialHelpers.OpenLibraryTabIfNeeded,
-            FulfillPrerequisites = () => TutorialHelpers.EnsureProjectAsync("Tutorial"),
+            CanStart = () => TutorialHelpers.OpenLibraryTabIfNeeded(editorService),
+            FulfillPrerequisites = () => TutorialHelpers.EnsureProjectAsync(projectService, editorService, "Tutorial"),
             Steps =
             [
                 // Step 1: Add an ellipse to the timeline
@@ -53,7 +53,7 @@ public static class TimelineBasicsTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         step1Subscription = TutorialHelpers.SubscribeToElementAdded<EllipseShape>(
@@ -78,7 +78,7 @@ public static class TimelineBasicsTutorial
                     IsActionRequired = true,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         step2Subscription = TutorialHelpers.SubscribeToElementSelection(
                             editVm,
                             () => TutorialService.Current.AdvanceStep());
@@ -111,7 +111,7 @@ public static class TimelineBasicsTutorial
                     TargetElements = [new TargetElementDefinition { ElementResolver = FindWidthPropertyEditor, IsPrimary = true }],
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm.Scene);
@@ -140,7 +140,7 @@ public static class TimelineBasicsTutorial
                     TargetElements = [new TargetElementDefinition { ElementResolver = FindWidthPropertyEditor, IsPrimary = true }],
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         var clock = editVm.GetService<IEditorClock>();
@@ -185,7 +185,7 @@ public static class TimelineBasicsTutorial
                     TargetElements = [new TargetElementDefinition { ElementResolver = FindWidthPropertyEditor, IsPrimary = true }],
                     OnDismissed = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         if (editVm == null) return;
 
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm.Scene);
@@ -213,7 +213,7 @@ public static class TimelineBasicsTutorial
                     PreferredPlacement = TutorialStepPlacement.Bottom,
                     OnShown = () =>
                     {
-                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel();
+                        EditViewModel? editVm = TutorialHelpers.GetEditViewModel(editorService);
                         Element? element = TutorialHelpers.FindElementWithObject<EllipseShape>(editVm?.Scene);
                         TutorialHelpers.PrepareForPlayback(editVm, element);
                     },

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -12,14 +12,14 @@ namespace Beutl.Services.Tutorials;
 
 public static class TutorialHelpers
 {
-    public static EditViewModel? GetEditViewModel()
+    public static EditViewModel? GetEditViewModel(EditorService editorService)
     {
-        return EditorService.Current.SelectedTabItem.Value?.Context.Value as EditViewModel;
+        return editorService.SelectedTabItem.Value?.Context.Value as EditViewModel;
     }
 
-    public static bool OpenLibraryTabIfNeeded()
+    public static bool OpenLibraryTabIfNeeded(EditorService editorService)
     {
-        var editVm = GetEditViewModel();
+        var editVm = GetEditViewModel(editorService);
         if (editVm == null) return false;
 
         var tab = editVm.FindToolTab<LibraryTabViewModel>() ?? new LibraryTabViewModel(editVm);
@@ -27,9 +27,9 @@ public static class TutorialHelpers
         return true;
     }
 
-    public static async Task<bool> EnsureProjectAsync(string projectName = "Tutorial")
+    public static async Task<bool> EnsureProjectAsync(ProjectService projectService, EditorService editorService, string projectName = "Tutorial")
     {
-        Project? currentProject = ProjectService.Current.CurrentProject.Value;
+        Project? currentProject = projectService.CurrentProject.Value;
         // プロジェクトが開いていない場合、新規プロジェクトを作成
         if (currentProject == null)
         {
@@ -42,7 +42,7 @@ public static class TutorialHelpers
             string fullProjectName = $"{projectName}_{DateTime.Now:yyyyMMddHHmmss}";
 
             // プロジェクト作成処理
-            currentProject = await ProjectService.Current.CreateProject(
+            currentProject = await projectService.CreateProject(
                 width: 1920,
                 height: 1080,
                 framerate: 30,
@@ -59,13 +59,13 @@ public static class TutorialHelpers
         Scene? scene = currentProject.Items.OfType<Scene>().FirstOrDefault();
         if (scene != null)
         {
-            EditorService.Current.ActivateTabItem(scene);
+            editorService.ActivateTabItem(scene);
         }
 
         // UIの更新を待つ
         await Task.Delay(200);
 
-        return GetEditViewModel() != null;
+        return GetEditViewModel(editorService) != null;
     }
 
     public static IDisposable? SubscribeToElementSelection(EditViewModel? editVm, Action onSelected)

--- a/src/Beutl/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Beutl/ViewModels/CommandPaletteViewModel.cs
@@ -19,7 +19,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
     private readonly IDisposable _activeTabSubscription;
     private CompositeDisposable _stateChangeSubscriptions = [];
 
-    public CommandPaletteViewModel(CommandPaletteService service)
+    public CommandPaletteViewModel(CommandPaletteService service, EditorService editorService)
     {
         _service = service;
         FilteredCommands = new ReadOnlyObservableCollection<CommandPaletteItemViewModel>(_filteredCommands);
@@ -32,7 +32,7 @@ public sealed class CommandPaletteViewModel : BaseViewModel
 
         // パレット表示中にアクティブタブが切り替わったらスナップショットを取り直して
         // コマンド一覧と CanExecute 結果を最新の状態に追従させる。
-        _activeTabSubscription = EditorService.Current.SelectedTabItem
+        _activeTabSubscription = editorService.SelectedTabItem
             .Skip(1)
             .ObserveOnUIDispatcher()
             .Subscribe(_ =>

--- a/src/Beutl/ViewModels/Dialogs/AddOutputProfileViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/AddOutputProfileViewModel.cs
@@ -11,7 +11,7 @@ public sealed class AddOutputProfileViewModel
     public AddOutputProfileViewModel(OutputTabViewModel outputTabViewModel)
     {
         _outputTabViewModel = outputTabViewModel;
-        AvailableExtensions = OutputService.GetExtensions(outputTabViewModel.EditViewModel.Scene.GetType());
+        AvailableExtensions = outputTabViewModel.GetExtensions(outputTabViewModel.EditViewModel.Scene.GetType());
 
         CanAdd = SelectedExtension.Select(x => x != null)
             .ToReadOnlyReactivePropertySlim();

--- a/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewProjectViewModel.cs
@@ -9,8 +9,11 @@ namespace Beutl.ViewModels.Dialogs;
 
 public sealed class CreateNewProjectViewModel
 {
-    public CreateNewProjectViewModel()
+    private readonly ProjectService _projectService;
+
+    public CreateNewProjectViewModel(ProjectService projectService)
     {
+        _projectService = projectService;
         Location.Value = GetDefaultLocation();
         Name.Value = GenProjectName(Location.Value);
 
@@ -84,7 +87,7 @@ public sealed class CreateNewProjectViewModel
         Create.Subscribe(async () =>
         {
             // CreateProject surfaces failures to the user itself, so no fallback notification here.
-            await ProjectService.Current.CreateProject(
+            await _projectService.CreateProject(
                 Size.Value.Width, Size.Value.Height,
                 FrameRate.Value, SampleRate.Value,
                 Name.Value,

--- a/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
@@ -11,10 +11,12 @@ namespace Beutl.ViewModels.Dialogs;
 public sealed class CreateNewSceneViewModel
 {
     private readonly Project? _proj;
+    private readonly EditorService _editorService;
 
-    public CreateNewSceneViewModel()
+    public CreateNewSceneViewModel(ProjectService projectService, EditorService editorService)
     {
-        _proj = ProjectService.Current.CurrentProject.Value;
+        _editorService = editorService;
+        _proj = projectService.CurrentProject.Value;
         Location.Value = GetInitialLocation();
         Name.Value = GenSceneName(Location.Value);
 
@@ -86,7 +88,7 @@ public sealed class CreateNewSceneViewModel
 
             // Activation is not part of persistence, so a failure here must not be reported as a
             // save failure — kept outside the try above.
-            EditorService.Current.ActivateTabItem(scene);
+            _editorService.ActivateTabItem(scene);
         });
     }
 

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -123,7 +123,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
 
         var fallback = Factory.GetAnchoredDock(DockAnchor.Left) ?? Factory.FindFirstToolDock();
 
-        var extensions = ExtensionProvider.Current.AllExtensions
+        var extensions = _editViewModel.ExtensionProvider.AllExtensions
             .OfType<ToolTabExtension>()
             .Where(e => e.OpenByDefault)
             .OrderBy(e => (int)e.DefaultAnchor)
@@ -545,7 +545,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         if (obj["extension"] is not JsonObject extObj || !extObj.TryGetDiscriminator(out Type? extType))
             return null;
 
-        var extension = ExtensionProvider.Current.AllExtensions
+        var extension = _editViewModel.ExtensionProvider.AllExtensions
             .FirstOrDefault(x => x.GetType() == extType) as ToolTabExtension;
         if (extension is null) return null;
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -56,6 +56,10 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
     public EditViewModel(Scene scene, Beutl.Api.Services.ExtensionProvider extensionProvider, EditorService editorService)
     {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(extensionProvider);
+        ArgumentNullException.ThrowIfNull(editorService);
+
         _logger.LogInformation("Initializing EditViewModel for Scene ({SceneId}).", scene.Id);
 
         Scene = scene;
@@ -780,6 +784,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         if (serviceType.IsAssignableTo(typeof(IBufferStatus)))
             return BufferStatus;
+
+        if (serviceType == typeof(Beutl.Api.Services.ExtensionProvider))
+            return ExtensionProvider;
 
         if (serviceType.IsAssignableTo(typeof(IPropertyEditorFactory)))
             return _propertyEditorFactory ??= new Services.Adapters.PropertyEditorFactoryAdapter(ExtensionProvider);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -343,8 +343,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     public Scene Scene { get; private set; }
 
     // Host services injected from the composition root via EditorExtension.TryCreateContext;
-    // exposed so editor-scoped view models (DockHost, output, property editors) can reach
-    // them without the former ExtensionProvider.Current / EditorService.Current singletons.
+    // exposed so editor-scoped view models (DockHost, output, property editors) can reach them.
     public Beutl.Api.Services.ExtensionProvider ExtensionProvider { get; }
 
     public EditorService EditorService { get; }

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -50,13 +50,17 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     private NodeGraphMutationService? _nodeGraphMutationService;
     private ElementObjectService? _elementObjectService;
     private IClipboardGateway? _clipboardGateway;
+    private Services.Adapters.PropertyEditorFactoryAdapter? _propertyEditorFactory;
+    private Services.Adapters.PropertiesEditorFactoryImpl? _propertiesEditorFactory;
     private volatile bool _viewStateSaveSuppressed;
 
-    public EditViewModel(Scene scene)
+    public EditViewModel(Scene scene, Beutl.Api.Services.ExtensionProvider extensionProvider, EditorService editorService)
     {
         _logger.LogInformation("Initializing EditViewModel for Scene ({SceneId}).", scene.Id);
 
         Scene = scene;
+        ExtensionProvider = extensionProvider;
+        EditorService = editorService;
         SceneId = scene.Id.ToString();
 
         _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
@@ -333,6 +337,13 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     public string SceneId { get; }
 
     public Scene Scene { get; private set; }
+
+    // Host services injected from the composition root via EditorExtension.TryCreateContext;
+    // exposed so editor-scoped view models (DockHost, output, property editors) can reach
+    // them without the former ExtensionProvider.Current / EditorService.Current singletons.
+    public Beutl.Api.Services.ExtensionProvider ExtensionProvider { get; }
+
+    public EditorService EditorService { get; }
 
     public ReadOnlyReactivePropertySlim<SceneRenderer> Renderer { get; }
 
@@ -771,10 +782,10 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             return BufferStatus;
 
         if (serviceType.IsAssignableTo(typeof(IPropertyEditorFactory)))
-            return Services.Adapters.PropertyEditorFactoryAdapter.Instance;
+            return _propertyEditorFactory ??= new Services.Adapters.PropertyEditorFactoryAdapter(ExtensionProvider);
 
         if (serviceType.IsAssignableTo(typeof(IPropertiesEditorFactory)))
-            return Services.Adapters.PropertiesEditorFactoryImpl.Instance;
+            return _propertiesEditorFactory ??= new Services.Adapters.PropertiesEditorFactoryImpl(ExtensionProvider);
 
         return null;
     }

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -10,11 +10,13 @@ namespace Beutl.ViewModels;
 public class EditorHostViewModel
 {
     private readonly ILogger _logger = Log.CreateLogger<EditorHostViewModel>();
-    private readonly ProjectService _projectService = ProjectService.Current;
-    private readonly EditorService _editorService = EditorService.Current;
+    private readonly ProjectService _projectService;
+    private readonly EditorService _editorService;
 
-    public EditorHostViewModel()
+    public EditorHostViewModel(ProjectService projectService, EditorService editorService)
     {
+        _projectService = projectService;
+        _editorService = editorService;
         _projectService.ProjectObservable.Subscribe(item => DispatchProjectChange(item.New, item.Old));
     }
 

--- a/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/AudioEffectEditorViewModel.cs
@@ -64,7 +64,7 @@ public sealed class AudioEffectEditorViewModel : ValueEditorViewModel<AudioEffec
                     }
                     else if (v != null)
                     {
-                        Properties.Value = new PropertiesEditorViewModel(v);
+                        Properties.Value = new PropertiesEditorViewModel(v, GetExtensionProvider());
                     }
 
                     AcceptChild();

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -34,6 +34,11 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     private EditViewModel? _editViewModel;
     private IEditorClock? _clock;
     private IServiceProvider? _parentServices;
+    // Carries the editor session's ExtensionProvider once Accept injects the EditViewModel.
+    // Editors that build child property-editor contexts gate on this (instead of the removed
+    // ExtensionProvider.Current singleton); it becomes available at the same point as the rest
+    // of the editor session (clock, element, ...), which Accept also wires up.
+    private readonly ReactivePropertySlim<Beutl.Api.Services.ExtensionProvider?> _extensionProvider = new();
 
     protected BaseEditorViewModel(IPropertyAdapter property)
     {
@@ -214,6 +219,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
             _element = serviceProvider.GetService<Element>();
             _editViewModel = serviceProvider.GetService<EditViewModel>();
             _clock = serviceProvider.GetService<IEditorClock>();
+            _extensionProvider.Value = _editViewModel?.ExtensionProvider;
 
             if (_clock != null)
             {
@@ -292,6 +298,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     {
         Disposables.Dispose();
         _canPaste.Dispose();
+        _extensionProvider.Dispose();
         _currentFrameRevoker?.Dispose();
         _currentFrameRevoker = null;
         _editViewModel = null!;
@@ -440,6 +447,24 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
             return PropertyAdapter;
 
         return _parentServices?.GetService(serviceType) ?? _editViewModel?.GetService(serviceType);
+    }
+
+    // Resolve the editor session's ExtensionProvider through the injected EditViewModel
+    // (populated in Accept). Used by editors that build child property-editor contexts after
+    // Accept has run (e.g. behind IsExpanded) so they can call PropertyEditorService.MatchProperty
+    // without the former global singleton.
+    protected Beutl.Api.Services.ExtensionProvider GetExtensionProvider()
+    {
+        return this.GetRequiredService<EditViewModel>().ExtensionProvider;
+    }
+
+    // Fires the editor session's ExtensionProvider once Accept has injected it. Editors whose
+    // child contexts are built eagerly (subscribed in their constructor, before Accept) combine
+    // their value stream with this so the child PropertiesEditorViewModel is only built once the
+    // provider is known.
+    protected IObservable<Beutl.Api.Services.ExtensionProvider> ObserveExtensionProvider()
+    {
+        return _extensionProvider.Where(x => x != null)!;
     }
 
     public void InvalidateFrameCache()

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -219,7 +219,8 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
             _element = serviceProvider.GetService<Element>();
             _editViewModel = serviceProvider.GetService<EditViewModel>();
             _clock = serviceProvider.GetService<IEditorClock>();
-            _extensionProvider.Value = _editViewModel?.ExtensionProvider;
+            _extensionProvider.Value = serviceProvider.GetService<Beutl.Api.Services.ExtensionProvider>()
+                ?? _editViewModel?.ExtensionProvider;
 
             if (_clock != null)
             {
@@ -449,13 +450,14 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
         return _parentServices?.GetService(serviceType) ?? _editViewModel?.GetService(serviceType);
     }
 
-    // Resolve the editor session's ExtensionProvider through the injected EditViewModel
-    // (populated in Accept). Used by editors that build child property-editor contexts after
-    // Accept has run (e.g. behind IsExpanded) so they can call PropertyEditorService.MatchProperty
-    // without the former global singleton.
+    // Resolve the editor session's ExtensionProvider from the host service chain (populated in
+    // Accept). Used by editors that build child property-editor contexts after Accept has run
+    // (e.g. behind IsExpanded) so they can call PropertyEditorService.MatchProperty without the
+    // former global singleton. Resolving the provider itself (rather than via EditViewModel) keeps
+    // nested editors working in non-scene hosts such as the encoder / extension settings dialogs.
     protected Beutl.Api.Services.ExtensionProvider GetExtensionProvider()
     {
-        return this.GetRequiredService<EditViewModel>().ExtensionProvider;
+        return this.GetRequiredService<Beutl.Api.Services.ExtensionProvider>();
     }
 
     // Fires the editor session's ExtensionProvider once Accept has injected it. Editors whose

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -35,9 +35,9 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
     private IEditorClock? _clock;
     private IServiceProvider? _parentServices;
     // Carries the editor session's ExtensionProvider once Accept injects the EditViewModel.
-    // Editors that build child property-editor contexts gate on this (instead of the removed
-    // ExtensionProvider.Current singleton); it becomes available at the same point as the rest
-    // of the editor session (clock, element, ...), which Accept also wires up.
+    // Editors that build child property-editor contexts gate on this; it becomes available at
+    // the same point as the rest of the editor session (clock, element, ...), which Accept also
+    // wires up.
     private readonly ReactivePropertySlim<Beutl.Api.Services.ExtensionProvider?> _extensionProvider = new();
 
     protected BaseEditorViewModel(IPropertyAdapter property)
@@ -452,9 +452,9 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     // Resolve the editor session's ExtensionProvider from the host service chain (populated in
     // Accept). Used by editors that build child property-editor contexts after Accept has run
-    // (e.g. behind IsExpanded) so they can call PropertyEditorService.MatchProperty without the
-    // former global singleton. Resolving the provider itself (rather than via EditViewModel) keeps
-    // nested editors working in non-scene hosts such as the encoder / extension settings dialogs.
+    // (e.g. behind IsExpanded) so they can call PropertyEditorService.MatchProperty. Resolving
+    // the provider itself (rather than via EditViewModel) keeps nested editors working in
+    // non-scene hosts such as the encoder / extension settings dialogs.
     protected Beutl.Api.Services.ExtensionProvider GetExtensionProvider()
     {
         return this.GetRequiredService<Beutl.Api.Services.ExtensionProvider>();

--- a/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BrushEditorViewModel.cs
@@ -9,6 +9,7 @@ using Beutl.Media;
 using Beutl.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 
 namespace Beutl.ViewModels.Editors;
 
@@ -33,7 +34,9 @@ public sealed class BrushEditorViewModel : BaseEditorViewModel, IFallbackObjectV
         });
 
         ChildContext = Value.Select(v => v as ICoreObject)
-            .Select(x => x != null ? new PropertiesEditorViewModel(x) : null)
+            .CombineLatest(ObserveExtensionProvider())
+            .Select(t => t.First != null ? new PropertiesEditorViewModel(t.First, t.Second) : null)
+            .DisposePreviousValue()
             .Do(AcceptChildren)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);

--- a/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/CoreObjectEditorViewModel.cs
@@ -74,7 +74,8 @@ public sealed class CoreObjectEditorViewModel<T> : BaseEditorViewModel<T>, ICore
             .DisposeWith(Disposables);
 
         Properties = Value
-            .Select(x => x != null ? new PropertiesEditorViewModel(x) : null)
+            .CombineLatest(ObserveExtensionProvider())
+            .Select(t => t.First != null ? new PropertiesEditorViewModel(t.First, t.Second) : null)
             .DisposePreviousValue()
             .Do(AcceptProperties)
             .ToReadOnlyReactivePropertySlim()

--- a/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/DisplacementMapTransformEditorViewModel.cs
@@ -91,7 +91,7 @@ public sealed class DisplacementMapTransformEditorViewModel : ValueEditorViewMod
 
                         if (v is not null)
                         {
-                            Properties.Value = new PropertiesEditorViewModel(v);
+                            Properties.Value = new PropertiesEditorViewModel(v, GetExtensionProvider());
                         }
 
                         AcceptChild();

--- a/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/FilterEffectEditorViewModel.cs
@@ -73,7 +73,7 @@ public sealed class FilterEffectEditorViewModel : ValueEditorViewModel<FilterEff
                         }
                         else if (v != null)
                         {
-                            Properties.Value = new PropertiesEditorViewModel(v);
+                            Properties.Value = new PropertiesEditorViewModel(v, GetExtensionProvider());
                         }
 
                         AcceptChild();

--- a/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GeometryEditorViewModel.cs
@@ -58,12 +58,12 @@ public sealed class GeometryEditorViewModel : ValueEditorViewModel<Geometry?>, I
                             IsExpanded = { Value = true }
                         };
 
-                        Properties.Value = new PropertiesEditorViewModel(group,
+                        Properties.Value = new PropertiesEditorViewModel(group, GetExtensionProvider(),
                             p => p == group.FillType);
                     }
                     else if (v is { } geometry)
                     {
-                        Properties.Value = new PropertiesEditorViewModel(geometry, (p) => p != geometry.Transform);
+                        Properties.Value = new PropertiesEditorViewModel(geometry, GetExtensionProvider(), (p) => p != geometry.Transform);
                     }
 
                     AcceptChild();

--- a/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
@@ -15,8 +15,13 @@ public sealed class GraphModelEditorViewModel : ValueEditorViewModel<GraphModel?
     public GraphModelEditorViewModel(IPropertyAdapter<GraphModel?> property)
         : base(property)
     {
-        Value.Subscribe(v =>
+        // Gate on the editor session's ExtensionProvider (supplied by Accept) so node-member
+        // view models — which resolve IPropertyEditorFactory through the injected EditViewModel —
+        // are not constructed before Accept has wired it up.
+        Value.CombineLatest(ObserveExtensionProvider())
+            .Subscribe(t =>
             {
+                GraphModel? v = t.First;
                 DisposeNodeMembers();
                 _graphModelDisposables.Clear();
 

--- a/src/Beutl/ViewModels/Editors/GraphModelNodeMemberViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GraphModelNodeMemberViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Specialized;
 using Beutl.Editor;
+using Beutl.Editor.Services;
 using Beutl.NodeGraph;
 using Beutl.NodeGraph.Nodes;
 using Beutl.Services;
@@ -172,7 +173,7 @@ public sealed class GraphModelNodeMemberViewModel : IDisposable, IPropertyEditor
             if (aproperty != null)
             {
                 atmp[0] = aproperty;
-                (_, PropertyEditorExtension? ext) = PropertyEditorService.MatchProperty(atmp);
+                (_, PropertyEditorExtension? ext) = this.GetRequiredService<IPropertyEditorFactory>().MatchProperty(atmp);
                 ext?.TryCreateContext(atmp, out context);
 
                 context?.Accept(this);

--- a/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
@@ -149,6 +149,12 @@ public sealed class ListEditorViewModel<TItem> : BaseEditorViewModel, IListEdito
 
         IsExpanded.Skip(1)
             .Take(1)
+            // Materializing items resolves IPropertyEditorFactory from the host service chain, which is
+            // only wired once Accept has run. Group editors (filter-effect / transform / geometry /
+            // audio / path) assign their child list already expanded before calling AcceptChild, so
+            // gate the first materialization on the ExtensionProvider becoming available — the same
+            // signal Accept publishes — instead of running it eagerly from the object initializer.
+            .SelectMany(_ => ObserveExtensionProvider().Take(1))
             .Subscribe(_ =>
                 List.Subscribe(list =>
                     {

--- a/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ListEditorViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Specialized;
 using System.Text.Json.Nodes;
 using Beutl.Animation;
+using Beutl.Editor.Services;
 using Beutl.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
@@ -91,13 +92,13 @@ public interface IListEditorViewModel
 
 public sealed class ListItemEditorViewModel<TItem> : IDisposable, IListItemEditorViewModel
 {
-    public ListItemEditorViewModel(ListEditorViewModel<TItem> parent, ListItemAccessorImpl<TItem?> itemAccessor)
+    public ListItemEditorViewModel(ListEditorViewModel<TItem> parent, ListItemAccessorImpl<TItem?> itemAccessor, IPropertyEditorFactory factory)
     {
         Parent = parent;
         ItemAccessor = itemAccessor;
 
         var tmp = new IPropertyAdapter[] { itemAccessor };
-        (_, PropertyEditorExtension? ext) = PropertyEditorService.MatchProperty(tmp);
+        (_, PropertyEditorExtension? ext) = factory.MatchProperty(tmp);
         if (ext?.TryCreateContextForListItem(itemAccessor, out IPropertyEditorContext? context) == true)
         {
             Context = context;
@@ -195,7 +196,7 @@ public sealed class ListEditorViewModel<TItem> : BaseEditorViewModel, IListEdito
         {
             var visitor = new Visitor(this);
             var itemAccessor = new ListItemAccessorImpl<TItem?>(index, obj, List.Value!);
-            var item = new ListItemEditorViewModel<TItem>(this, itemAccessor);
+            var item = new ListItemEditorViewModel<TItem>(this, itemAccessor, this.GetRequiredService<IPropertyEditorFactory>());
 
             item.Context?.Accept(visitor);
             Items.Insert(index, item);

--- a/src/Beutl/ViewModels/Editors/PathFigureEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PathFigureEditorViewModel.cs
@@ -33,7 +33,7 @@ public sealed class PathFigureEditorViewModel : ValueEditorViewModel<PathFigure>
                             var prop = new EnginePropertyAdapter<ICoreList<PathSegment>>(group.Segments, group);
                             Group.Value = new ListEditorViewModel<PathSegment>(prop) { IsExpanded = { Value = true } };
 
-                            Properties.Value = new PropertiesEditorViewModel(group,
+                            Properties.Value = new PropertiesEditorViewModel(group, GetExtensionProvider(),
                                 p => p == group.StartPoint
                                      || p == group.IsClosed);
                         }

--- a/src/Beutl/ViewModels/Editors/PathOperationEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PathOperationEditorViewModel.cs
@@ -53,7 +53,7 @@ public sealed class PathOperationEditorViewModel : ValueEditorViewModel<PathSegm
 
                         if (v != null)
                         {
-                            Properties.Value = new PropertiesEditorViewModel(v);
+                            Properties.Value = new PropertiesEditorViewModel(v, GetExtensionProvider());
                         }
 
                         AcceptProperties();

--- a/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
@@ -28,7 +28,7 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
             .DisposeWith(Disposables);
 
         // CombineLatest with the provider so the eager initial Value emission waits until Accept
-        // has supplied the editor session's ExtensionProvider (the former singleton source).
+        // has supplied the editor session's ExtensionProvider.
         Value.CombineLatest(ObserveExtensionProvider())
             .Subscribe(t => Update(t.First, t.Second))
             .DisposeWith(Disposables);

--- a/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PenEditorViewModel.cs
@@ -2,13 +2,14 @@
 using Avalonia.Input;
 using Beutl.Collections.Pooled;
 using Beutl.Editor.Components.Helpers;
+using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Media;
 using Beutl.PropertyAdapters;
 using Beutl.Serialization;
 using Beutl.Services;
-
 using DynamicData;
+using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings;
 
 namespace Beutl.ViewModels.Editors;
@@ -26,20 +27,23 @@ public sealed class PenEditorViewModel : BaseEditorViewModel
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(Disposables);
 
-        Value.Subscribe(Update)
+        // CombineLatest with the provider so the eager initial Value emission waits until Accept
+        // has supplied the editor session's ExtensionProvider (the former singleton source).
+        Value.CombineLatest(ObserveExtensionProvider())
+            .Subscribe(t => Update(t.First, t.Second))
             .DisposeWith(Disposables);
     }
 
-    private void Update(Pen? pen)
+    private void Update(Pen? pen, Beutl.Api.Services.ExtensionProvider extensionProvider)
     {
-        static void CreateContexts(PooledList<IPropertyAdapter> props, CoreList<IPropertyEditorContext> dst)
+        void CreateContexts(PooledList<IPropertyAdapter> props, CoreList<IPropertyEditorContext> dst)
         {
             IPropertyAdapter[]? foundItems;
             PropertyEditorExtension? extension;
 
             do
             {
-                (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+                (foundItems, extension) = PropertyEditorService.MatchProperty(props, extensionProvider);
                 if (foundItems != null && extension != null)
                 {
                     if (extension.TryCreateContext(foundItems, out IPropertyEditorContext? context))

--- a/src/Beutl/ViewModels/Editors/PropertiesEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/PropertiesEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Api.Services;
 using Beutl.Engine;
 using Beutl.PropertyAdapters;
 using Beutl.Services;
@@ -8,8 +9,11 @@ namespace Beutl.ViewModels.Editors;
 
 public sealed class PropertiesEditorViewModel : IDisposable, IJsonSerializable, IPropertiesEditorViewModel
 {
-    public PropertiesEditorViewModel(ICoreObject obj)
+    private readonly ExtensionProvider _extensionProvider;
+
+    public PropertiesEditorViewModel(ICoreObject obj, ExtensionProvider extensionProvider)
     {
+        _extensionProvider = extensionProvider;
         Target = obj;
         if (obj is EngineObject engineObject)
         {
@@ -21,20 +25,23 @@ public sealed class PropertiesEditorViewModel : IDisposable, IJsonSerializable, 
         }
     }
 
-    public PropertiesEditorViewModel(ICoreObject obj, Predicate<CorePropertyMetadata> predicate)
+    public PropertiesEditorViewModel(ICoreObject obj, ExtensionProvider extensionProvider, Predicate<CorePropertyMetadata> predicate)
     {
+        _extensionProvider = extensionProvider;
         Target = obj;
         InitializeCoreObject(obj, (_, v) => predicate(v));
     }
 
-    public PropertiesEditorViewModel(ICoreObject obj, Func<CoreProperty, CorePropertyMetadata, bool> predicate)
+    public PropertiesEditorViewModel(ICoreObject obj, ExtensionProvider extensionProvider, Func<CoreProperty, CorePropertyMetadata, bool> predicate)
     {
+        _extensionProvider = extensionProvider;
         Target = obj;
         InitializeCoreObject(obj, predicate);
     }
 
-    public PropertiesEditorViewModel(EngineObject obj, Func<IProperty, bool> predicate)
+    public PropertiesEditorViewModel(EngineObject obj, ExtensionProvider extensionProvider, Func<IProperty, bool> predicate)
     {
+        _extensionProvider = extensionProvider;
         Target = obj;
         InitializeEngineObject(obj, predicate);
     }
@@ -111,7 +118,7 @@ public sealed class PropertiesEditorViewModel : IDisposable, IJsonSerializable, 
 
         do
         {
-            (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+            (foundItems, extension) = PropertyEditorService.MatchProperty(props, _extensionProvider);
             if (foundItems != null && extension != null)
             {
                 if (extension.TryCreateContext(foundItems, out IPropertyEditorContext? context))
@@ -143,7 +150,7 @@ public sealed class PropertiesEditorViewModel : IDisposable, IJsonSerializable, 
 
         do
         {
-            (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+            (foundItems, extension) = PropertyEditorService.MatchProperty(props, _extensionProvider);
             if (foundItems != null && extension != null)
             {
                 if (extension.TryCreateContext(foundItems, out IPropertyEditorContext? context))

--- a/src/Beutl/ViewModels/Editors/TextureSourceEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TextureSourceEditorViewModel.cs
@@ -27,7 +27,8 @@ public sealed class TextureSourceEditorViewModel : BaseEditorViewModel
             .DisposeWith(Disposables);
 
         ChildContext = Value.Select(v => v)
-            .Select(x => x != null ? new PropertiesEditorViewModel(x) : null)
+            .CombineLatest(ObserveExtensionProvider())
+            .Select(t => t.First != null ? new PropertiesEditorViewModel(t.First, t.Second) : null)
             .DisposePreviousValue()
             .Do(AcceptChildren)
             .ToReadOnlyReactivePropertySlim()

--- a/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/TransformEditorViewModel.cs
@@ -127,7 +127,7 @@ public sealed class TransformEditorViewModel : ValueEditorViewModel<Transform?>,
                     }
                     else if (v != null)
                     {
-                        Properties.Value = new PropertiesEditorViewModel(v);
+                        Properties.Value = new PropertiesEditorViewModel(v, GetExtensionProvider());
                     }
 
                     AcceptChild();

--- a/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
+++ b/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
@@ -2,9 +2,11 @@
 using Beutl.Api.Services;
 using Beutl.Editor;
 using Beutl.Editor.Observers;
+using Beutl.Editor.Services;
 using Beutl.Media.Encoding;
 using Beutl.PropertyAdapters;
 using Beutl.Services;
+using Beutl.Services.Adapters;
 using Beutl.ViewModels.Editors;
 using DynamicData;
 
@@ -14,6 +16,8 @@ public sealed class EncoderSettingsViewModel : IPropertyEditorContextVisitor, IS
 {
     private readonly HistoryManager _history;
     private readonly ExtensionProvider _extensionProvider;
+    private PropertyEditorFactoryAdapter? _propertyEditorFactory;
+    private PropertiesEditorFactoryImpl? _propertiesEditorFactory;
 
     public EncoderSettingsViewModel(MediaEncoderSettings settings, ExtensionProvider extensionProvider)
     {
@@ -34,6 +38,18 @@ public sealed class EncoderSettingsViewModel : IPropertyEditorContextVisitor, IS
         {
             return _history;
         }
+
+        // Expose the session ExtensionProvider and property-editor factories so nested object /
+        // list editors resolve them through the service chain even though this host is not an
+        // EditViewModel (the former global singleton path is gone).
+        if (serviceType == typeof(ExtensionProvider))
+            return _extensionProvider;
+
+        if (serviceType.IsAssignableTo(typeof(IPropertyEditorFactory)))
+            return _propertyEditorFactory ??= new PropertyEditorFactoryAdapter(_extensionProvider);
+
+        if (serviceType.IsAssignableTo(typeof(IPropertiesEditorFactory)))
+            return _propertiesEditorFactory ??= new PropertiesEditorFactoryImpl(_extensionProvider);
 
         return null;
     }

--- a/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
+++ b/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
@@ -41,7 +41,7 @@ public sealed class EncoderSettingsViewModel : IPropertyEditorContextVisitor, IS
 
         // Expose the session ExtensionProvider and property-editor factories so nested object /
         // list editors resolve them through the service chain even though this host is not an
-        // EditViewModel (the former global singleton path is gone).
+        // EditViewModel.
         if (serviceType == typeof(ExtensionProvider))
             return _extensionProvider;
 

--- a/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
+++ b/src/Beutl/ViewModels/EncoderSettingsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Api.Services;
 using Beutl.Editor;
 using Beutl.Editor.Observers;
 using Beutl.Media.Encoding;
@@ -12,10 +13,12 @@ namespace Beutl.ViewModels;
 public sealed class EncoderSettingsViewModel : IPropertyEditorContextVisitor, IServiceProvider, IDisposable
 {
     private readonly HistoryManager _history;
+    private readonly ExtensionProvider _extensionProvider;
 
-    public EncoderSettingsViewModel(MediaEncoderSettings settings)
+    public EncoderSettingsViewModel(MediaEncoderSettings settings, ExtensionProvider extensionProvider)
     {
         Settings = settings;
+        _extensionProvider = extensionProvider;
         var sequenceGenerator = new OperationSequenceGenerator();
         _history = new HistoryManager(settings, sequenceGenerator);
         InitializeCoreObject(settings, (_, m) => m.Browsable);
@@ -60,7 +63,7 @@ public sealed class EncoderSettingsViewModel : IPropertyEditorContextVisitor, IS
 
         do
         {
-            (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+            (foundItems, extension) = PropertyEditorService.MatchProperty(props, _extensionProvider);
             if (foundItems != null && extension != null)
             {
                 if (extension.TryCreateContext(foundItems, out IPropertyEditorContext? context))

--- a/src/Beutl/ViewModels/ExtensionsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Api;
+using Beutl.Services;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels.ExtensionsPages;
 using Reactive.Bindings;
@@ -12,7 +13,7 @@ public sealed class ExtensionsPageViewModel : IToolWindowContext
     private Lazy<DiscoverPageViewModel>? _discover;
     private Lazy<LibraryPageViewModel>? _library;
 
-    public ExtensionsPageViewModel(BeutlApiApplication clients)
+    public ExtensionsPageViewModel(BeutlApiApplication clients, EditorService editorService, ProjectService projectService)
     {
         IsAuthenticated = clients.AuthenticatedUser
             .Select(x => x != null)
@@ -22,10 +23,10 @@ public sealed class ExtensionsPageViewModel : IToolWindowContext
         clients.AuthenticatedUser.Subscribe(user =>
             {
                 _authDisposables.Clear();
-                _discover = new(() => new DiscoverPageViewModel(clients)
+                _discover = new(() => new DiscoverPageViewModel(clients, editorService, projectService)
                     .DisposeWith(_authDisposables));
 
-                _library = new(() => new LibraryPageViewModel(user, clients)
+                _library = new(() => new LibraryPageViewModel(user, clients, editorService, projectService)
                     .DisposeWith(_authDisposables));
             })
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPageViewModel.cs
@@ -17,11 +17,11 @@ public sealed class DiscoverPageViewModel : BasePageViewModel, ISupportRefreshVi
     private readonly DiscoverService _discover;
     private readonly BeutlApiApplication _apiApp;
 
-    public DiscoverPageViewModel(BeutlApiApplication apiApp)
+    public DiscoverPageViewModel(BeutlApiApplication apiApp, EditorService editorService, ProjectService projectService)
     {
         _apiApp = apiApp;
         _discover = apiApp.GetResource<DiscoverService>();
-        DataContextFactory = new DataContextFactory(_discover, apiApp);
+        DataContextFactory = new DataContextFactory(_discover, apiApp, editorService, projectService);
 
         Refresh = new AsyncReactiveCommand(IsBusy.Not())
             .WithSubscribe(async () =>

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/DataContextFactory.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/DataContextFactory.cs
@@ -1,10 +1,11 @@
 ﻿using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
+using Beutl.Services;
 
 namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 
-public class DataContextFactory(DiscoverService discoverService, BeutlApiApplication application)
+public class DataContextFactory(DiscoverService discoverService, BeutlApiApplication application, EditorService editorService, ProjectService projectService)
 {
     public SearchPageViewModel SearchPage(string keyword)
     {
@@ -13,6 +14,6 @@ public class DataContextFactory(DiscoverService discoverService, BeutlApiApplica
 
     public PackageDetailsPageViewModel PackageDetailPage(Package package)
     {
-        return new PackageDetailsPageViewModel(package, application);
+        return new PackageDetailsPageViewModel(package, application, editorService, projectService);
     }
 }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -1,4 +1,4 @@
-using Beutl.Api;
+﻿using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Beutl.Api;
+using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;
@@ -19,11 +19,11 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
     private readonly LibraryService _library;
     private readonly BeutlApiApplication _app;
 
-    public PackageDetailsPageViewModel(Package package, BeutlApiApplication app)
+    public PackageDetailsPageViewModel(Package package, BeutlApiApplication app, EditorService editorService, ProjectService projectService)
     {
         Package = package;
         _app = app;
-        _handler = new PackageOperationHandler(app);
+        _handler = new PackageOperationHandler(app, editorService, projectService);
         _library = app.GetResource<LibraryService>();
 
         DisplayName = package.DisplayName
@@ -215,7 +215,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                 try
                 {
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Updating;
@@ -264,7 +264,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             {
                 try
                 {
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Uninstalling;

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Collections;
+using Avalonia.Collections;
 using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
@@ -18,12 +18,16 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
     private readonly BeutlApiApplication _clients;
     private readonly CompositeDisposable _disposables = [];
     private readonly LibraryService _service;
+    private readonly EditorService _editorService;
+    private readonly ProjectService _projectService;
 
-    public LibraryPageViewModel(AuthenticatedUser? user, BeutlApiApplication clients)
+    public LibraryPageViewModel(AuthenticatedUser? user, BeutlApiApplication clients, EditorService editorService, ProjectService projectService)
     {
         _user = user;
         _clients = clients;
         _service = new LibraryService(clients);
+        _editorService = editorService;
+        _projectService = projectService;
 
         Refresh = new AsyncReactiveCommand(IsBusy.Not())
             .WithSubscribe(async () =>
@@ -103,7 +107,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
                             if (remotePackage != null)
                                 Packages.Remove(remotePackage);
-                            remotePackage ??= new RemoteUserPackageViewModel(item.Package, _clients)
+                            remotePackage ??= new RemoteUserPackageViewModel(item.Package, _clients, _editorService, _projectService)
                             {
                                 OnRemoveFromLibrary = OnPackageRemoveFromLibrary
                             };
@@ -191,7 +195,7 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
 
         foreach (KeyValuePair<string, LocalPackage> item in dict)
         {
-            LocalPackages.Add(new LocalUserPackageViewModel(item.Value, _clients));
+            LocalPackages.Add(new LocalUserPackageViewModel(item.Value, _clients, _editorService, _projectService));
         }
     }
 
@@ -216,13 +220,13 @@ public sealed class LibraryPageViewModel : BasePageViewModel, ISupportRefreshVie
                 {
                     var item = installed.FirstOrDefault(i => i.Name == name);
                     if (item != null)
-                        Packages.Add(new LocalUserPackageViewModel(item, _clients));
+                        Packages.Add(new LocalUserPackageViewModel(item, _clients, _editorService, _projectService));
                 }
             }
 
             if (remote != null)
             {
-                Packages.Add(new RemoteUserPackageViewModel(remote, _clients)
+                Packages.Add(new RemoteUserPackageViewModel(remote, _clients, _editorService, _projectService)
                 {
                     OnRemoveFromLibrary = OnPackageRemoveFromLibrary
                 });

--- a/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LibraryPageViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Collections;
+﻿using Avalonia.Collections;
 using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -1,4 +1,4 @@
-using Beutl.Api;
+﻿using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Beutl.Api;
+using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;
@@ -17,14 +17,14 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
     private readonly PackageOperationHandler _handler;
     private readonly PackageIdentity _packageIdentity;
 
-    public LocalUserPackageViewModel(LocalPackage package, BeutlApiApplication app)
+    public LocalUserPackageViewModel(LocalPackage package, BeutlApiApplication app, EditorService editorService, ProjectService projectService)
     {
         Package = package;
         _packageIdentity = new PackageIdentity(package.Name, new NuGetVersion(package.Version));
         DisplayName = new ReactivePropertySlim<string>(package.DisplayName);
         LogoUrl = new ReactivePropertySlim<string>(package.Logo);
 
-        _handler = new PackageOperationHandler(app);
+        _handler = new PackageOperationHandler(app, editorService, projectService);
 
         IObservable<PackageChangesQueue.EventType> observable = _handler.Queue.GetObservable(package.Name);
         CanCancel = observable.Select(x => x != PackageChangesQueue.EventType.None)
@@ -99,7 +99,7 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
                 try
                 {
                     IsBusy.Value = true;
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Updating;
@@ -149,7 +149,7 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
                 try
                 {
                     IsBusy.Value = true;
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Uninstalling;

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -20,12 +20,17 @@ internal class PackageOperationHandler
     private readonly PackageManager _packageManager;
     private readonly PackageInstaller _packageInstaller;
 
-    public PackageOperationHandler(BeutlApiApplication app)
+    private readonly EditorService _editorService;
+    private readonly ProjectService _projectService;
+
+    public PackageOperationHandler(BeutlApiApplication app, EditorService editorService, ProjectService projectService)
     {
         _installedPackageRepository = app.GetResource<InstalledPackageRepository>();
         _queue = app.GetResource<PackageChangesQueue>();
         _packageManager = app.GetResource<PackageManager>();
         _packageInstaller = app.GetResource<PackageInstaller>();
+        _editorService = editorService;
+        _projectService = projectService;
     }
 
     public InstalledPackageRepository InstalledPackageRepository => _installedPackageRepository;
@@ -147,9 +152,9 @@ internal class PackageOperationHandler
         }
     }
 
-    public static async Task<bool> EnsureProjectClosed()
+    public async Task<bool> EnsureProjectClosed()
     {
-        if (!ProjectService.Current.IsOpened.Value)
+        if (!_projectService.IsOpened.Value)
             return true;
 
         var dialog = new ContentDialog
@@ -167,28 +172,28 @@ internal class PackageOperationHandler
         if (result == ContentDialogResult.Secondary)
         {
             await SaveAll();
-            ProjectService.Current.CloseProject();
+            _projectService.CloseProject();
             return true;
         }
 
         if (result == ContentDialogResult.Primary)
         {
-            ProjectService.Current.CloseProject();
+            _projectService.CloseProject();
             return true;
         }
 
         return false;
     }
 
-    private static async Task SaveAll()
+    private async Task SaveAll()
     {
-        Project? project = ProjectService.Current.CurrentProject.Value;
+        Project? project = _projectService.CurrentProject.Value;
         if (project != null)
         {
             CoreSerializer.StoreToUri(project, project.Uri!);
         }
 
-        foreach (EditorTabItem item in EditorService.Current.TabItems)
+        foreach (EditorTabItem item in _editorService.TabItems)
         {
             if (item.Commands.Value != null)
             {

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
@@ -22,11 +22,11 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
     private readonly LibraryService _library;
     private readonly DiscoverService _discover;
 
-    public RemoteUserPackageViewModel(Package package, BeutlApiApplication app)
+    public RemoteUserPackageViewModel(Package package, BeutlApiApplication app, EditorService editorService, ProjectService projectService)
     {
         Package = package;
         _app = app;
-        _handler = new PackageOperationHandler(app);
+        _handler = new PackageOperationHandler(app, editorService, projectService);
         _library = app.GetResource<LibraryService>();
         _discover = app.GetResource<DiscoverService>();
 
@@ -114,7 +114,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                 try
                 {
                     IsBusy.Value = true;
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Updating;
@@ -172,7 +172,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                 try
                 {
                     IsBusy.Value = true;
-                    if (!await PackageOperationHandler.EnsureProjectClosed())
+                    if (!await _handler.EnsureProjectClosed())
                         return;
 
                     StatusText.Value = ExtensionsStrings.Uninstalling;

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -22,7 +22,8 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     public MainViewModel()
     {
         _authHttpClient = new HttpClient();
-        _beutlClients = new BeutlApiApplication(_authHttpClient);
+        ExtensionProvider extensionProvider = ExtensionProvider.Current;
+        _beutlClients = new BeutlApiApplication(_authHttpClient, extensionProvider);
         ContextCommandManager = _beutlClients.GetResource<ContextCommandManager>();
 
         MenuBar = new MenuBarViewModel();
@@ -41,7 +42,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             () => MenuBar);
         CommandPalette = new CommandPaletteViewModel(paletteService);
 
-        ICoreReadOnlyList<Extension> allExtension = ExtensionProvider.Current.AllExtensions;
+        ICoreReadOnlyList<Extension> allExtension = extensionProvider.AllExtensions;
 
         var comparer = SortExpressionComparer<Extension>.Ascending(i => i.Name);
         IObservable<IChangeSet<Extension>> changeSet = allExtension

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -26,7 +26,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     {
         _authHttpClient = new HttpClient();
         // Composition root: own the editor-session services here and thread the instances
-        // down to child view models and services instead of exposing them as global singletons.
+        // down to child view models and services.
         _extensionProvider = new ExtensionProvider();
         _projectService = new ProjectService();
         _editorService = new EditorService(_extensionProvider);
@@ -95,7 +95,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     public EditorHostViewModel EditorHost { get; }
 
     // Exposed so views bound to this composition root (MainView, MacWindow) can read the
-    // injected singletons via their DataContext instead of calling X.Current themselves.
+    // injected singletons via their DataContext.
     internal ProjectService ProjectService => _projectService;
 
     internal EditorService EditorService => _editorService;

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -18,31 +18,42 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 {
     internal readonly BeutlApiApplication _beutlClients;
     private readonly HttpClient _authHttpClient;
+    private readonly ProjectService _projectService;
+    private readonly EditorService _editorService;
+    private readonly ExtensionProvider _extensionProvider;
 
     public MainViewModel()
     {
         _authHttpClient = new HttpClient();
-        ExtensionProvider extensionProvider = ExtensionProvider.Current;
-        _beutlClients = new BeutlApiApplication(_authHttpClient, extensionProvider);
+        // Composition root: own the editor-session services here and thread the instances
+        // down to child view models and services instead of exposing them as global singletons.
+        _extensionProvider = new ExtensionProvider();
+        _projectService = new ProjectService();
+        _editorService = new EditorService(_extensionProvider);
+        _beutlClients = new BeutlApiApplication(_authHttpClient, _extensionProvider);
         ContextCommandManager = _beutlClients.GetResource<ContextCommandManager>();
 
-        MenuBar = new MenuBarViewModel();
+        MenuBar = new MenuBarViewModel(_projectService, _editorService);
 
-        IsProjectOpened = ProjectService.Current.IsOpened;
-        NameOfOpenProject = ProjectService.Current.CurrentProject.Select(v =>
+        IsProjectOpened = _projectService.IsOpened;
+        NameOfOpenProject = _projectService.CurrentProject.Select(v =>
                 v is { Uri.LocalPath: { } path } ? Path.GetFileName(path) : null)
             .ToReadOnlyReactivePropertySlim();
         WindowTitle = NameOfOpenProject.Select(v => string.IsNullOrWhiteSpace(v) ? "Beutl" : $"Beutl - {v}")
             .ToReadOnlyReactivePropertySlim("Beutl");
-        TitleBreadcrumbBar = new TitleBreadcrumbBarViewModel(this, EditorService.Current);
+        TitleBreadcrumbBar = new TitleBreadcrumbBarViewModel(this, _editorService);
+
+        EditorHost = new EditorHostViewModel(_projectService, _editorService);
 
         var paletteService = new CommandPaletteService(
             ContextCommandManager,
-            new CommandPaletteHandlerProvider(() => this),
-            () => MenuBar);
-        CommandPalette = new CommandPaletteViewModel(paletteService);
+            new CommandPaletteHandlerProvider(() => this, _editorService),
+            () => MenuBar,
+            _editorService,
+            _extensionProvider);
+        CommandPalette = new CommandPaletteViewModel(paletteService, _editorService);
 
-        ICoreReadOnlyList<Extension> allExtension = extensionProvider.AllExtensions;
+        ICoreReadOnlyList<Extension> allExtension = _extensionProvider.AllExtensions;
 
         var comparer = SortExpressionComparer<Extension>.Ascending(i => i.Name);
         IObservable<IChangeSet<Extension>> changeSet = allExtension
@@ -81,7 +92,15 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     public TitleBreadcrumbBarViewModel TitleBreadcrumbBar { get; }
 
-    public EditorHostViewModel EditorHost { get; } = new();
+    public EditorHostViewModel EditorHost { get; }
+
+    // Exposed so views bound to this composition root (MainView, MacWindow) can read the
+    // injected singletons via their DataContext instead of calling X.Current themselves.
+    internal ProjectService ProjectService => _projectService;
+
+    internal EditorService EditorService => _editorService;
+
+    internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
     public IReadOnlyReactiveProperty<bool> IsProjectOpened { get; }
 
@@ -97,13 +116,13 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     public SettingsDialogViewModel CreateSettingsDialog()
     {
-        return new SettingsDialogViewModel(_beutlClients);
+        return new SettingsDialogViewModel(_beutlClients, _extensionProvider);
     }
 
     public Startup RunStartupTask()
     {
         IsRunningStartupTasks.Value = true;
-        var startup = new Startup(_beutlClients);
+        var startup = new Startup(_beutlClients, _projectService, _editorService);
         startup.WaitAll().ContinueWith(_ => IsRunningStartupTasks.Value = false);
 
         return startup;
@@ -120,7 +139,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     public override void Dispose()
     {
         CommandPalette.Dispose();
-        ProjectService.Current.CloseProject();
+        _projectService.CloseProject();
         BeutlApplication.Current.Items.Clear();
     }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -12,14 +12,14 @@ public partial class MenuBarViewModel
     [MemberNotNull(nameof(CloseFile), nameof(CloseProject), nameof(Save), nameof(SaveAll), nameof(ExportProject))]
     private void InitializeFilesCommands()
     {
-        CloseFile = new ReactiveCommandSlim(EditorService.Current.SelectedTabItem.Select(i => i != null))
+        CloseFile = new ReactiveCommandSlim(_editorService.SelectedTabItem.Select(i => i != null))
             .WithSubscribe(() => OnCloseFileCore(null));
 
         CloseFileCore = new ReactiveCommandSlim<EditorTabItem>()
             .WithSubscribe(OnCloseFileCore);
 
         CloseProject = new ReactiveCommandSlim(IsProjectOpened)
-            .WithSubscribe(ProjectService.Current.CloseProject);
+            .WithSubscribe(_projectService.CloseProject);
 
         Save = new AsyncReactiveCommand(IsProjectOpened)
             .WithSubscribe(OnSave);
@@ -50,7 +50,7 @@ public partial class MenuBarViewModel
             }
             else
             {
-                await ProjectService.Current.OpenProject(file);
+                await _projectService.OpenProject(file);
             }
         });
     }
@@ -104,7 +104,7 @@ public partial class MenuBarViewModel
     private async Task OnSaveAll()
     {
         using Activity? activity = Telemetry.StartActivity("SaveAll");
-        Project? project = ProjectService.Current.CurrentProject.Value;
+        Project? project = _projectService.CurrentProject.Value;
         int itemsCount = 0;
 
         try
@@ -116,7 +116,7 @@ public partial class MenuBarViewModel
 
             itemsCount++;
 
-            foreach (EditorTabItem? item in EditorService.Current.TabItems)
+            foreach (EditorTabItem? item in _editorService.TabItems)
             {
                 if (item.Commands.Value != null)
                 {
@@ -137,7 +137,7 @@ public partial class MenuBarViewModel
             NotificationService.ShowSuccess(string.Empty, string.Format(MessageStrings.ItemsSaved, itemsCount.ToString()));
 
             if (GlobalConfiguration.Instance.EditorConfig.IsAutoSaveEnabled
-                && EditorService.Current.TabItems.All(v => v.Context.Value is ISupportAutoSaveEditorContext))
+                && _editorService.TabItems.All(v => v.Context.Value is ISupportAutoSaveEditorContext))
             {
                 NotificationService.ShowInformation(string.Empty, MessageStrings.FilesAutoSaved);
             }
@@ -157,7 +157,7 @@ public partial class MenuBarViewModel
     private async Task OnSave()
     {
         using Activity? activity = Telemetry.StartActivity("Save");
-        EditorTabItem? item = EditorService.Current.SelectedTabItem.Value;
+        EditorTabItem? item = _editorService.SelectedTabItem.Value;
         if (item != null)
         {
             try
@@ -193,11 +193,11 @@ public partial class MenuBarViewModel
         }
     }
 
-    internal static void OpenFileCore(string file)
+    internal void OpenFileCore(string file)
     {
         try
         {
-            Project? project = ProjectService.Current.CurrentProject.Value;
+            Project? project = _projectService.CurrentProject.Value;
 
             var uri = UriHelper.CreateFromPath(file);
             ProjectItem? projItem = null;
@@ -211,7 +211,7 @@ public partial class MenuBarViewModel
                 ProjectPersistence.AddItemAndPersist(project, projItem);
             }
 
-            EditorService.Current.ActivateTabItem(projItem);
+            _editorService.ActivateTabItem(projItem);
         }
         catch (Exception ex)
         {
@@ -227,10 +227,10 @@ public partial class MenuBarViewModel
         }
         else
         {
-            EditorTabItem? tabItem = item ?? EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? tabItem = item ?? _editorService.SelectedTabItem.Value;
             if (tabItem != null)
             {
-                await EditorService.Current.CloseTabItem(tabItem);
+                await _editorService.CloseTabItem(tabItem);
             }
         }
     }

--- a/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
@@ -18,8 +18,8 @@ public partial class MenuBarViewModel
     [MemberNotNull(nameof(DeleteLayer), nameof(ExcludeLayer), nameof(CutLayer), nameof(PasteLayer), nameof(CopyLayer), nameof(ShowSceneSettings), nameof(RemoveFromProject))]
     private void InitializeSceneCommands(IObservable<bool> isSceneOpened)
     {
-        IObservable<bool> isProjectOpenedAndTabOpened = ProjectService.Current.IsOpened
-            .CombineLatest(EditorService.Current.SelectedTabItem)
+        IObservable<bool> isProjectOpenedAndTabOpened = _projectService.IsOpened
+            .CombineLatest(_editorService.SelectedTabItem)
             .Select(i => i is { First: true, Second: not null });
 
         RemoveFromProject = new(isProjectOpenedAndTabOpened);
@@ -73,9 +73,9 @@ public partial class MenuBarViewModel
 
     public ReactiveCommandSlim ShowSceneSettings { get; private set; }
 
-    private static bool TryGetSelectedEditViewModel([NotNullWhen(true)] out EditViewModel? viewModel)
+    private bool TryGetSelectedEditViewModel([NotNullWhen(true)] out EditViewModel? viewModel)
     {
-        if (EditorService.Current.SelectedTabItem.Value?.Context.Value is EditViewModel editViewModel)
+        if (_editorService.SelectedTabItem.Value?.Context.Value is EditViewModel editViewModel)
         {
             viewModel = editViewModel;
             return true;

--- a/src/Beutl/ViewModels/MenuBarViewModel.View.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.View.cs
@@ -16,7 +16,7 @@ public partial class MenuBarViewModel
     //    Reset dock layout
     public ReactiveCommandSlim ResetDockLayout { get; private set; }
 
-    private static void OnResetDockLayout()
+    private void OnResetDockLayout()
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel))
         {

--- a/src/Beutl/ViewModels/MenuBarViewModel.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.cs
@@ -10,13 +10,17 @@ namespace Beutl.ViewModels;
 public sealed partial class MenuBarViewModel
 {
     private readonly ILogger _logger = Log.CreateLogger<MenuBarViewModel>();
+    private readonly ProjectService _projectService;
+    private readonly EditorService _editorService;
 
 #pragma warning disable CS8618
-    public MenuBarViewModel()
+    public MenuBarViewModel(ProjectService projectService, EditorService editorService)
     {
-        IsProjectOpened = ProjectService.Current.IsOpened;
+        _projectService = projectService;
+        _editorService = editorService;
+        IsProjectOpened = _projectService.IsOpened;
 
-        IObservable<bool> isSceneOpened = EditorService.Current.SelectedTabItem
+        IObservable<bool> isSceneOpened = _editorService.SelectedTabItem
             .SelectMany(i => i?.Context ?? Observable.Empty<IEditorContext?>())
             .Select(v => v is EditViewModel);
 
@@ -43,16 +47,16 @@ public sealed partial class MenuBarViewModel
 
     public IReadOnlyReactiveProperty<bool> IsProjectOpened { get; }
 
-    private static async Task OnUndo()
+    private async Task OnUndo()
     {
-        IKnownEditorCommands? commands = EditorService.Current.SelectedTabItem.Value?.Commands.Value;
+        IKnownEditorCommands? commands = _editorService.SelectedTabItem.Value?.Commands.Value;
         if (commands != null)
             await commands.OnUndo();
     }
 
-    private static async Task OnRedo()
+    private async Task OnRedo()
     {
-        IKnownEditorCommands? commands = EditorService.Current.SelectedTabItem.Value?.Commands.Value;
+        IKnownEditorCommands? commands = _editorService.SelectedTabItem.Value?.Commands.Value;
         if (commands != null)
             await commands.OnRedo();
     }

--- a/src/Beutl/ViewModels/SettingsDialogViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsDialogViewModel.cs
@@ -16,15 +16,15 @@ public sealed class SettingsDialogViewModel : IDisposable
     private readonly Lazy<InformationPageViewModel> _information;
     private readonly Lazy<KeyMapSettingsPageViewModel> _keyMap;
 
-    public SettingsDialogViewModel(BeutlApiApplication clients)
+    public SettingsDialogViewModel(BeutlApiApplication clients, ExtensionProvider extensionProvider)
     {
         _account = new(() => new AccountSettingsPageViewModel(clients));
         _editor = new(() => new EditorSettingsPageViewModel());
         _view = new(() => new ViewSettingsPageViewModel(_editor));
         _font = new(() => new FontSettingsPageViewModel());
-        _extensionsPage = new(() => new ExtensionsSettingsPageViewModel());
+        _extensionsPage = new(() => new ExtensionsSettingsPageViewModel(extensionProvider));
         _information = new(() => new InformationPageViewModel());
-        _keyMap = new(() => new KeyMapSettingsPageViewModel(clients.GetResource<ContextCommandManager>()));
+        _keyMap = new(() => new KeyMapSettingsPageViewModel(clients.GetResource<ContextCommandManager>(), extensionProvider));
     }
 
     public AccountSettingsPageViewModel Account => _account.Value;

--- a/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
@@ -53,7 +53,7 @@ public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEdi
 
         // Expose the session ExtensionProvider and property-editor factories so nested object /
         // list editors resolve them through the service chain even though this host is not an
-        // EditViewModel (the former global singleton path is gone).
+        // EditViewModel.
         if (serviceType == typeof(ExtensionProvider))
             return _extensionProvider;
 

--- a/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Api.Services;
 using Beutl.Controls.Navigation;
 using Beutl.Editor;
 using Beutl.PropertyAdapters;
@@ -15,14 +16,14 @@ public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEdi
 {
     private readonly HistoryManager _history;
 
-    public AnExtensionSettingsPageViewModel(Extension extension)
+    public AnExtensionSettingsPageViewModel(Extension extension, ExtensionProvider extensionProvider)
     {
         Extension = extension;
 
         var sequenceGenerator = new OperationSequenceGenerator();
         _history = new HistoryManager(extension.Settings!, sequenceGenerator);
 
-        InitializeCoreObject(extension.Settings!, (_, m) => m.Browsable);
+        InitializeCoreObject(extension.Settings!, (_, m) => m.Browsable, extensionProvider);
 
         NavigateParent.Subscribe(async () =>
         {
@@ -51,7 +52,7 @@ public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEdi
     {
     }
 
-    private void InitializeCoreObject(ExtensionSettings obj, Func<CoreProperty, CorePropertyMetadata, bool>? predicate = null)
+    private void InitializeCoreObject(ExtensionSettings obj, Func<CoreProperty, CorePropertyMetadata, bool>? predicate, ExtensionProvider extensionProvider)
     {
         Type objType = obj.GetType();
         Type adapterType = typeof(CorePropertyAdapter<>);
@@ -71,7 +72,7 @@ public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEdi
 
         do
         {
-            (foundItems, extension) = PropertyEditorService.MatchProperty(props);
+            (foundItems, extension) = PropertyEditorService.MatchProperty(props, extensionProvider);
             if (foundItems != null && extension != null)
             {
                 if (extension.TryCreateContextForSettings(foundItems, out IPropertyEditorContext? context))

--- a/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/AnExtensionSettingsPageViewModel.cs
@@ -2,8 +2,10 @@
 using Beutl.Api.Services;
 using Beutl.Controls.Navigation;
 using Beutl.Editor;
+using Beutl.Editor.Services;
 using Beutl.PropertyAdapters;
 using Beutl.Services;
+using Beutl.Services.Adapters;
 using Beutl.ViewModels.Editors;
 
 using DynamicData;
@@ -15,10 +17,14 @@ namespace Beutl.ViewModels.SettingsPages;
 public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEditorContextVisitor, IServiceProvider
 {
     private readonly HistoryManager _history;
+    private readonly ExtensionProvider _extensionProvider;
+    private PropertyEditorFactoryAdapter? _propertyEditorFactory;
+    private PropertiesEditorFactoryImpl? _propertiesEditorFactory;
 
     public AnExtensionSettingsPageViewModel(Extension extension, ExtensionProvider extensionProvider)
     {
         Extension = extension;
+        _extensionProvider = extensionProvider;
 
         var sequenceGenerator = new OperationSequenceGenerator();
         _history = new HistoryManager(extension.Settings!, sequenceGenerator);
@@ -44,6 +50,18 @@ public sealed class AnExtensionSettingsPageViewModel : PageContext, IPropertyEdi
         {
             return _history;
         }
+
+        // Expose the session ExtensionProvider and property-editor factories so nested object /
+        // list editors resolve them through the service chain even though this host is not an
+        // EditViewModel (the former global singleton path is gone).
+        if (serviceType == typeof(ExtensionProvider))
+            return _extensionProvider;
+
+        if (serviceType.IsAssignableTo(typeof(IPropertyEditorFactory)))
+            return _propertyEditorFactory ??= new PropertyEditorFactoryAdapter(_extensionProvider);
+
+        if (serviceType.IsAssignableTo(typeof(IPropertiesEditorFactory)))
+            return _propertiesEditorFactory ??= new PropertiesEditorFactoryImpl(_extensionProvider);
 
         return null;
     }

--- a/src/Beutl/ViewModels/SettingsPages/EditorExtensionPriorityPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/EditorExtensionPriorityPageViewModel.cs
@@ -18,9 +18,9 @@ public sealed class EditorExtensionPriorityPageViewModel : BasePageViewModel
 
     public sealed record EditorExtensionWrapper(string DisplayName, string Name, string TypeName);
 
-    public EditorExtensionPriorityPageViewModel()
+    public EditorExtensionPriorityPageViewModel(ExtensionProvider extensionProvider)
     {
-        ICoreReadOnlyList<Extension> allExtension = ExtensionProvider.Current.AllExtensions;
+        ICoreReadOnlyList<Extension> allExtension = extensionProvider.AllExtensions;
 
         var comparer = SortExpressionComparer<Extension>.Ascending(i => i.Name);
         allExtension.ToObservableChangeSet<ICoreReadOnlyList<Extension>, Extension>()
@@ -52,7 +52,7 @@ public sealed class EditorExtensionPriorityPageViewModel : BasePageViewModel
                             if (type.Type != null)
                             {
                                 Extension? ext =
-                                    ExtensionProvider.Current.AllExtensions.FirstOrDefault(item =>
+                                    extensionProvider.AllExtensions.FirstOrDefault(item =>
                                         item.GetType() == type.Type);
                                 displayName = ext?.DisplayName;
                                 name = ext?.Name;

--- a/src/Beutl/ViewModels/SettingsPages/ExtensionsSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/ExtensionsSettingsPageViewModel.cs
@@ -12,11 +12,14 @@ namespace Beutl.ViewModels.SettingsPages;
 public sealed class ExtensionsSettingsPageViewModel : PageContext, IDisposable
 {
     private readonly CompositeDisposable _disposables = [];
+    private readonly ExtensionProvider _extensionProvider;
     private EditorExtensionPriorityPageViewModel? _editorPriority;
     private DecoderPriorityPageViewModel? _decoderPriority;
 
-    public ExtensionsSettingsPageViewModel()
+    public ExtensionsSettingsPageViewModel(ExtensionProvider extensionProvider)
     {
+        _extensionProvider = extensionProvider;
+
         NavigateToEditorPriority = new AsyncReactiveCommand()
             .WithSubscribe(async () =>
             {
@@ -43,11 +46,11 @@ public sealed class ExtensionsSettingsPageViewModel : PageContext, IDisposable
                 INavigationProvider nav = await GetNavigation();
                 await nav.NavigateAsync(
                     x => x?.Extension == e,
-                    () => new AnExtensionSettingsPageViewModel(e));
+                    () => new AnExtensionSettingsPageViewModel(e, extensionProvider));
             })
             .DisposeWith(_disposables);
 
-        ICoreReadOnlyList<Extension> allExtension = ExtensionProvider.Current.AllExtensions;
+        ICoreReadOnlyList<Extension> allExtension = extensionProvider.AllExtensions;
         var comparer = SortExpressionComparer<Extension>.Ascending(i => i.Name);
         allExtension.ToObservableChangeSet<ICoreReadOnlyList<Extension>, Extension>()
             .Filter(v => v.Settings != null)
@@ -59,7 +62,7 @@ public sealed class ExtensionsSettingsPageViewModel : PageContext, IDisposable
         Extensions = extensions;
     }
 
-    public EditorExtensionPriorityPageViewModel EditorPriority => _editorPriority ??= new();
+    public EditorExtensionPriorityPageViewModel EditorPriority => _editorPriority ??= new(_extensionProvider);
 
     public DecoderPriorityPageViewModel DecoderPriority => _decoderPriority ??= new();
 

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -61,9 +61,20 @@ public class KeyMapSettingsPageViewModel : PageContext
         Group = _commandManager.GetDefinitions()
             .GroupBy(i => i.ExtensionType)
             .Select(i =>
-                new KeyMapSettingsGroup(
-                    extensionProvider.AllExtensions.First(j => j.GetType() == i.Key),
-                    i.Select(j => new KeyMapSettingsItem(j, _commandManager)).ToArray()))
+            {
+                // A command definition can name an ExtensionType that has no registered extension
+                // (e.g. a disabled plugin); skip those groups instead of throwing from First.
+                var extension = extensionProvider.AllExtensions.FirstOrDefault(j => j.GetType() == i.Key);
+                if (extension is null)
+                {
+                    return null;
+                }
+
+                return new KeyMapSettingsGroup(
+                    extension,
+                    i.Select(j => new KeyMapSettingsItem(j, _commandManager)).ToArray());
+            })
+            .OfType<KeyMapSettingsGroup>()
             .ToArray();
     }
 

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -55,14 +55,14 @@ public class KeyMapSettingsPageViewModel : PageContext
 {
     private readonly ContextCommandManager _commandManager;
 
-    public KeyMapSettingsPageViewModel(ContextCommandManager commandManager)
+    public KeyMapSettingsPageViewModel(ContextCommandManager commandManager, ExtensionProvider extensionProvider)
     {
         _commandManager = commandManager;
         Group = _commandManager.GetDefinitions()
             .GroupBy(i => i.ExtensionType)
             .Select(i =>
                 new KeyMapSettingsGroup(
-                    ExtensionProvider.Current.AllExtensions.First(j => j.GetType() == i.Key),
+                    extensionProvider.AllExtensions.First(j => j.GetType() == i.Key),
                     i.Select(j => new KeyMapSettingsItem(j, _commandManager)).ToArray()))
             .ToArray();
     }

--- a/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
@@ -118,7 +118,7 @@ public class OutputTabViewModel : IToolContext
     }
 
     // Exposes the editor session's output extensions (filtered for the scene type) so views and
-    // dialogs that hold this tab VM can reach them without the removed ExtensionProvider.Current.
+    // dialogs that hold this tab VM can reach them.
     public OutputExtension[] GetExtensions(Type type)
     {
         return _outputService.GetExtensions(type);

--- a/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
@@ -117,12 +117,19 @@ public class OutputTabViewModel : IToolContext
         }
     }
 
+    // Exposes the editor session's output extensions (filtered for the scene type) so views and
+    // dialogs that hold this tab VM can reach them without the removed ExtensionProvider.Current.
+    public OutputExtension[] GetExtensions(Type type)
+    {
+        return _outputService.GetExtensions(type);
+    }
+
     private void CreateDefaultProfile()
     {
         if (Items.Count != 0) return;
 
         _logger.LogInformation("Creating default profile.");
-        var ext = OutputService.GetExtensions(EditViewModel.Scene.GetType());
+        var ext = _outputService.GetExtensions(EditViewModel.Scene.GetType());
         if (ext.Length == 1)
         {
             AddItem(ext[0]);

--- a/src/Beutl/ViewModels/Tools/OutputViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputViewModel.cs
@@ -70,7 +70,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
                 s.SourceSize = Model.FrameSize;
                 s.DestinationSize = Model.FrameSize;
-                return new EncoderSettingsViewModel(s);
+                return new EncoderSettingsViewModel(s, _editViewModel.ExtensionProvider);
             })
             .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
@@ -78,7 +78,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
         AudioSettings = Controller.Select(c => c?.AudioSettings)
             .DistinctUntilChanged()
-            .Select(s => s == null ? null : new EncoderSettingsViewModel(s))
+            .Select(s => s == null ? null : new EncoderSettingsViewModel(s, _editViewModel.ExtensionProvider))
             .DisposePreviousValue()
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposable);
@@ -103,7 +103,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposable);
 
-        ExtensionProvider.Current
+        _editViewModel.ExtensionProvider
             .GetExtensions<ControllableEncodingExtension>()
             .AsObservableChangeSet()
             .Filter(DestinationFile.Select<string?, Func<ControllableEncodingExtension, bool>>(f => f == null
@@ -189,7 +189,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
 
     public event EventHandler? Finished;
 
-    public static FilePickerFileType[] GetFilePickerFileTypes()
+    public FilePickerFileType[] GetFilePickerFileTypes()
     {
         static string[] ToPatterns(ControllableEncodingExtension encoder)
         {
@@ -215,7 +215,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
                 .ToArray();
         }
 
-        return ExtensionProvider.Current
+        return _editViewModel.ExtensionProvider
             .GetExtensions<ControllableEncodingExtension>()
             .Select(x => new FilePickerFileType(x.Name) { Patterns = ToPatterns(x) })
             .ToArray();
@@ -537,9 +537,9 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
         }
     }
 
-    private static void ClearEditViewModelCaches()
+    private void ClearEditViewModelCaches()
     {
-        foreach (EditorTabItem item in EditorService.Current.TabItems)
+        foreach (EditorTabItem item in _editViewModel.EditorService.TabItems)
         {
             if (item.Context.Value is EditViewModel editViewModel)
             {
@@ -674,7 +674,7 @@ public sealed class OutputViewModel : IOutputContext, ISupportOutputPreset
             && encoderNode is JsonValue encoderValue
             && encoderValue.TryGetValue(out string? encoderStr)
             && TypeFormat.ToType(encoderStr) is { } encoderType
-            && ExtensionProvider.Current.GetExtensions<ControllableEncodingExtension>()
+            && _editViewModel.ExtensionProvider.GetExtensions<ControllableEncodingExtension>()
                 .FirstOrDefault(x => x.GetType() == encoderType) is { } encoder)
         {
             SelectedEncoder.Value = encoder;

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -18,9 +18,6 @@
                   PrimaryButtonText="{x:Static lang:Strings.Back}"
                   SecondaryButtonText="{x:Static lang:Strings.Next}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.DataContext>
-        <vm:CreateNewProjectViewModel />
-    </ui:ContentDialog.DataContext>
     <Carousel x:Name="carousel">
         <Carousel.Items>
             <StackPanel Spacing="8">

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml
@@ -18,9 +18,6 @@
                   PrimaryButtonCommand="{CompiledBinding Create}"
                   PrimaryButtonText="{x:Static lang:Strings.CreateNew}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.DataContext>
-        <vm:CreateNewSceneViewModel />
-    </ui:ContentDialog.DataContext>
     <StackPanel Spacing="8">
         <TextBlock Text="{x:Static lang:Strings.Name}" />
         <TextBox InputMethod.IsInputMethodEnabled="True" Text="{CompiledBinding Name.Value, Mode=TwoWay}" />

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -149,13 +149,13 @@ public sealed partial class MacWindow : Window
         if (viewMenuItem == null || editorTabMenu == null || toolTabMenu == null || toolWindowMenu == null) return;
 
         // ToolTabExtensionをメニューに表示する
-        static NativeMenuItem CreateToolTabMenuItem(ToolTabExtension item)
+        NativeMenuItem CreateToolTabMenuItem(ToolTabExtension item)
         {
             var menuItem = new NativeMenuItem() { Header = item.Header, CommandParameter = item };
 
             menuItem.Click += (s, e) =>
             {
-                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
+                if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
                     && s is NativeMenuItem { CommandParameter: ToolTabExtension ext }
                     && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
                 {
@@ -183,7 +183,7 @@ public sealed partial class MacWindow : Window
             toolTabMenu.Items.Clear);
 
         // EditorExtensionをメニューに表示する
-        static NativeMenuItem CreateEditorMenuItem(EditorExtension item)
+        NativeMenuItem CreateEditorMenuItem(EditorExtension item)
         {
             var menuItem = new NativeMenuItem()
             {
@@ -196,7 +196,7 @@ public sealed partial class MacWindow : Window
 
             menuItem.Click += async (s, e) =>
             {
-                EditorTabItem? selectedTab = EditorService.Current.SelectedTabItem.Value;
+                EditorTabItem? selectedTab = viewModel.EditorService.SelectedTabItem.Value;
                 if (s is NativeMenuItem { CommandParameter: EditorExtension editorExtension } menuItem
                     && selectedTab != null)
                 {
@@ -206,7 +206,10 @@ public sealed partial class MacWindow : Window
                         await commands.OnSave();
                     }
 
-                    if (editorExtension.TryCreateContext(selectedTab.Context.Value.Object, out IEditorContext? context))
+                    if (editorExtension.TryCreateContext(
+                            selectedTab.Context.Value.Object,
+                            new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
+                            out IEditorContext? context))
                     {
                         selectedTab.Context.Value.Dispose();
                         selectedTab.Context.Value = context;
@@ -239,7 +242,7 @@ public sealed partial class MacWindow : Window
 
         viewMenuItem.Menu!.Opening += (s, e) =>
         {
-            EditorTabItem? selectedTab = EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? selectedTab = viewModel.EditorService.SelectedTabItem.Value;
             if (selectedTab != null)
             {
                 foreach (NativeMenuItem item in list2.OfType<NativeMenuItem>())

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -12,6 +12,7 @@ using Beutl.Models;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Beutl.ViewModels;
+using Beutl.ViewModels.Dialogs;
 using Beutl.Views.Dialogs;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,6 +32,7 @@ public partial class MainView
         viewModel.MenuBar.CreateNewProject.Subscribe(async () =>
         {
             var dialog = new CreateNewProject();
+            dialog.DataContext = new CreateNewProjectViewModel(viewModel.ProjectService);
             await dialog.ShowAsync();
         }).AddTo(_disposables);
 
@@ -42,6 +44,7 @@ public partial class MainView
         viewModel.MenuBar.NewScene.Subscribe(async () =>
         {
             var dialog = new CreateNewScene();
+            dialog.DataContext = new CreateNewSceneViewModel(viewModel.ProjectService, viewModel.EditorService);
             await dialog.ShowAsync();
         }).AddTo(_disposables);
 
@@ -96,9 +99,10 @@ public partial class MainView
             .AddTo(_disposables);
     }
 
-    private static bool TryGetSelectedEditViewModel([NotNullWhen(true)] out EditViewModel? viewModel)
+    private bool TryGetSelectedEditViewModel([NotNullWhen(true)] out EditViewModel? viewModel)
     {
-        if (EditorService.Current.SelectedTabItem.Value?.Context.Value is EditViewModel editViewModel)
+        if (DataContext is not MainViewModel mv) { viewModel = null; return false; }
+        if (mv.EditorService.SelectedTabItem.Value?.Context.Value is EditViewModel editViewModel)
         {
             viewModel = editViewModel;
             return true;
@@ -134,10 +138,11 @@ public partial class MainView
         }
     }
 
-    private static async void OnRemoveFromProject(EditorTabItem? item)
+    private async void OnRemoveFromProject(EditorTabItem? item)
     {
-        Project? project = ProjectService.Current.CurrentProject.Value;
-        EditorTabItem? selectedTabItem = item ?? EditorService.Current.SelectedTabItem.Value;
+        if (DataContext is not MainViewModel mv) return;
+        Project? project = mv.ProjectService.CurrentProject.Value;
+        EditorTabItem? selectedTabItem = item ?? mv.EditorService.SelectedTabItem.Value;
 
         if (project != null && selectedTabItem != null)
         {
@@ -179,7 +184,7 @@ public partial class MainView
 
         var filters = new List<FilePickerFileType>();
 
-        filters.AddRange(ExtensionProvider.Current.GetExtensions<EditorExtension>()
+        filters.AddRange(viewModel.ExtensionProvider.GetExtensions<EditorExtension>()
             .Select(e => e.GetFilePickerFileType())
             .ToArray());
         var options = new FilePickerOpenOptions { AllowMultiple = true, FileTypeFilter = filters };
@@ -191,7 +196,7 @@ public partial class MainView
             {
                 if (file.TryGetLocalPath() is { } path)
                 {
-                    MenuBarViewModel.OpenFileCore(path);
+                    viewModel.MenuBar.OpenFileCore(path);
                 }
             }
         }
@@ -216,7 +221,7 @@ public partial class MainView
             if (result.Count > 0
                 && result[0].TryGetLocalPath() is string localPath)
             {
-                await ProjectService.Current.OpenProject(localPath);
+                if (DataContext is MainViewModel mv) await mv.ProjectService.OpenProject(localPath);
             }
         }
     }
@@ -228,7 +233,8 @@ public partial class MainView
             return;
         }
 
-        Project? project = ProjectService.Current.CurrentProject.Value;
+        if (DataContext is not MainViewModel exportVm) return;
+        Project? project = exportVm.ProjectService.CurrentProject.Value;
         if (project?.Uri == null)
         {
             return;
@@ -344,7 +350,7 @@ public partial class MainView
 
             if (project?.Uri != null)
             {
-                await ProjectService.Current.OpenProject(project.Uri.LocalPath);
+                if (DataContext is MainViewModel importVm) await importVm.ProjectService.OpenProject(project.Uri.LocalPath);
                 NotificationService.ShowSuccess(Strings.ImportProject, MessageStrings.OperationCompletedSuccessfully);
             }
             else

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -167,13 +167,13 @@ public sealed partial class MainView : UserControl
     private void InitExtMenuItems(MainViewModel viewModel)
     {
         // ToolTabExtensionをメニューに表示する
-        static MenuItem CreateToolTabMenuItem(ToolTabExtension item)
+        MenuItem CreateToolTabMenuItem(ToolTabExtension item)
         {
             var menuItem = new MenuItem() { Header = item.Header, DataContext = item };
 
             menuItem.Click += (s, e) =>
             {
-                if (EditorService.Current.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
+                if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
                     && s is MenuItem { DataContext: ToolTabExtension ext }
                     && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
                 {
@@ -199,7 +199,7 @@ public sealed partial class MainView : UserControl
         toolTabMenuItem.ItemsSource = list1;
 
         // EditorExtensionをメニューに表示する
-        static MenuItem CreateEditorMenuItem(EditorExtension item)
+        MenuItem CreateEditorMenuItem(EditorExtension item)
         {
             var menuItem = new MenuItem()
             {
@@ -211,7 +211,7 @@ public sealed partial class MainView : UserControl
 
             menuItem.Click += async (s, e) =>
             {
-                EditorTabItem? selectedTab = EditorService.Current.SelectedTabItem.Value;
+                EditorTabItem? selectedTab = viewModel.EditorService.SelectedTabItem.Value;
                 if (s is MenuItem { DataContext: EditorExtension editorExtension } menuItem
                     && selectedTab != null)
                 {
@@ -221,7 +221,10 @@ public sealed partial class MainView : UserControl
                         await commands.OnSave();
                     }
 
-                    if (editorExtension.TryCreateContext(selectedTab.Context.Value.Object, out IEditorContext? context))
+                    if (editorExtension.TryCreateContext(
+                            selectedTab.Context.Value.Object,
+                            new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
+                            out IEditorContext? context))
                     {
                         selectedTab.Context.Value.Dispose();
                         selectedTab.Context.Value = context;
@@ -252,7 +255,7 @@ public sealed partial class MainView : UserControl
 
         viewMenuItem.SubmenuOpened += (s, e) =>
         {
-            EditorTabItem? selectedTab = EditorService.Current.SelectedTabItem.Value;
+            EditorTabItem? selectedTab = viewModel.EditorService.SelectedTabItem.Value;
             if (selectedTab != null)
             {
                 foreach (MenuItem item in list2.OfType<MenuItem>())

--- a/src/Beutl/Views/Tools/OutputTab.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputTab.axaml.cs
@@ -29,7 +29,7 @@ public partial class OutputTab : UserControl
     {
         if (DataContext is not OutputTabViewModel viewModel) return;
 
-        var ext = OutputService.GetExtensions(viewModel.EditViewModel.Scene.GetType());
+        var ext = viewModel.GetExtensions(viewModel.EditViewModel.Scene.GetType());
         if (ext.Length == 1)
         {
             viewModel.AddItem(ext[0]);

--- a/src/Beutl/Views/Tools/OutputView.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputView.axaml.cs
@@ -20,7 +20,7 @@ public partial class OutputView : UserControl
         {
             var options = new FilePickerSaveOptions()
             {
-                FileTypeChoices = OutputViewModel.GetFilePickerFileTypes()
+                FileTypeChoices = viewModel.GetFilePickerFileTypes()
             };
             IStorageFile? file = await topLevel.StorageProvider.SaveFilePickerAsync(options);
 

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -19,4 +19,20 @@ public sealed class BeutlApiApplicationTests
         Assert.That(registeredProvider, Is.SameAs(extensionProvider));
         Assert.That(packageManager.ExtensionProvider, Is.SameAs(extensionProvider));
     }
+
+    [Test]
+    public void Constructor_NullHttpClient_Throws()
+    {
+        var extensionProvider = new ExtensionProvider();
+
+        Assert.Throws<ArgumentNullException>(() => _ = new BeutlApiApplication(null!, extensionProvider));
+    }
+
+    [Test]
+    public void Constructor_NullExtensionProvider_Throws()
+    {
+        using var httpClient = new HttpClient();
+
+        Assert.Throws<ArgumentNullException>(() => _ = new BeutlApiApplication(httpClient, null!));
+    }
 }

--- a/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
+++ b/tests/Beutl.UnitTests/Api/BeutlApiApplicationTests.cs
@@ -1,0 +1,22 @@
+﻿using Beutl.Api;
+using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class BeutlApiApplicationTests
+{
+    [Test]
+    public void Constructor_RegistersProvidedExtensionProvider()
+    {
+        using var httpClient = new HttpClient();
+        var extensionProvider = new ExtensionProvider();
+        var app = new BeutlApiApplication(httpClient, extensionProvider);
+
+        ExtensionProvider registeredProvider = app.GetResource<ExtensionProvider>();
+        PackageManager packageManager = app.GetResource<PackageManager>();
+
+        Assert.That(registeredProvider, Is.SameAs(extensionProvider));
+        Assert.That(packageManager.ExtensionProvider, Is.SameAs(extensionProvider));
+    }
+}

--- a/tests/Beutl.UnitTests/Api/ExtensionProviderTests.cs
+++ b/tests/Beutl.UnitTests/Api/ExtensionProviderTests.cs
@@ -1,0 +1,58 @@
+﻿using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public sealed class ExtensionProviderTests
+{
+    private sealed class StubExtension : Extension;
+
+    private sealed class OtherStubExtension : Extension;
+
+    [Test]
+    public void ExtensionProvider_ImplementsIExtensionProvider()
+    {
+        var provider = new ExtensionProvider();
+
+        Assert.That(provider, Is.InstanceOf<IExtensionProvider>());
+    }
+
+    [Test]
+    public void IExtensionProvider_AllExtensions_ReflectsAddedExtensions()
+    {
+        var provider = new ExtensionProvider();
+        IExtensionProvider abstraction = provider;
+
+        Assert.That(abstraction.AllExtensions, Is.Empty);
+
+        var ext = new StubExtension();
+        provider.AddExtensions(1, [ext]);
+
+        Assert.That(abstraction.AllExtensions, Has.Member(ext));
+    }
+
+    [Test]
+    public void IExtensionProvider_GetExtensions_FiltersByType()
+    {
+        var provider = new ExtensionProvider();
+        IExtensionProvider abstraction = provider;
+
+        var first = new StubExtension();
+        var second = new OtherStubExtension();
+        provider.AddExtensions(1, [first]);
+        provider.AddExtensions(2, [second]);
+
+        StubExtension[] matched = abstraction.GetExtensions<StubExtension>();
+
+        Assert.That(matched, Is.EquivalentTo(new[] { first }));
+    }
+
+    [Test]
+    public void IExtensionProvider_MatchEditorExtension_ReturnsNullForUnknownFile()
+    {
+        IExtensionProvider abstraction = new ExtensionProvider();
+
+        Assert.That(abstraction.MatchEditorExtension("unknown.bogus"), Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\src\Beutl.Editor.Components\Beutl.Editor.Components.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Configuration\Beutl.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
Replaces the global `ProjectService.Current`, `EditorService.Current`, and `ExtensionProvider.Current` singletons with constructor injection threaded from the composition roots.

- `MainViewModel` (and `Beutl.PackageTools.UI`'s `MainViewModel`) own the instances and thread them into child view models, services, views (via `DataContext`), startup tasks (`Startup` -> `LoadPrimitiveExtensionTask` / `RestoreLastProjectTask`), settings pages, and the per-editor tier (`EditViewModel` -> `DockHostViewModel` / `OutputViewModel` / `OutputService` / property editors).
- `BeutlApiApplication` receives its `ExtensionProvider` from the composition root instead of resolving `ExtensionProvider.Current` internally.
- Editor contexts are created without globals: `EditorExtension.TryCreateContext` now receives a typed `IEditorContextServices` — a new host-services seam in `Beutl.Extensibility` exposing `IExtensionProvider`. `ExtensionProvider` implements `IExtensionProvider`.
- The built-in tutorials receive their services through `DefaultTutorialExtension`'s constructor (built by `LoadPrimitiveExtensionTask`); its static `Instance` is removed.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
1. `EditorExtension.TryCreateContext` gains an `IEditorContextServices` parameter:
   `TryCreateContext(CoreObject obj, IEditorContextServices services, out IEditorContext? context)`.
   Implementations must add the parameter; those that need no host services may ignore it. Use `services.ExtensionProvider` (`IExtensionProvider`) to query other extensions.
2. `BeutlApiApplication(HttpClient)` was replaced with `BeutlApiApplication(HttpClient, ExtensionProvider)`. Callers must pass the provider from their composition root.
3. `ProjectService.Current`, `EditorService.Current`, and `ExtensionProvider.Current` are removed. Obtain these services via constructor injection / `IEditorContext.GetRequiredService<...>` instead.

## Test plan
- `dotnet build Beutl.slnx` -> 0 errors.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0` -> 3670 passed, no regressions. (3 `AutoSaveServiceTests` cases fail only on Windows local: `CoreSerializer.StoreToUri` auto-creates the target directory, so a save to a "non-existent" path succeeds and emits no `SaveError`. On the Linux CI runner the root path is not creatable, so they pass. Pre-existing and unrelated to this change.)
- New coverage: `tests/Beutl.UnitTests/Api/ExtensionProviderTests.cs` (new) and extended `BeutlApiApplicationTests.cs`.
- `dotnet format Beutl.slnx --verify-no-changes` over the changed set -> clean (after restoring UTF-8 BOM on 5 files that lost it during editing).

## Fixed issues / References
- Project board: b-editor/projects/9 ("設計改善: グローバル singleton / service locator を減らす")
- The earlier follow-up "continue moving remaining `*.Current` use sites toward composition-root injection" is completed by this PR (all three statics removed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor extensions can now receive host-provided services when creating editor contexts.
  * Extension-related settings and the command palette now consistently reflect the extensions currently available.
* **Bug Fixes**
  * Improved project/editor/package workflows by removing reliance on shared global state, making open/restore and extension matching more reliable.
  * Fixed prefetch handling for out-of-order chunk requests to prevent inconsistent streaming behavior.
* **Style**
  * Cleaned up dialog/view DataContext usage to rely on externally provided view models.
* **Tests**
  * Added unit tests for extension provider behavior and constructor argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->