### PR TITLE
fix(ffmpeg): avoid -22 Invalid argument on seek past EOF

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegFrameValidation.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegFrameValidation.cs
@@ -1,0 +1,17 @@
+﻿#if BEUTL_FFMPEG_WORKER
+namespace Beutl.FFmpegWorker.Decoding;
+#else
+namespace Beutl.Extensions.FFmpeg.Decoding;
+#endif
+
+internal static class FFmpegFrameValidation
+{
+    // AV_PIX_FMT_NONE. A decode that ends on EAGAIN/EOF leaves the frame unreferenced
+    // (avcodec_receive_frame unrefs before output), resetting format here and size to 0.
+    private const int PixelFormatNone = -1;
+
+    // Such an unreferenced frame makes FFmpeg's buffersrc fail with AVERROR(EINVAL)
+    // ("Unspecified pixel format"), so callers must drop it rather than build a graph from it.
+    public static bool IsUsableVideoFrame(int pixelFormat, int width, int height)
+        => pixelFormat != PixelFormatNone && width > 0 && height > 0;
+}

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -32,6 +32,7 @@
     <Compile Include="..\Beutl.Extensions.FFmpeg\Encoding\FFmpegVideoEncoderSettings.cs" Link="Linked\FFmpegVideoEncoderSettings.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Encoding\FFmpegAudioEncoderSettings.cs" Link="Linked\FFmpegAudioEncoderSettings.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegDecodingSettings.cs" Link="Linked\FFmpegDecodingSettings.cs" />
+    <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegFrameValidation.cs" Link="Linked\FFmpegFrameValidation.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -350,7 +350,14 @@ public sealed class FFmpegReader : MediaReader
             return null;
 
         long skip = frame - _videoNowFrame;
-        if (skip > 100 || skip < 0)
+
+        // If the previous grab left the active frame unreferenced (a seek/grab that could not
+        // reach a decodable frame), _videoNowFrame no longer describes a usable frame, so `skip`
+        // (which can be 0) must not be trusted — force a fresh seek so a later in-range request
+        // recovers the frame instead of repeatedly returning the empty one.
+        bool currentUsable =
+            FFmpegFrameValidation.IsUsableVideoFrame(videoFrame.Format, videoFrame.Width, videoFrame.Height);
+        if (!currentUsable || skip > 100 || skip < 0)
         {
             SeekVideo(frame);
             skip = 0;
@@ -365,6 +372,12 @@ public sealed class FFmpegReader : MediaReader
         // GrabVideo後にActiveVideoFrameを再取得
         videoFrame = ActiveVideoFrame;
         if (videoFrame == null)
+            return null;
+
+        // A seek/grab that could not reach a decodable frame (e.g. the target is at or past
+        // EOF) leaves the frame unreferenced by avcodec_receive_frame. Drop it instead of
+        // feeding AV_PIX_FMT_NONE to the buffer source, which would throw AVERROR(EINVAL).
+        if (!FFmpegFrameValidation.IsUsableVideoFrame(videoFrame.Format, videoFrame.Width, videoFrame.Height))
             return null;
 
         // AVFilterグラフを初期化（入力パラメータ変更時のみ再構築）
@@ -395,6 +408,13 @@ public sealed class FFmpegReader : MediaReader
         // 入力パラメータが変わっていなければ再構築不要
         if (_filterGraph != null && _filterWidth == width && _filterHeight == height && _filterSrcPixFmt == srcPixFmt)
             return;
+
+        // Invalidate the cache before rebuilding so that if the build below throws, the next
+        // call rebuilds from scratch instead of matching a stale cache and reusing a
+        // half-initialised graph.
+        _filterWidth = 0;
+        _filterHeight = 0;
+        _filterSrcPixFmt = AVPixelFormat.AV_PIX_FMT_NONE;
 
         _filterGraph?.Dispose();
 

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -355,7 +355,6 @@ internal sealed class VideoRingBuffer : IDisposable
                         {
                             var destination = new Span<byte>(pfPtr + slotOffset, (int)_slotSize);
 
-                            // スロットに収まる範囲でデコードできたときのみ書き込む
                             if (_reader.ReadVideo(nextFrame, destination, out var pfInfo)
                                 && pfInfo.DataLength <= _slotSize)
                             {

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -335,6 +335,7 @@ internal sealed class VideoRingBuffer : IDisposable
                     // 既にキャッシュ済みならスキップ
                     if (FindSlot(nextFrame) >= 0) continue;
 
+                    bool decodedAhead = false;
                     _readerLock.Wait(ct);
                     try
                     {
@@ -354,15 +355,15 @@ internal sealed class VideoRingBuffer : IDisposable
                         {
                             var destination = new Span<byte>(pfPtr + slotOffset, (int)_slotSize);
 
-                            if (!_reader.ReadVideo(nextFrame, destination, out var pfInfo))
-                                continue;
-
-                            if (pfInfo.DataLength > _slotSize)
-                                continue; // スロットに収まらない場合はスキップ
-
-                            _slots[writeSlot] = SlotMetadata.FromFrameInfo(nextFrame, pfInfo);
-                            _slotFrameNumbers[writeSlot] = nextFrame;
-                            _nextWriteSlot = (writeSlot + 1) % _slotCount;
+                            // スロットに収まる範囲でデコードできたときのみ書き込む
+                            if (_reader.ReadVideo(nextFrame, destination, out var pfInfo)
+                                && pfInfo.DataLength <= _slotSize)
+                            {
+                                _slots[writeSlot] = SlotMetadata.FromFrameInfo(nextFrame, pfInfo);
+                                _slotFrameNumbers[writeSlot] = nextFrame;
+                                _nextWriteSlot = (writeSlot + 1) % _slotCount;
+                                decodedAhead = true;
+                            }
                         }
                         finally
                         {
@@ -372,6 +373,15 @@ internal sealed class VideoRingBuffer : IDisposable
                     finally
                     {
                         _readerLock.Release();
+                    }
+
+                    if (!decodedAhead)
+                    {
+                        // Could not decode/store the next frame (EOF, undecodable, or larger than the
+                        // slot). Wait for the next request instead of busy-retrying the same uncached
+                        // frame, which would otherwise spin a CPU core under the reader lock.
+                        _prefetchSignal.Wait(ct);
+                        _prefetchSignal.Reset();
                     }
                 }
             }

--- a/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
+++ b/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
@@ -23,6 +23,7 @@
        FFmpeg direct-call types have moved to Beutl.FFmpegWorker; settings types remain in the extension. -->
   <ItemGroup>
     <Compile Include="..\..\src\Beutl.FFmpegWorker\Decoding\FFmpegReader.cs" Link="Linked\FFmpegReader.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegFrameValidation.cs" Link="Linked\FFmpegFrameValidation.cs" />
     <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegDecodingSettings.cs" Link="Linked\FFmpegDecodingSettings.cs" />
     <Compile Include="..\..\src\Beutl.FFmpegWorker\ColorSpaceHelper.cs" Link="Linked\ColorSpaceHelper.cs" />
   </ItemGroup>

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegFrameValidationTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegFrameValidationTests.cs
@@ -1,0 +1,26 @@
+﻿using Beutl.Extensions.FFmpeg.Decoding;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegFrameValidationTests
+{
+    [TestCase(0, 1920, 1080)] // AV_PIX_FMT_YUV420P
+    [TestCase(2, 2560, 1440)] // AV_PIX_FMT_RGB24
+    [TestCase(0, 1, 1)]
+    public void IsUsableVideoFrame_True_ForDecodedFrame(int pixelFormat, int width, int height)
+    {
+        Assert.That(FFmpegFrameValidation.IsUsableVideoFrame(pixelFormat, width, height), Is.True);
+    }
+
+    [TestCase(-1, 2560, 1440)] // AV_PIX_FMT_NONE: unreferenced after EAGAIN/EOF
+    [TestCase(-1, 0, 0)]
+    [TestCase(0, 0, 1080)]
+    [TestCase(0, 1920, 0)]
+    [TestCase(0, -1, 1080)]
+    [TestCase(0, 1920, -1)]
+    public void IsUsableVideoFrame_False_ForUnusableFrame(int pixelFormat, int width, int height)
+    {
+        Assert.That(FFmpegFrameValidation.IsUsableVideoFrame(pixelFormat, width, height), Is.False);
+    }
+}


### PR DESCRIPTION
## Description
- Fixes a UI-facing crash where seeking the playhead to a frame at or past a clip's EOF threw `FFmpeg error [-22] Invalid argument` (`[buffer] [error] Unspecified pixel format`) from the FFmpeg worker, propagated across IPC to `PlayerViewModel`.
- Root cause: a failed seek/grab leaves the reused video frame unreferenced (`avcodec_receive_frame` unrefs before returning EAGAIN/EOF), so its pixel format becomes `AV_PIX_FMT_NONE` and size becomes 0. `ReadVideoCore` only null-checked the frame object and handed the empty frame to `InitFilterGraph`, whose `buffersrc` rejected the unspecified pixel format with `AVERROR(EINVAL)`.

Changes:
- `FFmpegFrameValidation.IsUsableVideoFrame` — shared predicate added to MIT `Beutl.Extensions.FFmpeg`, compiled into the GPL worker via the existing `<Compile Link>` + `#if BEUTL_FFMPEG_WORKER` switch (stays unit-testable across the boundary).
- `FFmpegReader.ReadVideoCore` — drop unusable frames before building the graph, and force a re-seek when the current frame is unusable so a later in-range request recovers it (stale `_videoNowFrame` after a failed grab).
- `FFmpegReader.InitFilterGraph` — invalidate the filter-graph cache up-front so a throw during rebuild can't reuse a half-built graph.
- `VideoRingBuffer.StartPrefetch` — wait for the next request instead of busy-retrying an undecodable frame (prevented a CPU spin under the reader lock near EOF when the container frame count over-reports decodable frames).

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Internal worker behavior only; no public API or IPC contract change.

## Test plan
- Added `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegFrameValidationTests.cs` (9 cases) pinning `IsUsableVideoFrame` for `AV_PIX_FMT_NONE` and zero/negative dimensions, reached across the GPL/MIT boundary via the existing `InternalsVisibleTo`.
- Build: `dotnet build src/Beutl.FFmpegWorker -f net10.0` → 0 errors / 0 warnings; predicate tests 9/9 pass; `dotnet format --verify-no-changes` clean.
- Manual repro: open a project and seek the playhead to a frame at/past a clip's EOF (original report: frame 922 on a 2560x1440 clip). Before: `FFmpeg error [-22] Invalid argument` per frame. After: no crash — the last valid frame renders and out-of-range positions degrade to a transparent frame.

## Fixed issues / References
None (reported via runtime log: `FFmpeg error [-22] Invalid argument`).

## Follow-ups
- No end-to-end seek-past-EOF regression test for `ReadVideoCore` / `VideoRingBuffer` prefetch: it requires spawning the GPL worker with real FFmpeg natives plus a clip whose container frame count over-reports decodable frames (high-cost / flaky). The drop-path, forced re-seek, prefetch convergence, and cache invalidation are covered indirectly by the predicate unit test plus the manual frame=922 repro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable video frame usability check to help ensure only valid decoded frames are processed.
* **Bug Fixes**
  * Improved video frame validation during frame reuse/seeking to avoid returning invalid or unusable frames.
  * Updated prefetching behavior to prevent tight retry/spin when a decoded frame can’t be stored or used.
  * Fixed filter graph caching to avoid reusing stale or partially initialized configurations if rebuild fails.
* **Tests**
  * Added unit tests covering valid and invalid frame dimension/pixel-format combinations for the new validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->