### PR TITLE
fix(mediafoundation): dispose MFDecoder on init failure

### DIFF
--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -97,11 +97,13 @@ internal sealed class MFDecoder : IDisposable
         }
         catch (NoVideoStreamException)
         {
+            DisposeAfterInitializationFailure();
             throw;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception occurred during initialization of the video stream.");
+            DisposeAfterInitializationFailure();
             throw;
         }
     }
@@ -451,6 +453,18 @@ internal sealed class MFDecoder : IDisposable
 
         _firstGapTimeStamp = firstVideoTimeStamp;
         _logger.LogInformation("TestFirstReadSample - firstGapTimeStamp: {firstGapTimeStamp}", _firstGapTimeStamp);
+    }
+
+    private void DisposeAfterInitializationFailure()
+    {
+        try
+        {
+            Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispose Media Foundation decoder resources after initialization failure.");
+        }
     }
 
     public void Dispose()

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -401,7 +401,7 @@ internal sealed class MFDecoder : IDisposable
         {
             BitmapInfoHeader bih = default;
 
-            IMFMediaType mediaType = sourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
+            using IMFMediaType mediaType = sourceReader.GetCurrentMediaType(_mediaInfo.VideoStreamIndex);
 
             MediaFactory.MFCreateMFVideoFormatFromMFMediaType(mediaType, out IntPtr pMFVF, out var pcbSize);
             var ppMFVF = (MFVIDEOFORMAT*)pMFVF;

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
@@ -40,9 +40,17 @@ public class MFDecoderLifecycleTests
     [OneTimeTearDown]
     public void OneTimeTearDown()
     {
-        if (OperatingSystem.IsWindows())
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
         {
             MediaFactory.MFShutdown();
+        }
+        finally
+        {
             SharpGen.Runtime.Configuration.EnableObjectTracking = _prevEnableObjectTracking;
             SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = _prevEnableReleaseOnFinalizer;
             SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = _prevUseThreadStaticObjectTracking;

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
@@ -14,9 +14,6 @@ namespace Beutl.Extensions.MediaFoundation.Tests;
 public class MFDecoderLifecycleTests
 {
     private string _workDir = string.Empty;
-    private bool _prevEnableObjectTracking;
-    private bool _prevEnableReleaseOnFinalizer;
-    private bool _prevUseThreadStaticObjectTracking;
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
@@ -26,11 +23,11 @@ public class MFDecoderLifecycleTests
             Assert.Ignore("Media Foundation is only available on Windows.");
         }
 
-        // Enable tracking before the baseline count below — the MFDecoder ctor sets these same flags
-        // but too late to count the wrappers it creates. Process-global statics, so capture/restore.
-        _prevEnableObjectTracking = SharpGen.Runtime.Configuration.EnableObjectTracking;
-        _prevEnableReleaseOnFinalizer = SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer;
-        _prevUseThreadStaticObjectTracking = SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking;
+        // SharpGen's Configuration is a process-global that becomes immutable on first use (the first
+        // COM wrapper / ObjectTracker access). Enable tracking here, before this fixture creates any
+        // Media Foundation COM object, so the baseline count sees the wrappers the MFDecoder ctor
+        // creates — the ctor sets the same flags, but too late to count its own wrappers. These flags
+        // are one-way switches that cannot be restored afterwards, so OneTimeTearDown leaves them as-is.
         SharpGen.Runtime.Configuration.EnableObjectTracking = true;
         SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = true;
         SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = true;
@@ -45,16 +42,10 @@ public class MFDecoderLifecycleTests
             return;
         }
 
-        try
-        {
-            MediaFactory.MFShutdown();
-        }
-        finally
-        {
-            SharpGen.Runtime.Configuration.EnableObjectTracking = _prevEnableObjectTracking;
-            SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = _prevEnableReleaseOnFinalizer;
-            SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = _prevUseThreadStaticObjectTracking;
-        }
+        // The SharpGen tracking flags enabled in OneTimeSetUp cannot be restored: Configuration is
+        // immutable once a COM object has been created, so assigning them again throws. They are
+        // process-global one-way switches; just shut Media Foundation down.
+        MediaFactory.MFShutdown();
     }
 
     [SetUp]

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
@@ -1,0 +1,131 @@
+﻿using System.Runtime.Versioning;
+using Beutl.Embedding.MediaFoundation.Decoding;
+using Beutl.Media.Decoding;
+using SharpGen.Runtime;
+using SharpGen.Runtime.Diagnostics;
+using Vortice.MediaFoundation;
+
+namespace Beutl.Extensions.MediaFoundation.Tests;
+
+[TestFixture]
+[Platform("Win")]
+[NonParallelizable]
+[SupportedOSPlatform("windows")]
+public class MFDecoderLifecycleTests
+{
+    private string _workDir = string.Empty;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Media Foundation is only available on Windows.");
+        }
+
+        SharpGen.Runtime.Configuration.EnableObjectTracking = true;
+        SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = true;
+        SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = true;
+        MediaFactory.MFStartup();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            MediaFactory.MFShutdown();
+        }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), "beutl-mf-lifecycle-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            Directory.Delete(_workDir, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Test]
+    public void Constructor_NoVideoStream_DisposesPartiallyCreatedComObjects()
+    {
+        string wav = WriteSineWav();
+        int before = CountTrackedMediaFoundationObjects();
+
+        Assert.Throws<NoVideoStreamException>(() =>
+            _ = new MFDecoder(wav, new MediaOptions(MediaMode.Video), new MFDecodingExtension()));
+
+        int after = CountTrackedMediaFoundationObjects();
+        Assert.That(after, Is.EqualTo(before),
+            "MFDecoder must deterministically dispose COM wrappers created before constructor failure.");
+    }
+
+    private static int CountTrackedMediaFoundationObjects()
+    {
+        int count = 0;
+        foreach (WeakReference<CppObject> reference in ObjectTracker.FindActiveObjects())
+        {
+            if (reference.TryGetTarget(out CppObject? target)
+                && target.GetType().Namespace?.StartsWith("Vortice.MediaFoundation", StringComparison.Ordinal) == true)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private string WriteSineWav(int sampleRate = 44100, int channels = 2, double seconds = 0.2)
+    {
+        string path = Path.Combine(_workDir, "audio.wav");
+
+        const short bitsPerSample = 16;
+        int totalFrames = (int)(sampleRate * seconds);
+        short blockAlign = (short)(channels * bitsPerSample / 8);
+        int byteRate = sampleRate * blockAlign;
+        int dataSize = totalFrames * blockAlign;
+
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write("RIFF"u8.ToArray());
+        writer.Write(36 + dataSize);
+        writer.Write("WAVE"u8.ToArray());
+
+        writer.Write("fmt "u8.ToArray());
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)channels);
+        writer.Write(sampleRate);
+        writer.Write(byteRate);
+        writer.Write(blockAlign);
+        writer.Write(bitsPerSample);
+
+        writer.Write("data"u8.ToArray());
+        writer.Write(dataSize);
+
+        for (int i = 0; i < totalFrames; i++)
+        {
+            double t = (double)i / sampleRate;
+            var sample = (short)(Math.Sin(2 * Math.PI * 440 * t) * short.MaxValue * 0.3);
+            for (int ch = 0; ch < channels; ch++)
+            {
+                writer.Write(sample);
+            }
+        }
+
+        return path;
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs
@@ -14,6 +14,9 @@ namespace Beutl.Extensions.MediaFoundation.Tests;
 public class MFDecoderLifecycleTests
 {
     private string _workDir = string.Empty;
+    private bool _prevEnableObjectTracking;
+    private bool _prevEnableReleaseOnFinalizer;
+    private bool _prevUseThreadStaticObjectTracking;
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
@@ -23,6 +26,11 @@ public class MFDecoderLifecycleTests
             Assert.Ignore("Media Foundation is only available on Windows.");
         }
 
+        // Enable tracking before the baseline count below — the MFDecoder ctor sets these same flags
+        // but too late to count the wrappers it creates. Process-global statics, so capture/restore.
+        _prevEnableObjectTracking = SharpGen.Runtime.Configuration.EnableObjectTracking;
+        _prevEnableReleaseOnFinalizer = SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer;
+        _prevUseThreadStaticObjectTracking = SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking;
         SharpGen.Runtime.Configuration.EnableObjectTracking = true;
         SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = true;
         SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = true;
@@ -35,6 +43,9 @@ public class MFDecoderLifecycleTests
         if (OperatingSystem.IsWindows())
         {
             MediaFactory.MFShutdown();
+            SharpGen.Runtime.Configuration.EnableObjectTracking = _prevEnableObjectTracking;
+            SharpGen.Runtime.Configuration.EnableReleaseOnFinalizer = _prevEnableReleaseOnFinalizer;
+            SharpGen.Runtime.Configuration.UseThreadStaticObjectTracking = _prevUseThreadStaticObjectTracking;
         }
     }
 


### PR DESCRIPTION
## Description
- Dispose partially initialized Media Foundation COM wrappers when `MFDecoder` construction fails before the object is returned.
- Preserve the original initialization exception if cleanup itself logs an error.
- Add a Windows-gated regression test for the audio-only `NoVideoStreamException` path using SharpGen object tracking.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only
- [x] Media decoding extension (`src/Beutl.Extensions.MediaFoundation`)

## Breaking changes
None

## Test plan
- Added `tests/Beutl.Extensions.MediaFoundation.Tests/MFDecoderLifecycleTests.cs` to assert tracked Vortice MediaFoundation COM wrappers return to baseline after an audio-only constructor failure.
- `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --filter "FullyQualifiedName~MFDecoderLifecycleTests"` (macOS: exit 0, Windows-only fixture platform-skipped).
- `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0 --artifacts-path /tmp/beutl-mfdecoder-artifacts-final2 /p:PlatformTarget=AnyCPU` (macOS: exit 0, 38 passed; Windows-only fixtures platform-skipped by NUnit).
- `git diff --cached --check`

Local validation notes:
- Plain `dotnet test tests/Beutl.Extensions.MediaFoundation.Tests/Beutl.Extensions.MediaFoundation.Tests.csproj -f net10.0` still fails on this macOS host with the existing `FileNotFoundException` for `Beutl.Embedding.MediaFoundation`; the isolated `--artifacts-path` plus `PlatformTarget=AnyCPU` route avoids the local assembly-load mismatch.
- `dotnet format ... --verify-no-changes --no-restore` was attempted but stalled in this sandbox, so formatting validation used the staged diff whitespace check.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[Bug] MFDecoder 自身のコンストラクタが初期化失敗時に COM オブジェクト(_attributes/_videoSourceReader)をリークする")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup during media decoder initialization so any partially created resources are disposed reliably when construction fails.
  * Ensured the media type retrieved during media info checks is always released to prevent lingering allocations.
* **Tests**
  * Added Windows-only lifecycle tests that verify deterministic disposal when decoding fails because the input contains no video stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->