### PR TITLE
test(rendering): assert LayerRenderNode emits Unbounded EffectiveScale

### DIFF
--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ResolutionScaleTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/ResolutionScaleTests.cs
@@ -367,6 +367,29 @@ public class ResolutionScaleTests
             Is.EqualTo((201, 101)), "fractional bounds * w ceils up");
     }
 
+    // --- Flatten nodes own no buffer and re-rasterize at any scale: must report Unbounded supply ---------
+
+    [Test]
+    public void LayerRenderNode_Process_EmitsUnboundedEffectiveScale()
+    {
+        // SaveLayer flatten owns no buffer and re-rasterizes at any working scale, so it must report
+        // Unbounded supply density; a wrongly-concrete value would inflate the upstream working scale.
+        using var node = new LayerRenderNode(new Rect(0, 0, 100, 100));
+
+        RenderNodeOperation[] result = node.Process(new RenderNodeContext([]));
+        try
+        {
+            Assert.That(result, Has.Length.EqualTo(1));
+            Assert.That(result[0].EffectiveScale.IsUnbounded, Is.True,
+                "LayerRenderNode flattens via SaveLayer and re-rasterizes at any scale, so it emits Unbounded.");
+        }
+        finally
+        {
+            foreach (RenderNodeOperation r in result)
+                r.Dispose();
+        }
+    }
+
     // --- Node-graph input boundary: EffectiveScale must survive the RefCountedProxy re-wrap ---------------
 
     [Test]


### PR DESCRIPTION
## Description
- `LayerRenderNode.Process` flattens its input via `SaveLayer`, owns no buffer, and re-rasterizes at any working scale, so it emits `effectiveScale: EffectiveScale.Unbounded` (`src/Beutl.Engine/Graphics/Rendering/LayerRenderNode.cs:45`).
- A regression to a concrete `EffectiveScale.At(...)` would wrongly inflate the upstream working scale `w` for the whole effect boundary.
- The only existing `LayerRenderNode` test (`GraphicsContext2DTests.PushLayer_ShouldCreateLayerRenderNode`) asserts node **type** only — never the emitted supply density.
- This PR pins that behavior with a regression test. Test-only; no production change.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

(Engine **tests** only — no production code changed.)

## Breaking changes
None — behavior-preserving, test-only addition.

## Test plan
- Added `LayerRenderNode_Process_EmitsUnboundedEffectiveScale` to `tests/Beutl.UnitTests/Engine/Graphics/Rendering/ResolutionScaleTests.cs`, mirroring the existing `OperationWrapperProxy_ForwardsEffectiveScale` pattern: drives `Process(new RenderNodeContext([]))` and asserts the single emitted op reports `EffectiveScale.IsUnbounded`.
- Because the production code is already correct, the test is a characterization/regression baseline: it is green on the unmodified tree.
- `dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~ResolutionScaleTests"` → **55 passed, 0 failed, 0 skipped**.
- `dotnet format Beutl.slnx --include tests/Beutl.UnitTests/Engine/Graphics/Rendering/ResolutionScaleTests.cs --verify-no-changes` → clean.

## Fixed issues / References
- Project board: b-editor/projects/9 ("test(rendering): assert LayerRenderNode emits Unbounded EffectiveScale")
- Follow-up from the ultracode review of commit `e322d3587` (003 resolution-independent pipeline); the HIGH/MEDIUM items were addressed in `28ae9e0ff` / `4762e184e` / `3ff7ceb56` / `73a052955`, this is the remaining low-priority test-coverage follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a unit test to verify graphics rendering behavior when processing layer nodes with unbounded effective scale, ensuring rendering operations maintain proper scaling characteristics during layer flattening operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->