### PR TITLE
fix(engine): dispose truncated FormattedText glyph resources on shrink

### DIFF
--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -87,9 +87,8 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         IsDisposed = true;
     }
 
-    // Releases a single _pathList entry. The geometry must be disposed too: it owns the per-glyph
-    // SKPath (set via SetSKPath(..., clone: false)), which the resource's cached render path does not
-    // cover. Both calls release native handles, so the resource must not be accessed afterwards.
+    // Dispose the geometry too: it owns the per-glyph SKPath (set via SetSKPath(..., clone: false)),
+    // which the resource's cached render path does not cover.
     private static void DisposePathListEntry(SKPathGeometry.Resource? resource)
     {
         resource?.GetOriginal().Dispose();
@@ -322,9 +321,8 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         Span<SKPathGeometry.Resource> pathList = default;
         if (updatePathList)
         {
-            // When the glyph count shrank, SetCount truncates the trailing _pathList entries; those
-            // dropped resources are then unreachable for Dispose() to release, so their owned glyph
-            // SKPath / cached render handles would leak to finalizers. Dispose them before truncating.
+            // SetCount truncates trailing entries without disposing them; release them first so their
+            // owned glyph SKPaths don't leak to finalizers.
             int glyphCount = result.Codepoints.Length;
             for (int i = glyphCount; i < _pathList.Count; i++)
             {

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -77,10 +77,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         (_textBlob, _fillPath, _strokePath).DisposeAll();
         foreach (SKPathGeometry.Resource? resource in _pathList)
         {
-            // Dispose the geometry too: it owns the per-glyph SKPath (set via SetSKPath(..., clone: false)),
-            // which the resource's cached render path does not cover.
-            resource?.GetOriginal().Dispose();
-            resource?.Dispose();
+            DisposePathListEntry(resource);
         }
 
         _pathList = [];
@@ -88,6 +85,15 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         _fillPath = null;
         _strokePath = null;
         IsDisposed = true;
+    }
+
+    // Releases a single _pathList entry. The geometry must be disposed too: it owns the per-glyph
+    // SKPath (set via SetSKPath(..., clone: false)), which the resource's cached render path does not
+    // cover. Both calls release native handles, so the resource must not be accessed afterwards.
+    private static void DisposePathListEntry(SKPathGeometry.Resource? resource)
+    {
+        resource?.GetOriginal().Dispose();
+        resource?.Dispose();
     }
 
     public FontWeight Weight
@@ -316,7 +322,16 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
         Span<SKPathGeometry.Resource> pathList = default;
         if (updatePathList)
         {
-            CollectionsMarshal.SetCount(_pathList, result.Codepoints.Length);
+            // When the glyph count shrank, SetCount truncates the trailing _pathList entries; those
+            // dropped resources are then unreachable for Dispose() to release, so their owned glyph
+            // SKPath / cached render handles would leak to finalizers. Dispose them before truncating.
+            int glyphCount = result.Codepoints.Length;
+            for (int i = glyphCount; i < _pathList.Count; i++)
+            {
+                DisposePathListEntry(_pathList[i]);
+            }
+
+            CollectionsMarshal.SetCount(_pathList, glyphCount);
             pathList = CollectionsMarshal.AsSpan(_pathList);
         }
 

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -135,6 +135,64 @@ public class FormattedTextDisposalTests
     }
 
     [Test]
+    public void MeasureCore_ShrinkingGlyphCount_DisposesTruncatedTrailingResources()
+    {
+        FormattedText ft = CreateText("ABCDE");
+
+        // ToGeometies() returns the live _pathList, so capture the long count before any shrink.
+        IReadOnlyList<Geometry.Resource> longGeometries = ft.ToGeometies();
+        int longCount = longGeometries.Count;
+        // Font shaping is environment-dependent, so treat the "shrink actually happens" facts as
+        // assumptions (skip inconclusive) rather than hard failures if a font ligates differently.
+        Assume.That(longCount, Is.GreaterThan(2), "Need more glyphs than the shrunk text to exercise truncation.");
+
+        // Derive the shrunk glyph count without hardcoding it: _pathList length is driven by HarfBuzz
+        // Codepoints.Length, not Text.Length (ligatures / fallback can decouple the two).
+        int shortCount;
+        using (FormattedText probe = CreateText("AB"))
+        {
+            shortCount = probe.ToGeometies().Count;
+        }
+
+        Assume.That(shortCount, Is.LessThan(longCount), "Shrink must actually reduce the glyph count.");
+
+        // Snapshot the trailing resources [shortCount, longCount) and their owned glyph SKPaths BEFORE the
+        // shrink: CollectionsMarshal.SetCount truncates the live _pathList in place, so after the re-measure
+        // these objects are no longer reachable through it.
+        List<Geometry.Resource> trailingResources = longGeometries.Skip(shortCount).ToList();
+        Assert.That(trailingResources, Has.Count.EqualTo(longCount - shortCount));
+
+        List<SKPath> trailingGlyphPaths = trailingResources
+            .OfType<SKPathGeometry.Resource>()
+            .Select(r => r.GetOriginal().Path)
+            .Where(p => p is not null)
+            .Select(p => p!)
+            .ToList();
+        Assume.That(trailingGlyphPaths, Is.Not.Empty, "Trailing glyphs should own SKPaths before the shrink.");
+        Assert.That(trailingResources.All(r => !r.IsDisposed), Is.True, "Trailing resources must be live before the shrink.");
+        Assert.That(trailingGlyphPaths.All(p => p.Handle != IntPtr.Zero), Is.True,
+            "Trailing glyph SKPaths must have live handles before the shrink.");
+
+        // Shrink the text and force a re-measure -> MeasureCore's SetCount truncates _pathList.
+        ft.Text = "AB";
+        _ = ft.Bounds;
+        Assert.That(ft.ToGeometies().Count, Is.EqualTo(shortCount), "Re-measure should have shrunk the live _pathList.");
+
+        foreach (Geometry.Resource r in trailingResources)
+        {
+            Assert.That(r.IsDisposed, Is.True, "Truncated trailing path-list resource must be disposed on shrink.");
+        }
+
+        foreach (SKPath p in trailingGlyphPaths)
+        {
+            Assert.That(p.Handle, Is.EqualTo(IntPtr.Zero),
+                "Owned glyph SKPath of a truncated trailing entry must be deterministically released.");
+        }
+
+        ft.Dispose();
+    }
+
+    [Test]
     public void LineEnumerable_Dispose_DisposesContainedFormattedTexts()
     {
         TextElements elements = new(

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -139,15 +139,13 @@ public class FormattedTextDisposalTests
     {
         FormattedText ft = CreateText("ABCDE");
 
-        // ToGeometies() returns the live _pathList, so capture the long count before any shrink.
+        // ToGeometies() returns the live _pathList; capture the long count before any shrink.
         IReadOnlyList<Geometry.Resource> longGeometries = ft.ToGeometies();
         int longCount = longGeometries.Count;
-        // Font shaping is environment-dependent, so treat the "shrink actually happens" facts as
-        // assumptions (skip inconclusive) rather than hard failures if a font ligates differently.
+        // Font shaping is environment-dependent, so gate the glyph-count facts on Assume, not Assert.
         Assume.That(longCount, Is.GreaterThan(2), "Need more glyphs than the shrunk text to exercise truncation.");
 
-        // Derive the shrunk glyph count without hardcoding it: _pathList length is driven by HarfBuzz
-        // Codepoints.Length, not Text.Length (ligatures / fallback can decouple the two).
+        // Glyph count is driven by HarfBuzz Codepoints.Length, not Text.Length, so derive it from a probe.
         int shortCount;
         using (FormattedText probe = CreateText("AB"))
         {
@@ -156,9 +154,8 @@ public class FormattedTextDisposalTests
 
         Assume.That(shortCount, Is.LessThan(longCount), "Shrink must actually reduce the glyph count.");
 
-        // Snapshot the trailing resources [shortCount, longCount) and their owned glyph SKPaths BEFORE the
-        // shrink: CollectionsMarshal.SetCount truncates the live _pathList in place, so after the re-measure
-        // these objects are no longer reachable through it.
+        // Snapshot the trailing resources before the shrink: SetCount truncates _pathList in place,
+        // so they become unreachable through it afterwards.
         List<Geometry.Resource> trailingResources = longGeometries.Skip(shortCount).ToList();
         Assert.That(trailingResources, Has.Count.EqualTo(longCount - shortCount));
 
@@ -173,7 +170,7 @@ public class FormattedTextDisposalTests
         Assert.That(trailingGlyphPaths.All(p => p.Handle != IntPtr.Zero), Is.True,
             "Trailing glyph SKPaths must have live handles before the shrink.");
 
-        // Shrink the text and force a re-measure -> MeasureCore's SetCount truncates _pathList.
+        // Shrink the text and force a re-measure -> MeasureCore truncates _pathList.
         ft.Text = "AB";
         _ = ft.Bounds;
         Assert.That(ft.ToGeometies().Count, Is.EqualTo(shortCount), "Re-measure should have shrunk the live _pathList.");
@@ -197,10 +194,10 @@ public class FormattedTextDisposalTests
     {
         FormattedText ft = CreateText("ABCDE");
 
-        // ToGeometies() returns the live _pathList, so capture the long count before any shrink.
+        // ToGeometies() returns the live _pathList; capture the long count before any shrink.
         IReadOnlyList<Geometry.Resource> longGeometries = ft.ToGeometies();
         int longCount = longGeometries.Count;
-        // Font shaping is environment-dependent, so gate the "shrink actually happens" facts on Assume.
+        // Font shaping is environment-dependent, so gate the glyph-count facts on Assume, not Assert.
         Assume.That(longCount, Is.GreaterThan(2), "Need more glyphs than the shrunk text to exercise truncation.");
 
         int shortCount;
@@ -212,9 +209,8 @@ public class FormattedTextDisposalTests
         Assume.That(shortCount, Is.GreaterThan(0), "Shrunk text must still produce glyphs.");
         Assume.That(shortCount, Is.LessThan(longCount), "Shrink must actually reduce the glyph count.");
 
-        // Capture the surviving [0, shortCount) entries. MeasureCore reuses them in place across the shrink
-        // (exist.GetOriginal().SetSKPath(...) on the same Resource), so the trailing-dispose loop must not
-        // touch them. A front-edge off-by-one in that loop would dispose a survivor the re-measure then reuses.
+        // Survivors [0, shortCount) are reused in place across the shrink, so the trailing-dispose loop
+        // must not touch them (guards a front-edge off-by-one that would dispose a reused survivor).
         List<Geometry.Resource> survivors = longGeometries.Take(shortCount).ToList();
         Assert.That(survivors.All(r => !r.IsDisposed), Is.True, "Survivors must be live before the shrink.");
 
@@ -232,9 +228,8 @@ public class FormattedTextDisposalTests
                 "Surviving path-list resource must stay live across a shrink (guards a front-edge off-by-one).");
         }
 
-        // Grow back to the original length. CollectionsMarshal.SetCount cleared the truncated reference-type
-        // slots on the shrink, so MeasureCore must build fresh resources there rather than resurrect a disposed
-        // one. If a disposed Resource were reused, GetRenderBounds would throw ObjectDisposedException.
+        // Grow back: the shrink cleared the truncated slots, so MeasureCore must build fresh resources
+        // rather than resurrect a disposed one (which would throw ObjectDisposedException).
         ft.Text = "ABCDE";
         Assert.DoesNotThrow(() => _ = ft.Bounds, "Re-measure after grow-back must not touch a disposed resource.");
 

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -193,6 +193,64 @@ public class FormattedTextDisposalTests
     }
 
     [Test]
+    public void MeasureCore_ShrinkThenGrow_KeepsSurvivorsLiveAndRebuildsTruncatedSlots()
+    {
+        FormattedText ft = CreateText("ABCDE");
+
+        // ToGeometies() returns the live _pathList, so capture the long count before any shrink.
+        IReadOnlyList<Geometry.Resource> longGeometries = ft.ToGeometies();
+        int longCount = longGeometries.Count;
+        // Font shaping is environment-dependent, so gate the "shrink actually happens" facts on Assume.
+        Assume.That(longCount, Is.GreaterThan(2), "Need more glyphs than the shrunk text to exercise truncation.");
+
+        int shortCount;
+        using (FormattedText probe = CreateText("AB"))
+        {
+            shortCount = probe.ToGeometies().Count;
+        }
+
+        Assume.That(shortCount, Is.GreaterThan(0), "Shrunk text must still produce glyphs.");
+        Assume.That(shortCount, Is.LessThan(longCount), "Shrink must actually reduce the glyph count.");
+
+        // Capture the surviving [0, shortCount) entries. MeasureCore reuses them in place across the shrink
+        // (exist.GetOriginal().SetSKPath(...) on the same Resource), so the trailing-dispose loop must not
+        // touch them. A front-edge off-by-one in that loop would dispose a survivor the re-measure then reuses.
+        List<Geometry.Resource> survivors = longGeometries.Take(shortCount).ToList();
+        Assert.That(survivors.All(r => !r.IsDisposed), Is.True, "Survivors must be live before the shrink.");
+
+        // Shrink -> re-measure disposes + truncates [shortCount, longCount).
+        ft.Text = "AB";
+        _ = ft.Bounds;
+
+        IReadOnlyList<Geometry.Resource> shrunk = ft.ToGeometies();
+        Assert.That(shrunk.Count, Is.EqualTo(shortCount), "Re-measure should have shrunk the live _pathList.");
+        for (int i = 0; i < shortCount; i++)
+        {
+            Assert.That(ReferenceEquals(shrunk[i], survivors[i]), Is.True,
+                "Surviving entries must be reused in place, not recreated.");
+            Assert.That(survivors[i].IsDisposed, Is.False,
+                "Surviving path-list resource must stay live across a shrink (guards a front-edge off-by-one).");
+        }
+
+        // Grow back to the original length. CollectionsMarshal.SetCount cleared the truncated reference-type
+        // slots on the shrink, so MeasureCore must build fresh resources there rather than resurrect a disposed
+        // one. If a disposed Resource were reused, GetRenderBounds would throw ObjectDisposedException.
+        ft.Text = "ABCDE";
+        Assert.DoesNotThrow(() => _ = ft.Bounds, "Re-measure after grow-back must not touch a disposed resource.");
+
+        IReadOnlyList<Geometry.Resource> regrown = ft.ToGeometies();
+        Assert.That(regrown.Count, Is.EqualTo(longCount), "Re-measure should have regrown the live _pathList.");
+        foreach (Geometry.Resource r in regrown)
+        {
+            Assert.That(r.IsDisposed, Is.False, "Regrown entry must be live (no disposed resource resurrected).");
+            Assert.DoesNotThrow(() => _ = r.GetRenderBounds(null),
+                "Regrown entry must be renderable; a resurrected disposed resource would throw here.");
+        }
+
+        ft.Dispose();
+    }
+
+    [Test]
     public void LineEnumerable_Dispose_DisposesContainedFormattedTexts()
     {
         TextElements elements = new(


### PR DESCRIPTION
## Description

- Fixes a native-handle leak in `FormattedText`. On re-measure, `MeasureCore` calls `CollectionsMarshal.SetCount(_pathList, glyphCount)`. When the glyph count **shrinks** (a cached `FormattedText` whose `Text` is shortened to fewer glyphs), `SetCount` truncates the trailing `List<SKPathGeometry.Resource>` entries **without disposing them**. Each dropped entry owns a per-glyph `SKPath` (handed off via `SetSKPath(..., clone: false)`) plus the resource's cached render/stroke `SKPath`s; once removed from `_pathList` they are no longer reachable for `Dispose()` to release, so the Skia handles leak until finalization.
- The fix disposes the soon-to-be-truncated tail `[glyphCount, oldCount)` **before** `SetCount`, mirroring the per-entry cleanup `Dispose()` already performs. The shared two-call disposal (`GetOriginal().Dispose()` + `Dispose()`) is extracted into a `DisposePathListEntry` helper used by both the `Dispose()` loop and the new shrink loop.
- Same class of leak as the per-glyph `SKPathGeometry` `Dispose()` release added in #1974, but on the shrink path.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None. Behavior-preserving apart from releasing the previously-leaked handles deterministically; the non-shrinking measure paths are untouched.

## Test plan

- Added `FormattedTextDisposalTests.MeasureCore_ShrinkingGlyphCount_DisposesTruncatedTrailingResources` (baseline-first / red→green): measures `"ABCDE"`, snapshots the trailing `SKPathGeometry.Resource`s + their owned glyph `SKPath` handles **before** the shrink (because `ToGeometies()` returns the live `_pathList` that `SetCount` truncates in place), re-measures `"AB"`, then asserts the truncated resources are `IsDisposed` and their owned `SKPath.Handle == IntPtr.Zero`.
  - Confirmed **RED** on unmodified code (`IsDisposed` Expected `True` but was `False`).
  - **GREEN** after the fix; all 15 `FormattedText*` fixture tests pass.
  - The glyph count is derived at runtime (not hardcoded), and the font-shaping preconditions use `Assume.That` so the test is inconclusive — not a hard failure — on a font that ligates differently.
- `dotnet format Beutl.slnx --include <changed files> --verify-no-changes` is clean.

## Follow-ups

Surfaced by an adjacent disposal/ownership sweep while fixing this — separate, out of scope for this PR:

- **`FormattedText.GetScaledTextCache` orphan window** (`FormattedText.cs` ~419-434): if the eviction loop's `Dispose()` or the `_scaledTextCache.Add` step throws after `MeasureCore` allocates `textBlob` / `strokePath`, those handles are never handed to a `ScaledTextCache` and leak. Low severity.
- **Stale per-glyph cache after slot reuse** (`SKPathGeometry.SetSKPath`, consumed at `FormattedText.cs:349/368`): `SetSKPath` calls `RaiseEdited()` but does not bump `EngineObject.Resource.Version`. Per-glyph resources reused in place across a re-measure keep rendering a **stale** cached path (`Geometry.Resource._cachedPath/_cachedStrokePath` invalidate only on a `Version` change). Correctness defect (not a leak), medium severity.
- **Post-`Dispose` accessor guards** (`FormattedText.cs:64-71`): measuring members re-allocate Skia handles after `Dispose` (documented but unenforced). Low severity.

## Fixed issues / References

- Project board: b-editor/projects/9 ("FormattedText: dispose trailing _pathList resources on glyph-count shrink (SetCount truncation leak)")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory/resource leak in formatted text when re-measuring after text length changes, ensuring truncated glyph resources and their underlying native paths are properly released.

* **Tests**
  * Added unit coverage for shrinking and subsequent re-growing scenarios to verify disposed trailing resources are released deterministically, while surviving entries remain live and reusable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->