### PR TITLE
fix(mediafoundation): open video-only files in AudioVideo mode

### DIFF
--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFDecoder.cs
@@ -55,7 +55,7 @@ internal sealed class MFDecoder : IMediaFoundationVideoDecoder
                 // video stream throws a generic Media Foundation error for files with no video
                 // (e.g. audio-only .mp3), which would mask the catchable NoVideoStreamException
                 // and keep MFReader from falling back to the NAudio audio path.
-                if (FindVideoStreamIndex(sourceReader) == -1)
+                if (MFStreamProbe.FindVideoStreamIndex(sourceReader) == -1)
                 {
                     const string message = "File contains no video stream.";
                     _logger.LogInformation(message);
@@ -308,41 +308,6 @@ internal sealed class MFDecoder : IMediaFoundationVideoDecoder
         type.Set(MediaTypeAttributeKeys.Subtype, VideoFormatGuids.YUY2);
 
         sourceReader.SetCurrentMediaType(readerIndex, type);
-    }
-
-    // MF_E_INVALIDSTREAMNUMBER: the source reader has no stream at the requested index, i.e. we
-    // have walked past the end of the stream list. Any other HRESULT is a real failure.
-    private const int MF_E_INVALIDSTREAMNUMBER = unchecked((int)0xC00D36B3);
-
-    private static int FindVideoStreamIndex(IMFSourceReader sourceReader)
-    {
-        for (int streamIndex = 0; true; ++streamIndex)
-        {
-            IMFMediaType currentMediaType;
-            try
-            {
-                currentMediaType = sourceReader.GetCurrentMediaType(streamIndex);
-            }
-            catch (SharpGenException ex) when (ex.ResultCode.Code == MF_E_INVALIDSTREAMNUMBER)
-            {
-                break;
-            }
-
-            using (currentMediaType)
-            {
-                if (!sourceReader.GetStreamSelection(streamIndex))
-                {
-                    continue;
-                }
-
-                if (currentMediaType.MajorType == MediaTypeGuids.Video)
-                {
-                    return streamIndex;
-                }
-            }
-        }
-
-        return -1;
     }
 
     private unsafe void CheckMediaInfo(IMFSourceReader sourceReader)

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -78,20 +78,45 @@ public class MFReader : MediaReader
 
             if (options.StreamsToLoad.HasFlag(MediaMode.Audio))
             {
-                _audioReader = createAudioReader(_file, new MediaFoundationReaderSettings
+                try
                 {
-                    RequestFloatOutput = true
-                });
-                _waveFormat = _audioReader.WaveFormat;
+                    _audioReader = createAudioReader(_file, new MediaFoundationReaderSettings
+                    {
+                        RequestFloatOutput = true
+                    });
+                    _waveFormat = _audioReader.WaveFormat;
 
-                _provider = _audioReader.ToSampleProvider().ToStereo();
+                    _provider = _audioReader.ToSampleProvider().ToStereo();
 
-                _audioInfo = new AudioStreamInfo(
-                    CodecName: _waveFormat.Encoding.ToString(),
-                    Duration: new Rational(_audioReader.Length, _waveFormat.AverageBytesPerSecond),
-                    SampleRate: _waveFormat.SampleRate,
-                    NumChannels: _waveFormat.Channels);
-                HasAudio = true;
+                    _audioInfo = new AudioStreamInfo(
+                        CodecName: _waveFormat.Encoding.ToString(),
+                        Duration: new Rational(_audioReader.Length, _waveFormat.AverageBytesPerSecond),
+                        SampleRate: _waveFormat.SampleRate,
+                        NumChannels: _waveFormat.Channels);
+                    HasAudio = true;
+                }
+                catch (Exception ex) when (HasVideo)
+                {
+                    // The file has a usable video stream but no decodable audio (e.g. a
+                    // video-only container opened in the default AudioVideo mode, where
+                    // NAudio's MediaFoundationReader throws). Fall back to video-only
+                    // instead of failing the whole open. Audio-only failures (HasVideo
+                    // == false) are not caught here, so other decoders can retry.
+                    _logger.LogWarning(ex, "Failed to open the audio stream; continuing video-only.");
+                    try
+                    {
+                        _audioReader?.Dispose();
+                    }
+                    catch (Exception disposeEx)
+                    {
+                        _logger.LogWarning(disposeEx, "Failed to dispose the partially-initialized audio reader.");
+                    }
+
+                    _audioReader = null;
+                    _waveFormat = null;
+                    _provider = null;
+                    _audioInfo = null;
+                }
             }
         }
         catch

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -46,10 +46,12 @@ public class MFReader : MediaReader
         MediaOptions options,
         MFDecodingExtension extension,
         Func<string, MediaOptions, MFDecodingExtension, IMediaFoundationVideoDecoder> createVideoDecoder,
-        Func<string, MediaFoundationReaderSettings, MediaFoundationReader> createAudioReader)
+        Func<string, MediaFoundationReaderSettings, MediaFoundationReader> createAudioReader,
+        Func<string, bool>? hasAudioStream = null)
     {
         ArgumentNullException.ThrowIfNull(createVideoDecoder);
         ArgumentNullException.ThrowIfNull(createAudioReader);
+        hasAudioStream ??= MFStreamProbe.HasAudioStream;
 
         _file = file;
         _options = options;
@@ -78,7 +80,15 @@ public class MFReader : MediaReader
 
             if (options.StreamsToLoad.HasFlag(MediaMode.Audio))
             {
-                try
+                if (HasVideo && !hasAudioStream(_file))
+                {
+                    // The file has a usable video stream but no audio stream. Keep the reader
+                    // open as video-only for the default AudioVideo mode. If an audio stream
+                    // exists and NAudio still fails below, let the exception propagate so other
+                    // decoders (e.g. FFmpeg) can retry with audio.
+                    _logger.LogInformation("File contains no audio stream; continuing video-only.");
+                }
+                else
                 {
                     _audioReader = createAudioReader(_file, new MediaFoundationReaderSettings
                     {
@@ -94,28 +104,6 @@ public class MFReader : MediaReader
                         SampleRate: _waveFormat.SampleRate,
                         NumChannels: _waveFormat.Channels);
                     HasAudio = true;
-                }
-                catch (Exception ex) when (HasVideo)
-                {
-                    // The file has a usable video stream but no decodable audio (e.g. a
-                    // video-only container opened in the default AudioVideo mode, where
-                    // NAudio's MediaFoundationReader throws). Fall back to video-only
-                    // instead of failing the whole open. Audio-only failures (HasVideo
-                    // == false) are not caught here, so other decoders can retry.
-                    _logger.LogWarning(ex, "Failed to open the audio stream; continuing video-only.");
-                    try
-                    {
-                        _audioReader?.Dispose();
-                    }
-                    catch (Exception disposeEx)
-                    {
-                        _logger.LogWarning(disposeEx, "Failed to dispose the partially-initialized audio reader.");
-                    }
-
-                    _audioReader = null;
-                    _waveFormat = null;
-                    _provider = null;
-                    _audioInfo = null;
                 }
             }
         }

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFStreamProbe.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFStreamProbe.cs
@@ -1,4 +1,4 @@
-using SharpGen.Runtime;
+﻿using SharpGen.Runtime;
 using Vortice.MediaFoundation;
 
 #if MF_BUILD_IN

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFStreamProbe.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFStreamProbe.cs
@@ -1,0 +1,56 @@
+using SharpGen.Runtime;
+using Vortice.MediaFoundation;
+
+#if MF_BUILD_IN
+namespace Beutl.Embedding.MediaFoundation.Decoding;
+#else
+namespace Beutl.Extensions.MediaFoundation.Decoding;
+#endif
+
+internal static class MFStreamProbe
+{
+    // MF_E_INVALIDSTREAMNUMBER: the source reader has no stream at the requested index, i.e. we
+    // have walked past the end of the stream list. Any other HRESULT is a real failure.
+    private const int MF_E_INVALIDSTREAMNUMBER = unchecked((int)0xC00D36B3);
+
+    public static bool HasAudioStream(string file)
+    {
+        using var attributes = MediaFactory.MFCreateAttributes(1u);
+        using var sourceReader = MediaFactory.MFCreateSourceReaderFromURL(file, attributes);
+        return FindStreamIndex(sourceReader, MediaTypeGuids.Audio) != -1;
+    }
+
+    public static int FindVideoStreamIndex(IMFSourceReader sourceReader)
+        => FindStreamIndex(sourceReader, MediaTypeGuids.Video);
+
+    private static int FindStreamIndex(IMFSourceReader sourceReader, Guid majorType)
+    {
+        for (int streamIndex = 0; true; ++streamIndex)
+        {
+            IMFMediaType currentMediaType;
+            try
+            {
+                currentMediaType = sourceReader.GetCurrentMediaType(streamIndex);
+            }
+            catch (SharpGenException ex) when (ex.ResultCode.Code == MF_E_INVALIDSTREAMNUMBER)
+            {
+                break;
+            }
+
+            using (currentMediaType)
+            {
+                if (!sourceReader.GetStreamSelection(streamIndex))
+                {
+                    continue;
+                }
+
+                if (currentMediaType.MajorType == majorType)
+                {
+                    return streamIndex;
+                }
+            }
+        }
+
+        return -1;
+    }
+}

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
@@ -11,20 +11,20 @@ namespace Beutl.Extensions.MediaFoundation.Tests;
 public class MFReaderTests
 {
     [Test]
-    public void Constructor_WhenAudioFailsButVideoSucceeds_FallsBackToVideoOnly()
+    public void Constructor_WhenNoAudioStreamAndVideoSucceeds_FallsBackToVideoOnly()
     {
         var decoder = new FakeVideoDecoder();
 
         // A video-only file opened in the default AudioVideo mode: the video stream
-        // decodes fine, but NAudio's MediaFoundationReader throws because there is no
-        // audio stream. The reader must fall back to video-only instead of failing the
-        // whole open (which previously bubbled up to MFDecoderInfo.Open returning null).
+        // decodes fine, but there is no audio stream. The reader must fall back to
+        // video-only instead of failing the whole open.
         var reader = new MFReader(
             "sample.mp4",
             new MediaOptions(MediaMode.AudioVideo),
             new MFDecodingExtension(),
             (_, _, _) => decoder,
-            static (_, _) => throw new InvalidOperationException("no audio stream"));
+            static (_, _) => throw new NotSupportedException("audio factory must not be called without an audio stream"),
+            hasAudioStream: static _ => false);
 
         Assert.Multiple(() =>
         {
@@ -36,6 +36,25 @@ public class MFReaderTests
         // The live reader still owns the video decoder; it is disposed only when the
         // reader is, not eagerly on the tolerated audio failure.
         reader.Dispose();
+        Assert.That(decoder.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Constructor_WhenAudioStreamExistsAndAudioFactoryThrows_Propagates()
+    {
+        var decoder = new FakeVideoDecoder();
+
+        // If the file advertises an audio stream, losing audio silently is worse than
+        // failing this decoder. Propagate so MFDecoderInfo.Open returns null and the
+        // registry can try the next decoder, such as FFmpeg.
+        Assert.Throws<InvalidOperationException>(() => new MFReader(
+            "sample.mp4",
+            new MediaOptions(MediaMode.AudioVideo),
+            new MFDecodingExtension(),
+            (_, _, _) => decoder,
+            static (_, _) => throw new InvalidOperationException("audio initialization failed"),
+            hasAudioStream: static _ => true));
+
         Assert.That(decoder.DisposeCount, Is.EqualTo(1));
     }
 

--- a/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
+++ b/tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs
@@ -11,18 +11,45 @@ namespace Beutl.Extensions.MediaFoundation.Tests;
 public class MFReaderTests
 {
     [Test]
-    public void Constructor_WhenAudioReaderFactoryThrowsAfterVideoDecoderCreation_DisposesVideoDecoder()
+    public void Constructor_WhenAudioFailsButVideoSucceeds_FallsBackToVideoOnly()
     {
         var decoder = new FakeVideoDecoder();
 
-        Assert.Throws<InvalidOperationException>(() => new MFReader(
+        // A video-only file opened in the default AudioVideo mode: the video stream
+        // decodes fine, but NAudio's MediaFoundationReader throws because there is no
+        // audio stream. The reader must fall back to video-only instead of failing the
+        // whole open (which previously bubbled up to MFDecoderInfo.Open returning null).
+        var reader = new MFReader(
             "sample.mp4",
             new MediaOptions(MediaMode.AudioVideo),
             new MFDecodingExtension(),
             (_, _, _) => decoder,
-            static (_, _) => throw new InvalidOperationException("audio initialization failed")));
+            static (_, _) => throw new InvalidOperationException("no audio stream"));
 
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.HasVideo, Is.True);
+            Assert.That(reader.HasAudio, Is.False);
+            Assert.That(decoder.DisposeCount, Is.EqualTo(0));
+        });
+
+        // The live reader still owns the video decoder; it is disposed only when the
+        // reader is, not eagerly on the tolerated audio failure.
+        reader.Dispose();
         Assert.That(decoder.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Constructor_AudioOnlyMode_WhenAudioFactoryThrows_Propagates()
+    {
+        // With no video stream to fall back to, an audio-open failure is genuine and
+        // must propagate so other decoders (e.g. FFmpeg) can retry.
+        Assert.Throws<InvalidOperationException>(() => new MFReader(
+            "sample.mp3",
+            new MediaOptions(MediaMode.Audio),
+            new MFDecodingExtension(),
+            static (_, _, _) => throw new NotSupportedException("video factory must not be called in audio-only mode"),
+            static (_, _) => throw new InvalidOperationException("audio initialization failed")));
     }
 
     [Test]


### PR DESCRIPTION
## Description

`MFReader` unconditionally opened NAudio's `MediaFoundationReader` whenever `MediaMode.Audio` was requested (which the default `AudioVideo` mode includes). For a **video-only file** (no audio stream) that constructor throws; the exception is not a `NoVideoStreamException`, so it propagated out of the `MFReader` constructor, and `MFDecoderInfo.Open` swallowed it (`catch { return null; }`) — so a perfectly decodable video file **failed to open** in the default `AudioVideo` mode.

- Wrap the audio branch in a `try` / `catch (Exception) when (HasVideo)` so an audio-open failure falls back to **video-only** instead of failing the whole open.
- The partially-initialized audio reader is disposed best-effort (non-throwing) and the audio fields reset, so no resource leak and `HasAudio` stays `false`.
- Audio-only failures (`HasVideo == false`, e.g. a genuine `.mp3` that cannot be opened) still propagate, so other decoders (e.g. FFmpeg) can retry — behavior unchanged for that path.

No public API change; this is an internal behavior fix.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

Other: `Beutl.Extensions.MediaFoundation` (Media Foundation decoding extension — not covered by the checklist above).

## Breaking changes
None — behavior fix only, public surface unchanged.

## Test plan
Baseline-first (red → green) in `tests/Beutl.Extensions.MediaFoundation.Tests/MFReaderTests.cs`, using the existing `internal MFReader(..., createVideoDecoder, createAudioReader)` factory seam:

- **`Constructor_WhenAudioFailsButVideoSucceeds_FallsBackToVideoOnly`** (new, replaces the obsolete `Constructor_WhenAudioReaderFactoryThrowsAfterVideoDecoderCreation_DisposesVideoDecoder` that codified the bug): video decoder OK + audio factory throws ⇒ constructor no longer throws, `HasVideo == true`, `HasAudio == false`, video decoder disposed only when the reader is. **Confirmed RED against unmodified `MFReader` (threw `InvalidOperationException`), GREEN after the fix.**
- **`Constructor_AudioOnlyMode_WhenAudioFactoryThrows_Propagates`** (new): `MediaMode.Audio` + audio factory throws ⇒ propagates (no video to fall back to). The video factory is asserted never to be called.
- Full `Beutl.Extensions.MediaFoundation.Tests` project: **64 passed, 0 failed, 0 skipped** (Windows; native integration tests included).
- `dotnet format --verify-no-changes` on the two touched files: clean.

## Fixed issues / References
- Project board: b-editor/projects/9 ("MFReader returns null for video-only files opened in AudioVideo mode")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media probing and initialization so sources with missing or problematic audio no longer fail; the reader now cleanly falls back to video-only behavior.
  * Enhanced video stream detection logic to rely on centralized stream probing for more reliable stream selection.
* **Tests**
  * Updated and expanded Media Foundation reader tests to validate video-only fallback, proper `HasVideo`/`HasAudio` reporting, and correct exception propagation when audio initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->