### PR TITLE
fix(engine): preserve rasterize output and exceptions when RenderTarget disposal throws

### DIFF
--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -164,7 +164,6 @@ public class RenderNodeProcessor(
         RenderTarget? renderTarget = null;
         ImmediateCanvas? canvas = null;
         int consumed = 0;
-        bool succeeded = false;
         try
         {
             renderTarget =
@@ -182,30 +181,19 @@ public class RenderNodeProcessor(
                 }
             }
 
-            Bitmap result = renderTarget.Snapshot();
-            succeeded = true;
-            return result;
+            return renderTarget.Snapshot();
         }
         catch
         {
             RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
-            DisposeBestEffort(canvas);
-            DisposeBestEffort(renderTarget);
             throw;
         }
         finally
         {
-            if (succeeded)
-            {
-                try
-                {
-                    canvas?.Dispose();
-                }
-                finally
-                {
-                    renderTarget?.Dispose();
-                }
-            }
+            // Best-effort on both success and failure: a throwing GPU-native teardown must neither
+            // mask an in-flight render exception nor discard a successfully snapshotted bitmap.
+            DisposeBestEffort(canvas);
+            DisposeBestEffort(renderTarget);
         }
     }
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -66,8 +66,8 @@ public class RenderNodeProcessor(
             renderTarget = CreateRenderTarget(rect.Width, rect.Height);
             if (renderTarget == null)
             {
-                opDisposeStarted = true;
-                op.Dispose();
+                // Defer op disposal to the catch's best-effort path so a throwing op.Dispose()
+                // cannot mask the null-allocation failure.
                 throw new Exception("RenderTarget is null");
             }
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -139,8 +139,16 @@ public class RenderNodeProcessor(
                 consumed++;
                 if (RasterizeAt(op, OutputScale) is { } result)
                 {
-                    using RenderTarget renderTarget = result.RenderTarget;
-                    list.Add(renderTarget.Snapshot());
+                    try
+                    {
+                        list.Add(result.RenderTarget.Snapshot());
+                    }
+                    finally
+                    {
+                        // Best-effort: a throwing GPU-native teardown must not discard the bitmap
+                        // just snapshotted from this target.
+                        DisposeBestEffort(result.RenderTarget);
+                    }
                 }
             }
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -57,8 +57,8 @@ public class RenderNodeProcessor(
             return null;
         }
 
-        // Set before op.Dispose() so the catch does not re-dispose an op whose throwing
-        // OnDispose left IsDisposed false.
+        // A throwing OnDispose leaves the op's IsDisposed false, so the catch keys off this flag
+        // (not IsDisposed) to avoid re-disposing — and re-running OnDispose on — an op already torn down.
         RenderTarget? renderTarget = null;
         bool opDisposeStarted = false;
         try

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -159,14 +159,16 @@ public class RenderNodeProcessor(
         var bounds = ops.Aggregate(Rect.Empty, (a, n) => a.Union(n.Bounds));
         float w = OutputScale;
         var rect = w == 1f ? PixelRect.FromRect(bounds) : PixelRect.FromRect(bounds, w);
-        using var renderTarget =
+        var renderTarget =
             CreateRenderTarget(rect.Width, rect.Height) ?? throw new Exception("RenderTarget is null");
-        using var canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: bounds.Size);
-        canvas.Clear();
-
+        ImmediateCanvas? canvas = null;
         int consumed = 0;
+        bool succeeded = false;
         try
         {
+            canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: bounds.Size);
+            canvas.Clear();
+
             using (canvas.PushTransform(Matrix.CreateTranslation(-bounds.X, -bounds.Y)))
             {
                 foreach (var op in ops)
@@ -176,14 +178,32 @@ public class RenderNodeProcessor(
                     op.Dispose();
                 }
             }
+
+            Bitmap result = renderTarget.Snapshot();
+            succeeded = true;
+            return result;
         }
         catch
         {
             RenderNodeOperation.DisposeAll(ops.AsSpan(consumed));
+            DisposeBestEffort(canvas);
+            DisposeBestEffort(renderTarget);
             throw;
         }
-
-        return renderTarget.Snapshot();
+        finally
+        {
+            if (succeeded)
+            {
+                try
+                {
+                    canvas?.Dispose();
+                }
+                finally
+                {
+                    renderTarget.Dispose();
+                }
+            }
+        }
     }
 
     private static void DisposeRenderTargets(List<(RenderTarget RenderTarget, Rect Bounds)> targets)
@@ -202,8 +222,11 @@ public class RenderNodeProcessor(
         }
     }
 
-    private static void DisposeBestEffort(IDisposable disposable)
+    private static void DisposeBestEffort(IDisposable? disposable)
     {
+        if (disposable == null)
+            return;
+
         try
         {
             disposable.Dispose();

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -22,7 +22,7 @@ public class RenderNodeProcessor(
     /// Override to substitute a custom allocation (e.g. pooling, a test double whose
     /// <see cref="RenderTarget.Dispose()"/> throws). Defaults to <see cref="RenderTarget.Create"/>.
     /// </summary>
-    protected internal virtual RenderTarget? CreateRenderTarget(int width, int height)
+    protected virtual RenderTarget? CreateRenderTarget(int width, int height)
         => RenderTarget.Create(width, height);
 
     public void Render(ImmediateCanvas canvas)

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -19,8 +19,7 @@ public class RenderNodeProcessor(
 
     /// <summary>
     /// Allocates the intermediate <see cref="RenderTarget"/> used to rasterize each operation.
-    /// Override to substitute a custom allocation (e.g. pooling, a test double whose
-    /// <see cref="RenderTarget.Dispose()"/> throws). Defaults to <see cref="RenderTarget.Create"/>.
+    /// Override to substitute a custom allocation (e.g. pooling). Defaults to <see cref="RenderTarget.Create"/>.
     /// </summary>
     protected virtual RenderTarget? CreateRenderTarget(int width, int height)
         => RenderTarget.Create(width, height);

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -58,18 +58,20 @@ public class RenderNodeProcessor(
             return null;
         }
 
-        var renderTarget = CreateRenderTarget(rect.Width, rect.Height);
-        if (renderTarget == null)
-        {
-            op.Dispose();
-            throw new Exception("RenderTarget is null");
-        }
-
         // Set before op.Dispose() so the catch does not re-dispose an op whose throwing
         // OnDispose left IsDisposed false.
+        RenderTarget? renderTarget = null;
         bool opDisposeStarted = false;
         try
         {
+            renderTarget = CreateRenderTarget(rect.Width, rect.Height);
+            if (renderTarget == null)
+            {
+                opDisposeStarted = true;
+                op.Dispose();
+                throw new Exception("RenderTarget is null");
+            }
+
             using var canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: op.Bounds.Size);
             canvas.Clear();
 
@@ -159,13 +161,14 @@ public class RenderNodeProcessor(
         var bounds = ops.Aggregate(Rect.Empty, (a, n) => a.Union(n.Bounds));
         float w = OutputScale;
         var rect = w == 1f ? PixelRect.FromRect(bounds) : PixelRect.FromRect(bounds, w);
-        var renderTarget =
-            CreateRenderTarget(rect.Width, rect.Height) ?? throw new Exception("RenderTarget is null");
+        RenderTarget? renderTarget = null;
         ImmediateCanvas? canvas = null;
         int consumed = 0;
         bool succeeded = false;
         try
         {
+            renderTarget =
+                CreateRenderTarget(rect.Width, rect.Height) ?? throw new Exception("RenderTarget is null");
             canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: bounds.Size);
             canvas.Clear();
 
@@ -200,7 +203,7 @@ public class RenderNodeProcessor(
                 }
                 finally
                 {
-                    renderTarget.Dispose();
+                    renderTarget?.Dispose();
                 }
             }
         }

--- a/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderNodeProcessor.cs
@@ -17,6 +17,14 @@ public class RenderNodeProcessor(
     /// <summary>Working-scale ceiling seeded into every <see cref="RenderNodeContext"/>. <c>+Inf</c> = no ceiling.</summary>
     public float MaxWorkingScale { get; } = RenderNodeContext.SanitizeMaxWorkingScale(maxWorkingScale);
 
+    /// <summary>
+    /// Allocates the intermediate <see cref="RenderTarget"/> used to rasterize each operation.
+    /// Override to substitute a custom allocation (e.g. pooling, a test double whose
+    /// <see cref="RenderTarget.Dispose()"/> throws). Defaults to <see cref="RenderTarget.Create"/>.
+    /// </summary>
+    protected internal virtual RenderTarget? CreateRenderTarget(int width, int height)
+        => RenderTarget.Create(width, height);
+
     public void Render(ImmediateCanvas canvas)
     {
         var ops = PullToRoot();
@@ -50,7 +58,7 @@ public class RenderNodeProcessor(
             return null;
         }
 
-        var renderTarget = RenderTarget.Create(rect.Width, rect.Height);
+        var renderTarget = CreateRenderTarget(rect.Width, rect.Height);
         if (renderTarget == null)
         {
             op.Dispose();
@@ -152,7 +160,7 @@ public class RenderNodeProcessor(
         float w = OutputScale;
         var rect = w == 1f ? PixelRect.FromRect(bounds) : PixelRect.FromRect(bounds, w);
         using var renderTarget =
-            RenderTarget.Create(rect.Width, rect.Height) ?? throw new Exception("RenderTarget is null");
+            CreateRenderTarget(rect.Width, rect.Height) ?? throw new Exception("RenderTarget is null");
         using var canvas = new ImmediateCanvas(renderTarget, w, MaxWorkingScale, logicalSize: bounds.Size);
         canvas.Clear();
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -33,7 +33,7 @@ public class RenderTarget : IDisposable
 
     ~RenderTarget()
     {
-        Dispose();
+        Dispose(disposing: false);
     }
 
     internal SKSurface Value =>
@@ -172,14 +172,25 @@ public class RenderTarget : IDisposable
         _dispatcher?.VerifyAccess();
     }
 
-    public virtual void Dispose()
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the backing surface and texture. Subclasses (custom allocations / test doubles)
+    /// override this to customize disposal semantics. When <paramref name="disposing"/> is
+    /// <see langword="false"/> (finalizer-driven), overrides must not throw and must not touch
+    /// finalized managed state.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
     {
         if (IsDisposed) return;
 
         _surface.Release();
         _texture?.Release();
         IsDisposed = true;
-        GC.SuppressFinalize(this);
     }
 
     internal void BeginDraw()

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -188,9 +188,15 @@ public class RenderTarget : IDisposable
     {
         if (IsDisposed) return;
 
-        _surface.Release();
-        _texture?.Release();
         IsDisposed = true;
+        try
+        {
+            _surface.Release();
+        }
+        finally
+        {
+            _texture?.Release();
+        }
     }
 
     internal void BeginDraw()

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -21,6 +21,16 @@ public class RenderTarget : IDisposable
         _texture = texture;
     }
 
+    /// <summary>
+    /// For subclasses (custom allocations / test doubles). Wraps a raw <paramref name="surface"/>
+    /// with no shared texture. The surface is released by <see cref="Dispose()"/> unless a
+    /// subclass overrides it.
+    /// </summary>
+    protected RenderTarget(SKSurface surface, int width, int height)
+        : this(new SKSurfaceCounter<SKSurface>(surface), width, height)
+    {
+    }
+
     ~RenderTarget()
     {
         Dispose();
@@ -162,7 +172,7 @@ public class RenderTarget : IDisposable
         _dispatcher?.VerifyAccess();
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         if (IsDisposed) return;
 

--- a/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
+++ b/src/Beutl.Engine/Graphics/Rendering/RenderTarget.cs
@@ -43,7 +43,7 @@ public class RenderTarget : IDisposable
 
     public int Height { get; }
 
-    public bool IsDisposed { get; private set; }
+    public bool IsDisposed { get; protected set; }
 
     internal ITexture2D? Texture => _texture?.Value;
 
@@ -180,9 +180,10 @@ public class RenderTarget : IDisposable
 
     /// <summary>
     /// Releases the backing surface and texture. Subclasses (custom allocations / test doubles)
-    /// override this to customize disposal semantics. When <paramref name="disposing"/> is
-    /// <see langword="false"/> (finalizer-driven), overrides must not throw and must not touch
-    /// finalized managed state.
+    /// override this to customize disposal semantics; an override must call
+    /// <see langword="base"/>.<see cref="Dispose(bool)"/>, or the object stays finalizable and the
+    /// finalizer re-enters the override. When <paramref name="disposing"/> is <see langword="false"/>
+    /// (finalizer-driven), overrides must not throw and must not touch finalized managed state.
     /// </summary>
     protected virtual void Dispose(bool disposing)
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -232,9 +232,8 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "throws", "remaining" }));
     }
 
-    // RasterizeAt routes the faulting op's render-target disposal through DisposeBestEffort, so a
-    // throwing GPU-native RenderTarget.Dispose() is swallowed and cannot mask the in-flight render
-    // exception. Only Rasterize / RasterizeToRenderTargets reach RasterizeAt's catch.
+    // RasterizeAt disposes the faulting op's render target via DisposeBestEffort, so a throwing
+    // RenderTarget.Dispose() cannot mask the in-flight render exception.
     [Test]
     public void RasterizeToRenderTargets_PreservesRenderException_WhenRenderTargetDisposeThrows()
     {
@@ -343,32 +342,30 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
     }
 
-    // The outer DisposeRenderTargets sweep must keep going and preserve the original render
-    // exception when an already-built (list-resident) RenderTarget throws on Dispose during cleanup.
+    // DisposeRenderTargets must keep sweeping past a list-resident RenderTarget that throws on
+    // Dispose, without masking the render exception.
     [Test]
     public void RasterizeToRenderTargets_ContinuesCleanupAndPreservesException_WhenBuiltRenderTargetDisposeThrows()
     {
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
-            CreateOperation("first", disposed),                               // renders OK -> its RT enters the list
-            CreateOperation("second", disposed),                              // also list-resident; proves sweep continues
-            CreateOperation("render-fault", disposed, throwOnRender: true));  // faults; its own RT is disposed in RasterizeAt
-        // Only the first (list-resident) RT throws on Dispose; the faulting op's RT does not, so
-        // the only throwing-dispose that fires here is the built-resource sweep.
+            CreateOperation("first", disposed),                               // renders OK; its RT enters the list
+            CreateOperation("second", disposed),                              // also list-resident
+            CreateOperation("render-fault", disposed, throwOnRender: true));  // faults; its RT disposed in RasterizeAt
+        // i => i == 0: only the first list-resident RT throws on Dispose, exercising the cleanup sweep.
         var processor = new FakeRenderNodeProcessor(node, i => i == 0);
 
         var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
 
         Assert.That(ex!.Message, Is.EqualTo("render-fault"));
         Assert.That(processor.CreatedTargets, Has.Count.EqualTo(3));
-        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);   // swept despite throwing
-        Assert.That(processor.CreatedTargets[1].DisposeWasCalled, Is.True);   // sweep continued after the throwing target
-        Assert.That(processor.CreatedTargets[2].DisposeWasCalled, Is.True);   // disposed in RasterizeAt catch
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(processor.CreatedTargets[1].DisposeWasCalled, Is.True);
+        Assert.That(processor.CreatedTargets[2].DisposeWasCalled, Is.True);
         Assert.That(disposed, Is.EqualTo(new[] { "first", "second", "render-fault" }));
     }
 
-    // A throwing Dispose() during RasterizeAndConcat's post-success cleanup must not discard the
-    // bitmap the render already produced — the caller still gets its result.
+    // A throwing Dispose() during post-success cleanup must not discard the already-produced bitmap.
     [Test]
     public void RasterizeAndConcat_ReturnsBitmap_WhenRenderSucceedsButRenderTargetDisposeThrows()
     {
@@ -429,8 +426,7 @@ public class RenderNodeProcessorExceptionSafetyTests
     }
 
     // Substitutes RenderTarget allocation so the exception-safety paths can be exercised with a
-    // RenderTarget whose Dispose() throws. Backed by a null SKSurface so ImmediateCanvas can draw
-    // into it without a GPU context.
+    // RenderTarget whose Dispose() throws.
     private sealed class FakeRenderNodeProcessor(
         RenderNode root,
         Func<int, bool> shouldThrowOnDispose,

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -1,4 +1,4 @@
-using Beutl.Graphics;
+﻿using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using SkiaSharp;
 

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -338,7 +338,7 @@ public class RenderNodeProcessorExceptionSafetyTests
     {
         public List<FakeRenderTarget> CreatedTargets { get; } = new();
 
-        protected internal override RenderTarget? CreateRenderTarget(int width, int height)
+        protected override RenderTarget? CreateRenderTarget(int width, int height)
         {
             var target = new FakeRenderTarget(width, height, shouldThrowOnDispose(CreatedTargets.Count));
             CreatedTargets.Add(target);
@@ -351,22 +351,21 @@ public class RenderNodeProcessorExceptionSafetyTests
     {
         public bool DisposeWasCalled { get; private set; }
 
-        public override void Dispose()
+        // Throw only on explicit disposal (disposing == true). The finalizer drives
+        // Dispose(disposing: false), which must stay throw-free so a GC-collected double
+        // cannot tear down the runtime from the finalizer thread.
+        protected override void Dispose(bool disposing)
         {
-            // Idempotent guard: the base finalizer (~RenderTarget) re-invokes this virtual Dispose,
-            // so a throwing path that already fired must not throw again from the finalizer.
-            if (DisposeWasCalled)
+            if (disposing)
             {
-                return;
+                DisposeWasCalled = true;
+                if (throwOnDispose)
+                {
+                    throw new InvalidOperationException("rt-dispose-fault");
+                }
             }
 
-            DisposeWasCalled = true;
-            if (throwOnDispose)
-            {
-                throw new InvalidOperationException("rt-dispose-fault");
-            }
-
-            base.Dispose();
+            base.Dispose(disposing);
         }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -267,6 +267,22 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
     }
 
+    [Test]
+    public void RasterizeAndConcat_PreservesRenderException_WhenRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("render-fault", disposed, throwOnRender: true));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
+    }
+
     // The outer DisposeRenderTargets sweep must keep going and preserve the original render
     // exception when an already-built (list-resident) RenderTarget throws on Dispose during cleanup.
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -283,6 +283,66 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
     }
 
+    [Test]
+    public void RasterizeToRenderTargets_DisposesCurrentAndRemainingOperations_WhenRenderTargetCreateThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("current", disposed),
+            CreateOperation("remaining", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "current", "remaining" }));
+    }
+
+    [Test]
+    public void Rasterize_DisposesCurrentAndRemainingOperations_WhenRenderTargetCreateThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("current", disposed),
+            CreateOperation("remaining", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "current", "remaining" }));
+    }
+
+    [Test]
+    public void RasterizeAndConcat_DisposesPulledOperations_WhenRenderTargetCreateThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("second", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+
+        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
+    }
+
+    [Test]
+    public void RasterizeAndConcat_DisposesPulledOperations_WhenRenderTargetCreateReturnsNull()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("second", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, returnNullOnCreate: true);
+
+        var ex = Assert.Throws<Exception>(() => processor.RasterizeAndConcat());
+
+        Assert.That(ex!.Message, Is.EqualTo("RenderTarget is null"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
+    }
+
     // The outer DisposeRenderTargets sweep must keep going and preserve the original render
     // exception when an already-built (list-resident) RenderTarget throws on Dispose during cleanup.
     [Test]
@@ -291,6 +351,7 @@ public class RenderNodeProcessorExceptionSafetyTests
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
             CreateOperation("first", disposed),                               // renders OK -> its RT enters the list
+            CreateOperation("second", disposed),                              // also list-resident; proves sweep continues
             CreateOperation("render-fault", disposed, throwOnRender: true));  // faults; its own RT is disposed in RasterizeAt
         // Only the first (list-resident) RT throws on Dispose; the faulting op's RT does not, so
         // the only throwing-dispose that fires here is the built-resource sweep.
@@ -299,10 +360,11 @@ public class RenderNodeProcessorExceptionSafetyTests
         var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
 
         Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(2));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(3));
         Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);   // swept despite throwing
-        Assert.That(processor.CreatedTargets[1].DisposeWasCalled, Is.True);   // disposed in RasterizeAt catch
-        Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault" }));
+        Assert.That(processor.CreatedTargets[1].DisposeWasCalled, Is.True);   // sweep continued after the throwing target
+        Assert.That(processor.CreatedTargets[2].DisposeWasCalled, Is.True);   // disposed in RasterizeAt catch
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second", "render-fault" }));
     }
 
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
@@ -349,13 +411,27 @@ public class RenderNodeProcessorExceptionSafetyTests
     // Substitutes RenderTarget allocation so the exception-safety paths can be exercised with a
     // RenderTarget whose Dispose() throws. Backed by a null SKSurface so ImmediateCanvas can draw
     // into it without a GPU context.
-    private sealed class FakeRenderNodeProcessor(RenderNode root, Func<int, bool> shouldThrowOnDispose)
+    private sealed class FakeRenderNodeProcessor(
+        RenderNode root,
+        Func<int, bool> shouldThrowOnDispose,
+        bool throwOnCreate = false,
+        bool returnNullOnCreate = false)
         : RenderNodeProcessor(root, useRenderCache: false)
     {
         public List<FakeRenderTarget> CreatedTargets { get; } = new();
 
         protected override RenderTarget? CreateRenderTarget(int width, int height)
         {
+            if (throwOnCreate)
+            {
+                throw new InvalidOperationException("rt-create-fault");
+            }
+
+            if (returnNullOnCreate)
+            {
+                return null;
+            }
+
             var target = new FakeRenderTarget(width, height, shouldThrowOnDispose(CreatedTargets.Count));
             CreatedTargets.Add(target);
             return target;
@@ -372,16 +448,17 @@ public class RenderNodeProcessorExceptionSafetyTests
         // cannot tear down the runtime from the finalizer thread.
         protected override void Dispose(bool disposing)
         {
+            bool shouldThrow = disposing && throwOnDispose;
             if (disposing)
             {
                 DisposeWasCalled = true;
-                if (throwOnDispose)
-                {
-                    throw new InvalidOperationException("rt-dispose-fault");
-                }
             }
 
             base.Dispose(disposing);
+            if (shouldThrow)
+            {
+                throw new InvalidOperationException("rt-dispose-fault");
+            }
         }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -1,5 +1,6 @@
 ﻿using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
+using SkiaSharp;
 
 namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 
@@ -231,6 +232,63 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EquivalentTo(new[] { "first", "throws", "remaining" }));
     }
 
+    // RasterizeAt routes the faulting op's render-target disposal through DisposeBestEffort, so a
+    // throwing GPU-native RenderTarget.Dispose() is swallowed and cannot mask the in-flight render
+    // exception. Only Rasterize / RasterizeToRenderTargets reach RasterizeAt's catch.
+    [Test]
+    public void RasterizeToRenderTargets_PreservesRenderException_WhenRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("render-fault", disposed, throwOnRender: true));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
+    }
+
+    [Test]
+    public void Rasterize_PreservesRenderException_WhenRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("render-fault", disposed, throwOnRender: true));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
+    }
+
+    // The outer DisposeRenderTargets sweep must keep going and preserve the original render
+    // exception when an already-built (list-resident) RenderTarget throws on Dispose during cleanup.
+    [Test]
+    public void RasterizeToRenderTargets_ContinuesCleanupAndPreservesException_WhenBuiltRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),                               // renders OK -> its RT enters the list
+            CreateOperation("render-fault", disposed, throwOnRender: true));  // faults; its own RT is disposed in RasterizeAt
+        // Only the first (list-resident) RT throws on Dispose; the faulting op's RT does not, so
+        // the only throwing-dispose that fires here is the built-resource sweep.
+        var processor = new FakeRenderNodeProcessor(node, i => i == 0);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(2));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);   // swept despite throwing
+        Assert.That(processor.CreatedTargets[1].DisposeWasCalled, Is.True);   // disposed in RasterizeAt catch
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault" }));
+    }
+
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
     {
         return new StaticRenderNode(
@@ -270,5 +328,45 @@ public class RenderNodeProcessorExceptionSafetyTests
     private sealed class StaticRenderNode(params RenderNodeOperation[] operations) : RenderNode
     {
         public override RenderNodeOperation[] Process(RenderNodeContext context) => operations;
+    }
+
+    // Substitutes RenderTarget allocation so the exception-safety paths can be exercised with a
+    // RenderTarget whose Dispose() throws. Backed by a null SKSurface so ImmediateCanvas can draw
+    // into it without a GPU context.
+    private sealed class FakeRenderNodeProcessor(RenderNode root, Func<int, bool> shouldThrowOnDispose)
+        : RenderNodeProcessor(root, useRenderCache: false)
+    {
+        public List<FakeRenderTarget> CreatedTargets { get; } = new();
+
+        protected internal override RenderTarget? CreateRenderTarget(int width, int height)
+        {
+            var target = new FakeRenderTarget(width, height, shouldThrowOnDispose(CreatedTargets.Count));
+            CreatedTargets.Add(target);
+            return target;
+        }
+    }
+
+    private sealed class FakeRenderTarget(int width, int height, bool throwOnDispose)
+        : RenderTarget(SKSurface.CreateNull(width, height), width, height)
+    {
+        public bool DisposeWasCalled { get; private set; }
+
+        public override void Dispose()
+        {
+            // Idempotent guard: the base finalizer (~RenderTarget) re-invokes this virtual Dispose,
+            // so a throwing path that already fired must not throw again from the finalizer.
+            if (DisposeWasCalled)
+            {
+                return;
+            }
+
+            DisposeWasCalled = true;
+            if (throwOnDispose)
+            {
+                throw new InvalidOperationException("rt-dispose-fault");
+            }
+
+            base.Dispose();
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -142,6 +142,23 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
     }
 
+    // When the null-allocation path also hits a throwing op.Dispose(), the "RenderTarget is null"
+    // failure must still surface rather than the op's dispose throw.
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void PreservesNullAllocationFailure_WhenOpDisposeAlsoThrows(Action<RenderNodeProcessor> rasterize)
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed, throwOnDispose: true),
+            CreateOperation("second", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, returnNullOnCreate: true);
+
+        var ex = Assert.Throws<Exception>(() => rasterize(processor));
+
+        Assert.That(ex!.Message, Is.EqualTo("RenderTarget is null"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
+    }
+
     [Test]
     public void Render_DisposesFaultingAndRemainingOperations_WhenRenderThrows()
     {

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -1,4 +1,4 @@
-﻿using Beutl.Graphics;
+using Beutl.Graphics;
 using Beutl.Graphics.Rendering;
 using SkiaSharp;
 
@@ -7,8 +7,21 @@ namespace Beutl.UnitTests.Engine.Graphics.Rendering;
 [TestFixture]
 public class RenderNodeProcessorExceptionSafetyTests
 {
-    [Test]
-    public void Rasterize_DisposesFaultingAndRemainingOperations_WhenRenderThrows()
+    // The three rasterize entry points share one disposal contract, so every scenario below runs
+    // against all of them. Rasterize and RasterizeToRenderTargets dispose per-op through RasterizeAt;
+    // RasterizeAndConcat renders into a single shared canvas and disposes through its catch sweep.
+    private static IEnumerable<TestCaseData> RasterizeMethods()
+    {
+        yield return new TestCaseData((Action<RenderNodeProcessor>)(p => p.Rasterize()))
+            .SetName("{m}(Rasterize)");
+        yield return new TestCaseData((Action<RenderNodeProcessor>)(p => p.RasterizeAndConcat()))
+            .SetName("{m}(RasterizeAndConcat)");
+        yield return new TestCaseData((Action<RenderNodeProcessor>)(p => p.RasterizeToRenderTargets()))
+            .SetName("{m}(RasterizeToRenderTargets)");
+    }
+
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void DisposesFaultingAndRemainingOperations_WhenRenderThrows(Action<RenderNodeProcessor> rasterize)
     {
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
@@ -17,30 +30,14 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
 
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "fault", "remaining" }));
     }
 
-    [Test]
-    public void RasterizeAndConcat_DisposesFaultingAndRemainingOperations_WhenRenderThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("first", disposed),
-            CreateOperation("fault", disposed, throwOnRender: true),
-            CreateOperation("remaining", disposed));
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
-
-        Assert.That(ex!.Message, Is.EqualTo("fault"));
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
-    }
-
-    [Test]
-    public void RasterizeAndConcat_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows()
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows(Action<RenderNodeProcessor> rasterize)
     {
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
@@ -49,128 +46,100 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
+        // A double-dispose would re-run the faulting op's OnDispose (use-after-free for GPU-backed
+        // ops) and skip the remaining op, so the faulting op must be disposed exactly once.
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
 
-        // The propagated exception must be the faulting op's Dispose, not a masked second throw.
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        // The faulting op must be disposed exactly once, and the remaining op must still be
-        // cleaned up: a double-dispose re-runs OnDispose (use-after-free for GPU-backed ops)
-        // and skips the remaining op.
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "fault", "remaining" }));
     }
 
-    [Test]
-    public void Rasterize_DoesNotDoubleDisposeFaultingOperation_WhenDisposeThrows()
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows(
+        Action<RenderNodeProcessor> rasterize)
+    {
+        var disposed = new List<string>();
+        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
+        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(disposed, Is.EqualTo(new[]
+        {
+            "first",
+            "render-fault",
+            "throwing-remaining-1",
+            "throwing-remaining-2",
+            "remaining"
+        }));
+    }
+
+    // The faulting op throws on both render and dispose: the render throw must propagate while the
+    // dispose throw is swallowed during cleanup (RasterizeAt's DisposeBestEffort, or the DisposeAll
+    // sweep in RasterizeAndConcat's catch).
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void PreservesRenderException_WhenFaultingOpAlsoThrowsOnDispose(Action<RenderNodeProcessor> rasterize)
     {
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
             CreateOperation("first", disposed),
-            CreateOperation("fault", disposed, throwOnDispose: true),
+            CreateOperation("render-fault", disposed, throwOnRender: true, throwOnDispose: true,
+                disposeFaultMessage: "dispose-fault"),
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        // Rasterize delegates per-op disposal to RasterizeAt, which used to dispose the op once in
-        // its try and again in its catch — re-running a throwing OnDispose (use-after-free).
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
-
-        Assert.That(ex!.Message, Is.EqualTo("fault"));
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
-    }
-
-    [Test]
-    public void RasterizeToRenderTargets_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(disposed, Is.EqualTo(new[]
-        {
-            "first",
-            "render-fault",
-            "throwing-remaining-1",
-            "throwing-remaining-2",
-            "remaining"
-        }));
-    }
-
-    [Test]
-    public void Rasterize_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(disposed, Is.EqualTo(new[]
-        {
-            "first",
-            "render-fault",
-            "throwing-remaining-1",
-            "throwing-remaining-2",
-            "remaining"
-        }));
-    }
-
-    [Test]
-    public void RasterizeAndConcat_ContinuesCleanupAndPreservesOriginalException_WhenSweepDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = CreateRenderThrowWithThrowingRemainingOps(disposed);
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(disposed, Is.EqualTo(new[]
-        {
-            "first",
-            "render-fault",
-            "throwing-remaining-1",
-            "throwing-remaining-2",
-            "remaining"
-        }));
-    }
-
-    // RasterizeAt's own catch disposes the faulting op AND its render target. Both go through
-    // DisposeBestEffort, so a throwing op Dispose() there is swallowed and the original render
-    // exception still propagates. Only Rasterize/RasterizeToRenderTargets reach RasterizeAt;
-    // RasterizeAndConcat renders directly into a shared canvas and is covered above.
-    [Test]
-    public void RasterizeToRenderTargets_PreservesRenderException_WhenFaultingOpAlsoThrowsOnDispose()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("first", disposed),
-            CreateOperation("render-fault", disposed, throwOnRender: true, throwOnDispose: true, disposeFaultMessage: "dispose-fault"),
-            CreateOperation("remaining", disposed));
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
 
         Assert.That(ex!.Message, Is.EqualTo("render-fault"));
         Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault", "remaining" }));
     }
 
-    [Test]
-    public void Rasterize_PreservesRenderException_WhenFaultingOpAlsoThrowsOnDispose()
+    // A throwing RenderTarget.Dispose() during faulting-op cleanup must not mask the render exception.
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void PreservesRenderException_WhenRenderTargetDisposeThrows(Action<RenderNodeProcessor> rasterize)
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("render-fault", disposed, throwOnRender: true));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
+
+        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
+    }
+
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void DisposesPulledOperations_WhenRenderTargetCreateThrows(Action<RenderNodeProcessor> rasterize)
     {
         var disposed = new List<string>();
         using var node = new StaticRenderNode(
             CreateOperation("first", disposed),
-            CreateOperation("render-fault", disposed, throwOnRender: true, throwOnDispose: true, disposeFaultMessage: "dispose-fault"),
-            CreateOperation("remaining", disposed));
-        var processor = new RenderNodeProcessor(node, useRenderCache: false);
+            CreateOperation("second", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
+        var ex = Assert.Throws<InvalidOperationException>(() => rasterize(processor));
 
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(disposed, Is.EqualTo(new[] { "first", "render-fault", "remaining" }));
+        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
+    }
+
+    [TestCaseSource(nameof(RasterizeMethods))]
+    public void DisposesPulledOperations_WhenRenderTargetCreateReturnsNull(Action<RenderNodeProcessor> rasterize)
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("first", disposed),
+            CreateOperation("second", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => false, returnNullOnCreate: true);
+
+        var ex = Assert.Throws<Exception>(() => rasterize(processor));
+
+        Assert.That(ex!.Message, Is.EqualTo("RenderTarget is null"));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
     }
 
     [Test]
@@ -183,16 +152,15 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        using var renderTarget = RenderTarget.Create(4, 4);
-        Assume.That(renderTarget, Is.Not.Null);
-        using var canvas = new ImmediateCanvas(renderTarget!);
+        using var renderTarget = RenderTarget.CreateNull(4, 4);
+        using var canvas = new ImmediateCanvas(renderTarget);
 
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        // A mid-loop render throw must still dispose the faulting op and every op after it,
-        // or the GPU handles those ops back leak.
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        // A mid-loop render throw must still dispose the faulting op and every op after it, or those
+        // ops' GPU handles leak.
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "fault", "remaining" }));
     }
 
     [Test]
@@ -205,15 +173,13 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed));
         var processor = new RenderNodeProcessor(node, useRenderCache: false);
 
-        using var renderTarget = RenderTarget.Create(4, 4);
-        Assume.That(renderTarget, Is.Not.Null);
-        using var canvas = new ImmediateCanvas(renderTarget!);
+        using var renderTarget = RenderTarget.CreateNull(4, 4);
+        using var canvas = new ImmediateCanvas(renderTarget);
 
         var ex = Assert.Throws<InvalidOperationException>(() => processor.Render(canvas));
 
         Assert.That(ex!.Message, Is.EqualTo("fault"));
-        // The faulting op must not be re-disposed by the sweep; the remaining op still gets cleaned up.
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "fault", "remaining" }));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "fault", "remaining" }));
     }
 
     [Test]
@@ -227,123 +193,14 @@ public class RenderNodeProcessorExceptionSafetyTests
             CreateOperation("remaining", disposed),
         ];
 
-        // DisposeAll must swallow a faulting Dispose so the sweep reaches every trailing op.
         Assert.DoesNotThrow(() => RenderNodeOperation.DisposeAll(ops));
-        Assert.That(disposed, Is.EquivalentTo(new[] { "first", "throws", "remaining" }));
+        Assert.That(disposed, Is.EqualTo(new[] { "first", "throws", "remaining" }));
     }
 
-    // RasterizeAt disposes the faulting op's render target via DisposeBestEffort, so a throwing
-    // RenderTarget.Dispose() cannot mask the in-flight render exception.
-    [Test]
-    public void RasterizeToRenderTargets_PreservesRenderException_WhenRenderTargetDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("render-fault", disposed, throwOnRender: true));
-        var processor = new FakeRenderNodeProcessor(node, _ => true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
-        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
-        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
-    }
-
-    [Test]
-    public void Rasterize_PreservesRenderException_WhenRenderTargetDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("render-fault", disposed, throwOnRender: true));
-        var processor = new FakeRenderNodeProcessor(node, _ => true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
-        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
-        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
-    }
-
-    [Test]
-    public void RasterizeAndConcat_PreservesRenderException_WhenRenderTargetDisposeThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("render-fault", disposed, throwOnRender: true));
-        var processor = new FakeRenderNodeProcessor(node, _ => true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
-
-        Assert.That(ex!.Message, Is.EqualTo("render-fault"));
-        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
-        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
-        Assert.That(disposed, Is.EqualTo(new[] { "render-fault" }));
-    }
-
-    [Test]
-    public void RasterizeToRenderTargets_DisposesCurrentAndRemainingOperations_WhenRenderTargetCreateThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("current", disposed),
-            CreateOperation("remaining", disposed));
-        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeToRenderTargets());
-
-        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
-        Assert.That(disposed, Is.EqualTo(new[] { "current", "remaining" }));
-    }
-
-    [Test]
-    public void Rasterize_DisposesCurrentAndRemainingOperations_WhenRenderTargetCreateThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("current", disposed),
-            CreateOperation("remaining", disposed));
-        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.Rasterize());
-
-        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
-        Assert.That(disposed, Is.EqualTo(new[] { "current", "remaining" }));
-    }
-
-    [Test]
-    public void RasterizeAndConcat_DisposesPulledOperations_WhenRenderTargetCreateThrows()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("first", disposed),
-            CreateOperation("second", disposed));
-        var processor = new FakeRenderNodeProcessor(node, _ => false, throwOnCreate: true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => processor.RasterizeAndConcat());
-
-        Assert.That(ex!.Message, Is.EqualTo("rt-create-fault"));
-        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
-    }
-
-    [Test]
-    public void RasterizeAndConcat_DisposesPulledOperations_WhenRenderTargetCreateReturnsNull()
-    {
-        var disposed = new List<string>();
-        using var node = new StaticRenderNode(
-            CreateOperation("first", disposed),
-            CreateOperation("second", disposed));
-        var processor = new FakeRenderNodeProcessor(node, _ => false, returnNullOnCreate: true);
-
-        var ex = Assert.Throws<Exception>(() => processor.RasterizeAndConcat());
-
-        Assert.That(ex!.Message, Is.EqualTo("RenderTarget is null"));
-        Assert.That(disposed, Is.EqualTo(new[] { "first", "second" }));
-    }
-
-    // DisposeRenderTargets must keep sweeping past a list-resident RenderTarget that throws on
-    // Dispose, without masking the render exception.
+    // RasterizeToRenderTargets keeps successfully-rendered targets in a list, so a list-resident
+    // target that throws on Dispose during cleanup must not stop the sweep or mask the render
+    // exception. Rasterize snapshots and disposes each target immediately and RasterizeAndConcat
+    // uses a single target, so neither has list-resident targets — this path is theirs alone.
     [Test]
     public void RasterizeToRenderTargets_ContinuesCleanupAndPreservesException_WhenBuiltRenderTargetDisposeThrows()
     {
@@ -448,8 +305,8 @@ public class RenderNodeProcessorExceptionSafetyTests
         public override RenderNodeOperation[] Process(RenderNodeContext context) => operations;
     }
 
-    // Substitutes RenderTarget allocation so the exception-safety paths can be exercised with a
-    // RenderTarget whose Dispose() throws.
+    // Substitutes RenderTarget allocation so the exception-safety paths can run with a RenderTarget
+    // whose Dispose() throws, or with a failing/null allocation, none of which a real GPU target offers.
     private sealed class FakeRenderNodeProcessor(
         RenderNode root,
         Func<int, bool> shouldThrowOnDispose,

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -384,6 +384,29 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "ok" }));
     }
 
+    // A throwing Dispose() during post-snapshot cleanup must not discard the already-snapshotted bitmaps.
+    [Test]
+    public void Rasterize_ReturnsBitmaps_WhenRenderSucceedsButRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("ok", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        var result = processor.Rasterize();
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        using (result[0])
+        {
+            Assert.That(result[0].Width, Is.EqualTo(4));
+            Assert.That(result[0].Height, Is.EqualTo(4));
+        }
+
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "ok" }));
+    }
+
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
     {
         return new StaticRenderNode(

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs
@@ -367,6 +367,26 @@ public class RenderNodeProcessorExceptionSafetyTests
         Assert.That(disposed, Is.EqualTo(new[] { "first", "second", "render-fault" }));
     }
 
+    // A throwing Dispose() during RasterizeAndConcat's post-success cleanup must not discard the
+    // bitmap the render already produced — the caller still gets its result.
+    [Test]
+    public void RasterizeAndConcat_ReturnsBitmap_WhenRenderSucceedsButRenderTargetDisposeThrows()
+    {
+        var disposed = new List<string>();
+        using var node = new StaticRenderNode(
+            CreateOperation("ok", disposed));
+        var processor = new FakeRenderNodeProcessor(node, _ => true);
+
+        using var result = processor.RasterizeAndConcat();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Width, Is.EqualTo(4));
+        Assert.That(result.Height, Is.EqualTo(4));
+        Assert.That(processor.CreatedTargets, Has.Count.EqualTo(1));
+        Assert.That(processor.CreatedTargets[0].DisposeWasCalled, Is.True);
+        Assert.That(disposed, Is.EqualTo(new[] { "ok" }));
+    }
+
     private static StaticRenderNode CreateRenderThrowWithThrowingRemainingOps(ICollection<string> disposed)
     {
         return new StaticRenderNode(
@@ -439,9 +459,15 @@ public class RenderNodeProcessorExceptionSafetyTests
     }
 
     private sealed class FakeRenderTarget(int width, int height, bool throwOnDispose)
-        : RenderTarget(SKSurface.CreateNull(width, height), width, height)
+        : RenderTarget(CreateReadbackSurface(width, height), width, height)
     {
         public bool DisposeWasCalled { get; private set; }
+
+        // A CPU raster surface (CreateNull has no backing store and fails ReadPixels) so the
+        // RasterizeAndConcat success path can read pixels back through Snapshot() without a GPU.
+        private static SKSurface CreateReadbackSurface(int width, int height) =>
+            SKSurface.Create(new SKImageInfo(
+                width, height, SKColorType.RgbaF16, SKAlphaType.Premul, SKColorSpace.CreateSrgbLinear()));
 
         // Throw only on explicit disposal (disposing == true). The finalizer drives
         // Dispose(disposing: false), which must stay throw-free so a GC-collected double


### PR DESCRIPTION
## Description
- Closes the two `RenderTarget`-dispose exception-safety paths left open as a `[follow-up][low]` item by PR #1970 (*fix(engine): preserve rasterize cleanup exceptions*):
  1. **`RasterizeAt`'s catch** when the faulting op's **render-target** `Dispose()` throws (GPU-native teardown) and would mask the in-flight render exception.
  2. **The outer `DisposeRenderTargets` sweep** when an already-built, list-resident `RenderTarget` throws on `Dispose` during cleanup.
- Both paths already route through `DisposeBestEffort` (shipped in #1970). The new tests are **characterization tests** confirming the swallow logic holds at these specific render-target entry points — they pass green against the current code, so **no behavior fix was needed**.
- To make `RenderTarget` substitutable for the tests, adds a minimal, backward-compatible extensibility seam (no signature break, no `[Obsolete]` shims):
  - `RenderNodeProcessor.CreateRenderTarget` — `protected virtual` hook over `RenderTarget.Create` (also a genuine allocation extensibility point).
  - `RenderTarget` — canonical `Dispose(bool disposing)` pattern (safe virtual disposal from the finalizer) + a `protected` ctor wrapping a raw `SKSurface`.

### Design review
`beutl-design-reviewer` reviewed the extensibility surface. Its one medium finding — that a naive `virtual Dispose()` reached from `~RenderTarget()` is a finalizer-crash foot-gun for throwing overrides — is fixed in the second commit by switching to the `Dispose(bool disposing)` pattern (the test double throws only when `disposing == true`, so finalizer-driven disposal is throw-free by construction). Reviewer's minor note to tighten `protected internal` → `protected` also applied.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
None. `Dispose()` stays non-virtual to the outside; a new `protected virtual Dispose(bool)` and `protected` ctor / virtual `CreateRenderTarget` hook are additive. All existing call sites compile and behave identically (420 surrounding rendering tests green).

## Test plan
- New tests in `tests/Beutl.UnitTests/Engine/Graphics/Rendering/RenderNodeProcessorExceptionSafetyTests.cs`:
  - `RasterizeToRenderTargets_PreservesRenderException_WhenRenderTargetDisposeThrows` (path #1)
  - `Rasterize_PreservesRenderException_WhenRenderTargetDisposeThrows` (path #1, mirror)
  - `RasterizeToRenderTargets_ContinuesCleanupAndPreservesException_WhenBuiltRenderTargetDisposeThrows` (path #2, RT sweep)
- Baseline-first: written alongside the seam; run against the already-shipped `DisposeBestEffort` logic → green (15/15 ExceptionSafety, 420/420 broader rendering filter).
- `dotnet format --verify-no-changes` clean on the three touched files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-23][follow-up][low] Test renderTarget.Dispose()-throws path in RasterizeAt catch + built RT/Bitmap sweep")

## Follow-ups
- **Path #2 Bitmap sweep** (`DisposeBitmaps` with a throwing built `Bitmap`) is intentionally out of scope: `Bitmap` is `sealed`, so it requires unsealing + `virtual Dispose` for low marginal value — the sweep behavior is mechanically identical to the `RenderTarget` sweep now covered here.
- **`IRenderTarget` interface**: the chosen virtual seam (`CreateRenderTarget` + `Dispose(bool)` + protected `SKSurface` ctor) is the smaller, more orthogonal change and matches the user-confirmed decision. If/when a real plugin need appears (RT pooling, software-only raster, headless tests without Skia), revisit extracting `IRenderTarget` and flowing it through `ImmediateCanvas`/`Renderer`/cache as its own `feat!:` / `BREAKING CHANGE:` change. The protected ctor currently bakes in a Skia assumption, which is the main signal for that future refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overridable hook to customize how intermediate render targets are created during rendering.
* **Bug Fixes**
  * Improved exception safety so the original render error is preserved even if render-target disposal throws.
  * Strengthened cleanup to prevent resource leaks when render-target creation fails or returns no target; snapshot creation now survives teardown faults.
* **Tests**
  * Added unit coverage for exception preservation and best-effort disposal across render, concat, and failure/success scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->