### PR TITLE
refactor(ffmpeg): extract codec-editor query/apply decisions for unit tests

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatEditorViewModel.cs
@@ -97,12 +97,12 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         if (_settings == null)
         {
             _refresh.Supersede();
-            ApplyFormats(GetAllFormats());
+            ApplyFormats(AudioFormatOptions.All());
             return;
         }
 
-        QueryParams query = CreateQueryParams(_settings);
-        string key = BuildCacheKey(query);
+        CodecQueryParams query = CodecOptionQuery.Create(_settings.Codec, _settings.OutputFile);
+        string key = CodecOptionQuery.BuildCacheKey(query);
         if (FFmpegOptionsCaches.AudioFormats.TryGetCached(key, out AudioFormat[]? cached))
         {
             _refresh.Supersede();
@@ -114,7 +114,7 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
+    private async Task UpdateAsync(CodecQueryParams query, string key, CancellationToken ct)
     {
         OptionsQueryResult<AudioFormat> result;
         try
@@ -129,15 +129,13 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             if (LatestRefreshTracker.IsCurrent(ct))
             {
                 s_logger.LogWarning(ex, "Failed to refresh audio formats from FFmpeg worker");
-                await ApplyOnUiThreadAsync(ct, () => ApplyFormats(GetAllFormats())).ConfigureAwait(false);
+                await ApplyOnUiThreadAsync(ct, () => ApplyFormats(AudioFormatOptions.All())).ConfigureAwait(false);
             }
 
             return;
         }
 
-        // Applying the degraded (empty) fallback would mark the current format unsupported and reset
-        // the model value to Default, so show every format instead — matching the catch above.
-        AudioFormat[] formats = result.Degraded ? GetAllFormats() : result.Items;
+        AudioFormat[] formats = AudioFormatOptions.ResolveSupported(result);
         await ApplyOnUiThreadAsync(ct, () => ApplyFormats(formats)).ConfigureAwait(false);
     }
 
@@ -177,23 +175,18 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
             editor.Items = _currentItems;
         }
 
-        // Check whether the current value is present in the list.
-        var currentValue = _property.GetValue();
-        int index = Array.IndexOf(_currentFormats, currentValue);
-        _selectedIndex.Value = -1; // Reset once.
-        if (index < 0 && currentValue != AudioFormat.Default)
+        FormatSelectionResult selection =
+            CodecFormatSelection.Resolve(_currentFormats, _property.GetValue(), AudioFormat.Default);
+        _selectedIndex.Value = -1; // Force a transition so the binding re-fires even if the index is unchanged.
+        if (selection.ResetToSentinel)
         {
-            // Reset to Auto when an unsupported format is selected.
             _property.SetValue(AudioFormat.Default);
-            _selectedIndex.Value = 0;
         }
-        else
-        {
-            _selectedIndex.Value = Math.Max(index, 0);
-        }
+
+        _selectedIndex.Value = selection.SelectedIndex;
     }
 
-    private static async Task<OptionsQueryResult<AudioFormat>> QueryAudioFormatsAsync(QueryParams query)
+    private static async Task<OptionsQueryResult<AudioFormat>> QueryAudioFormatsAsync(CodecQueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QueryAudioFormatsRequest, QueryAudioFormatsResponse>(
@@ -206,27 +199,6 @@ internal sealed class AudioFormatEditorViewModel : IPropertyEditorContext
         return new OptionsQueryResult<AudioFormat>(
             response.Formats.Select(f => (AudioFormat)f).ToArray(), response.Degraded);
     }
-
-    private static AudioFormat[] GetAllFormats()
-    {
-        // ApplyFormats prepends AudioFormat.Default ("Auto"), so exclude it here to avoid a duplicate.
-        return Enum.GetValues<AudioFormat>()
-            .Where(f => f != AudioFormat.Default)
-            .ToArray();
-    }
-
-    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
-    // _settings mutates mid-flight.
-    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
-
-    private static QueryParams CreateQueryParams(FFmpegAudioEncoderSettings settings)
-        => new(
-            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-            settings.OutputFile);
-
-    private static string BuildCacheKey(QueryParams query)
-        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatOptions.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatOptions.cs
@@ -1,0 +1,24 @@
+﻿using AudioFormat = Beutl.Extensions.FFmpeg.Encoding.FFmpegAudioEncoderSettings.AudioFormat;
+
+namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>
+/// The audio-format option set the editor offers, and the rule for turning a worker query result into
+/// that set. Kept out of the ViewModel so the degraded-handling decision can be unit tested directly.
+/// </summary>
+internal static class AudioFormatOptions
+{
+    /// <summary>Every selectable format. Excludes Default ("Auto"), which the editor prepends itself.</summary>
+    public static AudioFormat[] All()
+        => Enum.GetValues<AudioFormat>()
+            .Where(f => f != AudioFormat.Default)
+            .ToArray();
+
+    /// <summary>
+    /// A degraded (worker-fallback) result is shown as every format rather than its empty payload:
+    /// applying the empty list would mark the current format unsupported and reset the model value to
+    /// Default, so the full set keeps the current selection intact.
+    /// </summary>
+    public static AudioFormat[] ResolveSupported(OptionsQueryResult<AudioFormat> result)
+        => result.Degraded ? All() : result.Items;
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatOptions.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/AudioFormatOptions.cs
@@ -4,7 +4,7 @@ namespace Beutl.Extensions.FFmpeg.PropertyEditors;
 
 /// <summary>
 /// The audio-format option set the editor offers, and the rule for turning a worker query result into
-/// that set. Kept out of the ViewModel so the degraded-handling decision can be unit tested directly.
+/// that set.
 /// </summary>
 internal static class AudioFormatOptions
 {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecFormatSelection.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecFormatSelection.cs
@@ -1,0 +1,26 @@
+﻿namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>The selection a codec editor should apply: which index to select, and whether to reset the model value to the sentinel.</summary>
+internal readonly record struct FormatSelectionResult(int SelectedIndex, bool ResetToSentinel);
+
+/// <summary>
+/// Decides which entry of an option list a codec editor should select. Shared by the pixel-format and
+/// audio-format editors, which both prepend an "Auto" sentinel and reset to it when the current value
+/// is no longer offered.
+/// </summary>
+internal static class CodecFormatSelection
+{
+    /// <param name="formatsWithSentinel">The option list with the "Auto" sentinel already prepended.</param>
+    /// <returns>
+    /// A reset to <paramref name="sentinel"/> (index 0) when <paramref name="current"/> is absent and is
+    /// not itself the sentinel; otherwise the current value's index (0 when it is the sentinel).
+    /// </returns>
+    public static FormatSelectionResult Resolve<T>(T[] formatsWithSentinel, T current, T sentinel)
+        where T : struct
+    {
+        int index = Array.IndexOf(formatsWithSentinel, current);
+        return index < 0 && !EqualityComparer<T>.Default.Equals(current, sentinel)
+            ? new FormatSelectionResult(0, ResetToSentinel: true)
+            : new FormatSelectionResult(Math.Max(index, 0), ResetToSentinel: false);
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecOptionQuery.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecOptionQuery.cs
@@ -22,7 +22,10 @@ internal static class CodecOptionQuery
     public static CodecQueryParams Create(CodecRecord codec, string? outputFile)
         => new(codec.Equals(CodecRecord.Default) ? null : codec.Name, outputFile);
 
-    /// <summary>Builds the option-cache key. NUL cannot appear in a codec name or path, so keys never collide.</summary>
+    /// <summary>
+    /// Builds the option-cache key. NUL cannot appear in a codec name or path, so keys never collide; null
+    /// maps to a placeholder distinct from empty string so the two never alias.
+    /// </summary>
     public static string BuildCacheKey(CodecQueryParams query)
-        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
+        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile ?? "<null>"}";
 }

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecOptionQuery.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/CodecOptionQuery.cs
@@ -1,0 +1,28 @@
+﻿using Beutl.Extensions.FFmpeg.Encoding;
+
+namespace Beutl.Extensions.FFmpeg.PropertyEditors;
+
+/// <summary>
+/// The codec + output-file snapshot a codec property editor queries the FFmpeg worker with. Both the
+/// worker request and the cache key derive from one instance so they cannot diverge if the underlying
+/// settings mutate mid-flight.
+/// </summary>
+internal readonly record struct CodecQueryParams(string? CodecName, string? OutputFile);
+
+/// <summary>
+/// Shared snapshot + cache-key derivation for the codec property editors (pixel format / audio format /
+/// sample rate), so the three editors cannot drift apart on how they key the option cache.
+/// </summary>
+internal static class CodecOptionQuery
+{
+    /// <summary>
+    /// Snapshots the codec and output file. The Default codec maps to a null name so the worker
+    /// enumerates every option rather than filtering to a specific codec.
+    /// </summary>
+    public static CodecQueryParams Create(CodecRecord codec, string? outputFile)
+        => new(codec.Equals(CodecRecord.Default) ? null : codec.Name, outputFile);
+
+    /// <summary>Builds the option-cache key. NUL cannot appear in a codec name or path, so keys never collide.</summary>
+    public static string BuildCacheKey(CodecQueryParams query)
+        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
+}

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/PixelFormatEditorViewModel.cs
@@ -101,8 +101,8 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        QueryParams query = CreateQueryParams(_settings);
-        string key = BuildCacheKey(query);
+        CodecQueryParams query = CodecOptionQuery.Create(_settings.Codec, _settings.OutputFile);
+        string key = CodecOptionQuery.BuildCacheKey(query);
         if (FFmpegOptionsCaches.PixelFormats.TryGetCached(key, out PixelFormatInfo[]? cached))
         {
             _refresh.Supersede();
@@ -114,7 +114,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
+    private async Task UpdateAsync(CodecQueryParams query, string key, CancellationToken ct)
     {
         OptionsQueryResult<PixelFormatInfo> result;
         try
@@ -171,20 +171,15 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             editor.Items = _currentItems;
         }
 
-        // Check whether the current value is present in the list.
-        var currentValue = _property.GetValue();
-        int index = Array.IndexOf(_currentFormats, currentValue);
-        _selectedIndex.Value = -1; // Reset once.
-        if (index < 0 && currentValue != FFPixelFormat.None)
+        FormatSelectionResult selection =
+            CodecFormatSelection.Resolve(_currentFormats, _property.GetValue(), FFPixelFormat.None);
+        _selectedIndex.Value = -1; // Force a transition so the binding re-fires even if the index is unchanged.
+        if (selection.ResetToSentinel)
         {
-            // Reset to Auto when an unsupported format is selected.
             _property.SetValue(FFPixelFormat.None);
-            _selectedIndex.Value = 0;
         }
-        else
-        {
-            _selectedIndex.Value = Math.Max(index, 0);
-        }
+
+        _selectedIndex.Value = selection.SelectedIndex;
     }
 
     private void ApplyFallback()
@@ -200,7 +195,7 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private static async Task<OptionsQueryResult<PixelFormatInfo>> QueryPixelFormatsAsync(QueryParams query)
+    private static async Task<OptionsQueryResult<PixelFormatInfo>> QueryPixelFormatsAsync(CodecQueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QueryPixelFormatsRequest, QueryPixelFormatsResponse>(
@@ -212,19 +207,6 @@ internal sealed class PixelFormatEditorViewModel : IPropertyEditorContext
             }).ConfigureAwait(false);
         return new OptionsQueryResult<PixelFormatInfo>(response.Formats, response.Degraded);
     }
-
-    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
-    // _settings mutates mid-flight.
-    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
-
-    private static QueryParams CreateQueryParams(FFmpegVideoEncoderSettings settings)
-        => new(
-            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-            settings.OutputFile);
-
-    private static string BuildCacheKey(QueryParams query)
-        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
+++ b/src/Beutl.Extensions.FFmpeg/PropertyEditors/SampleRateEditorViewModel.cs
@@ -99,8 +99,8 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             return;
         }
 
-        QueryParams query = CreateQueryParams(_settings);
-        string key = BuildCacheKey(query);
+        CodecQueryParams query = CodecOptionQuery.Create(_settings.Codec, _settings.OutputFile);
+        string key = CodecOptionQuery.BuildCacheKey(query);
         if (FFmpegOptionsCaches.SampleRates.TryGetCached(key, out int[]? cached))
         {
             _refresh.Supersede();
@@ -112,7 +112,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         _ = UpdateAsync(query, key, ct);
     }
 
-    private async Task UpdateAsync(QueryParams query, string key, CancellationToken ct)
+    private async Task UpdateAsync(CodecQueryParams query, string key, CancellationToken ct)
     {
         OptionsQueryResult<int> result;
         try
@@ -164,7 +164,7 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
         }
     }
 
-    private static async Task<OptionsQueryResult<int>> QuerySampleRatesAsync(QueryParams query)
+    private static async Task<OptionsQueryResult<int>> QuerySampleRatesAsync(CodecQueryParams query)
     {
         var connection = await FFmpegWorkerProcess.DecodingInstance.EnsureStartedAsync().ConfigureAwait(false);
         var response = await connection.RequestAsync<QuerySampleRatesRequest, QuerySampleRatesResponse>(
@@ -176,19 +176,6 @@ internal sealed class SampleRateEditorViewModel : IPropertyEditorContext
             }).ConfigureAwait(false);
         return new OptionsQueryResult<int>(response.SampleRates, response.Degraded);
     }
-
-    // The cache key and the worker query both derive from this snapshot, so they cannot diverge if
-    // _settings mutates mid-flight.
-    private readonly record struct QueryParams(string? CodecName, string? OutputFile);
-
-    private static QueryParams CreateQueryParams(FFmpegAudioEncoderSettings settings)
-        => new(
-            settings.Codec.Equals(CodecRecord.Default) ? null : settings.Codec.Name,
-            settings.OutputFile);
-
-    private static string BuildCacheKey(QueryParams query)
-        // Use NUL as the delimiter since it cannot appear in a codec name or file path.
-        => $"{query.CodecName ?? "<default>"}\0{query.OutputFile}";
 
     private void OnValueConfirmed(object? sender, PropertyEditorValueChangedEventArgs e)
     {

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/AudioFormatDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/AudioFormatDecisionTests.cs
@@ -1,0 +1,64 @@
+﻿using Beutl.Extensions.FFmpeg.PropertyEditors;
+using AudioFormat = Beutl.Extensions.FFmpeg.Encoding.FFmpegAudioEncoderSettings.AudioFormat;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class AudioFormatDecisionTests
+{
+    [Test]
+    public void ResolveSupportedFormats_NonDegraded_ReturnsItemsVerbatim()
+    {
+        AudioFormat[] items = [AudioFormat.S16, AudioFormat.Fltp];
+
+        AudioFormat[] resolved = AudioFormatOptions.ResolveSupported(
+            new OptionsQueryResult<AudioFormat>(items, Degraded: false));
+
+        Assert.That(resolved, Is.EqualTo(items));
+    }
+
+    [Test]
+    public void ResolveSupportedFormats_Degraded_ReturnsEveryFormatExceptDefault()
+    {
+        AudioFormat[] resolved = AudioFormatOptions.ResolveSupported(
+            new OptionsQueryResult<AudioFormat>([], Degraded: true));
+
+        AudioFormat[] expected = Enum.GetValues<AudioFormat>()
+            .Where(f => f != AudioFormat.Default)
+            .ToArray();
+        Assert.That(resolved, Is.EqualTo(expected));
+        Assert.That(resolved, Is.Not.Empty);
+        Assert.That(resolved, Does.Not.Contain(AudioFormat.Default));
+    }
+
+    // The point of the degraded->all rule: a degraded result must NOT collapse the list to empty,
+    // because an empty list would make the editor reset the user's current format to Default. Showing
+    // every format keeps the selection. This composes ResolveSupportedFormats with CodecFormatSelection
+    // exactly as AudioFormatEditorViewModel.UpdateAsync/ApplyFormats do.
+    [Test]
+    public void DegradedResult_PreservesCurrentSelection_InsteadOfResettingToDefault()
+    {
+        var degraded = new OptionsQueryResult<AudioFormat>([], Degraded: true);
+
+        AudioFormat[] supported = AudioFormatOptions.ResolveSupported(degraded);
+        AudioFormat[] withSentinel = [AudioFormat.Default, .. supported];
+        FormatSelectionResult selection =
+            CodecFormatSelection.Resolve(withSentinel, AudioFormat.Fltp, AudioFormat.Default);
+
+        Assert.That(selection.ResetToSentinel, Is.False, "degraded must keep the current format selected");
+        Assert.That(withSentinel[selection.SelectedIndex], Is.EqualTo(AudioFormat.Fltp));
+    }
+
+    // Contrast: had the degraded branch instead applied the empty payload, the same current format
+    // would be unsupported and the editor would reset it to Default.
+    [Test]
+    public void EmptyFormatList_WouldResetCurrentToDefault()
+    {
+        AudioFormat[] withSentinel = [AudioFormat.Default];
+
+        FormatSelectionResult selection =
+            CodecFormatSelection.Resolve(withSentinel, AudioFormat.Fltp, AudioFormat.Default);
+
+        Assert.That(selection.ResetToSentinel, Is.True);
+    }
+}

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecFormatSelectionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecFormatSelectionTests.cs
@@ -1,0 +1,56 @@
+﻿using Beutl.Extensions.FFmpeg.PropertyEditors;
+using AudioFormat = Beutl.Extensions.FFmpeg.Encoding.FFmpegAudioEncoderSettings.AudioFormat;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class CodecFormatSelectionTests
+{
+    [Test]
+    public void Resolve_CurrentPresent_SelectsItsIndexWithoutReset()
+    {
+        AudioFormat[] formats = [AudioFormat.Default, AudioFormat.U8, AudioFormat.S16, AudioFormat.Fltp];
+
+        FormatSelectionResult result = CodecFormatSelection.Resolve(formats, AudioFormat.S16, AudioFormat.Default);
+
+        Assert.That(result.ResetToSentinel, Is.False);
+        Assert.That(result.SelectedIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Resolve_CurrentAbsentAndNotSentinel_ResetsToSentinelAtIndex0()
+    {
+        AudioFormat[] formats = [AudioFormat.Default, AudioFormat.U8, AudioFormat.S16];
+
+        FormatSelectionResult result = CodecFormatSelection.Resolve(formats, AudioFormat.Fltp, AudioFormat.Default);
+
+        Assert.That(result.ResetToSentinel, Is.True);
+        Assert.That(result.SelectedIndex, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Resolve_CurrentIsSentinel_KeepsSentinelWithoutReset()
+    {
+        AudioFormat[] formats = [AudioFormat.Default, AudioFormat.U8, AudioFormat.S16];
+
+        FormatSelectionResult result = CodecFormatSelection.Resolve(formats, AudioFormat.Default, AudioFormat.Default);
+
+        Assert.That(result.ResetToSentinel, Is.False);
+        Assert.That(result.SelectedIndex, Is.EqualTo(0));
+    }
+
+    // The pixel-format editor keys on int with FFPixelFormat.None (-1) as the sentinel, so the same
+    // generic decision must hold for value types other than the audio enum.
+    [TestCase(62, false, 2)]   // present -> selected, no reset
+    [TestCase(999, true, 0)]   // absent & not sentinel -> reset to sentinel
+    [TestCase(-1, false, 0)]   // the sentinel itself -> no reset
+    public void Resolve_IntPixelFormats_BehavesLikeEnum(int current, bool expectedReset, int expectedIndex)
+    {
+        int[] formats = [-1, 0, 62];
+
+        FormatSelectionResult result = CodecFormatSelection.Resolve(formats, current, -1);
+
+        Assert.That(result.ResetToSentinel, Is.EqualTo(expectedReset));
+        Assert.That(result.SelectedIndex, Is.EqualTo(expectedIndex));
+    }
+}

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecOptionQueryTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecOptionQueryTests.cs
@@ -62,4 +62,13 @@ public class CodecOptionQueryTests
         Assert.That(aac, Is.Not.EqualTo(mp3));
         Assert.That(aac, Is.Not.EqualTo(otherFile));
     }
+
+    [Test]
+    public void BuildCacheKey_NullVsEmptyOutputFile_ProduceDistinctKeys()
+    {
+        string nullFile = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("aac", null));
+        string emptyFile = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("aac", ""));
+
+        Assert.That(nullFile, Is.Not.EqualTo(emptyFile));
+    }
 }

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecOptionQueryTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/CodecOptionQueryTests.cs
@@ -1,0 +1,65 @@
+﻿using Beutl.Extensions.FFmpeg.Encoding;
+using Beutl.Extensions.FFmpeg.PropertyEditors;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class CodecOptionQueryTests
+{
+    [Test]
+    public void Create_DefaultCodec_MapsToNullName()
+    {
+        CodecQueryParams query = CodecOptionQuery.Create(CodecRecord.Default, "out.mp4");
+
+        Assert.That(query.CodecName, Is.Null);
+        Assert.That(query.OutputFile, Is.EqualTo("out.mp4"));
+    }
+
+    [Test]
+    public void Create_NamedCodec_KeepsName()
+    {
+        CodecQueryParams query = CodecOptionQuery.Create(new CodecRecord("aac", "AAC"), "out.mp4");
+
+        Assert.That(query.CodecName, Is.EqualTo("aac"));
+        Assert.That(query.OutputFile, Is.EqualTo("out.mp4"));
+    }
+
+    [Test]
+    public void BuildCacheKey_NullCodec_UsesDefaultSentinelAndNulDelimiter()
+    {
+        string key = CodecOptionQuery.BuildCacheKey(new CodecQueryParams(null, "out.mp4"));
+
+        Assert.That(key, Is.EqualTo("<default>\0out.mp4"));
+    }
+
+    [Test]
+    public void BuildCacheKey_NamedCodec_UsesNameAndNulDelimiter()
+    {
+        string key = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("aac", "out.mp4"));
+
+        Assert.That(key, Is.EqualTo("aac\0out.mp4"));
+    }
+
+    // The cache key and the worker request both derive from one CodecQueryParams, so equal snapshots
+    // must produce one key and any difference must produce a distinct one.
+    [Test]
+    public void BuildCacheKey_EqualSnapshots_ProduceEqualKeys()
+    {
+        var a = CodecOptionQuery.Create(new CodecRecord("aac", "AAC"), "out.mp4");
+        var b = CodecOptionQuery.Create(new CodecRecord("aac", "different long name"), "out.mp4");
+
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(CodecOptionQuery.BuildCacheKey(a), Is.EqualTo(CodecOptionQuery.BuildCacheKey(b)));
+    }
+
+    [Test]
+    public void BuildCacheKey_DifferentCodecOrFile_ProduceDistinctKeys()
+    {
+        string aac = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("aac", "out.mp4"));
+        string mp3 = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("mp3", "out.mp4"));
+        string otherFile = CodecOptionQuery.BuildCacheKey(new CodecQueryParams("aac", "other.mp4"));
+
+        Assert.That(aac, Is.Not.EqualTo(mp3));
+        Assert.That(aac, Is.Not.EqualTo(otherFile));
+    }
+}


### PR DESCRIPTION
## Description
- Extract the three FFmpeg codec property editors' duplicated query/apply decision logic into shared, UI-free helpers so the editor-side decisions can be unit-tested without a live worker or an Avalonia dispatcher.
- `CodecOptionQuery` replaces the three copy-pasted `QueryParams`/`CreateQueryParams`/`BuildCacheKey` blocks; `CodecFormatSelection.Resolve<T>` is the reset-to-sentinel decision shared by the pixel and audio editors; `AudioFormatOptions` holds the degraded→show-all rule that keeps a degraded worker result from resetting the current audio format.
- Behavior-preserving: the editors delegate to these helpers; only the location of the decision logic moves.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary) — specifically `Beutl.Extensions.FFmpeg` (MIT) codec property editors + `Beutl.UnitTests`

## Breaking changes
None — all new types are `internal`; no public surface change.

## Test plan
- Baseline-first: ran the existing `Extensions.FFmpeg` suite green before/after; new logic ships with tests.
- New NUnit fixtures: `CodecOptionQueryTests` (cache-key snapshot consistency, default-codec→null, NUL delimiter), `CodecFormatSelectionTests` (present/absent/sentinel for enum + int), `AudioFormatDecisionTests` (degraded→show-all preserves the current selection; the empty-list contrast would reset).
- `dotnet test tests/Beutl.UnitTests -f net10.0 --filter "FullyQualifiedName~Extensions.FFmpeg"` → 67 passed, 0 failed.
- Note: `dotnet format --verify-no-changes` could not run in the sandbox (Roslyn build-host named-pipe blocked); `dotnet format whitespace --folder --verify-no-changes` passed. CI will run the full format check.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Make FFmpeg codec property editors unit-testable (inject worker query)")

## Follow-ups
- `PixelFormatEditorViewModel.UpdateAsync` ignores `result.Degraded` and applies the empty `result.Items` directly, so a degraded worker result resets the user's selected pixel format to Auto — asymmetric with the audio editor's degraded handling and likely a latent bug. Out of scope for this behavior-preserving refactor; should be fixed (or explicitly documented as intentional) separately.

## Design note
The issue title suggests "inject the worker query." I deliberately did not add a query-delegate seam: `Beutl.UnitTests` has no Avalonia headless harness, so even with an injected fake query the editor's apply path (`Dispatcher.UIThread.InvokeAsync`) cannot be driven in a plain NUnit test — a query seam alone would be untested dead surface. Extracting the pure decisions (the actual testable units) into shared helpers tests exactly the logic the issue flagged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFmpeg editor refresh behavior for audio, pixel, and sample-rate formats: supported options are now resolved consistently, and when results are missing/unsupported the selection falls back to “Auto” without incorrectly clearing the user’s current choice.

* **Refactor**
  * Consolidated codec option querying, cache-key generation, and shared format-selection/sentinel handling into shared FFmpeg extension utilities.

* **Tests**
  * Added/extended unit tests covering codec format selection, audio format decision rules, and codec option cache-key edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->