### PR TITLE
fix(engine): rebuild cached glyph geometry path on FormattedText slot reuse

### DIFF
--- a/src/Beutl.Engine/Media/Geometry/Geometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/Geometry.cs
@@ -77,6 +77,22 @@ public abstract partial class Geometry : EngineObject
             return _cachedStrokePath;
         }
 
+        // Forces the cached fill/stroke paths to rebuild on next access. The cache is keyed on Version,
+        // which composition's Update path bumps on a property change. Callers that mutate the underlying
+        // geometry's path in place (e.g. FormattedText reusing a per-glyph slot via SetSKPath) bypass that
+        // path and leave Version unchanged, so they must invalidate explicitly; otherwise GetCachedPath
+        // keeps returning the previous glyph's outline.
+        //
+        // Disposing the now-stale cached paths is intentionally deferred to the next GetCachedPath /
+        // GetCachedStrokePath (the same as the Version-change rebuild path) rather than freed here: a
+        // render thread may still hold the previously returned SKPath, and PostDispose covers the case
+        // where no further access occurs.
+        internal void InvalidateCachedPaths()
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+            _capturedVersion = null;
+        }
+
         public Rect GetRenderBounds(Pen.Resource? pen)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);

--- a/src/Beutl.Engine/Media/Geometry/Geometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/Geometry.cs
@@ -77,25 +77,11 @@ public abstract partial class Geometry : EngineObject
             return _cachedStrokePath;
         }
 
-        // Signals that the underlying geometry's path was mutated in place, by bumping Version.
-        //
-        // Version is the invalidation key for two cache layers, and composition's Update path is what
-        // normally bumps it. A caller that rewrites the path without going through that path (e.g.
-        // FormattedText reusing a per-glyph slot via SetSKPath) leaves Version unchanged, so both layers
-        // keep serving the previous glyph:
-        //   * this resource's own Version-keyed fill/stroke path cache (GetCachedPath / GetCachedStrokePath), and
-        //   * any render node that captured a (resource, Version) snapshot and skips redraw while it looks
-        //     unchanged (GeometryRenderNode.Update -> ResourceExtension.Compare), which in turn keeps a stale
-        //     rasterized RenderNodeCache tile alive.
-        // Bumping Version invalidates both: the next GetCachedPath rebuilds, and the render node observes a
-        // new Version, reports HasChanges, redraws, and resets its cache-eligibility counter. Setting only
-        // _capturedVersion = null would rebuild this resource's own cache but leave the render node — and its
-        // rasterized tile — stale.
-        //
-        // Disposing the now-stale cached paths is intentionally deferred to the next GetCachedPath /
-        // GetCachedStrokePath (the same as the ordinary Version-change rebuild path) rather than freed here:
-        // a render thread may still hold the previously returned SKPath, and PostDispose covers the case
-        // where no further access occurs.
+        // Bumps Version after the underlying path was mutated in place (e.g. FormattedText reusing a
+        // per-glyph slot via SetSKPath, which bypasses composition's Update path). Version gates both this
+        // resource's fill/stroke path cache and any render node's captured (resource, Version) snapshot, so
+        // without this both keep serving the previous glyph. Stale paths are disposed lazily on the next
+        // GetCachedPath/GetCachedStrokePath, not here, since a render thread may still hold the old SKPath.
         internal void InvalidateCachedPaths()
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);

--- a/src/Beutl.Engine/Media/Geometry/Geometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/Geometry.cs
@@ -77,11 +77,8 @@ public abstract partial class Geometry : EngineObject
             return _cachedStrokePath;
         }
 
-        // Bumps Version after the underlying path was mutated in place (e.g. FormattedText reusing a
-        // per-glyph slot via SetSKPath, which bypasses composition's Update path). Version gates both this
-        // resource's fill/stroke path cache and any render node's captured (resource, Version) snapshot, so
-        // without this both keep serving the previous glyph. Stale paths are disposed lazily on the next
-        // GetCachedPath/GetCachedStrokePath, not here, since a render thread may still hold the old SKPath.
+        // Version keys both the fill/stroke path cache and any render node's (resource, Version) snapshot,
+        // so bumping it invalidates both. Stale paths are disposed lazily (a render thread may hold the old one).
         internal void InvalidateCachedPaths()
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);

--- a/src/Beutl.Engine/Media/Geometry/Geometry.cs
+++ b/src/Beutl.Engine/Media/Geometry/Geometry.cs
@@ -77,20 +77,29 @@ public abstract partial class Geometry : EngineObject
             return _cachedStrokePath;
         }
 
-        // Forces the cached fill/stroke paths to rebuild on next access. The cache is keyed on Version,
-        // which composition's Update path bumps on a property change. Callers that mutate the underlying
-        // geometry's path in place (e.g. FormattedText reusing a per-glyph slot via SetSKPath) bypass that
-        // path and leave Version unchanged, so they must invalidate explicitly; otherwise GetCachedPath
-        // keeps returning the previous glyph's outline.
+        // Signals that the underlying geometry's path was mutated in place, by bumping Version.
+        //
+        // Version is the invalidation key for two cache layers, and composition's Update path is what
+        // normally bumps it. A caller that rewrites the path without going through that path (e.g.
+        // FormattedText reusing a per-glyph slot via SetSKPath) leaves Version unchanged, so both layers
+        // keep serving the previous glyph:
+        //   * this resource's own Version-keyed fill/stroke path cache (GetCachedPath / GetCachedStrokePath), and
+        //   * any render node that captured a (resource, Version) snapshot and skips redraw while it looks
+        //     unchanged (GeometryRenderNode.Update -> ResourceExtension.Compare), which in turn keeps a stale
+        //     rasterized RenderNodeCache tile alive.
+        // Bumping Version invalidates both: the next GetCachedPath rebuilds, and the render node observes a
+        // new Version, reports HasChanges, redraws, and resets its cache-eligibility counter. Setting only
+        // _capturedVersion = null would rebuild this resource's own cache but leave the render node — and its
+        // rasterized tile — stale.
         //
         // Disposing the now-stale cached paths is intentionally deferred to the next GetCachedPath /
-        // GetCachedStrokePath (the same as the Version-change rebuild path) rather than freed here: a
-        // render thread may still hold the previously returned SKPath, and PostDispose covers the case
+        // GetCachedStrokePath (the same as the ordinary Version-change rebuild path) rather than freed here:
+        // a render thread may still hold the previously returned SKPath, and PostDispose covers the case
         // where no further access occurs.
         internal void InvalidateCachedPaths()
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
-            _capturedVersion = null;
+            Version++;
         }
 
         public Rect GetRenderBounds(Pen.Resource? pen)

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -346,7 +346,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                     }
                     else
                     {
-                        // Reuse the slot in place; SetSKPath doesn't bump Version, so invalidate caches explicitly.
+                        // SetSKPath reuses the slot without bumping Version, so invalidate the caches explicitly.
                         exist.GetOriginal().SetSKPath(tmp, false);
                         exist.InvalidateCachedPaths();
                     }
@@ -367,7 +367,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                 }
                 else
                 {
-                    // Reuse the slot in place; invalidate caches so the now-empty slot stops serving the old glyph.
+                    // Empty glyph: invalidate the caches so the reused slot stops serving the old path.
                     exist.GetOriginal().SetSKPath(tmp, false);
                     exist.InvalidateCachedPaths();
                 }

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -346,7 +346,11 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                     }
                     else
                     {
+                        // Reuse the slot in place. SetSKPath bypasses the composition Update path, so the
+                        // resource's Version is unchanged; invalidate its cache so the next render rebuilds
+                        // from this glyph's outline instead of the previously cached one.
                         exist.GetOriginal().SetSKPath(tmp, false);
+                        exist.InvalidateCachedPaths();
                     }
                 }
                 else
@@ -365,7 +369,11 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                 }
                 else
                 {
+                    // Reuse the slot in place (see the glyph-bearing branch above); the path went from a
+                    // real outline to null, so invalidate the cache too — otherwise GetCachedPath keeps
+                    // returning the stale previous glyph for a slot that should now be empty.
                     exist.GetOriginal().SetSKPath(tmp, false);
+                    exist.InvalidateCachedPaths();
                 }
             }
         }

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -346,9 +346,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                     }
                     else
                     {
-                        // Reuse the slot in place. SetSKPath bypasses the composition Update path, so the
-                        // resource's Version is unchanged; invalidate its cache so the next render rebuilds
-                        // from this glyph's outline instead of the previously cached one.
+                        // Reuse the slot in place; SetSKPath doesn't bump Version, so invalidate caches explicitly.
                         exist.GetOriginal().SetSKPath(tmp, false);
                         exist.InvalidateCachedPaths();
                     }
@@ -369,9 +367,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
                 }
                 else
                 {
-                    // Reuse the slot in place (see the glyph-bearing branch above); the path went from a
-                    // real outline to null, so invalidate the cache too — otherwise GetCachedPath keeps
-                    // returning the stale previous glyph for a slot that should now be empty.
+                    // Reuse the slot in place; invalidate caches so the now-empty slot stops serving the old glyph.
                     exist.GetOriginal().SetSKPath(tmp, false);
                     exist.InvalidateCachedPaths();
                 }

--- a/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
@@ -98,9 +98,8 @@ public class FormattedTextGeometryCacheTests
             "the stroked render bounds height should also match a freshly measured glyph.");
     }
 
-    // Regression at the render-node layer: GeometryRenderNode diffs on a captured (resource, Version)
-    // snapshot, so a slot reuse that keeps the same resource reference looks unchanged unless Version is
-    // bumped — leaving the previous glyph's rasterized tile on screen. The Resource-level tests miss this.
+    // Render-node layer: GeometryRenderNode diffs on a captured (resource, Version) snapshot, so a slot
+    // reuse keeping the same resource reference looks unchanged unless Version is bumped.
     [Test]
     public void ReMeasure_ReusingGlyphSlot_MarksGeometryRenderNodeChanged()
     {

--- a/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
@@ -94,6 +94,8 @@ public class FormattedTextGeometryCacheTests
         Assert.That(wideStroke.Width, Is.GreaterThan(narrowStroke.Width),
             "the stroked render bounds must follow the new glyph, not the stale cached stroke path.");
         Assert.That(wideStroke.Width, Is.EqualTo(referenceStroke.Width).Within(0.01));
+        Assert.That(wideStroke.Height, Is.EqualTo(referenceStroke.Height).Within(0.01),
+            "the stroked render bounds height should also match a freshly measured glyph.");
     }
 
     // Regression at the render-node layer: GeometryRenderNode diffs on a captured (resource, Version)

--- a/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
@@ -1,5 +1,6 @@
 ﻿using Beutl.Composition;
 using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
 using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.TextFormatting;
@@ -85,7 +86,8 @@ public class FormattedTextGeometryCacheTests
 
         text.Text = "W";
         Geometry.Resource reused = text.ToGeometies()[0];
-        Assert.That(reused, Is.SameAs(glyph));
+        Assert.That(reused, Is.SameAs(glyph),
+            "single-codepoint re-measure should reuse the slot in place (the stale-cache precondition).");
 
         Rect wideStroke = reused.GetRenderBounds(pen);
 
@@ -95,5 +97,31 @@ public class FormattedTextGeometryCacheTests
         Assert.That(wideStroke.Width, Is.GreaterThan(narrowStroke.Width),
             "the stroked render bounds must follow the new glyph, not the stale cached stroke path.");
         Assert.That(wideStroke.Width, Is.EqualTo(referenceStroke.Width).Within(0.01));
+    }
+
+    // Regression at the render-node layer. GeometryRenderNode diffs on a captured (resource, Version)
+    // snapshot (ResourceExtension.Compare), and RenderNodeCache only resets a node's cache-eligibility
+    // counter — and ultimately invalidates its rasterized tile — when the node reports HasChanges. A slot
+    // reuse keeps the same resource reference, so unless the in-place mutation bumps Version the render node
+    // sees "unchanged", keeps its cached tile, and the previous glyph stays on screen (the SplitByCharacters
+    // TextBlock path). Asserting at the Geometry.Resource level alone does not cover this.
+    [Test]
+    public void ReMeasure_ReusingGlyphSlot_MarksGeometryRenderNodeChanged()
+    {
+        using FormattedText text = CreateText("I");
+        Geometry.Resource glyph = text.ToGeometies()[0];
+
+        using var node = new GeometryRenderNode(glyph, null, null);
+        Assert.That(node.Update(glyph, null, null), Is.False,
+            "an unchanged geometry must not mark the render node dirty (baseline).");
+
+        text.Text = "W";
+        Geometry.Resource reused = text.ToGeometies()[0];
+        Assert.That(reused, Is.SameAs(glyph),
+            "single-codepoint re-measure should reuse the slot in place (the stale-cache precondition).");
+
+        Assert.That(node.Update(reused, null, null), Is.True,
+            "slot reuse must mark the render node changed so its rasterized cache tile is invalidated.");
+        Assert.That(node.HasChanges, Is.True);
     }
 }

--- a/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
@@ -14,8 +14,7 @@ public class FormattedTextGeometryCacheTests
     [SetUp]
     public void Setup()
     {
-        // Log.LoggerFactory is write-once (??=); skip allocating a factory we would only discard
-        // when another fixture already set one.
+        // Log.LoggerFactory is write-once; don't allocate a factory another fixture may already have set.
         if (Log.LoggerFactory is null)
         {
             Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
@@ -37,16 +36,14 @@ public class FormattedTextGeometryCacheTests
         };
     }
 
-    // Regression: changing a FormattedText's text re-measures in place, reusing the per-glyph
-    // SKPathGeometry slot via SetSKPath without bumping the resource Version. Geometry.Resource caches
-    // its render path keyed on Version, so before the fix GetCachedPath kept returning the previous
-    // glyph's outline (a narrow 'I' even after the text became a wide 'W').
+    // Regression: re-measuring in place reuses the per-glyph slot without bumping Version, so before the
+    // fix the Version-keyed path cache kept returning the previous glyph (narrow 'I' after switching to 'W').
     [Test]
     public void ReMeasure_ReusingGlyphSlot_RebuildsCachedGeometryPath()
     {
         using FormattedText text = CreateText("I");
 
-        // Populate the per-glyph geometry resource cache for the narrow glyph 'I'.
+        // Populate the cache for the narrow glyph 'I'.
         Geometry.Resource glyph = text.ToGeometies()[0];
         Rect narrowBounds = glyph.Bounds;
 
@@ -99,12 +96,9 @@ public class FormattedTextGeometryCacheTests
         Assert.That(wideStroke.Width, Is.EqualTo(referenceStroke.Width).Within(0.01));
     }
 
-    // Regression at the render-node layer. GeometryRenderNode diffs on a captured (resource, Version)
-    // snapshot (ResourceExtension.Compare), and RenderNodeCache only resets a node's cache-eligibility
-    // counter — and ultimately invalidates its rasterized tile — when the node reports HasChanges. A slot
-    // reuse keeps the same resource reference, so unless the in-place mutation bumps Version the render node
-    // sees "unchanged", keeps its cached tile, and the previous glyph stays on screen (the SplitByCharacters
-    // TextBlock path). Asserting at the Geometry.Resource level alone does not cover this.
+    // Regression at the render-node layer: GeometryRenderNode diffs on a captured (resource, Version)
+    // snapshot, so a slot reuse that keeps the same resource reference looks unchanged unless Version is
+    // bumped — leaving the previous glyph's rasterized tile on screen. The Resource-level tests miss this.
     [Test]
     public void ReMeasure_ReusingGlyphSlot_MarksGeometryRenderNodeChanged()
     {

--- a/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs
@@ -1,0 +1,99 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Logging;
+using Beutl.Media;
+using Beutl.Media.TextFormatting;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.UnitTests.Engine;
+
+[TestFixture]
+public class FormattedTextGeometryCacheTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        // Log.LoggerFactory is write-once (??=); skip allocating a factory we would only discard
+        // when another fixture already set one.
+        if (Log.LoggerFactory is null)
+        {
+            Log.LoggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole());
+        }
+
+        _ = TypefaceProvider.Typeface();
+    }
+
+    private static FormattedText CreateText(string text, float size = 64f)
+    {
+        Typeface typeface = TypefaceProvider.Typeface();
+        return new FormattedText
+        {
+            Font = typeface.FontFamily,
+            Style = typeface.Style,
+            Weight = typeface.Weight,
+            Size = size,
+            Text = text
+        };
+    }
+
+    // Regression: changing a FormattedText's text re-measures in place, reusing the per-glyph
+    // SKPathGeometry slot via SetSKPath without bumping the resource Version. Geometry.Resource caches
+    // its render path keyed on Version, so before the fix GetCachedPath kept returning the previous
+    // glyph's outline (a narrow 'I' even after the text became a wide 'W').
+    [Test]
+    public void ReMeasure_ReusingGlyphSlot_RebuildsCachedGeometryPath()
+    {
+        using FormattedText text = CreateText("I");
+
+        // Populate the per-glyph geometry resource cache for the narrow glyph 'I'.
+        Geometry.Resource glyph = text.ToGeometies()[0];
+        Rect narrowBounds = glyph.Bounds;
+
+        // A single-codepoint re-measure reuses slot 0 in place; the outline is now the much wider 'W'.
+        text.Text = "W";
+        Geometry.Resource reused = text.ToGeometies()[0];
+        Assert.That(reused, Is.SameAs(glyph),
+            "single-codepoint re-measure should reuse the slot in place (the stale-cache precondition).");
+
+        Rect wideBounds = reused.Bounds;
+
+        // Ground truth: a freshly built FormattedText for 'W' has no stale cache to confuse it.
+        using FormattedText reference = CreateText("W");
+        Rect referenceBounds = reference.ToGeometies()[0].Bounds;
+
+        Assert.That(wideBounds.Width, Is.GreaterThan(narrowBounds.Width),
+            "after re-measure the cached path must reflect the wider 'W', not the stale 'I'.");
+        Assert.That(wideBounds.Width, Is.EqualTo(referenceBounds.Width).Within(0.01),
+            "the reused slot's cached path must match a freshly measured 'W'.");
+        Assert.That(wideBounds.Height, Is.EqualTo(referenceBounds.Height).Within(0.01),
+            "the reused slot's cached path must match a freshly measured 'W'.");
+    }
+
+    // The stroke-path cache shares the same Version gate; invalidation must clear it too.
+    [Test]
+    public void ReMeasure_ReusingGlyphSlot_RebuildsCachedStrokePath()
+    {
+        using FormattedText text = CreateText("I");
+        using Pen.Resource pen = new Pen
+        {
+            Thickness = { CurrentValue = 4f },
+            Brush = { CurrentValue = Brushes.White }
+        }.ToResource(CompositionContext.Default);
+
+        Geometry.Resource glyph = text.ToGeometies()[0];
+        Rect narrowStroke = glyph.GetRenderBounds(pen);
+
+        text.Text = "W";
+        Geometry.Resource reused = text.ToGeometies()[0];
+        Assert.That(reused, Is.SameAs(glyph));
+
+        Rect wideStroke = reused.GetRenderBounds(pen);
+
+        using FormattedText reference = CreateText("W");
+        Rect referenceStroke = reference.ToGeometies()[0].GetRenderBounds(pen);
+
+        Assert.That(wideStroke.Width, Is.GreaterThan(narrowStroke.Width),
+            "the stroked render bounds must follow the new glyph, not the stale cached stroke path.");
+        Assert.That(wideStroke.Width, Is.EqualTo(referenceStroke.Width).Within(0.01));
+    }
+}


### PR DESCRIPTION
## Description
- `FormattedText.MeasureCore` reuses per-glyph `SKPathGeometry` slots in place via `exist.GetOriginal().SetSKPath(tmp, false)` on re-measure. `SetSKPath` swaps the geometry's path but bypasses composition's `Update`, so the wrapping `Geometry.Resource.Version` is unchanged.
- `Version` is the invalidation key for **two** cache layers, and a slot reused in place invalidates neither:
  - `Geometry.Resource.GetCachedPath` / `GetCachedStrokePath` rebuild their cached fill/stroke paths only when `Version` changes, so the resource kept returning the **previous** glyph's path (e.g. text `I` → `W`, same codepoint count → slot 0 reused).
  - `GeometryRenderNode` diffs on a captured `(resource, Version)` snapshot (`ResourceExtension.Compare`). With the reference and `Version` both unchanged it reports `HasChanges = false`, so `RenderNodeCache` never resets its eligibility counter and a previously rasterized tile keeps replaying the stale glyph (the `SplitByCharacters` `TextBlock` → `DrawGeometry` path).
- Fix: add internal `Geometry.Resource.InvalidateCachedPaths()` and call it right after each in-place `SetSKPath` in `MeasureCore`. It **bumps `Version`**, which invalidates both layers at once: the resource's own path cache rebuilds, and the render node observes a new `Version`, redraws, and drops its stale cached tile. (An earlier revision only reset the captured version — `_capturedVersion = null` — which fixed the resource's own cache but left the render-node tile stale; see the render-node regression test below.) Disposal of the stale cached path is intentionally deferred to the next access (mirroring the ordinary Version-change rebuild path; a render thread may still hold the prior `SKPath`, and `PostDispose` covers the no-render case).
- The two reuse sites are the **only** `SetSKPath` callers that mutate a geometry which already has a live resource — every other call operates on a fresh geometry before `ToResource`.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. `InvalidateCachedPaths()` is `internal`; no public surface change.

## Test plan
- `tests/Beutl.UnitTests/Engine/FormattedTextGeometryCacheTests.cs` (NUnit), three regression tests:
  - `ReMeasure_ReusingGlyphSlot_RebuildsCachedGeometryPath` — fill-path cache (`Bounds`).
  - `ReMeasure_ReusingGlyphSlot_RebuildsCachedStrokePath` — stroke-path cache (`GetRenderBounds`; same `Version` gate).
  - `ReMeasure_ReusingGlyphSlot_MarksGeometryRenderNodeChanged` — **render-node layer**: asserts `GeometryRenderNode.Update` reports a change (`HasChanges`) after a slot reuse, so the rasterized cache tile is invalidated. This guards the layer the other two cannot see.
  - Each asserts the reused slot is the **same** `Geometry.Resource` instance (the stale-cache precondition).
- Baseline-first (red→green): the render-node test **fails** against the captured-version-only revision (`Update` returns `false`) and **passes** with the `Version` bump; the full `FormattedTextGeometryCache` filter is green (3 passed). `dotnet format` clean on the touched files.

## Follow-ups
- `FormattedText.MeasureCore` calls `CollectionsMarshal.SetCount(_pathList, ...)` on re-measure; when the new text is **shorter**, the truncated `SKPathGeometry.Resource` slots are dropped without disposal (pre-existing leak, not introduced here). A shrink-then-dispose test under `FormattedTextDisposalTests` would cover it.
- `InvalidateCachedPaths` / `GetCachedPath` touch `Version` / `_cachedPath` without a memory barrier. This is safe under the engine's per-frame single-thread-render invariant (re-measure happens between frames, not concurrently with a render); worth an explicit comment asserting that invariant.

## Fixed issues / References
- Project board: b-editor/projects/9 ("FormattedText: per-glyph SKPathGeometry.Resource renders stale cached path after in-place slot reuse")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale cached fill/stroke paths when formatted text is re-measured after text changes.
  * When glyph geometry slots are reused, cached geometry/stroke paths are now invalidated so bounds and rendered output match the updated glyph outlines.
  * Improved update signaling so geometry render nodes refresh correctly after cached resource updates.
* **Tests**
  * Added regression tests for glyph slot reuse, cached geometry/stroke rebuilds, and render-node change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
