### PR TITLE
docs: Harden branch naming and auto-register follow-ups in AI-review skill

### DIFF
--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -163,13 +163,21 @@ Pick the branch name from the branch you are currently on:
 ```bash
 # Derive the prefix from the current branch and swap the feature part.
 CURRENT=$(git branch --show-current)
-PREFIX=${CURRENT%%/*}                       # e.g. "yuto-trd"; falls back to CURRENT if no "/"
-case "$CURRENT" in main|master|"") PREFIX="<your-prefix>";; esac
+case "$CURRENT" in
+  */*)            PREFIX=${CURRENT%%/*} ;;   # personal feature branch -> keep its "<prefix>/"
+  *)              PREFIX="<your-prefix>" ;;  # main/master OR a flat/worktree name (no "/") -> use
+                                             #   your personal prefix; never reuse a flat branch
+                                             #   name (e.g. "error-missing-task-input") as a prefix
+esac
 FEATURE=<descriptive-slug>                  # e.g. speednode-arraypool
 BRANCH="$PREFIX/$FEATURE"
 
 git switch -c "$BRANCH" origin/main         # branch off the latest main, before editing
 ```
+
+Note the `*/*` case is *only* a true `<prefix>/<feature>` branch. A branch name with no `/`
+(common in worktrees, e.g. `error-missing-task-input`) is treated like `main` — do **not** splice
+the whole flat name in as a prefix, or you get a branch like `error-missing-task-input/<slug>`.
 
 ## Step 4 — Implement
 
@@ -256,10 +264,67 @@ gh pr create --base main --head "$BRANCH" \
 
 Fill the PR template's **Affected areas**, **Breaking changes** (`None` for behavior-preserving),
 **Test plan** (mention the baseline-first verification + pass counts), and **References**
-(`Project board: b-editor/projects/9 ("<title>")`). Opening the PR triggers the automatic
-`claude-code-review.yml` review.
+(`Project board: b-editor/projects/9 ("<title>")`). If the work surfaced any follow-ups, capture
+them now (see Step 7). Opening the PR triggers the automatic `claude-code-review.yml` review.
 
-## Step 7 — Update the board
+## Step 7 — Capture follow-ups (auto-register to the board)
+
+If the work surfaced any follow-up — a deferred edge case, a known TODO, a refactor you scoped out,
+a test you could not add yet — **do not let it evaporate** (AGENTS.md "Follow-up tasks"). Split it
+the same way AGENTS.md does:
+
+- **PR-local follow-ups** (tightly coupled to this PR) go in the PR body under a `## Follow-ups`
+  list — that is part of Step 6, not the board.
+- **Cross-cutting / longer-horizon follow-ups** go to the board as **Draft items in project #9**.
+  This workflow already operates that board (claim → `In Progress`, false-positive, `Done`), so
+  board-edit authorization is normally in place for the whole turn. **When it is, register these
+  follow-ups to project #9 automatically — do NOT stop to ask the user first** (this is the one
+  outward-facing action exempt from the per-action confirmation in Guardrails). Only fall back to
+  AskUserQuestion if board-edit authorization is *not* yet in place this turn.
+
+**Dedup first — do not re-file what the board already tracks.** Findings from the same review
+sweep cluster, so a follow-up you just spotted is often already an item (e.g. a sibling `[diff]`
+finding from the same PR). Before creating anything, check it against the board. Reuse the Step 1
+snapshot if you still have it; otherwise re-fetch:
+
+```bash
+# BOARD = the snapshot file from Step 1 (re-fetch if it is gone or stale).
+[ -s "$BOARD" ] || { BOARD=$(mktemp /tmp/ai-review-board.XXXX.json); \
+  gh project item-list 9 --owner b-editor --limit 2000 --format json > "$BOARD"; }
+
+# Print existing titles that look related, so you can eyeball a match before creating a dup.
+python3 -c "
+import json,sys
+needle=sys.argv[1].lower()
+for it in json.load(open('$BOARD'))['items']:
+    t=it.get('content',{}).get('title','')
+    if any(w in t.lower() for w in needle.split() if len(w)>3):
+        print(it.get('status','?'),'|',t)
+" "<keywords from the follow-up you are about to file>"
+```
+
+If a substantively equivalent item already exists (any status — even `Done`/`False positive`
+means it is already known), **skip creation**; do not duplicate it. Only when nothing matches,
+add one Draft item per genuinely-new follow-up, with a clear title and a one-line body that states
+the context and references the originating PR/commit, then drop it into `Backlog` so this very
+skill can pick it up on a later run:
+
+```bash
+NEW_ITEM=$(gh project item-create 9 --owner b-editor \
+  --title "<concise follow-up title>" \
+  --body "<one-line context>. From PR #<n> / item \"<finding title>\"." \
+  --format json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+
+# Put it in the normal triage queue (Backlog) so it becomes a future candidate.
+gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
+  --id "$NEW_ITEM" \
+  --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
+  --single-select-option-id d97cd69b   # Backlog
+```
+
+If there are no follow-ups (or every one is already on the board), skip this step.
+
+## Step 8 — Update the board
 
 The item was already moved to `In Progress` when you claimed it (see "Claim the item immediately"
 in Step 2), so nothing changes here while the PR is open. **After the PR merges**, move it to `Done`:
@@ -278,6 +343,10 @@ resumed work — just ensure it is `In Progress` now, option id `47fc9ee4`.)
 
 - **Confirm outward-facing actions.** Push / PR / board edits change shared state — confirm with
   the user (AskUserQuestion) before doing them unless they already authorized it this turn.
+- **Exception — follow-up registration.** Registering follow-ups as Draft items in project #9
+  (Step 7) is exempt from that per-action confirmation: when board-edit authorization is already in
+  place this turn, do it automatically without asking. (The same "already authorized this turn"
+  condition still applies — if it is not, ask once before registering.)
 - One task per invocation by default. After finishing, offer the next candidate rather than
   batching many.
 - Never force-push to `main`/`master` (hook-enforced). Work on a feature branch.

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -164,7 +164,7 @@ Pick the branch name from the branch you are currently on:
 # Derive the prefix from the current branch and swap the feature part.
 CURRENT=$(git branch --show-current)
 case "$CURRENT" in
-  */*)            PREFIX=${CURRENT%%/*} ;;   # personal feature branch -> keep its "<prefix>/"
+  */*)            PREFIX=${CURRENT%%/*} ;;   # personal feature branch -> reuse its prefix segment
   *)              PREFIX="<your-prefix>" ;;  # main/master OR a flat/worktree name (no "/") -> use
                                              #   your personal prefix; never reuse a flat branch
                                              #   name (e.g. "error-missing-task-input") as a prefix
@@ -288,7 +288,7 @@ finding from the same PR). Before creating anything, check it against the board.
 snapshot if you still have it; otherwise re-fetch:
 
 ```bash
-# BOARD = the snapshot file from Step 1 (re-fetch if it is gone or stale).
+# BOARD = the snapshot file from Step 1 (re-fetch if it is missing or empty).
 [ -s "$BOARD" ] || { BOARD=$(mktemp /tmp/ai-review-board.XXXX.json); \
   gh project item-list 9 --owner b-editor --limit 2000 --format json > "$BOARD"; }
 


### PR DESCRIPTION
## Description
- Stop the beutl-ai-review-task skill from splicing a flat (slash-less) worktree branch name in as a branch prefix (e.g. `error-missing-task-input/<slug>`); such names are now treated like `main`.
- Add a Step 7 that auto-registers cross-cutting follow-ups as Draft items in project #9 with board dedup, so surfaced follow-ups don't evaporate.

## Affected areas
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
Documentation/skill-instruction change only; no code or tests affected.

## Fixed issues / References
None.

https://claude.ai/code/session_01XDoVMQzhEfKrKugQHUqxTF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow branch-naming logic to distinguish personal branches from worktree configurations.
  * Added new "Capture follow-ups" step with deduplication and Draft item management procedures.
  * Modified guardrails to streamline authorization requirements for follow-up registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->