### PR TITLE
fix(engine): throw ObjectDisposedException from FormattedText measuring members after Dispose

### DIFF
--- a/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
+++ b/src/Beutl.Engine/Graphics/Shapes/TextElements.cs
@@ -61,8 +61,9 @@ public class TextElements : IReadOnlyList<TextElement>, IDisposable
         public bool IsDisposed { get; private set; }
 
         /// <remarks>
-        /// Idempotent and one-shot; do not enumerate after disposal. <see cref="GetEnumerator"/> would
-        /// re-allocate <see cref="FormattedText"/> instances that a later <see cref="Dispose"/> will not release.
+        /// Idempotent and one-shot; do not enumerate after disposal. <see cref="GetEnumerator"/> throws
+        /// <see cref="ObjectDisposedException"/> rather than re-allocating <see cref="FormattedText"/> instances
+        /// that a later <see cref="Dispose"/> could not release.
         /// </remarks>
         public void Dispose()
         {
@@ -81,6 +82,7 @@ public class TextElements : IReadOnlyList<TextElement>, IDisposable
 
         public LineEnumerator GetEnumerator()
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             int count = 0;
             foreach (TextElement item in _array)
             {

--- a/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
+++ b/src/Beutl.Engine/Media/TextFormatting/FormattedText.cs
@@ -63,8 +63,9 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
 
     /// <remarks>
     /// Disposal is idempotent and one-shot; the instance must not be used afterwards. Measuring members
-    /// (e.g. <see cref="Bounds"/> or the density-scaled blob/stroke accessors) would re-allocate Skia
-    /// handles that a later <see cref="Dispose"/> call will not release.
+    /// (e.g. <see cref="Bounds"/> or the density-scaled blob/stroke accessors) throw
+    /// <see cref="ObjectDisposedException"/> rather than re-allocating Skia handles that a later
+    /// <see cref="Dispose"/> call could not release.
     /// </remarks>
     // No finalizer: every owned field (SKTextBlob / SKPath / SKPathGeometry.Resource) is itself
     // finalizable via SkiaSharp, so deterministic Dispose only speeds up release. If a non-SkiaSharp
@@ -399,6 +400,7 @@ public class FormattedText : IEquatable<FormattedText>, IDisposable
 
     private void MeasureAndSetField()
     {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
         if (_isDirty)
         {
             Measure();

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -62,33 +62,40 @@ public class FormattedTextDisposalTests
     }
 
     [Test]
-    public void Dispose_ClearsMainSkiaHandleFields()
+    public void MeasuringMembers_AfterDispose_ThrowObjectDisposedException()
     {
         FormattedText ft = CreateText();
-        Assert.That(ft.GetTextBlob(), Is.Not.Null);
-        Assert.That(ft.GetFillPath(), Is.Not.Null);
+        _ = ft.Bounds;
 
         ft.Dispose();
 
-        Assert.That(ft.GetTextBlob(), Is.Null, "TextBlob field should be cleared after Dispose.");
-        Assert.That(ft.GetFillPath(), Is.Null, "FillPath field should be cleared after Dispose.");
-        Assert.That(ft.GetStrokePath(), Is.Null, "StrokePath field should be cleared after Dispose.");
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ObjectDisposedException>(() => _ = ft.Bounds);
+            Assert.Throws<ObjectDisposedException>(() => _ = ft.ActualBounds);
+            Assert.Throws<ObjectDisposedException>(() => _ = ft.Metrics);
+            Assert.Throws<ObjectDisposedException>(() => ft.GetTextBlob());
+            Assert.Throws<ObjectDisposedException>(() => ft.GetFillPath());
+            Assert.Throws<ObjectDisposedException>(() => ft.GetStrokePath());
+            Assert.Throws<ObjectDisposedException>(() => ft.ToGeometies());
+        });
     }
 
     [Test]
-    public void Dispose_ClearsScaledTextCache()
+    public void ScaledAccessors_AfterDispose_ThrowObjectDisposedException()
     {
         FormattedText ft = CreateText();
-        SKTextBlob? before = ft.GetTextBlob(2f);
-        Assert.That(before, Is.Not.Null);
+        // Leave the instance dirty so a post-dispose access would otherwise re-measure and
+        // re-populate the scaled cache, leaking handles the idempotent Dispose can no longer release.
+        ft.Size = 32f;
 
         ft.Dispose();
 
-        SKTextBlob? after = ft.GetTextBlob(2f);
-        Assert.That(after, Is.Not.Null);
-        Assert.That(ReferenceEquals(before, after), Is.False,
-            "Scaled cache should have been cleared by Dispose; a fresh blob must be produced on re-access.");
-        ft.Dispose();
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ObjectDisposedException>(() => ft.GetTextBlob(2f));
+            Assert.Throws<ObjectDisposedException>(() => ft.GetStrokePath(2f));
+        });
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs
@@ -163,6 +163,19 @@ public class FormattedTextDisposalTests
     }
 
     [Test]
+    public void LineEnumerable_GetEnumerator_AfterDispose_ThrowsObjectDisposedException()
+    {
+        TextElements elements = new(
+        [
+            new TextElement { Size = 24, Text = "ABC" }
+        ]);
+
+        elements.Lines.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => elements.Lines.GetEnumerator());
+    }
+
+    [Test]
     public void TextElements_Dispose_DisposesLineEnumerable()
     {
         TextElements elements = new(


### PR DESCRIPTION
## Description
`FormattedText` documents (XML remark) that the instance must not be used after `Dispose`, but the measuring members did not enforce it. After `Dispose`, accessing a measuring member while the instance was dirty re-ran `Measure()` / `GetScaledTextCache()` and allocated fresh `SKTextBlob` / `SKPath` handles. Because `Dispose` is idempotent and one-shot, those re-allocated handles were never released — a silent leak.

- Guard the single choke point `MeasureAndSetField()` with `ObjectDisposedException.ThrowIf(IsDisposed, this)`. Every measuring member (`Bounds` / `ActualBounds` / `Metrics`, `GetTextBlob` / `GetFillPath` / `GetStrokePath` incl. their density overloads, and `ToGeometies`) routes through it, including the density-scaled cache path via `GetScaledTextCache`.
- Apply the same guard to `TextElements.LineEnumerable.GetEnumerator()` (reached via `foreach` over `TextElements.Lines`), which had the identical latent leak: re-enumerating a disposed `LineEnumerable` re-allocated the per-line `FormattedText` instances that the idempotent `Dispose` could no longer release. Its XML remark already declared post-dispose enumeration invalid; the guard now enforces it.
- Update the XML remarks to state the enforced contract (throws rather than silently re-allocating).

This replaces the previous lenient "return null / re-allocate fresh on re-access" behavior with a fail-fast contract.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)

## Breaking changes
Behavior change (not a public-type signature change): measuring members of a disposed `FormattedText`, and `TextElements.LineEnumerable.GetEnumerator()` (reached via `foreach` over `TextElements.Lines`), now throw `ObjectDisposedException` instead of returning `null` / re-allocating. The XML remarks already declared post-dispose use invalid, so no valid caller relied on the old behavior. In-tree consumers (`TextRenderNode`, `TextBlock`, `TextElements`) only touch these members during the active render lifetime, before disposal.

## Test plan
Baseline-first (characterization) in `tests/Beutl.UnitTests/Engine/FormattedTextDisposalTests.cs`:
- `MeasuringMembers_AfterDispose_ThrowObjectDisposedException` — `Bounds`/`ActualBounds`/`Metrics`/`GetTextBlob`/`GetFillPath`/`GetStrokePath`/`ToGeometies` all throw after `Dispose`.
- `ScaledAccessors_AfterDispose_ThrowObjectDisposedException` — density overloads (`GetTextBlob(2f)`/`GetStrokePath(2f)`) throw after `Dispose` (instance left dirty so the old code would have re-measured + re-populated the scaled cache).
- `LineEnumerable_GetEnumerator_AfterDispose_ThrowsObjectDisposedException` — enumerating a disposed `TextElements.LineEnumerable` throws (same latent re-allocation leak as the measuring members).
- The first two previously asserted the old lenient behavior (`Dispose_ClearsMainSkiaHandleFields` / `Dispose_ClearsScaledTextCache`) and were rewritten to assert the new throw contract.

Verification: the FormattedText tests fail (red) against unmodified code (8 missing throws), pass after the guard. After adding the `LineEnumerable` guard + test, the `FormattedText|TextElements|TextBlock` filter is green (20 tests, 0 failed). Style of the added guard/test matches `.editorconfig` (the original change was `dotnet format --verify-no-changes` clean).

## Fixed issues / References
- Project board: b-editor/projects/9 ("FormattedText: measuring members re-allocate Skia handles after Dispose (documented but unenforced)")

https://claude.ai/code/session_017DT44xD2Dou8iUTJ5VoiFY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated text formatting and text element disposal behavior to throw `ObjectDisposedException` when measurement/accessor members are accessed after disposal.
  * Ensures `LineEnumerable` enumeration (via `GetEnumerator`) immediately throws after disposal, instead of relying on re-allocation behavior.
* **Tests**
  * Revised and expanded unit tests to validate the new post-disposal exception behavior for both formatted text accessors and line enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
