### PR TITLE
docs: Forbid deferring tasks instead of capturing follow-ups

### DIFF
--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -264,65 +264,25 @@ gh pr create --base main --head "$BRANCH" \
 
 Fill the PR template's **Affected areas**, **Breaking changes** (`None` for behavior-preserving),
 **Test plan** (mention the baseline-first verification + pass counts), and **References**
-(`Project board: b-editor/projects/9 ("<title>")`). If the work surfaced any follow-ups, capture
-them now (see Step 7). Opening the PR triggers the automatic `claude-code-review.yml` review.
+(`Project board: b-editor/projects/9 ("<title>")`). Opening the PR triggers the automatic
+`claude-code-review.yml` review.
 
-## Step 7 — Capture follow-ups (auto-register to the board)
+## Step 7 — Do not defer work
 
-If the work surfaced any follow-up — a deferred edge case, a known TODO, a refactor you scoped out,
-a test you could not add yet — **do not let it evaporate** (AGENTS.md "Follow-up tasks"). Split it
-the same way AGENTS.md does:
+**Deferring is forbidden** (AGENTS.md "Do not defer work"). Whatever this task surfaced — an edge
+case, a known TODO, a refactor you scoped out, a test you could not add yet — **finish it inside
+this PR before opening it.** Do not park in-scope work behind a `## Follow-ups` list, a `// TODO`,
+or a fresh Draft item on the board; those are not a substitute for doing the work.
 
-- **PR-local follow-ups** (tightly coupled to this PR) go in the PR body under a `## Follow-ups`
-  list — that is part of Step 6, not the board.
-- **Cross-cutting / longer-horizon follow-ups** go to the board as **Draft items in project #9**.
-  This workflow already operates that board (claim → `In Progress`, false-positive, `Done`), so
-  board-edit authorization is normally in place for the whole turn. **When it is, register these
-  follow-ups to project #9 automatically — do NOT stop to ask the user first** (this is the one
-  outward-facing action exempt from the per-action confirmation in Guardrails). Only fall back to
-  AskUserQuestion if board-edit authorization is *not* yet in place this turn.
+The only two exits, and **both mean telling the user — never silently filing it away:**
 
-**Dedup first — do not re-file what the board already tracks.** Findings from the same review
-sweep cluster, so a follow-up you just spotted is often already an item (e.g. a sibling `[diff]`
-finding from the same PR). Before creating anything, check it against the board. Reuse the Step 1
-snapshot if you still have it; otherwise re-fetch:
+- **Genuinely out of scope** (a different feature/area that does not belong in this fix): raise it
+  with the user via `AskUserQuestion` and let them decide whether to widen the scope or track it
+  separately. Do not auto-create a board item to dodge the decision.
+- **Blocked** on something only the user can provide (access, an upstream fix, a product call):
+  state the blocker explicitly in your reply.
 
-```bash
-# BOARD = the snapshot file from Step 1 (re-fetch if it is missing or empty).
-[ -s "$BOARD" ] || { BOARD=$(mktemp /tmp/ai-review-board.XXXX.json); \
-  gh project item-list 9 --owner b-editor --limit 2000 --format json > "$BOARD"; }
-
-# Print existing titles that look related, so you can eyeball a match before creating a dup.
-python3 -c "
-import json,sys
-needle=sys.argv[1].lower()
-for it in json.load(open('$BOARD'))['items']:
-    t=it.get('content',{}).get('title','')
-    if any(w in t.lower() for w in needle.split() if len(w)>3):
-        print(it.get('status','?'),'|',t)
-" "<keywords from the follow-up you are about to file>"
-```
-
-If a substantively equivalent item already exists (any status — even `Done`/`False positive`
-means it is already known), **skip creation**; do not duplicate it. Only when nothing matches,
-add one Draft item per genuinely-new follow-up, with a clear title and a one-line body that states
-the context and references the originating PR/commit, then drop it into `Backlog` so this very
-skill can pick it up on a later run:
-
-```bash
-NEW_ITEM=$(gh project item-create 9 --owner b-editor \
-  --title "<concise follow-up title>" \
-  --body "<one-line context>. From PR #<n> / item \"<finding title>\"." \
-  --format json | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
-
-# Put it in the normal triage queue (Backlog) so it becomes a future candidate.
-gh project item-edit --project-id PVT_kwDOBLw8Fs4BW4g5 \
-  --id "$NEW_ITEM" \
-  --field-id PVTSSF_lADOBLw8Fs4BW4g5zhSJTXk \
-  --single-select-option-id d97cd69b   # Backlog
-```
-
-If there are no follow-ups (or every one is already on the board), skip this step.
+If nothing was surfaced beyond the fix itself, there is nothing to do here.
 
 ## Step 8 — Update the board
 
@@ -343,10 +303,9 @@ resumed work — just ensure it is `In Progress` now, option id `47fc9ee4`.)
 
 - **Confirm outward-facing actions.** Push / PR / board edits change shared state — confirm with
   the user (AskUserQuestion) before doing them unless they already authorized it this turn.
-- **Exception — follow-up registration.** Registering follow-ups as Draft items in project #9
-  (Step 7) is exempt from that per-action confirmation: when board-edit authorization is already in
-  place this turn, do it automatically without asking. (The same "already authorized this turn"
-  condition still applies — if it is not, ask once before registering.)
+- **Do not defer work.** Finish everything the task surfaced inside the PR (Step 7). Do not auto-file
+  a board Draft or a `## Follow-ups` entry to avoid doing in-scope work; raise genuinely out-of-scope
+  or blocked items with the user instead.
 - One task per invocation by default. After finishing, offer the next candidate rather than
   batching many.
 - Never force-push to `main`/`master` (hook-enforced). Work on a feature branch.

--- a/.claude/skills/beutl-ai-review-task/SKILL.md
+++ b/.claude/skills/beutl-ai-review-task/SKILL.md
@@ -241,7 +241,25 @@ fi
 (If you only want an interim progress peek while it runs, `grep` the output file — but still gate
 the commit/PR decision on `status`, not on any matched string.)
 
-## Step 6 — Commit, push, PR
+## Step 6 — Do not defer work (gate before you open the PR)
+
+Run this check **before** the commit/push/PR in Step 7 — it is a gate on opening the PR, not a
+post-PR afterthought. **Deferring is forbidden** (AGENTS.md "Do not defer work"). Whatever this
+task surfaced — an edge case, a known TODO, a refactor you scoped out, a test you could not add
+yet — **finish it on this branch now.** Do not park in-scope work behind a `## Follow-ups` list, a
+`// TODO`, or a fresh Draft item on the board; those are not a substitute for doing the work.
+
+The only two exits, and **both mean telling the user — never silently filing it away:**
+
+- **Genuinely out of scope** (a different feature/area that does not belong in this fix): raise it
+  with the user via `AskUserQuestion` and let them decide whether to widen the scope or track it
+  separately. Do not auto-create a board item to dodge the decision.
+- **Blocked** on something only the user can provide (access, an upstream fix, a product call):
+  state the blocker explicitly in your reply.
+
+If nothing was surfaced beyond the fix itself, there is nothing to do here — proceed to Step 7.
+
+## Step 7 — Commit, push, PR
 
 You are already on `$BRANCH` (created in Step 3 before any edits), so just commit and push it.
 `git push -u origin "$BRANCH"` pushes that existing branch — the refspec form does not create or
@@ -267,23 +285,6 @@ Fill the PR template's **Affected areas**, **Breaking changes** (`None` for beha
 (`Project board: b-editor/projects/9 ("<title>")`). Opening the PR triggers the automatic
 `claude-code-review.yml` review.
 
-## Step 7 — Do not defer work
-
-**Deferring is forbidden** (AGENTS.md "Do not defer work"). Whatever this task surfaced — an edge
-case, a known TODO, a refactor you scoped out, a test you could not add yet — **finish it inside
-this PR before opening it.** Do not park in-scope work behind a `## Follow-ups` list, a `// TODO`,
-or a fresh Draft item on the board; those are not a substitute for doing the work.
-
-The only two exits, and **both mean telling the user — never silently filing it away:**
-
-- **Genuinely out of scope** (a different feature/area that does not belong in this fix): raise it
-  with the user via `AskUserQuestion` and let them decide whether to widen the scope or track it
-  separately. Do not auto-create a board item to dodge the decision.
-- **Blocked** on something only the user can provide (access, an upstream fix, a product call):
-  state the blocker explicitly in your reply.
-
-If nothing was surfaced beyond the fix itself, there is nothing to do here.
-
 ## Step 8 — Update the board
 
 The item was already moved to `In Progress` when you claimed it (see "Claim the item immediately"
@@ -303,9 +304,9 @@ resumed work — just ensure it is `In Progress` now, option id `47fc9ee4`.)
 
 - **Confirm outward-facing actions.** Push / PR / board edits change shared state — confirm with
   the user (AskUserQuestion) before doing them unless they already authorized it this turn.
-- **Do not defer work.** Finish everything the task surfaced inside the PR (Step 7). Do not auto-file
-  a board Draft or a `## Follow-ups` entry to avoid doing in-scope work; raise genuinely out-of-scope
-  or blocked items with the user instead.
+- **Do not defer work.** Finish everything the task surfaced on the branch before opening the PR
+  (Step 6). Do not auto-file a board Draft or a `## Follow-ups` entry to avoid doing in-scope work;
+  raise genuinely out-of-scope or blocked items with the user instead.
 - One task per invocation by default. After finishing, offer the next candidate rather than
   batching many.
 - Never force-push to `main`/`master` (hook-enforced). Work on a feature branch.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,7 @@ Reminders (see CONTRIBUTING.md / AGENTS.md):
 - New logic ships with a NUnit test under `tests/`.
 - New XAML uses compiled bindings (`x:CompileBindings="True"` + `x:DataType`).
 - Do not cross the GPL/MIT boundary: MIT projects must not reference `Beutl.FFmpegWorker`.
+- Do not defer work: everything this change surfaced is finished here — no `## Follow-ups`
+  pile, no leftover `// TODO`. Anything genuinely out of scope or blocked was raised with a
+  maintainer, not quietly filed away (AGENTS.md "Do not defer work").
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,14 +72,16 @@ Conventional Commits, following the existing history:
 - `refactor: ...` — behavior-preserving refactor
 - `docs: ...` — documentation
 
-## Follow-up tasks
+## Do not defer work
 
-When work surfaces a follow-up — a deferred edge case, a known TODO, a refactor you scoped out, a test you could not add yet — **do not let it evaporate.** Capture it in one of two places:
+**Deferring tasks is forbidden.** When the change surfaces something — an edge case, a known TODO, a refactor you scoped out, a test you could not add yet — **finish it in the same change.** Do not split in-scope work off into a "later" pile, and do not treat capturing a follow-up (a PR `## Follow-ups` list, a `// TODO` comment, a Draft on the project board) as a substitute for doing the work. Those capture mechanisms exist to record genuinely separate work, **not** to dodge effort that belongs in the current change.
 
-1. **If a PR is open (or you are about to open one), append it to the PR description.** Add a dedicated `## Follow-ups` list so reviewers see it; fall back to `## Fixed issues / References` only when noting a linked issue/PR (that section is for closed/referenced issues, not for "fixed" follow-ups). This is the default for anything tightly coupled to the PR under review.
-2. **Otherwise, add it as a Draft item to GitHub Projects v2 — [b-editor/projects/9](https://github.com/orgs/b-editor/projects/9).** This is the default for cross-cutting or longer-horizon work that outlives the current PR. Give the draft a clear title and a one-line body describing the context; reference the originating PR/commit when one exists.
+There are only two legitimate reasons to stop short of completing what the change surfaced, and **both require telling the user — never silently file it away and move on:**
 
-Pick whichever fits; when unsure, prefer the PR description for PR-local items and the project board for everything else. Do not silently drop a follow-up just because it is out of scope for the current change.
+1. **Genuinely out of scope** — a different feature or area that does not belong in this change. Surface it to the user (e.g. via `AskUserQuestion`) and let them decide whether to widen the scope or track it separately.
+2. **Blocked** — you cannot resolve it without something only the user can provide (missing access, an upstream fix, a product decision). State the blocker explicitly.
+
+Do not leave `[Obsolete]` shims, `// TODO` markers, or "v2" stubs behind as deferral markers (see "Design priorities").
 
 ## Spec-Driven Development for large features
 


### PR DESCRIPTION
Replace the "Follow-up tasks" policy that tolerated deferring in-scope
work (capture it in the PR body or as a board Draft) with a prohibition:
finish whatever the change surfaces in the same change. The only exits are
genuinely out-of-scope or blocked items, and both require raising them with
the user rather than silently filing a follow-up.

- AGENTS.md: rewrite the section as "Do not defer work".
- PULL_REQUEST_TEMPLATE.md: add a no-deferral reminder.
- beutl-ai-review-task skill: replace Step 7 "Capture follow-ups
  (auto-register to the board)" and its Guardrails exception with the
  same prohibition.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SSBXdjDKZTXDLg51j9z2qC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow and process guidelines to require completing all in-scope work within the same pull request, with no deferred follow-ups.
  * Revised guidance for handling out-of-scope or blocked items, emphasizing explicit communication instead of silent deferral or project draft tracking.
  * Updated the pull request template with reminders to avoid `## Follow-ups` and ensure any exceptions are clearly raised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->