### PR TITLE
fix(editor): harden HistoryMutationPlaybackGuard.Dispose and SceneSettings Apply feedback

### DIFF
--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -81,10 +81,8 @@ public sealed class SceneSettingsTabViewModel : IToolContext
 
                         if (!TryReadSceneSettings(out frameSize, out start, out duration))
                         {
-                            // Pausing yielded to the UI thread; if the user invalidated an input
-                            // during that window the re-read fails. Tell them why Apply did nothing
-                            // instead of returning silently (the Apply button also disables itself,
-                            // but that alone does not explain the canceled click).
+                            // Pausing yielded to the UI thread, so the user may have invalidated an
+                            // input meanwhile. Warn instead of returning silently.
                             NotificationService.ShowWarning(
                                 Strings.SceneSettings,
                                 MessageStrings.SceneSettings_ApplyCanceledInputsInvalid);

--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -3,6 +3,7 @@
 using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -80,6 +81,13 @@ public sealed class SceneSettingsTabViewModel : IToolContext
 
                         if (!TryReadSceneSettings(out frameSize, out start, out duration))
                         {
+                            // Pausing yielded to the UI thread; if the user invalidated an input
+                            // during that window the re-read fails. Tell them why Apply did nothing
+                            // instead of returning silently (the Apply button also disables itself,
+                            // but that alone does not explain the canceled click).
+                            NotificationService.ShowWarning(
+                                Strings.SceneSettings,
+                                MessageStrings.SceneSettings_ApplyCanceledInputsInvalid);
                             return;
                         }
                     }

--- a/src/Beutl.Language/MessageStrings.ja.resx
+++ b/src/Beutl.Language/MessageStrings.ja.resx
@@ -386,4 +386,7 @@
   <data name="SaveImageElementRendersNothing" xml:space="preserve">
     <value>選択した要素は何も描画しないため (0 × 0 px)、画像として保存できません。</value>
   </data>
+  <data name="SceneSettings_ApplyCanceledInputsInvalid" xml:space="preserve">
+    <value>再生の一時停止中にシーン設定が無効になったため、適用をキャンセルしました。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/MessageStrings.resx
+++ b/src/Beutl.Language/MessageStrings.resx
@@ -391,4 +391,7 @@ Do you want to restart the application?</value>
   <data name="SaveImageElementRendersNothing" xml:space="preserve">
     <value>The selected element renders nothing (0 × 0 px), so it cannot be saved as an image.</value>
   </data>
+  <data name="SceneSettings_ApplyCanceledInputsInvalid" xml:space="preserve">
+    <value>Apply was canceled because the scene settings became invalid while pausing playback.</value>
+  </data>
 </root>

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -16,12 +16,8 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         ArgumentNullException.ThrowIfNull(drainPendingMutations);
         ArgumentNullException.ThrowIfNull(shouldPause);
         ArgumentNullException.ThrowIfNull(mutate);
-        // Reject callers that arrive after disposal deterministically. ExecuteHistoryMutationAsync
-        // catches this and skips the operation; relying on a disposed _gate to throw was unreliable
-        // because Dispose() leaves the gate intact when an operation holds it (see Dispose below).
-        // Callers and Dispose() both run on the UI thread, so no Dispose() can interleave between
-        // this check and the WaitAsync() below; were that single-thread invariant relaxed, WaitAsync()
-        // on a disposed gate would still surface ObjectDisposedException, only with the gate's name.
+        // Reject post-disposal callers. Relying on the disposed _gate to throw is unreliable:
+        // Dispose() leaves the gate intact when an operation still holds it (see Dispose).
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         await _gate.WaitAsync();
@@ -67,9 +63,8 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
             return;
         }
 
-        // New callers are rejected by the _disposed guard in RunAsync, so the gate has no further
-        // use. Dispose it when no operation holds it; if one is in flight (Wait(0) fails) it will
-        // Release on completion and the GC reclaims the SemaphoreSlim (no unmanaged handle is held).
+        // Dispose the gate only when no operation holds it; if one is in flight, let the GC
+        // reclaim the SemaphoreSlim on completion (no unmanaged handle is held).
         _disposed = true;
         if (_gate.Wait(0))
         {

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -5,6 +5,7 @@ namespace Beutl.Helpers;
 internal sealed class HistoryMutationPlaybackGuard : IDisposable
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
+    private volatile bool _disposed;
 
     internal async ValueTask<bool> RunAsync(
         IPreviewPlayer? player,
@@ -15,6 +16,13 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         ArgumentNullException.ThrowIfNull(drainPendingMutations);
         ArgumentNullException.ThrowIfNull(shouldPause);
         ArgumentNullException.ThrowIfNull(mutate);
+        // Reject callers that arrive after disposal deterministically. ExecuteHistoryMutationAsync
+        // catches this and skips the operation; relying on a disposed _gate to throw was unreliable
+        // because Dispose() leaves the gate intact when an operation holds it (see Dispose below).
+        // Callers and Dispose() both run on the UI thread, so no Dispose() can interleave between
+        // this check and the WaitAsync() below; were that single-thread invariant relaxed, WaitAsync()
+        // on a disposed gate would still surface ObjectDisposedException, only with the gate's name.
+        ObjectDisposedException.ThrowIf(_disposed, this);
 
         await _gate.WaitAsync();
         try
@@ -54,8 +62,15 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
 
     public void Dispose()
     {
-        // Disposing a SemaphoreSlim with a pending WaitAsync is undefined, so skip it
-        // while the gate is held and let the GC reclaim it (no unmanaged handle is held).
+        if (_disposed)
+        {
+            return;
+        }
+
+        // New callers are rejected by the _disposed guard in RunAsync, so the gate has no further
+        // use. Dispose it when no operation holds it; if one is in flight (Wait(0) fails) it will
+        // Release on completion and the GC reclaims the SemaphoreSlim (no unmanaged handle is held).
+        _disposed = true;
         if (_gate.Wait(0))
         {
             _gate.Dispose();

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -23,6 +23,11 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         await _gate.WaitAsync();
         try
         {
+            // Re-check after acquiring the gate: a caller that was already queued in WaitAsync()
+            // when Dispose() ran passed the pre-wait check, so reject it here too. The finally
+            // releases the gate before this propagates.
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             // shouldPause() reflects whether this operation will change scene state, including
             // any pending transaction the drain below will commit (callers' predicates check
             // HasPendingOperations). Evaluate it before draining so the pause can bracket the

--- a/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
+++ b/src/Beutl/Helpers/HistoryMutationPlaybackGuard.cs
@@ -24,8 +24,7 @@ internal sealed class HistoryMutationPlaybackGuard : IDisposable
         try
         {
             // Re-check after acquiring the gate: a caller that was already queued in WaitAsync()
-            // when Dispose() ran passed the pre-wait check, so reject it here too. The finally
-            // releases the gate before this propagates.
+            // when Dispose() ran passed the pre-wait check, so reject it here too.
             ObjectDisposedException.ThrowIf(_disposed, this);
 
             // shouldPause() reflects whether this operation will change scene state, including

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -231,8 +231,8 @@ public class HistoryMutationPlaybackGuardTests
         using var guard = new HistoryMutationPlaybackGuard();
         guard.Dispose();
 
-        // ExecuteHistoryMutationAsync catches ObjectDisposedException to skip the operation,
-        // so RunAsync must surface disposal as that exception rather than silently proceeding.
+        // Callers catch ObjectDisposedException to skip the operation, so disposal must surface
+        // as that exception rather than silently proceeding.
         Assert.ThrowsAsync<ObjectDisposedException>(async () =>
             await guard.RunAsync(null, () => { }, () => true, () => true));
     }
@@ -260,8 +260,8 @@ public class HistoryMutationPlaybackGuardTests
         player.CompleteDrain();
         bool inFlightResult = await inFlight;
 
-        // A caller arriving after disposal must be rejected deterministically — regardless of
-        // whether an operation happened to hold the gate when Dispose ran.
+        // A post-disposal caller must still be rejected, even though an operation held the gate
+        // when Dispose ran.
         Assert.Multiple(() =>
         {
             Assert.That(inFlightResult, Is.True, "the in-flight operation must complete normally");
@@ -277,7 +277,6 @@ public class HistoryMutationPlaybackGuardTests
         using var guard = new HistoryMutationPlaybackGuard();
         guard.Dispose();
 
-        // Dispose must be idempotent (IDisposable contract).
         Assert.DoesNotThrow(() => guard.Dispose());
     }
 

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -272,6 +272,49 @@ public class HistoryMutationPlaybackGuardTests
     }
 
     [Test]
+    public async Task Dispose_WhileWaiterIsQueued_RejectsThatWaiterAfterGateReleases()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true)
+        {
+            CompletePauseManually = true
+        };
+        bool inFlightMutated = false;
+        bool queuedMutated = false;
+
+        // A holds the gate and suspends at the pause drain.
+        Task<bool> inFlight = guard.RunAsync(player, () => { }, () => true, () =>
+        {
+            inFlightMutated = true;
+            return true;
+        }).AsTask();
+        await player.WaitForPauseStartedAsync();
+
+        // B passes the pre-wait check, then parks in WaitAsync() behind A — all synchronously,
+        // so B is already queued by the time RunAsync returns its task.
+        Task<bool> queued = guard.RunAsync(null, () => { }, () => false, () =>
+        {
+            queuedMutated = true;
+            return true;
+        }).AsTask();
+
+        // Dispose while A still holds the gate and B is already queued behind it.
+        guard.Dispose();
+        player.CompleteDrain();
+        bool inFlightResult = await inFlight;
+
+        // A finishes normally; B entered before disposal but must be rejected once it acquires
+        // the gate, and must never run its mutation.
+        Assert.Multiple(() =>
+        {
+            Assert.That(inFlightResult, Is.True, "the in-flight operation must complete normally");
+            Assert.That(inFlightMutated, Is.True);
+            Assert.That(queuedMutated, Is.False, "a waiter queued before disposal must not mutate after disposal");
+        });
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await queued);
+    }
+
+    [Test]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
         using var guard = new HistoryMutationPlaybackGuard();

--- a/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
+++ b/tests/Beutl.UnitTests/Editor/HistoryMutationPlaybackGuardTests.cs
@@ -225,6 +225,62 @@ public class HistoryMutationPlaybackGuardTests
         });
     }
 
+    [Test]
+    public void RunAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        guard.Dispose();
+
+        // ExecuteHistoryMutationAsync catches ObjectDisposedException to skip the operation,
+        // so RunAsync must surface disposal as that exception rather than silently proceeding.
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await guard.RunAsync(null, () => { }, () => true, () => true));
+    }
+
+    [Test]
+    public async Task Dispose_WhileOperationInFlight_RejectsLaterCallersDeterministically()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        using var player = new PreviewPlayerStub(isPlaying: true)
+        {
+            CompletePauseManually = true
+        };
+        bool inFlightMutated = false;
+
+        // Start an operation and let it suspend inside the gate at the pause drain.
+        Task<bool> inFlight = guard.RunAsync(player, () => { }, () => true, () =>
+        {
+            inFlightMutated = true;
+            return true;
+        }).AsTask();
+        await player.WaitForPauseStartedAsync();
+
+        // Dispose while the operation holds the gate. The in-flight operation must still finish.
+        guard.Dispose();
+        player.CompleteDrain();
+        bool inFlightResult = await inFlight;
+
+        // A caller arriving after disposal must be rejected deterministically — regardless of
+        // whether an operation happened to hold the gate when Dispose ran.
+        Assert.Multiple(() =>
+        {
+            Assert.That(inFlightResult, Is.True, "the in-flight operation must complete normally");
+            Assert.That(inFlightMutated, Is.True);
+        });
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await guard.RunAsync(player, () => { }, () => true, () => true));
+    }
+
+    [Test]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        using var guard = new HistoryMutationPlaybackGuard();
+        guard.Dispose();
+
+        // Dispose must be idempotent (IDisposable contract).
+        Assert.DoesNotThrow(() => guard.Dispose());
+    }
+
     private sealed class PreviewPlayerStub : IPreviewPlayer, IDisposable
     {
         private readonly ReactivePropertySlim<Ref<Bitmap>?> _previewImage = new();

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -19,20 +19,17 @@ namespace Beutl.UnitTests.Editor;
 [TestFixture]
 public class SceneSettingsTabViewModelTests
 {
-    // NotificationService.Handler is a process-global, write-once facade (set only by the app at
-    // startup, which does not run under test). Install a capturing handler once so the Apply path's
-    // ShowWarning is observable. Beutl.Core grants InternalsVisibleTo to Beutl.UnitTests, so the
-    // internal setter is reachable. The handler matches on the specific message, so notifications
-    // from other fixtures (different messages) never satisfy the assertion.
+    // NotificationService.Handler is a process-global, write-once facade (set by the app at startup,
+    // which does not run under test). Install a capturing handler so the Apply path's ShowWarning is
+    // observable; Beutl.Core grants InternalsVisibleTo to reach the internal setter.
     private static readonly CaptureNotificationHandler s_notificationHandler = new();
 
     [OneTimeSetUp]
     public void InstallNotificationHandler()
     {
         NotificationService.Handler = s_notificationHandler;
-        // The setter is write-once (??=); if another fixture installed a handler first this would
-        // silently no-op and the notification assertions would always see an empty queue. Fail
-        // loudly here instead of producing a confusing false-negative inside a test.
+        // The setter is write-once (??=); if another fixture installed a handler first this no-ops
+        // and the queue stays empty. Fail loudly instead of as a confusing false-negative in a test.
         Assert.That(NotificationService.Handler, Is.SameAs(s_notificationHandler),
             "Another fixture already installed a NotificationService handler; "
             + "SceneSettings notifications will not be captured.");

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Collections.Concurrent;
+using System.Numerics;
 using System.Reactive;
 using System.Reactive.Linq;
 
@@ -9,6 +10,7 @@ using Beutl.Extensibility;
 using Beutl.Media;
 using Beutl.Media.Source;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 
 using Reactive.Bindings;
 
@@ -17,6 +19,31 @@ namespace Beutl.UnitTests.Editor;
 [TestFixture]
 public class SceneSettingsTabViewModelTests
 {
+    // NotificationService.Handler is a process-global, write-once facade (set only by the app at
+    // startup, which does not run under test). Install a capturing handler once so the Apply path's
+    // ShowWarning is observable. Beutl.Core grants InternalsVisibleTo to Beutl.UnitTests, so the
+    // internal setter is reachable. The handler matches on the specific message, so notifications
+    // from other fixtures (different messages) never satisfy the assertion.
+    private static readonly CaptureNotificationHandler s_notificationHandler = new();
+
+    [OneTimeSetUp]
+    public void InstallNotificationHandler()
+    {
+        NotificationService.Handler = s_notificationHandler;
+        // The setter is write-once (??=); if another fixture installed a handler first this would
+        // silently no-op and the notification assertions would always see an empty queue. Fail
+        // loudly here instead of producing a confusing false-negative inside a test.
+        Assert.That(NotificationService.Handler, Is.SameAs(s_notificationHandler),
+            "Another fixture already installed a NotificationService handler; "
+            + "SceneSettings notifications will not be captured.");
+    }
+
+    [SetUp]
+    public void ClearCapturedNotifications()
+    {
+        s_notificationHandler.Clear();
+    }
+
     [Test]
     public async Task Apply_WhenInputsChangeWhilePausing_CommitsLatestInputs()
     {
@@ -77,11 +104,11 @@ public class SceneSettingsTabViewModelTests
         });
     }
 
-    [TestCase(0, 600, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommit_WhenWidthBecomesZeroWhilePausing")]
-    [TestCase(800, 0, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommit_WhenHeightBecomesZeroWhilePausing")]
-    [TestCase(800, 600, "-00:00:01", "00:00:12", TestName = "Apply_DoesNotCommit_WhenStartBecomesNegativeWhilePausing")]
-    [TestCase(800, 600, "00:00:03", "00:00:00", TestName = "Apply_DoesNotCommit_WhenDurationBecomesZeroWhilePausing")]
-    public async Task Apply_WhenInputsBecomeInvalidWhilePausing_DoesNotCommit(
+    [TestCase(0, 600, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenWidthBecomesZeroWhilePausing")]
+    [TestCase(800, 0, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenHeightBecomesZeroWhilePausing")]
+    [TestCase(800, 600, "-00:00:01", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenStartBecomesNegativeWhilePausing")]
+    [TestCase(800, 600, "00:00:03", "00:00:00", TestName = "Apply_DoesNotCommitAndNotifies_WhenDurationBecomesZeroWhilePausing")]
+    public async Task Apply_WhenInputsBecomeInvalidWhilePausing_DoesNotCommitAndNotifies(
         int width, int height, string start, string duration)
     {
         var scene = new Scene(640, 480, string.Empty)
@@ -129,7 +156,35 @@ public class SceneSettingsTabViewModelTests
         previewPlayer.CompletePause();
         await applyTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(sceneSettingsService.CallCount, Is.EqualTo(0));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sceneSettingsService.CallCount, Is.EqualTo(0));
+            Assert.That(
+                s_notificationHandler.Contains(Beutl.Language.MessageStrings.SceneSettings_ApplyCanceledInputsInvalid),
+                Is.True,
+                "Apply must warn the user instead of cancelling silently when inputs become invalid during the pause");
+        });
+    }
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        // Fully qualified: System.Reactive also defines a Notification type, so the bare name is ambiguous.
+        private readonly ConcurrentQueue<Beutl.Services.Notification> _notifications = new();
+
+        public void Show(Beutl.Services.Notification notification)
+        {
+            _notifications.Enqueue(notification);
+        }
+
+        public bool Contains(string message)
+        {
+            return _notifications.Any(n => n.Message == message);
+        }
+
+        public void Clear()
+        {
+            _notifications.Clear();
+        }
     }
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext


### PR DESCRIPTION
## Description

Two independent, behavior-preserving-where-possible fixes from the AI Review board (Project #9), both on the playback-pause path that brackets editor mutations:

- **`HistoryMutationPlaybackGuard.Dispose` was non-idempotent and non-deterministic.** It disposed the `SemaphoreSlim` only when `_gate.Wait(0)` succeeded, so:
  - if an operation held the gate at dispose time the gate was never disposed and a *later* `RunAsync` silently ran instead of throwing — although `ExecuteHistoryMutationAsync` is written to `catch (ObjectDisposedException)` and skip the operation;
  - a second `Dispose()` threw `ObjectDisposedException` from `_gate.Wait(0)` on an already-disposed semaphore, violating the `IDisposable` contract.

  Fix: a `volatile _disposed` flag, `ObjectDisposedException.ThrowIf(_disposed, this)` at `RunAsync` entry, and an idempotent `Dispose()`. The conditional gate-dispose is kept (an in-flight op's `finally` `Release()` stays safe; the `SemaphoreSlim` holds no unmanaged handle and is GC-reclaimed).

- **`SceneSettingsTabViewModel.Apply` canceled silently when inputs became invalid during the pause.** After `await player.Pause()` the command re-reads the inputs; if the user invalidated one during that window the re-read failed and `Apply` `return`ed with no feedback. Fix: show a warning notification on that path. The intentional re-read-that-commits-the-latest-valid-values behavior (covered by existing tests) is unchanged. A new localized message `MessageStrings.SceneSettings_ApplyCanceledInputsInvalid` (en + ja) backs it.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

Also touches `Beutl.Language` (new localized `MessageStrings` key, en + ja) and `src/Beutl/Helpers/` (the internal `HistoryMutationPlaybackGuard`).

## Breaking changes

None. `HistoryMutationPlaybackGuard` is an `internal sealed` type; the only behavioral change there makes post-dispose `RunAsync` rejection deterministic and `Dispose()` idempotent, both of which the existing caller already handles. The SceneSettings change is an additive notification on a path that previously did nothing.

## Test plan

Baseline-first (characterization) for both fixes, in `tests/Beutl.UnitTests/`:

- **Guard** (`HistoryMutationPlaybackGuardTests`): added 3 tests for deterministic post-dispose rejection, idempotent `Dispose`, and in-flight completion. Against unmodified code 2 of them failed (capturing the inconsistency + non-idempotency bugs) while the 8 existing tests stayed green; after the fix **11/11 pass**.
- **SceneSettings** (`SceneSettingsTabViewModelTests`): the existing invalid-during-pause cases now also assert the warning fires (verified red with the notification disabled, then green); a `[OneTimeSetUp]` installs a capturing `INotificationServiceHandler` via the write-once facade and asserts the install succeeded. **5/5 pass** (`CommitsLatest` + 4 invalid cases).
- Full `dotnet build Beutl.slnx`: **0 errors** (cross-project resx generation verified).
- `dotnet format --verify-no-changes` on all changed `.cs` files: clean.
- Each fix was adversarially reviewed by the `beutl-reviewer` subagent (verdict APPROVE-WITH-NITS; all nits addressed).

## Fixed issues / References
- Project board: b-editor/projects/9 ("[2026-06-24][diff][medium] HistoryMutationPlaybackGuard.Dispose skips gate disposal when in-flight")
- Project board: b-editor/projects/9 ("[2026-06-24][diff][medium] SceneSettingsTabViewModel silently aborts Apply when inputs change during Pause")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applying scene settings during paused playback now re-validates the inputs; if they become invalid, the apply is canceled and a warning is shown instead of failing silently.
  * Improved robustness of playback/history operations during repeated shutdown, with more deterministic disposal behavior.
* **Localization**
  * Added a localized warning message for when apply is canceled due to invalid scene settings while pausing.
* **Tests**
  * Expanded unit tests to verify the warning/cancel flow and added concurrent disposal scenario coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->