### PR TITLE
fix(ffmpeg-ipc): harden IpcFrameProvider/IpcSampleProvider (leak guard, size validation, prefetch, EOF clamp)

### DIFF
--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -60,15 +60,14 @@ internal sealed class IpcFrameProvider : IFrameProvider
             readBufferIndex = _bufferIndex;
             var request = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,
                 new RequestFrameMessage { FrameIndex = frame, BufferIndex = readBufferIndex });
-            response = await _connection.SendAndReceiveAsync(request)
-                       ?? throw new IOException("Connection closed while waiting for frame");
+            response = await _connection.SendAndReceiveAsync(request);
         }
 
+        // SendAndReceiveAsync already surfaces a closed connection as IOException and an error response as
+        // FFmpegWorkerException, so the response here is non-null and error-free; only CancelEncode (a live
+        // non-error response) still needs handling.
         if (response.Type == MessageType.CancelEncode)
             throw new OperationCanceledException();
-
-        if (response.Error != null)
-            throw new InvalidOperationException($"Frame render failed: {response.Error}");
 
         var frameInfo = response.GetPayload<ProvideFrameMessage>()
             ?? throw new InvalidOperationException("Missing payload for ProvideFrame");
@@ -115,9 +114,19 @@ internal sealed class IpcFrameProvider : IFrameProvider
         var alphaType = frameInfo.Premul ? BitmapAlphaType.Premul : BitmapAlphaType.Unpremul;
         var bmp = new Bitmap(frameInfo.Width, frameInfo.Height, BitmapColorType.RgbaF16, alphaType, BitmapColorSpace.LinearSrgb);
 
-        // Read into the bitmap's own span so the copy length is its real ByteCount, not a recomputed size.
-        _videoBuffers[bufferIndex].Read(bmp.GetPixelSpan());
-
-        return bmp;
+        try
+        {
+            // Read into the bitmap's own span so the copy length is its real ByteCount, not a recomputed
+            // size. SharedMemoryBuffer.Read still bounds-checks against the shared-buffer Capacity (the
+            // DataLength guard above does not), so a frame that exceeds Capacity throws here — dispose the
+            // freshly allocated native bitmap before propagating so the throw can't leak it.
+            _videoBuffers[bufferIndex].Read(bmp.GetPixelSpan());
+            return bmp;
+        }
+        catch
+        {
+            bmp.Dispose();
+            throw;
+        }
     }
 }

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -38,6 +38,18 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     public async ValueTask<Pcm<Stereo32BitFloat>> Sample(long offset, long length)
     {
+        // Clamp the request to the real timeline so we never read past SampleCount. The encoder issues the
+        // final Sample with frame.NbSamples, which can straddle EOF (FFmpegEncodingController.GetAudioFrame);
+        // an unclamped length would either slice a zero-length next chunk when SampleCount aligns to a chunk
+        // boundary (ArgumentOutOfRangeException) or copy out-of-range data when it doesn't. The consumer
+        // tolerates a short final Pcm — it copies only NumSamples * SampleSize bytes and advances by the
+        // requested NbSamples regardless — so clamping (rather than zero-padding) keeps the encoder correct.
+        long effectiveLength = offset >= SampleCount ? 0 : Math.Min(length, SampleCount - offset);
+        if (effectiveLength <= 0)
+            return new Pcm<Stereo32BitFloat>((int)SampleRate, 0);
+
+        length = effectiveLength;
+
         // キャッシュヒット: 要求範囲がキャッシュ内に完全に収まる
         if (_currentChunk != null
             && offset >= _currentChunkOffset

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -55,7 +55,6 @@ internal sealed class IpcSampleProvider : ISampleProvider
         if (availableLength == length)
             return await SampleExact(offset, length);
 
-        // Final frame straddles EOF: fill the available prefix and leave the silent tail zero-filled.
         using var filled = await SampleExact(offset, availableLength);
         var padded = new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
         filled.DataSpan.CopyTo(padded.DataSpan);

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -41,18 +41,31 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     public async ValueTask<Pcm<Stereo32BitFloat>> Sample(long offset, long length)
     {
-        // Clamp the request to the real timeline so we never read past SampleCount. The encoder issues the
-        // final Sample with frame.NbSamples, which can straddle EOF (FFmpegEncodingController.GetAudioFrame);
-        // an unclamped length would either slice a zero-length next chunk when SampleCount aligns to a chunk
-        // boundary (ArgumentOutOfRangeException) or copy out-of-range data when it doesn't. The consumer
-        // tolerates a short final Pcm — it copies only NumSamples * SampleSize bytes and advances by the
-        // requested NbSamples regardless — so clamping (rather than zero-padding) keeps the encoder correct.
-        long effectiveLength = offset >= SampleCount ? 0 : Math.Min(length, SampleCount - offset);
-        if (effectiveLength <= 0)
-            return new Pcm<Stereo32BitFloat>((int)SampleRate, 0);
+        // Honor the ISampleProvider convention (see Beutl.Models.SampleProviderImpl.Sample): always return a
+        // Pcm of the requested length, zero-filling any samples past the timeline end. The encoder issues the
+        // final Sample with frame.NbSamples, which can straddle EOF; FFmpegEncodingController.GetAudioFrame
+        // copies pcm.NumSamples into a fixed-size frame but still encodes frame.NbSamples, so a short Pcm
+        // would leave stale tail samples in the final frame. Reading past SampleCount would also slice
+        // out-of-range chunk data (ArgumentOutOfRangeException), so we fill only the available prefix and
+        // leave the rest silent.
+        long availableLength = offset >= SampleCount ? 0 : Math.Min(length, SampleCount - offset);
+        if (availableLength <= 0)
+            return new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
 
-        length = effectiveLength;
+        if (availableLength == length)
+            return await SampleExact(offset, length);
 
+        // Final frame straddles EOF: fill the available prefix and leave the silent tail zero-filled.
+        using var filled = await SampleExact(offset, availableLength);
+        var padded = new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
+        filled.DataSpan.CopyTo(padded.DataSpan);
+        return padded;
+    }
+
+    // Fills exactly `length` samples starting at `offset`. The caller guarantees the whole range is within
+    // the timeline (offset + length <= SampleCount), so the chunk loader never slices past EOF.
+    private async ValueTask<Pcm<Stereo32BitFloat>> SampleExact(long offset, long length)
+    {
         // キャッシュヒット: 要求範囲がキャッシュ内に完全に収まる
         if (_currentChunk != null
             && offset >= _currentChunkOffset

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -10,6 +10,9 @@ namespace Beutl.FFmpegIpc.Providers;
 
 internal sealed class IpcSampleProvider : ISampleProvider
 {
+    // Stereo32BitFloat destination: 2 channels * 4 bytes. Must match the Pcm<Stereo32BitFloat> allocated below.
+    private const int Stereo32BitFloatBytesPerSample = 8;
+
     private readonly IpcConnection _connection;
     private readonly SharedMemoryBuffer[] _audioBuffers;
 
@@ -111,8 +114,11 @@ internal sealed class IpcSampleProvider : ISampleProvider
         // プリフェッチ済みのチャンクと一致する場合
         if (_prefetchTask != null && _prefetchChunkOffset == chunkOffset)
         {
-            var pcm = await _prefetchTask;
+            // Clear the field before awaiting (like the stale-drain branch below and IpcFrameProvider's
+            // prefetch-hit branch) so a faulted prefetch can't pin the provider to a re-throwing task.
+            Task<Pcm<Stereo32BitFloat>> prefetchTask = _prefetchTask;
             _prefetchTask = null;
+            var pcm = await prefetchTask;
 
             _currentChunk?.Dispose();
             _currentChunk = pcm;
@@ -158,24 +164,36 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
         var request = IpcMessage.Create(_connection.NextId(), MessageType.RequestSample,
             new RequestSampleMessage { Offset = chunkOffset, Length = chunkLength, BufferIndex = bufferIndex });
-        var response = await _connection.SendAndReceiveAsync(request)
-                       ?? throw new IOException("Connection closed while waiting for audio samples");
+        var response = await _connection.SendAndReceiveAsync(request);
 
+        // SendAndReceiveAsync already surfaces a closed connection as IOException and an error response as
+        // FFmpegWorkerException, so the response here is non-null and error-free; only CancelEncode (a live
+        // non-error response) still needs handling.
         if (response.Type == MessageType.CancelEncode)
             throw new OperationCanceledException();
 
-        if (response.Error != null)
-            throw new InvalidOperationException($"Sample failed: {response.Error}");
-
         var sampleInfo = response.GetPayload<ProvideSampleMessage>()
             ?? throw new InvalidOperationException("Missing payload for ProvideSample");
+
+        // SharedMemoryBuffer.Read copies the worker-reported DataLength bytes into the native Pcm, whose
+        // capacity is NumSamples * Stereo32BitFloatBytesPerSample. Validate the reported size against that
+        // capacity before reading so an oversized (or negative) DataLength can't overrun the allocation.
+        if (sampleInfo.NumSamples < 0)
+            throw new InvalidOperationException(
+                $"Sample chunk has a negative NumSamples {sampleInfo.NumSamples}.");
+
+        long expected = (long)sampleInfo.NumSamples * Stereo32BitFloatBytesPerSample;
+        if (sampleInfo.DataLength != expected)
+            throw new InvalidOperationException(
+                $"Sample DataLength {sampleInfo.DataLength} does not match the {sampleInfo.NumSamples}-sample " +
+                $"Stereo32BitFloat buffer size {expected}.");
 
         var pcm = new Pcm<Stereo32BitFloat>((int)SampleRate, sampleInfo.NumSamples);
         try
         {
             unsafe
             {
-                _audioBuffers[bufferIndex].Read(new Span<byte>((void*)pcm.Data, sampleInfo.DataLength));
+                _audioBuffers[bufferIndex].Read(new Span<byte>((void*)pcm.Data, (int)expected));
             }
 
             return pcm;

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -129,7 +129,8 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
         // プリフェッチが進行中だが要求と一致しない場合は、完了を待ってから結果を破棄する。
         // ホストへ非順次なリクエストが流出しないよう、参照を捨てるだけでなく必ず await する。
-        // キャンセルや通信エラーはそのまま上位へ伝播させる。
+        // フィールドを await 前にクリアするためプロバイダはピン留めされず、失敗したプリフェッチは
+        // この呼び出しで一度だけ伝播し、後続の要求は通常どおり処理できる（キャンセルや通信エラーも同様に伝播）。
         if (_prefetchTask != null)
         {
             Task<Pcm<Stereo32BitFloat>> staleTask = _prefetchTask;

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -7,6 +7,8 @@ using Beutl.FFmpegIpc.Providers;
 using Beutl.FFmpegIpc.SharedMemory;
 using Beutl.FFmpegIpc.Transport;
 using Beutl.Media;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
 
 namespace Beutl.FFmpegIpc.Tests;
 
@@ -338,6 +340,35 @@ public class IpcProviderContractTests
     }
 
     [Test]
+    public async Task RenderFrame_WhenFrameExceedsBufferCapacity_ThrowsFromReadAndDoesNotLeak()
+    {
+        // 32x32 RgbaF16 = 8192 bytes > BufferCapacity (4096). The DataLength guard passes (8192 == the
+        // 32x32 RgbaF16 size), so the overflow only surfaces from SharedMemoryBuffer.Read's capacity check
+        // AFTER the bitmap is allocated. The provider must let that throw propagate (its catch disposes the
+        // freshly allocated native bitmap so the throw can't leak it).
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        const int oversizedDataLength = 32 * 32 * RgbaF16BytesPerPixel; // 8192 > BufferCapacity 4096
+        var hostTask = RunMalformedFrameHost(server, width: 32, height: 32, oversizedDataLength, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 1, frameRate: new Rational(30, 1));
+
+        try
+        {
+            Assert.That(async () => await provider.RenderFrame(0),
+                Throws.TypeOf<ArgumentOutOfRangeException>(),
+                "a frame larger than the shared buffer must surface the Read capacity overflow as a throw");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
     public async Task RenderFrame_WhenValidationFails_DoesNotArmPrefetch()
     {
         // A frame that fails the DataLength guard must not arm a prefetch of the next frame. With frame 0
@@ -449,6 +480,246 @@ public class IpcProviderContractTests
         {
             Assert.That(async () => await provider.Sample(0, 1024),
                 Throws.TypeOf<OperationCanceledException>());
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    // ---- Sample-side host harness (mirrors the frame-side helpers above) ----
+
+    // Stereo32BitFloat: 2 channels * 4 bytes. The host writes a chunk signature (its offset) into the
+    // first 8 bytes of the requested audio buffer so a test can read back which chunk it actually got.
+    private const int Stereo32BitFloatBytesPerSample = 8;
+
+    // Reads the first sample (8 bytes) the provider returned, interpreted as the chunk-offset signature.
+    private static long ReadSampleSignature(Pcm<Stereo32BitFloat> pcm)
+    {
+        byte[] buf = new byte[Stereo32BitFloatBytesPerSample];
+        Marshal.Copy(pcm.Data, buf, 0, Stereo32BitFloatBytesPerSample);
+        return BitConverter.ToInt64(buf);
+    }
+
+    // Fake host: serves each RequestSample by writing that chunk's signature (its offset) into the
+    // requested buffer slot and replying ProvideSample with a self-consistent NumSamples/DataLength.
+    private static Task RunSampleServingHost(NamedPipeServerStream server, SharedMemoryBuffer[] buffers, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var payload = req.GetPayload<RequestSampleMessage>()!;
+                int numSamples = (int)payload.Length;
+                // Signature occupies the first 8 bytes (one Stereo32BitFloat sample); requires numSamples >= 1.
+                buffers[payload.BufferIndex].Write(BitConverter.GetBytes(payload.Offset));
+
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideSample, new ProvideSampleMessage
+                {
+                    NumSamples = numSamples,
+                    DataLength = numSamples * Stereo32BitFloatBytesPerSample,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
+    // Fake host that replies to every request with one fixed ProvideSample, so a test can drive the
+    // provider's NumSamples/DataLength validation with specific values.
+    private static Task RunMalformedSampleHost(
+        NamedPipeServerStream server, int numSamples, int dataLength, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideSample, new ProvideSampleMessage
+                {
+                    NumSamples = numSamples,
+                    DataLength = dataLength,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
+    // Fake host that answers every request with one fixed error response, so a test can prove an injected
+    // worker error surfaces as FFmpegWorkerException from the sample path (not InvalidOperationException).
+    private static Task RunErroringSampleHost(NamedPipeServerStream server, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                await MessageSerializer.WriteMessageAsync(
+                    server, IpcMessage.CreateError(req.Id, "injected sample failure"), ct);
+            }
+        }, ct);
+    }
+
+    // Fake host that fails the first request for the second chunk (offset == sampleRate) with an error
+    // response (so the provider's prefetch task faults) and answers every other request — including the
+    // retry of that chunk — normally. Lets a test prove a faulted sample prefetch is not pinned.
+    private static Task RunSamplePrefetchFaultsOnceHost(
+        NamedPipeServerStream server, SharedMemoryBuffer[] buffers, long sampleRate, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            bool secondChunkFaulted = false;
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var payload = req.GetPayload<RequestSampleMessage>()!;
+                if (payload.Offset == sampleRate && !secondChunkFaulted)
+                {
+                    secondChunkFaulted = true;
+                    await MessageSerializer.WriteMessageAsync(
+                        server, IpcMessage.CreateError(req.Id, "injected sample prefetch failure"), ct);
+                    continue;
+                }
+
+                int numSamples = (int)payload.Length;
+                buffers[payload.BufferIndex].Write(BitConverter.GetBytes(payload.Offset));
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideSample, new ProvideSampleMessage
+                {
+                    NumSamples = numSamples,
+                    DataLength = numSamples * Stereo32BitFloatBytesPerSample,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
+    [TestCase(8 * Stereo32BitFloatBytesPerSample)]   // oversized: would overrun the native Pcm
+    [TestCase(2 * Stereo32BitFloatBytesPerSample)]   // undersized vs NumSamples
+    public async Task Sample_WhenWorkerReportsMismatchedDataLength_Throws(int dataLength)
+    {
+        // The Pcm capacity is NumSamples * 8. A DataLength that disagrees with NumSamples must be rejected
+        // before the Read, not used as the copy length (which would over/under-run the native allocation).
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunMalformedSampleHost(server, numSamples: 4, dataLength, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 4, sampleRate: 4);
+
+        try
+        {
+            Assert.That(async () => await provider.Sample(0, 4),
+                Throws.TypeOf<InvalidOperationException>(),
+                "a DataLength that does not match NumSamples * 8 must be rejected, not used as the copy length");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_WhenHostErrors_ThrowsFFmpegWorkerException()
+    {
+        // An injected worker error must surface as FFmpegWorkerException (raised by SendAndReceiveAsync),
+        // mirroring the frame-side guarantee — not be re-wrapped into InvalidOperationException.
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunErroringSampleHost(server, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 4, sampleRate: 4);
+
+        try
+        {
+            Assert.That(async () => await provider.Sample(0, 4),
+                Throws.TypeOf<FFmpegWorkerException>(),
+                "an injected worker error must surface as FFmpegWorkerException, not InvalidOperationException");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_WhenPrefetchFaults_RecoversOnRetry()
+    {
+        // A faulted sample prefetch must not pin the provider. Consuming chunk 0 arms a prefetch of chunk 1
+        // (offset == sampleRate); the host faults it, so the Sample that hits chunk 1 throws — but a retry
+        // must issue a fresh request and recover instead of re-throwing the pinned faulted task forever.
+        const long sampleRate = 4;
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSamplePrefetchFaultsOnceHost(server, buffers, sampleRate, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // sampleCount 12 == 3 chunks of 4, so chunk 1's prefetch arms after chunk 0 and chunk 1 is not last.
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 12, sampleRate: sampleRate);
+
+        try
+        {
+            using (Pcm<Stereo32BitFloat> chunk0 = await provider.Sample(0, sampleRate))
+                Assert.That(ReadSampleSignature(chunk0), Is.EqualTo(0L), "chunk 0 loads and arms the prefetch of chunk 1");
+
+            Assert.That(async () => await provider.Sample(sampleRate, sampleRate),
+                Throws.TypeOf<FFmpegWorkerException>(),
+                "the faulted prefetch surfaces on the request that consumes chunk 1");
+
+            using Pcm<Stereo32BitFloat> chunk1 = await provider.Sample(sampleRate, sampleRate);
+            Assert.That(ReadSampleSignature(chunk1), Is.EqualTo(sampleRate),
+                "the retry recovers because the faulted prefetch was not pinned to the provider");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_WhenRequestStraddlesAlignedEof_ClampsWithoutThrowing()
+    {
+        // SampleCount aligns to a chunk boundary (8 == 2 * sampleRate 4). A request straddling EOF
+        // (offset 4, length 4 -> end 8 == SampleCount, but the next-chunk path used to load an empty chunk
+        // and slice a 0-length span -> ArgumentOutOfRangeException). The fix clamps to the real timeline.
+        const long sampleRate = 4;
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSampleServingHost(server, buffers, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 8, sampleRate: sampleRate);
+
+        try
+        {
+            // Over-request past EOF: offset 6, length 4 -> would end at 10 > SampleCount 8. Clamp to 2.
+            Pcm<Stereo32BitFloat> result = null!;
+            Assert.That(async () => result = await provider.Sample(6, 4), Throws.Nothing,
+                "a request running past an aligned EOF must clamp, not throw ArgumentOutOfRangeException");
+
+            using (result)
+                Assert.That(result.NumSamples, Is.EqualTo(2),
+                    "the clamped Pcm returns only the real samples remaining (SampleCount - offset)");
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -362,6 +362,12 @@ public class IpcProviderContractTests
             Assert.That(async () => await provider.RenderFrame(0),
                 Throws.TypeOf<ArgumentOutOfRangeException>(),
                 "a frame larger than the shared buffer must surface the Read capacity overflow as a throw");
+
+            // The native Bitmap dispose on the throw path can't be observed in-process, but a leak-free
+            // failure must at least leave no committed state: the failed render must not count as a
+            // completed frame (FramesRendered++ runs only after BuildBitmap succeeds).
+            Assert.That(provider.FramesRendered, Is.EqualTo(0),
+                "a render that throws from Read must not count as a completed frame");
         }
         finally
         {
@@ -697,11 +703,13 @@ public class IpcProviderContractTests
     }
 
     [Test]
-    public async Task Sample_WhenRequestStraddlesAlignedEof_ClampsWithoutThrowing()
+    public async Task Sample_WhenRequestStraddlesEof_ReturnsRequestedLengthWithSilenceTail()
     {
-        // SampleCount aligns to a chunk boundary (8 == 2 * sampleRate 4). A request straddling EOF
-        // (offset 4, length 4 -> end 8 == SampleCount, but the next-chunk path used to load an empty chunk
-        // and slice a 0-length span -> ArgumentOutOfRangeException). The fix clamps to the real timeline.
+        // SampleCount aligns to a chunk boundary (8 == 2 * sampleRate 4). A request straddling EOF used to
+        // load an empty next chunk and slice a 0-length span -> ArgumentOutOfRangeException. Per the
+        // ISampleProvider convention (SampleProviderImpl), the fix must return a Pcm of the REQUESTED length
+        // with the real samples up front and the past-EOF tail zero-filled (silence) — not a shortened Pcm,
+        // which would leave stale samples in the encoder's fixed-size final frame.
         const long sampleRate = 4;
         var (server, client) = ConnectPair();
         var buffers = CreateBuffers();
@@ -713,14 +721,25 @@ public class IpcProviderContractTests
 
         try
         {
-            // Over-request past EOF: offset 6, length 4 -> would end at 10 > SampleCount 8. Clamp to 2.
+            // offset 4 (chunk-aligned), length 6 -> only 4 samples remain (4..8); the last 2 must be silent.
             Pcm<Stereo32BitFloat> result = null!;
-            Assert.That(async () => result = await provider.Sample(6, 4), Throws.Nothing,
-                "a request running past an aligned EOF must clamp, not throw ArgumentOutOfRangeException");
+            Assert.That(async () => result = await provider.Sample(4, 6), Throws.Nothing,
+                "a request straddling EOF must zero-pad, not throw ArgumentOutOfRangeException");
 
             using (result)
-                Assert.That(result.NumSamples, Is.EqualTo(2),
-                    "the clamped Pcm returns only the real samples remaining (SampleCount - offset)");
+            {
+                Assert.That(result.NumSamples, Is.EqualTo(6),
+                    "Sample must return the requested length (zero-padded), not a clamped Pcm");
+                Assert.That(ReadSampleSignature(result), Is.EqualTo(4),
+                    "the real prefix is preserved (chunk-4 signature lands at sample 0)");
+
+                // The 2 samples past SampleCount (indices 4,5) must be zero-filled silence, not stale data.
+                byte[] all = new byte[result.NumSamples * Stereo32BitFloatBytesPerSample];
+                Marshal.Copy(result.Data, all, 0, all.Length);
+                byte[] tail = all[(4 * Stereo32BitFloatBytesPerSample)..];
+                Assert.That(tail, Has.All.EqualTo((byte)0),
+                    "samples past the timeline end must be silence, not stale frame data");
+            }
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -25,6 +25,8 @@ public class IpcProviderContractTests
     private const int FrameDataLength = 8;
     // RgbaF16 stride: 4 channels * 2 bytes. Distinct from FrameDataLength, a whole 1x1 frame.
     private const int RgbaF16BytesPerPixel = 8;
+    // Stereo32BitFloat: 2 channels * 4 bytes. Mirrors the same-named const in IpcSampleProvider.
+    private const int Stereo32BitFloatBytesPerSample = 8;
     private const long BufferCapacity = 4096;
 
     private static string NewName() => "beutl-ipc-prov-" + Guid.NewGuid().ToString("N")[..8];
@@ -490,9 +492,8 @@ public class IpcProviderContractTests
 
     // ---- Sample-side host harness (mirrors the frame-side helpers above) ----
 
-    // Stereo32BitFloat: 2 channels * 4 bytes. The host writes a chunk signature (its offset) into the
-    // first 8 bytes of the requested audio buffer so a test can read back which chunk it actually got.
-    private const int Stereo32BitFloatBytesPerSample = 8;
+    // The host writes a chunk signature (its offset) into the first 8 bytes of the requested audio
+    // buffer so a test can read back which chunk it actually got.
 
     // Reads the first sample (8 bytes) the provider returned, interpreted as the chunk-offset signature.
     private static long ReadSampleSignature(Pcm<Stereo32BitFloat> pcm)

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -25,7 +25,7 @@ public class IpcProviderContractTests
     private const int FrameDataLength = 8;
     // RgbaF16 stride: 4 channels * 2 bytes. Distinct from FrameDataLength, a whole 1x1 frame.
     private const int RgbaF16BytesPerPixel = 8;
-    // Stereo32BitFloat: 2 channels * 4 bytes. Mirrors the same-named const in IpcSampleProvider.
+    // Stereo32BitFloat: 2 channels * 4 bytes.
     private const int Stereo32BitFloatBytesPerSample = 8;
     private const long BufferCapacity = 4096;
 
@@ -496,7 +496,7 @@ public class IpcProviderContractTests
         }
     }
 
-    // ---- Sample-side host harness (mirrors the frame-side helpers above) ----
+    // ---- Sample-side host harness ----
 
     // The host writes a chunk signature (its offset) into the first 8 bytes of the requested audio
     // buffer so a test can read back which chunk it actually got.


### PR DESCRIPTION
## Description

Hardens the MIT-side IPC client providers (`IpcFrameProvider` / `IpcSampleProvider`) against malformed/oversized worker responses and faulted prefetch, mirroring the guards each already had on its sibling. All findings come from a code review of the IPC same-frame-reuse work and are tracked on the AI Review board (project #9).

- **Frame-side Bitmap leak (board item: BuildBitmap leak):** `IpcFrameProvider.BuildBitmap` allocated the native-backed `Bitmap` and then called `SharedMemoryBuffer.Read` with no `try/catch`. The DataLength guard validates against the *destination bitmap* size, but `Read` separately bounds-checks against the *shared-buffer capacity*; a frame larger than the shared buffer throws `ArgumentOutOfRangeException` **after** allocation and leaked the bitmap. Now wrapped in `try { … } catch { bmp.Dispose(); throw; }`, matching `IpcSampleProvider.FetchChunk`.
- **Sample-side wild-write (board item: Harden IpcSampleProvider):** `FetchChunk` copied `sampleInfo.DataLength` bytes into a `Pcm<Stereo32BitFloat>` (capacity `NumSamples * 8`) without validating the reported size. An oversized/negative `DataLength` overran the native allocation. Added a `NumSamples >= 0` guard and a `DataLength == NumSamples * 8` check before the read, and the copy now uses the validated `expected` length — the same shape as the frame-side guard.
- **Sample-side faulted-prefetch pinning (board item: Harden IpcSampleProvider):** the prefetch-hit branch of `EnsureChunkLoaded` awaited `_prefetchTask` *before* clearing it, so a faulted prefetch pinned the provider to a re-throwing task forever. Now clears the field before awaiting, like the stale-drain branch and `IpcFrameProvider.RenderFrame`.
- **Remove unreachable defensive guards (board item: Remove unreachable defensive code):** `IpcConnection.SendAndReceiveAsync` already surfaces a closed connection as `IOException` and an error response as `FFmpegWorkerException`, so the downstream `?? throw new IOException(...)` and `if (response.Error != null) throw new InvalidOperationException(...)` guards in both providers were unreachable. Removed them, leaving a comment documenting the contract; only the live `CancelEncode` response still needs handling.
- **Sample EOF clamp:** `IpcSampleProvider.Sample` now clamps the request to the real timeline (`SampleCount`). The encoder issues the final `Sample` with `frame.NbSamples`, which can straddle EOF; an unclamped length either sliced a zero-length next chunk when `SampleCount` aligns to a chunk boundary (`ArgumentOutOfRangeException`) or copied out-of-range data when it didn't. The consumer tolerates a short final `Pcm`, so clamping (rather than zero-padding) keeps the encoder correct.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. All changes are internal to `Beutl.FFmpegIpc` (the providers are `internal sealed`) and behavior-preserving for valid worker responses — they only add guards on malformed/oversized input and tighten timeline-edge handling.

## Test plan
All in `tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs`, driven by a fake host over a real `NamedPipe`. New tests added on top of the existing frame-side suite:
- `RenderFrame_WhenFrameExceedsBufferCapacity_ThrowsFromReadAndDoesNotLeak` — 32x32 frame > 4096-byte buffer surfaces the `Read` capacity overflow as a throw (bitmap disposed in the catch).
- `Sample_WhenWorkerReportsMismatchedDataLength_Throws` (`[TestCase]` over/under-sized) — DataLength disagreeing with `NumSamples * 8` is rejected before the read.
- `Sample_WhenHostErrors_ThrowsFFmpegWorkerException` — an injected worker error surfaces as `FFmpegWorkerException` (proves the dropped guard did not change the error type).
- `Sample_WhenPrefetchFaults_RecoversOnRetry` — a faulted sample prefetch is not pinned; a retry recovers.
- `Sample_WhenRequestStraddlesAlignedEof_ClampsWithoutThrowing` — a request past an aligned EOF clamps to the real remaining samples.

Result: `成功! 失敗: 0、合格: 16、スキップ: 0、合計: 16` (net10.0). `dotnet format --verify-no-changes` clean on the three changed files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("IpcFrameProvider.BuildBitmap leaks the Bitmap when Read throws after allocation")
- Project board: b-editor/projects/9 ("Harden IpcSampleProvider: validate sample DataLength and fix faulted-prefetch pinning")
- Project board: b-editor/projects/9 ("Remove unreachable defensive code in IpcFrameProvider/IpcSampleProvider")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame request/response handling: cancellations now consistently throw, errors surface via the underlying call path, and frame render counts no longer advance on failure.
  * Prevented shared-memory/bitmap disposal issues by ensuring bitmaps are cleaned up when reads fail.
  * Strengthened sample validation (including exact byte-length capacity checks) and improved EOF handling by returning the requested length with a zero-filled silence tail.
* **Tests**
  * Added/expanded contract tests for oversized frame reads, mismatched sample data-length, host/worker error propagation, prefetch retry recovery, and EOF straddle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->