### PR TITLE
refactor!: make IFrameProvider/ISampleProvider IDisposable and guard IPC providers post-dispose

### DIFF
--- a/src/Beutl.Extensibility/EncodingController.cs
+++ b/src/Beutl.Extensibility/EncodingController.cs
@@ -10,6 +10,16 @@ public abstract class EncodingController(string outputFile)
 
     public abstract AudioEncoderSettings AudioSettings { get; }
 
+    /// <summary>
+    /// Encodes the frames and samples produced by the given providers to <see cref="OutputFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// The caller retains ownership of <paramref name="frameProvider"/> and <paramref name="sampleProvider"/>
+    /// and is responsible for disposing them after this method returns or throws. Implementations are
+    /// consumers, not owners: they must <b>not</b> call <see cref="IDisposable.Dispose"/> on either argument.
+    /// Disposing a provider tears down resources the caller still owns (e.g. it cancels a background producer
+    /// task feeding the provider), so the usual "the last user disposes" heuristic does not apply here.
+    /// </remarks>
     public abstract ValueTask Encode(
         IFrameProvider frameProvider, ISampleProvider sampleProvider, CancellationToken cancellationToken);
 }

--- a/src/Beutl.Extensibility/IFrameProvider.cs
+++ b/src/Beutl.Extensibility/IFrameProvider.cs
@@ -2,7 +2,16 @@
 
 namespace Beutl.Extensibility;
 
-public interface IFrameProvider
+/// <summary>
+/// Supplies decoded frames to an encoder.
+/// </summary>
+/// <remarks>
+/// Implementations are <see cref="IDisposable"/> so they can be torn down deterministically.
+/// <see cref="IDisposable.Dispose"/> must drain (observe) any in-flight prefetch the provider
+/// started so a faulted background task cannot later surface as an
+/// <see cref="System.Threading.Tasks.TaskScheduler.UnobservedTaskException"/>.
+/// </remarks>
+public interface IFrameProvider : IDisposable
 {
     public long FrameCount { get; }
 

--- a/src/Beutl.Extensibility/ISampleProvider.cs
+++ b/src/Beutl.Extensibility/ISampleProvider.cs
@@ -3,7 +3,16 @@ using Beutl.Media.Music.Samples;
 
 namespace Beutl.Extensibility;
 
-public interface ISampleProvider
+/// <summary>
+/// Supplies decoded audio samples to an encoder.
+/// </summary>
+/// <remarks>
+/// Implementations are <see cref="IDisposable"/> so they can be torn down deterministically.
+/// <see cref="IDisposable.Dispose"/> must drain (observe) any in-flight prefetch the provider
+/// started so a faulted background task cannot later surface as an
+/// <see cref="System.Threading.Tasks.TaskScheduler.UnobservedTaskException"/>.
+/// </remarks>
+public interface ISampleProvider : IDisposable
 {
     public long SampleCount { get; }
 

--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -147,10 +147,10 @@ internal sealed class IpcFrameProvider : IFrameProvider
         // .Wait()/.GetAwaiter().GetResult() could deadlock or rethrow the pipe-teardown fault. Instead attach
         // a fault-swallowing continuation so any fault is observed (preventing UnobservedTaskException) and
         // return promptly. Owning the connection is the caller's job, so we only neutralize our own task.
-        // OnlyOnFaulted is deliberate (and the asymmetry with IpcSampleProvider.Dispose is intentional): the
-        // prefetch yields a managed IpcMessage with nothing to release — the Bitmap is built lazily only when
-        // a frame is consumed — so a successful prefetch leaks nothing. IpcSampleProvider's prefetch instead
-        // yields a native Pcm, so its continuation must also dispose the result on the success path.
+        // OnlyOnFaulted here, but not in IpcSampleProvider.Dispose: a frame prefetch yields a managed
+        // IpcMessage with nothing to release (the Bitmap is built lazily only when a frame is consumed), so a
+        // successful prefetch leaks nothing — whereas a sample prefetch yields a native Pcm its continuation
+        // must dispose on the success path.
         _prefetchTask?.ContinueWith(
             static t => { _ = t.Exception; },
             CancellationToken.None,

--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -33,6 +33,8 @@ internal sealed class IpcFrameProvider : IFrameProvider
 
     public async ValueTask<Bitmap> RenderFrame(long frame)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         IpcMessage response;
         int readBufferIndex;
 
@@ -145,6 +147,10 @@ internal sealed class IpcFrameProvider : IFrameProvider
         // .Wait()/.GetAwaiter().GetResult() could deadlock or rethrow the pipe-teardown fault. Instead attach
         // a fault-swallowing continuation so any fault is observed (preventing UnobservedTaskException) and
         // return promptly. Owning the connection is the caller's job, so we only neutralize our own task.
+        // OnlyOnFaulted is deliberate (and the asymmetry with IpcSampleProvider.Dispose is intentional): the
+        // prefetch yields a managed IpcMessage with nothing to release — the Bitmap is built lazily only when
+        // a frame is consumed — so a successful prefetch leaks nothing. IpcSampleProvider's prefetch instead
+        // yields a native Pcm, so its continuation must also dispose the result on the success path.
         _prefetchTask?.ContinueWith(
             static t => { _ = t.Exception; },
             CancellationToken.None,

--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -16,6 +16,7 @@ internal sealed class IpcFrameProvider : IFrameProvider
     private Task<IpcMessage>? _prefetchTask;
     private int _prefetchBufferIndex;
     private long _prefetchFrameIndex;
+    private bool _disposed;
 
     public IpcFrameProvider(IpcConnection connection, SharedMemoryBuffer[] videoBuffers,
         long frameCount, Rational frameRate)
@@ -128,5 +129,27 @@ internal sealed class IpcFrameProvider : IFrameProvider
             bmp.Dispose();
             throw;
         }
+    }
+
+    // Test-only probe: lets a Dispose test wait until the in-flight prefetch has actually faulted before
+    // dropping it, so the faulted-task path is exercised deterministically without a sleep.
+    internal bool IsPrefetchFaultedForTest() => _prefetchTask?.IsFaulted == true;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // A prefetch may still be in flight when the encode is torn down (cancel, error, normal end). The
+        // connection/pipe it talks to may already be closing, so we must NOT synchronously wait on it here:
+        // .Wait()/.GetAwaiter().GetResult() could deadlock or rethrow the pipe-teardown fault. Instead attach
+        // a fault-swallowing continuation so any fault is observed (preventing UnobservedTaskException) and
+        // return promptly. Owning the connection is the caller's job, so we only neutralize our own task.
+        _prefetchTask?.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+        _prefetchTask = null;
     }
 }

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -42,6 +42,8 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     public async ValueTask<Pcm<Stereo32BitFloat>> Sample(long offset, long length)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         // Honor the ISampleProvider convention (see Beutl.Models.SampleProviderImpl.Sample): always return a
         // Pcm of the requested length, zero-filling any samples past the timeline end. The encoder issues the
         // final Sample with frame.NbSamples, which can straddle EOF; FFmpegEncodingController.GetAudioFrame

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -236,6 +236,13 @@ internal sealed class IpcSampleProvider : ISampleProvider
         // continuation that observes a fault (preventing UnobservedTaskException) and disposes the native Pcm
         // a successful prefetch would otherwise leak. Owning the connection is the caller's job, so we only
         // neutralize our own task. Returns promptly regardless of when the prefetch completes.
+        //
+        // The continuation handles all three terminal states: Faulted (observe the exception so it is not
+        // unobserved), CompletedSuccessfully (dispose the native Pcm the result holds), and Canceled (yields
+        // no result and no fault, so neither branch fires — cancellation is not an unobserved exception).
+        // ExecuteSynchronously is safe because t.Result.Dispose() is a single P/Invoke free: no lock
+        // contention and no throw path. If that body ever becomes heavier, drop ExecuteSynchronously so the
+        // runtime schedules the continuation on a pool thread instead of the completing (receive-loop) one.
         _prefetchTask?.ContinueWith(
             static t =>
             {

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -25,6 +25,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
     private Task<Pcm<Stereo32BitFloat>>? _prefetchTask;
     private long _prefetchChunkOffset;
     private int _prefetchBufferIndex;
+    private bool _disposed;
 
     public IpcSampleProvider(IpcConnection connection, SharedMemoryBuffer[] audioBuffers,
         long sampleCount, long sampleRate)
@@ -216,5 +217,37 @@ internal sealed class IpcSampleProvider : ISampleProvider
             pcm.Dispose();
             throw;
         }
+    }
+
+    // Test-only probe: lets a Dispose test wait until the in-flight prefetch has actually faulted before
+    // dropping it, so the faulted-task path is exercised deterministically without a sleep.
+    internal bool IsPrefetchFaultedForTest() => _prefetchTask?.IsFaulted == true;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // A prefetch may still be in flight when the encode is torn down (cancel, error, normal end). The
+        // connection/pipe it talks to may already be closing, so we must NOT synchronously wait on it here:
+        // .Wait()/.GetAwaiter().GetResult() could deadlock or rethrow the pipe-teardown fault. Attach a
+        // continuation that observes a fault (preventing UnobservedTaskException) and disposes the native Pcm
+        // a successful prefetch would otherwise leak. Owning the connection is the caller's job, so we only
+        // neutralize our own task. Returns promptly regardless of when the prefetch completes.
+        _prefetchTask?.ContinueWith(
+            static t =>
+            {
+                if (t.IsFaulted)
+                    _ = t.Exception;
+                else if (t.IsCompletedSuccessfully)
+                    t.Result.Dispose();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        _prefetchTask = null;
+
+        _currentChunk?.Dispose();
+        _currentChunk = null;
     }
 }

--- a/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/EncodingHandler.cs
@@ -88,9 +88,12 @@ internal sealed class EncodingHandler : IDisposable
                     AudioSharedMemoryName2 = audioShmName1,
                 }));
 
-            var frameProvider = new IpcFrameProvider(connection, videoBuffers,
+            // Dispose the providers once Encode returns or throws so any in-flight prefetch is observed
+            // (drained) and the cached chunk is freed — preventing a faulted background task from later
+            // surfacing as an UnobservedTaskException.
+            using var frameProvider = new IpcFrameProvider(connection, videoBuffers,
                 request.FrameCount, new Rational(request.FrameRateNum, request.FrameRateDen));
-            var sampleProvider = new IpcSampleProvider(connection, audioBuffers,
+            using var sampleProvider = new IpcSampleProvider(connection, audioBuffers,
                 request.SampleCount, request.ProviderSampleRate);
 
             await controller.Encode(frameProvider, sampleProvider, _encodeCts.Token);

--- a/tests/Beutl.Extensions.AVFoundation.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/EncodingCancellationTests.cs
@@ -75,5 +75,7 @@ public class EncodingCancellationTests
             cts.Cancel();
             return bitmap;
         }
+
+        public void Dispose() => _inner.Dispose();
     }
 }

--- a/tests/Beutl.Extensions.AVFoundation.Tests/TestProviders.cs
+++ b/tests/Beutl.Extensions.AVFoundation.Tests/TestProviders.cs
@@ -33,6 +33,11 @@ internal sealed class GradientFrameProvider(long frameCount, Rational frameRate,
         }
         return ValueTask.FromResult(bitmap);
     }
+
+    public void Dispose()
+    {
+        // Stateless test double — no prefetch or owned resources to drain.
+    }
 }
 
 // 440 Hz sine wave, Stereo 32-bit float interleaved.
@@ -53,6 +58,11 @@ internal sealed class SineSampleProvider(long sampleCount, long sampleRate) : IS
             span[i] = new Stereo32BitFloat(t, t);
         }
         return ValueTask.FromResult(pcm);
+    }
+
+    public void Dispose()
+    {
+        // Stateless test double — no prefetch or owned resources to drain.
     }
 }
 
@@ -80,5 +90,10 @@ internal sealed class SweepSampleProvider(long sampleCount, long sampleRate) : I
             span[i] = new Stereo32BitFloat(v, v);
         }
         return ValueTask.FromResult(pcm);
+    }
+
+    public void Dispose()
+    {
+        // Stateless test double — no prefetch or owned resources to drain.
     }
 }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -450,6 +450,122 @@ public class IpcProviderContractTests
         }
     }
 
+    // Captures every UnobservedTaskException raised on the finalizer thread while subscribed, so a test
+    // can prove a provider's Dispose drained its in-flight prefetch instead of leaking it to the GC.
+    private sealed class UnobservedTaskExceptionWatcher : IDisposable
+    {
+        private readonly List<Exception> _exceptions = [];
+        private readonly object _gate = new();
+
+        public UnobservedTaskExceptionWatcher()
+        {
+            TaskScheduler.UnobservedTaskException += OnUnobserved;
+        }
+
+        private void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            lock (_gate)
+                _exceptions.Add(e.Exception);
+            // Mark observed so the process-level escalation policy can't tear down the test host.
+            e.SetObserved();
+        }
+
+        // Force two finalizer passes so any unobserved Task that the GC reclaimed has had its
+        // UnobservedTaskException raised before we inspect the captured list.
+        public Exception[] Drain()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            lock (_gate)
+                return _exceptions.ToArray();
+        }
+
+        public void Dispose() => TaskScheduler.UnobservedTaskException -= OnUnobserved;
+    }
+
+    [Test]
+    public async Task Dispose_ObservesInFlightFaultedFramePrefetch_NoUnobservedTaskException()
+    {
+        // RenderFrame(0) arms a prefetch of frame 1; the host faults that prefetch. We then Dispose the
+        // provider WITHOUT consuming frame 1, so the faulted prefetch task is still in flight and is dropped
+        // by Dispose. Its fault-swallowing continuation must observe the exception so the GC never raises an
+        // UnobservedTaskException attributable to the provider.
+        using var watcher = new UnobservedTaskExceptionWatcher();
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunPrefetchFaultsOnceHost(server, buffers, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // frameCount 3: frame 0 arms a prefetch of frame 1, which the host faults. Frame 1 is never consumed.
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 3, frameRate: new Rational(30, 1));
+
+        try
+        {
+            using (Bitmap frame0 = await provider.RenderFrame(0))
+                Assert.That(ReadFrameSignature(frame0), Is.EqualTo(0L), "frame 0 renders and arms the prefetch of frame 1");
+
+            // Let the prefetch actually fault before we drop it, so we exercise the faulted-task path.
+            await WaitUntil(() => provider.IsPrefetchFaultedForTest(),
+                TimeSpan.FromSeconds(5), "the in-flight frame prefetch faults");
+
+            // Drop the faulted prefetch without ever awaiting it via RenderFrame(1).
+            provider.Dispose();
+            provider.Dispose(); // idempotent: a second Dispose must be a no-op.
+
+            Exception[] unobserved = watcher.Drain();
+            Assert.That(unobserved, Is.Empty,
+                "Dispose must observe the dropped faulted prefetch so no UnobservedTaskException is raised");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Dispose_ObservesInFlightFaultedSamplePrefetch_NoUnobservedTaskException()
+    {
+        // Consuming chunk 0 arms a prefetch of chunk 1 (offset == sampleRate); the host faults it. We then
+        // Dispose the provider WITHOUT consuming chunk 1, so the faulted sample prefetch is dropped by
+        // Dispose. Its observing continuation must mark the fault so no UnobservedTaskException is raised,
+        // and Dispose must also free the cached chunk.
+        const long sampleRate = 4;
+        using var watcher = new UnobservedTaskExceptionWatcher();
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSamplePrefetchFaultsOnceHost(server, buffers, sampleRate, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // sampleCount 12 == 3 chunks of 4, so chunk 1's prefetch arms after chunk 0 and is not last.
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 12, sampleRate: sampleRate);
+
+        try
+        {
+            using (Pcm<Stereo32BitFloat> chunk0 = await provider.Sample(0, sampleRate))
+                Assert.That(ReadSampleSignature(chunk0), Is.EqualTo(0L), "chunk 0 loads and arms the prefetch of chunk 1");
+
+            await WaitUntil(() => provider.IsPrefetchFaultedForTest(),
+                TimeSpan.FromSeconds(5), "the in-flight sample prefetch faults");
+
+            provider.Dispose();
+            provider.Dispose(); // idempotent: a second Dispose must be a no-op.
+
+            Exception[] unobserved = watcher.Drain();
+            Assert.That(unobserved, Is.Empty,
+                "Dispose must observe the dropped faulted sample prefetch so no UnobservedTaskException is raised");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
     [Test]
     public async Task RenderFrame_WhenHostCancels_ThrowsOperationCanceled()
     {


### PR DESCRIPTION
## Description
Stacked on #2012 (base = `yuto-trd/ipc-provider-hardening`). Gives the frame/sample provider abstractions a deterministic teardown contract and hardens the IPC implementations against use-after-dispose.

- `IFrameProvider` / `ISampleProvider` now implement `IDisposable`. An in-flight prefetch could previously outlive the encode and surface as an `UnobservedTaskException`; consumers can now dispose the provider, which neutralizes the pending prefetch (observing any fault and releasing a native `Pcm` on the success path).
- `IpcFrameProvider` / `IpcSampleProvider`: `Dispose()` is idempotent and attaches a continuation to the in-flight prefetch instead of blocking on a possibly-closing pipe. Public entry points (`RenderFrame` / `Sample`) now `ObjectDisposedException.ThrowIf` after dispose. The intentional success-path asymmetry between the two providers (managed `IpcMessage` vs native `Pcm`) is documented inline.
- `Beutl.FFmpegWorker.EncodingHandler` wraps the providers in `using` so the worker tears them down deterministically.

## Affected areas
- [x] `Beutl.Extensibility` (plugin abstractions)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)

## Breaking changes
`IFrameProvider` and `ISampleProvider` now extend `IDisposable`. Out-of-tree implementations must add a `Dispose()` method (it may be a no-op for stateless providers), and owners of a provider instance should dispose it. `refactor!:` + `BREAKING CHANGE:` footer present on the implementing commit.

## Test plan
- `tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs` (+116): two Dispose tests that drop an in-flight, deterministically-faulted prefetch (gated on an `IsPrefetchFaultedForTest()` probe, no sleeps) under an `UnobservedTaskException` watcher; existing serve/seek/cancel coverage retained.
- `tests/Beutl.Extensions.AVFoundation.Tests/TestProviders.cs` + `EncodingCancellationTests.cs`: test doubles updated for the new `IDisposable` member.
- Validated regression-free in a full-solution integration build + test (this branch cherry-picked with the other FFmpeg branches): `Beutl.FFmpegIpc.Tests` 18/18 green.

## Fixed issues / References
- Project board: b-editor/projects/9 ("IFrameProvider/ISampleProvider: no IDisposable, in-flight prefetch can become UnobservedTaskException")
- Stacked on #2012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup during encoding so frame and sample sources are disposed safely, reducing the risk of delayed background errors.
  * Prevented operations from continuing after a provider has been disposed, making encoding and playback-related workflows more reliable.
  * Fixed handling of in-flight background work so faults are observed instead of surfacing later as unhandled task exceptions.

* **Documentation**
  * Added clearer usage and disposal guidance for encoding and provider components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->