### PR TITLE
refactor(ffmpeg): extract seek/prefetch decisions as pure predicates + tests

### DIFF
--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -1,0 +1,46 @@
+﻿#if BEUTL_FFMPEG_WORKER
+namespace Beutl.FFmpegWorker.Decoding;
+#else
+namespace Beutl.Extensions.FFmpeg.Decoding;
+#endif
+
+internal static class FFmpegSeekDecision
+{
+    // Largest forward gap (in frames) we are willing to reach by sequentially grabbing frames
+    // instead of issuing a fresh seek. Beyond this, a seek is cheaper than decoding every frame.
+    private const long MaxSequentialSkip = 100;
+
+    // Decide whether the active video frame must be dropped and a fresh seek forced before serving
+    // the requested frame. This mirrors the inline condition in FFmpegReader.ReadVideoCore:
+    //   - currentUsable is false: the previous grab left the active frame unreferenced (a seek/grab
+    //     that could not reach a decodable frame), so _videoNowFrame no longer describes a usable
+    //     frame and the derived skip (which can be 0) must not be trusted.
+    //   - skip < 0: the request is behind the current position, which sequential grabbing cannot reach.
+    //   - skip > MaxSequentialSkip: the forward gap is large enough that seeking is cheaper.
+    public static bool ShouldReseek(bool currentUsable, long skip)
+        => !currentUsable || skip > MaxSequentialSkip || skip < 0;
+
+    // Decide whether there is a next prefetch target before EOF and compute it. This mirrors the
+    // inline conditions in VideoRingBuffer.StartPrefetch:
+    //   - baseFrame < 0: no frame has been requested yet, so there is nothing to prefetch ahead of.
+    //   - nextFrame = baseFrame + cachedAhead + 1: the first frame after the already-cached run.
+    //   - nextFrame >= totalFrames: the target is at or past EOF, so there is nothing to prefetch.
+    // When this returns false, nextFrame is set to -1 and the caller should stop advancing.
+    public static bool HasPrefetchTarget(int baseFrame, int cachedAhead, long totalFrames, out int nextFrame)
+    {
+        if (baseFrame < 0)
+        {
+            nextFrame = -1;
+            return false;
+        }
+
+        nextFrame = baseFrame + cachedAhead + 1;
+        if (nextFrame >= totalFrames)
+        {
+            nextFrame = -1;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegSeekDecision.cs
@@ -10,8 +10,7 @@ internal static class FFmpegSeekDecision
     // instead of issuing a fresh seek. Beyond this, a seek is cheaper than decoding every frame.
     private const long MaxSequentialSkip = 100;
 
-    // Decide whether the active video frame must be dropped and a fresh seek forced before serving
-    // the requested frame. This mirrors the inline condition in FFmpegReader.ReadVideoCore:
+    // Force a fresh seek before serving the requested frame when:
     //   - currentUsable is false: the previous grab left the active frame unreferenced (a seek/grab
     //     that could not reach a decodable frame), so _videoNowFrame no longer describes a usable
     //     frame and the derived skip (which can be 0) must not be trusted.
@@ -20,8 +19,7 @@ internal static class FFmpegSeekDecision
     public static bool ShouldReseek(bool currentUsable, long skip)
         => !currentUsable || skip > MaxSequentialSkip || skip < 0;
 
-    // Decide whether there is a next prefetch target before EOF and compute it. This mirrors the
-    // inline conditions in VideoRingBuffer.StartPrefetch:
+    // Compute the next prefetch target and report whether one exists before EOF:
     //   - baseFrame < 0: no frame has been requested yet, so there is nothing to prefetch ahead of.
     //   - nextFrame = baseFrame + cachedAhead + 1: the first frame after the already-cached run.
     //   - nextFrame >= totalFrames: the target is at or past EOF, so there is nothing to prefetch.

--- a/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
+++ b/src/Beutl.FFmpegWorker/Beutl.FFmpegWorker.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\Beutl.Extensions.FFmpeg\Encoding\FFmpegAudioEncoderSettings.cs" Link="Linked\FFmpegAudioEncoderSettings.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegDecodingSettings.cs" Link="Linked\FFmpegDecodingSettings.cs" />
     <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegFrameValidation.cs" Link="Linked\FFmpegFrameValidation.cs" />
+    <Compile Include="..\Beutl.Extensions.FFmpeg\Decoding\FFmpegSeekDecision.cs" Link="Linked\FFmpegSeekDecision.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -357,7 +357,7 @@ public sealed class FFmpegReader : MediaReader
         // recovers the frame instead of repeatedly returning the empty one.
         bool currentUsable =
             FFmpegFrameValidation.IsUsableVideoFrame(videoFrame.Format, videoFrame.Width, videoFrame.Height);
-        if (!currentUsable || skip > 100 || skip < 0)
+        if (FFmpegSeekDecision.ShouldReseek(currentUsable, skip))
         {
             SeekVideo(frame);
             skip = 0;

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -308,9 +308,6 @@ internal sealed class VideoRingBuffer : IDisposable
                 while (!ct.IsCancellationRequested)
                 {
                     int baseFrame = LastRequestedFrame;
-                    // Fast-path early break before the cached-ahead scan. HasPrefetchTarget below
-                    // re-checks this same baseFrame < 0 invariant so it stays a self-contained,
-                    // unit-testable predicate; keep both in sync.
                     if (baseFrame < 0) break;
 
                     // 既にバッファにあるフレーム数をカウント

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -329,8 +329,8 @@ internal sealed class VideoRingBuffer : IDisposable
                         continue;
                     }
 
-                    int nextFrame = baseFrame + cachedAhead + 1;
-                    if (nextFrame >= totalFrames) break;
+                    if (!FFmpegSeekDecision.HasPrefetchTarget(baseFrame, cachedAhead, totalFrames, out int nextFrame))
+                        break;
 
                     // 既にキャッシュ済みならスキップ
                     if (FindSlot(nextFrame) >= 0) continue;

--- a/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
+++ b/src/Beutl.FFmpegWorker/Handlers/VideoRingBuffer.cs
@@ -308,6 +308,9 @@ internal sealed class VideoRingBuffer : IDisposable
                 while (!ct.IsCancellationRequested)
                 {
                     int baseFrame = LastRequestedFrame;
+                    // Fast-path early break before the cached-ahead scan. HasPrefetchTarget below
+                    // re-checks this same baseFrame < 0 invariant so it stays a self-contained,
+                    // unit-testable predicate; keep both in sync.
                     if (baseFrame < 0) break;
 
                     // 既にバッファにあるフレーム数をカウント

--- a/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
+++ b/tests/Beutl.FFmpegBenchmarks/Beutl.FFmpegBenchmarks.csproj
@@ -23,6 +23,7 @@
        FFmpeg direct-call types have moved to Beutl.FFmpegWorker; settings types remain in the extension. -->
   <ItemGroup>
     <Compile Include="..\..\src\Beutl.FFmpegWorker\Decoding\FFmpegReader.cs" Link="Linked\FFmpegReader.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegSeekDecision.cs" Link="Linked\FFmpegSeekDecision.cs" />
     <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegFrameValidation.cs" Link="Linked\FFmpegFrameValidation.cs" />
     <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Decoding\FFmpegDecodingSettings.cs" Link="Linked\FFmpegDecodingSettings.cs" />
     <Compile Include="..\..\src\Beutl.FFmpegWorker\ColorSpaceHelper.cs" Link="Linked\ColorSpaceHelper.cs" />

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs
@@ -1,0 +1,56 @@
+﻿using Beutl.Extensions.FFmpeg.Decoding;
+
+namespace Beutl.UnitTests.Extensions.FFmpeg;
+
+[TestFixture]
+public class FFmpegSeekDecisionTests
+{
+    [TestCase(true, 0L)] // current frame usable, request is the current position
+    [TestCase(true, 1L)] // small forward skip handled by sequential grabbing
+    [TestCase(true, 100L)] // exactly at the sequential-skip boundary
+    public void ShouldReseek_False_WhenCurrentUsableAndSkipInRange(bool currentUsable, long skip)
+    {
+        Assert.That(FFmpegSeekDecision.ShouldReseek(currentUsable, skip), Is.False);
+    }
+
+    [TestCase(false, 0L)] // active frame unreferenced -> skip cannot be trusted
+    [TestCase(false, 5L)]
+    [TestCase(true, 101L)] // forward gap larger than the sequential-skip boundary
+    [TestCase(true, -1L)] // request is behind the current position
+    [TestCase(false, -1L)]
+    public void ShouldReseek_True_WhenCurrentUnusableOrSkipOutOfRange(bool currentUsable, long skip)
+    {
+        Assert.That(FFmpegSeekDecision.ShouldReseek(currentUsable, skip), Is.True);
+    }
+
+    [TestCase(10, 0, 100L, 11)] // next frame right after base, well below EOF
+    [TestCase(10, 3, 100L, 14)] // skip the cached run, target below EOF
+    [TestCase(0, 0, 5L, 1)]
+    [TestCase(10, 0, 12L, 11)] // boundary: nextFrame (11) < totalFrames (12)
+    public void HasPrefetchTarget_True_WhenTargetBelowEof(int baseFrame, int cachedAhead, long totalFrames, int expectedNext)
+    {
+        bool result = FFmpegSeekDecision.HasPrefetchTarget(baseFrame, cachedAhead, totalFrames, out int nextFrame);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(nextFrame, Is.EqualTo(expectedNext));
+        });
+    }
+
+    [TestCase(10, 0, 11L)] // nextFrame (11) == totalFrames -> at EOF
+    [TestCase(10, 0, 5L)] // nextFrame past EOF
+    [TestCase(10, 3, 14L)] // nextFrame (14) == totalFrames
+    [TestCase(-1, 0, 100L)] // negative base: nothing requested yet
+    [TestCase(-5, 2, 100L)]
+    public void HasPrefetchTarget_False_AtOrPastEofOrNegativeBase(int baseFrame, int cachedAhead, long totalFrames)
+    {
+        bool result = FFmpegSeekDecision.HasPrefetchTarget(baseFrame, cachedAhead, totalFrames, out int nextFrame);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(nextFrame, Is.EqualTo(-1));
+        });
+    }
+}


### PR DESCRIPTION
## Description
Extracts the reseek/prefetch branch conditions in the FFmpeg direct-call decoder into a small pure helper so they can be unit-tested without spinning up FFmpeg, and adds the seek-past-EOF regression coverage requested as a PR #1985 follow-up.

- New `FFmpegSeekDecision` (in `Beutl.Extensions.FFmpeg/Decoding`, namespace-switched to `Beutl.FFmpegWorker.Decoding` under `BEUTL_FFMPEG_WORKER`): `ShouldReseek(bool currentUsable, long skip)` and `HasPrefetchTarget(...)` capture the exact inline conditions from `FFmpegReader.ReadVideoCore` / `VideoRingBuffer`.
- `FFmpegReader.cs` and `VideoRingBuffer.cs` now call the helper; behavior is preserved (a `baseFrame < 0` invariant note added where the predicate is shared).
- Build: `Beutl.FFmpegWorker.csproj` and `Beutl.FFmpegBenchmarks.csproj` (which source-links `FFmpegReader.cs` directly) both source-link the new file.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] Build / CI / docs only (benchmark source-link)

## Breaking changes
None — behavior-preserving extraction.

## Test plan
- `tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegSeekDecisionTests.cs` (new, 17 table-driven cases) covering the reseek thresholds (`currentUsable`, large/negative `skip`, `MaxSequentialSkip` boundary) and prefetch-target selection.
- Green in the full-solution integration build + test alongside the other FFmpeg branches.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Add seek-past-EOF regression tests for FFmpegReader / VideoRingBuffer (PR #1985 follow-up)")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced video seeking and prefetching logic for smoother playback.
* **Bug Fixes**
  * Reduced unnecessary re-seeks when the current frame can be reused.
  * Improved behavior for backward skips and large forward jumps.
  * Prevented prefetching beyond the end of available frames.
* **Tests**
  * Added unit test coverage for the seek/reseeking and prefetch target decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->