### PR TITLE
docs: clarify Nuke-only publish for the FFmpeg worker; mark matrix collapse done

### DIFF
--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -99,12 +99,11 @@ plugin-facing: batch them into one `refactor!:` release train with a
 **Media backends**
 - The never-built in-process FFmpeg variant: `FFmpegOutOfProcess` csproj matrix,
   `#if !FFMPEG_OUT_OF_PROCESS` forks in ~12 files, `FFmpegPath.cs`, the duplicated
-  loader. **Partially done in PR #1909** (removed `FFmpegPath.cs` and the dead
-  `#if !FFMPEG_OUT_OF_PROCESS`/`#else` branches in the extension-only files);
-  **deferred follow-up:** collapse the `FFmpegOutOfProcess` csproj matrix itself —
-  the `!= True` (in-process) config no longer compiles after #1909 and is kept with
-  a NOTE comment only until the matrix is removed (a published build-knob removal →
-  `refactor!:`). Tracked on the project board.
+  loader. **Done.** PR #1909 removed `FFmpegPath.cs` and the dead
+  `#if !FFMPEG_OUT_OF_PROCESS`/`#else` branches; the deferred follow-up — collapsing
+  the `FFmpegOutOfProcess` csproj matrix and the `FFMPEG_OUT_OF_PROCESS` define — has
+  since landed, so the out-of-process/worker path is now unconditional (no
+  `FFmpegOutOfProcess`/`FFMPEG_OUT_OF_PROCESS` references remain in `src/`).
 - Worker legacy (non-ring-buffer) `ReadVideo` path (unreachable).
 - MediaFoundation rot: dead `MFDecoder` audio path + `MFSampleCache` audio caching
   (`MFReader` uses NAudio), hardcoded-off DXVA2 machinery, the `Vortice.Direct3D9`

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -108,12 +108,14 @@
        shared assemblies from its own deps.json inside that subdir, so its dependency closure
        never overwrites the app's. Nuke publishes lay the worker out separately (flat, copying
        only Beutl.FFmpegWorker* so the app's shared assemblies stay the single canonical set).
-       NOTE: CopyFFmpegWorkerForApp runs AfterTargets="Build" only, so this dev path populates
-       the worker for plain builds (e.g. dotnet run / IDE F5). It does NOT run on Publish, so a
-       bare `dotnet publish src/Beutl/Beutl.csproj` (NukePublish!=true) deliberately omits the
-       worker. Publishing a runnable app must go through Nuke (NukePublish=true), which lays out
-       the worker as above; non-Nuke publish is a build-graph convenience, not a supported
-       distribution path. -->
+       NOTE: CopyFFmpegWorkerForApp runs AfterTargets="Build" and copies the worker into the build
+       output ($(OutDir), i.e. bin), not the publish output. So this dev path populates the worker
+       for plain builds (e.g. dotnet run / IDE F5); and although the target still runs during the
+       build step of `dotnet publish` (unless --no-build), its files land in bin rather than under
+       $(PublishDir), so a bare `dotnet publish src/Beutl/Beutl.csproj` (NukePublish!=true)
+       deliberately leaves the worker out of the published output. Publishing a runnable app must
+       go through Nuke (NukePublish=true), which lays out the worker as above; non-Nuke publish is
+       a build-graph convenience, not a supported distribution path. -->
   <ItemGroup Condition="'$(NukePublish)'!='True'">
     <ProjectReference Include="..\Beutl.FFmpegWorker\Beutl.FFmpegWorker.csproj"
                       ReferenceOutputAssembly="false" />

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -108,14 +108,10 @@
        shared assemblies from its own deps.json inside that subdir, so its dependency closure
        never overwrites the app's. Nuke publishes lay the worker out separately (flat, copying
        only Beutl.FFmpegWorker* so the app's shared assemblies stay the single canonical set).
-       NOTE: CopyFFmpegWorkerForApp runs AfterTargets="Build" and copies the worker into the build
-       output ($(OutDir), i.e. bin), not the publish output. So this dev path populates the worker
-       for plain builds (e.g. dotnet run / IDE F5); and although the target still runs during the
-       build step of `dotnet publish` (unless --no-build), its files land in bin rather than under
-       $(PublishDir), so a bare `dotnet publish src/Beutl/Beutl.csproj` (NukePublish!=true)
-       deliberately leaves the worker out of the published output. Publishing a runnable app must
-       go through Nuke (NukePublish=true), which lays out the worker as above; non-Nuke publish is
-       a build-graph convenience, not a supported distribution path. -->
+       NOTE: CopyFFmpegWorkerForApp runs AfterTargets="Build" and copies into $(OutDir) (bin), not
+       $(PublishDir). A bare `dotnet publish` (NukePublish!=True) therefore omits the worker and
+       yields a non-runnable app; publishing a runnable app must go through Nuke (NukePublish=True),
+       which lays out the worker as above. -->
   <ItemGroup Condition="'$(NukePublish)'!='True'">
     <ProjectReference Include="..\Beutl.FFmpegWorker\Beutl.FFmpegWorker.csproj"
                       ReferenceOutputAssembly="false" />

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -107,7 +107,13 @@
        AppContext.BaseDirectory). The worker resolves its own (possibly different-versioned)
        shared assemblies from its own deps.json inside that subdir, so its dependency closure
        never overwrites the app's. Nuke publishes lay the worker out separately (flat, copying
-       only Beutl.FFmpegWorker* so the app's shared assemblies stay the single canonical set). -->
+       only Beutl.FFmpegWorker* so the app's shared assemblies stay the single canonical set).
+       NOTE: CopyFFmpegWorkerForApp runs AfterTargets="Build" only, so this dev path populates
+       the worker for plain builds (e.g. dotnet run / IDE F5). It does NOT run on Publish, so a
+       bare `dotnet publish src/Beutl/Beutl.csproj` (NukePublish!=true) deliberately omits the
+       worker. Publishing a runnable app must go through Nuke (NukePublish=true), which lays out
+       the worker as above; non-Nuke publish is a build-graph convenience, not a supported
+       distribution path. -->
   <ItemGroup Condition="'$(NukePublish)'!='True'">
     <ProjectReference Include="..\Beutl.FFmpegWorker\Beutl.FFmpegWorker.csproj"
                       ReferenceOutputAssembly="false" />


### PR DESCRIPTION
## Description
Documents the intended publish path for the GPL `Beutl.FFmpegWorker` process and closes two stale board follow-ups as documentation.

- `src/Beutl/Beutl.csproj`: a comment near `CopyFFmpegWorkerForApp` (`AfterTargets="Build"`) clarifies that a bare `dotnet publish` does **not** carry the worker — publishing must go through Nuke (`NukePublish=true`), which is the supported/release path. No build behavior changes.
- `docs/refactoring-plan.md`: marks the FFmpegOutOfProcess build-matrix collapse follow-up as Done.

Per the maintainer decision, "include the worker in non-Nuke publish outputs" is resolved as **documented Nuke-only** rather than wiring the worker into bare `dotnet publish` (which would risk dragging GPL output into MIT publish flows).

## Affected areas
- [x] Build / CI / docs only

## Breaking changes
None — comment + docs only.

## Test plan
No code paths changed. Verified that the existing `CopyFFmpegWorkerForApp` target is build-order only and that the Nuke publish target remains the worker-carrying path; full-solution build stays green.

## Fixed issues / References
- Project board: b-editor/projects/9 ("Include Beutl.FFmpegWorker in non-Nuke publish outputs")
- Project board: b-editor/projects/9 ("Follow-up (PR #1909): collapse the FFmpegOutOfProcess build matrix")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the refactoring plan to reflect completion of the FFmpeg configuration cleanup, with no remaining FFmpeg out-of-process references in the source tree.
  * Clarified how the FFmpeg worker is handled across build vs. publish workflows, including when the worker is copied and where it appears in build outputs versus publish outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->