### PR TITLE
test(ffmpeg-ipc): fix Windows hang in IpcConnection multiplexed tests (drain outbound request)

### DIFF
--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -216,7 +216,11 @@ public class IpcConnectionMultiplexedTests
             var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
             var firstTask = conn.SendAndReceiveAsync(firstReq, cts.Token).AsTask();
 
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request enters pending dict");
+            // 送信を完了させてから応答待ち状態でキャンセルする。drain しないと送信が止まったまま
+            // (Windows で未読パイプ書き込みが返らない)、配送有無がプラットフォーム差になり後続も割れる。
+            var drainedFirst = await MessageSerializer.ReadMessageAsync(server);
+            Assert.That(drainedFirst!.Id, Is.EqualTo(firstId));
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request awaits its response");
             cts.Cancel();
             Assert.CatchAsync<OperationCanceledException>(async () => await firstTask);
             await WaitUntil(() => PendingCount(conn) == 0, TimeSpan.FromSeconds(5), "pending dict drains after cancel");
@@ -231,7 +235,11 @@ public class IpcConnectionMultiplexedTests
         var secondReq = IpcMessage.CreateSimple(secondId, RequestType);
         var secondTask = conn.SendAndReceiveAsync(secondReq).AsTask();
 
-        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "second request enters pending dict");
+        // 送信を完了させ応答待ち段階に入れる。drain しないと secondTask が送信で止まり、
+        // 応答を返しても完了しない。
+        var drainedSecond = await MessageSerializer.ReadMessageAsync(server);
+        Assert.That(drainedSecond!.Id, Is.EqualTo(secondId));
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "second request awaits its response");
 
         // ハンドラを差し替えてから応答を返す (二本目で再度発火させない)。
         conn.DroppedResponseHandler = null;
@@ -419,7 +427,13 @@ public class IpcConnectionMultiplexedTests
         var req = IpcMessage.CreateSimple(id, RequestType);
         var requestTask = conn.SendAndReceiveAsync(req).AsTask();
 
-        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
+        // 送出したリクエストを server 側で読み切り、クライアントの送信を完了させてから fault を注入する。
+        // 実 peer は必ずリクエストを読むが、テスト server が読まないと SendAsync のパイプ書き込みが
+        // 完了せず (Windows では未読のパイプ書き込みが返らない)、リクエストが「応答待ち」段階に到達しない。
+        // その状態で badLength を流しても、送信で止まったタスクは fault では解放されずテストがハングする。
+        var sentRequest = await MessageSerializer.ReadMessageAsync(server);
+        Assert.That(sentRequest!.Id, Is.EqualTo(id));
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request awaits its response");
 
         // 長さ -1 は MessageSerializer.ReadMessageAsync で
         // "Invalid message length" の InvalidOperationException を引き起こす。
@@ -427,6 +441,10 @@ public class IpcConnectionMultiplexedTests
         await server.WriteAsync(badLength);
         await server.FlushAsync();
 
+        // 受信ループ死亡後にリクエストが fault することを上限付きで待つ。万一伝播が壊れても
+        // 無制限 await でハングさせず、明確な Assert.Fail で落とす。
+        var completed = await Task.WhenAny(requestTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.That(completed, Is.SameAs(requestTask), "request must fault after the loop dies, not hang");
         var ex = Assert.CatchAsync<IOException>(async () => await requestTask);
         Assert.That(ex!.Message, Does.Contain("unexpected protocol or deserialization error"));
         Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
@@ -448,12 +466,19 @@ public class IpcConnectionMultiplexedTests
         int firstId = conn.NextId();
         var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
         var firstTask = conn.SendAndReceiveAsync(firstReq).AsTask();
-        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request enters pending dict");
+
+        // 送出したリクエストを読み切って送信を完了させ、応答待ち段階に入れてから受信ループを殺す。
+        // (詳細は ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause のコメント参照)
+        var sentRequest = await MessageSerializer.ReadMessageAsync(server);
+        Assert.That(sentRequest!.Id, Is.EqualTo(firstId));
+        await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request awaits its response");
 
         byte[] badLength = [0xFF, 0xFF, 0xFF, 0xFF];
         await server.WriteAsync(badLength);
         await server.FlushAsync();
 
+        var firstCompleted = await Task.WhenAny(firstTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.That(firstCompleted, Is.SameAs(firstTask), "first request must fault after the loop dies, not hang");
         Assert.CatchAsync<IOException>(async () => await firstTask);
 
         // ここでループは死んで _receiveLoopFault が公開されている。次のリクエストは
@@ -483,7 +508,13 @@ public class IpcConnectionMultiplexedTests
             int id = conn.NextId();
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req).AsTask();
-            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request enters pending dict");
+
+            // 送信を完了させ応答待ち段階に入れてから Dispose する。drain しないと送信が
+            // (ct 無しのため) 止まったままで、Dispose のパイプ破棄が ObjectDisposedException を
+            // 引き起こし、本テストが期待する「自己 Dispose = OperationCanceledException」を観測できない。
+            var drained = await MessageSerializer.ReadMessageAsync(server);
+            Assert.That(drained!.Id, Is.EqualTo(id));
+            await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request awaits its response");
 
             conn.Dispose();
 

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -216,11 +216,9 @@ public class IpcConnectionMultiplexedTests
             var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
             var firstTask = conn.SendAndReceiveAsync(firstReq, cts.Token).AsTask();
 
-            // Drain the outbound request so the send completes before we cancel it while it awaits a
-            // response. Without the drain the send stays pending (on Windows an unread pipe write does
-            // not return), so whether the request was delivered becomes platform-dependent and later
-            // steps diverge. Bound the drain (like the waits below) so a future send regression fails
-            // fast with an assertion instead of hanging the suite.
+            // Drain the outbound request so the send completes before we cancel it: on Windows an
+            // unread pipe write does not return, so without the drain whether the request was delivered
+            // is platform-dependent.
             var drainedFirst = await AwaitWithResult(
                 MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
             Assert.That(drainedFirst!.Id, Is.EqualTo(firstId));
@@ -433,10 +431,9 @@ public class IpcConnectionMultiplexedTests
         var requestTask = conn.SendAndReceiveAsync(req).AsTask();
 
         // Drain the outbound request on the server side so the client's send completes before we inject
-        // the fault. A real peer always reads the request; a test server that does not leaves SendAsync's
-        // pipe write pending (on Windows an unread pipe write does not return), so the request never
-        // reaches the await-on-response stage. Injecting badLength then cannot complete a task still stuck
-        // in the send, so the test would hang. Bound the drain so a future send regression fails fast.
+        // the fault. A real peer always reads the request; without draining, SendAsync's pipe write stays
+        // pending (on Windows an unread pipe write does not return), so the request never reaches the
+        // await-on-response stage and the fault injection cannot complete a send that is still stuck.
         var sentRequest = await AwaitWithResult(
             MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
         Assert.That(sentRequest!.Id, Is.EqualTo(id));
@@ -448,8 +445,6 @@ public class IpcConnectionMultiplexedTests
         await server.WriteAsync(badLength);
         await server.FlushAsync();
 
-        // Wait (bounded) for the request to fault after the receive loop dies. If propagation ever breaks,
-        // fail fast with a clear Assert.Fail instead of hanging on an unbounded await.
         var completed = await Task.WhenAny(requestTask, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.That(completed, Is.SameAs(requestTask), "request must fault after the loop dies, not hang");
         var ex = Assert.CatchAsync<IOException>(async () => await requestTask);
@@ -475,8 +470,7 @@ public class IpcConnectionMultiplexedTests
         var firstTask = conn.SendAndReceiveAsync(firstReq).AsTask();
 
         // Drain the outbound request so the send completes and the request parks on its response TCS before
-        // we kill the receive loop. (See ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause for
-        // why; bound the drain so a future send regression fails fast instead of hanging.)
+        // we kill the receive loop. (See ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause for why.)
         var sentRequest = await AwaitWithResult(
             MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
         Assert.That(sentRequest!.Id, Is.EqualTo(firstId));
@@ -521,7 +515,7 @@ public class IpcConnectionMultiplexedTests
             // Drain the outbound request so the send completes and the request parks on its response TCS
             // before Dispose. Without the drain the send stays stuck (there is no ct to cancel it), and
             // Dispose's pipe teardown raises ObjectDisposedException instead of the OperationCanceledException
-            // this test expects from a self-dispose. Bound the drain so a future send regression fails fast.
+            // this test expects from a self-dispose.
             var drained = await AwaitWithResult(
                 MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
             Assert.That(drained!.Id, Is.EqualTo(id));

--- a/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs
@@ -216,9 +216,13 @@ public class IpcConnectionMultiplexedTests
             var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
             var firstTask = conn.SendAndReceiveAsync(firstReq, cts.Token).AsTask();
 
-            // 送信を完了させてから応答待ち状態でキャンセルする。drain しないと送信が止まったまま
-            // (Windows で未読パイプ書き込みが返らない)、配送有無がプラットフォーム差になり後続も割れる。
-            var drainedFirst = await MessageSerializer.ReadMessageAsync(server);
+            // Drain the outbound request so the send completes before we cancel it while it awaits a
+            // response. Without the drain the send stays pending (on Windows an unread pipe write does
+            // not return), so whether the request was delivered becomes platform-dependent and later
+            // steps diverge. Bound the drain (like the waits below) so a future send regression fails
+            // fast with an assertion instead of hanging the suite.
+            var drainedFirst = await AwaitWithResult(
+                MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
             Assert.That(drainedFirst!.Id, Is.EqualTo(firstId));
             await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request awaits its response");
             cts.Cancel();
@@ -235,9 +239,10 @@ public class IpcConnectionMultiplexedTests
         var secondReq = IpcMessage.CreateSimple(secondId, RequestType);
         var secondTask = conn.SendAndReceiveAsync(secondReq).AsTask();
 
-        // 送信を完了させ応答待ち段階に入れる。drain しないと secondTask が送信で止まり、
-        // 応答を返しても完了しない。
-        var drainedSecond = await MessageSerializer.ReadMessageAsync(server);
+        // Drain the outbound request so the send completes and secondTask parks on its response TCS;
+        // otherwise secondTask stalls in the send and never completes even after the response is written.
+        var drainedSecond = await AwaitWithResult(
+            MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
         Assert.That(drainedSecond!.Id, Is.EqualTo(secondId));
         await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "second request awaits its response");
 
@@ -427,11 +432,13 @@ public class IpcConnectionMultiplexedTests
         var req = IpcMessage.CreateSimple(id, RequestType);
         var requestTask = conn.SendAndReceiveAsync(req).AsTask();
 
-        // 送出したリクエストを server 側で読み切り、クライアントの送信を完了させてから fault を注入する。
-        // 実 peer は必ずリクエストを読むが、テスト server が読まないと SendAsync のパイプ書き込みが
-        // 完了せず (Windows では未読のパイプ書き込みが返らない)、リクエストが「応答待ち」段階に到達しない。
-        // その状態で badLength を流しても、送信で止まったタスクは fault では解放されずテストがハングする。
-        var sentRequest = await MessageSerializer.ReadMessageAsync(server);
+        // Drain the outbound request on the server side so the client's send completes before we inject
+        // the fault. A real peer always reads the request; a test server that does not leaves SendAsync's
+        // pipe write pending (on Windows an unread pipe write does not return), so the request never
+        // reaches the await-on-response stage. Injecting badLength then cannot complete a task still stuck
+        // in the send, so the test would hang. Bound the drain so a future send regression fails fast.
+        var sentRequest = await AwaitWithResult(
+            MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
         Assert.That(sentRequest!.Id, Is.EqualTo(id));
         await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request awaits its response");
 
@@ -441,8 +448,8 @@ public class IpcConnectionMultiplexedTests
         await server.WriteAsync(badLength);
         await server.FlushAsync();
 
-        // 受信ループ死亡後にリクエストが fault することを上限付きで待つ。万一伝播が壊れても
-        // 無制限 await でハングさせず、明確な Assert.Fail で落とす。
+        // Wait (bounded) for the request to fault after the receive loop dies. If propagation ever breaks,
+        // fail fast with a clear Assert.Fail instead of hanging on an unbounded await.
         var completed = await Task.WhenAny(requestTask, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.That(completed, Is.SameAs(requestTask), "request must fault after the loop dies, not hang");
         var ex = Assert.CatchAsync<IOException>(async () => await requestTask);
@@ -467,9 +474,11 @@ public class IpcConnectionMultiplexedTests
         var firstReq = IpcMessage.CreateSimple(firstId, RequestType);
         var firstTask = conn.SendAndReceiveAsync(firstReq).AsTask();
 
-        // 送出したリクエストを読み切って送信を完了させ、応答待ち段階に入れてから受信ループを殺す。
-        // (詳細は ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause のコメント参照)
-        var sentRequest = await MessageSerializer.ReadMessageAsync(server);
+        // Drain the outbound request so the send completes and the request parks on its response TCS before
+        // we kill the receive loop. (See ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause for
+        // why; bound the drain so a future send regression fails fast instead of hanging.)
+        var sentRequest = await AwaitWithResult(
+            MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
         Assert.That(sentRequest!.Id, Is.EqualTo(firstId));
         await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "first request awaits its response");
 
@@ -509,10 +518,12 @@ public class IpcConnectionMultiplexedTests
             var req = IpcMessage.CreateSimple(id, RequestType);
             var requestTask = conn.SendAndReceiveAsync(req).AsTask();
 
-            // 送信を完了させ応答待ち段階に入れてから Dispose する。drain しないと送信が
-            // (ct 無しのため) 止まったままで、Dispose のパイプ破棄が ObjectDisposedException を
-            // 引き起こし、本テストが期待する「自己 Dispose = OperationCanceledException」を観測できない。
-            var drained = await MessageSerializer.ReadMessageAsync(server);
+            // Drain the outbound request so the send completes and the request parks on its response TCS
+            // before Dispose. Without the drain the send stays stuck (there is no ct to cancel it), and
+            // Dispose's pipe teardown raises ObjectDisposedException instead of the OperationCanceledException
+            // this test expects from a self-dispose. Bound the drain so a future send regression fails fast.
+            var drained = await AwaitWithResult(
+                MessageSerializer.ReadMessageAsync(server).AsTask(), TimeSpan.FromSeconds(5));
             Assert.That(drained!.Id, Is.EqualTo(id));
             await WaitUntil(() => PendingCount(conn) == 1, TimeSpan.FromSeconds(5), "request awaits its response");
 


### PR DESCRIPTION
## Description
Fixes a Windows-only deterministic hang in `IpcConnectionMultiplexedTests` (the fixture added in #1826). Four tests started a request via `SendAndReceiveAsync` but the test server never read the outbound request:

- `ProtocolCorruption_PendingRequestsObserveIOExceptionWithCause`
- `AfterReceiveLoopDies_NewRequestsFailFast`
- `DroppedResponseHandler_Throws_ReceiveLoopSurvives`
- `DisposeWhileRequestPending_ObservesCancellationNotIOException`

On Windows, a named-pipe write to a peer that never reads does not complete, so `SendAsync`'s pipe write stayed pending and the request never reached the await-on-response stage these tests exercise. Injecting a malformed frame, disposing, or replying then could not complete the stuck task, so the run **hung** (ProtocolCorruption / AfterReceiveLoopDies), observed `ObjectDisposedException` instead of `OperationCanceledException` (DisposeWhileRequestPending), or **timed out** (DroppedResponseHandler). On Linux the small write buffers immediately, so CI never caught it. A hang dump (`dumpasync`) pinned the stuck await at `MessageSerializer.WriteMessageAsync` inside the initial send — i.e. the request never got past *send*, not *receive*.

**Fix:** read (drain) the outbound request from the server so the client's send completes and the request parks on its response TCS — mirroring a real peer that reads the request before responding — and assert the drained id. Also bound the previously unbounded await-on-fault waits so a future regression fails fast with a clear assertion instead of hanging the whole suite for hours.

No production change: a real worker always reads requests, and a broken pipe fails a blocked write, so `IpcConnection` itself is unaffected.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary) — test only

## Breaking changes
None — test-only.

## Test plan
- `tests/Beutl.FFmpegIpc.Tests/IpcConnectionMultiplexedTests.cs`: 18/18 green, run 3× consecutively (5s each, no hang) on Windows where it previously hung deterministically at the 60s blame-hang timeout. Full `Beutl.FFmpegIpc.Tests` project: 28/28 green. `dotnet format --verify-no-changes` clean.

## Fixed issues / References
- Follow-up to #1826 (added these multiplexed tests + the cancellation hardening they cover)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved determinism for receive-loop cancellation and failure scenarios.
  * Ensured pending/protocol-faulted requests are fully progressed and observed before triggering cancellation, protocol corruption, or disposal.
  * Added bounded waits to avoid hangs and make test failures surface promptly.
  * Updated assertions so requests reliably fault/fail-fast after the receive loop shuts down, and disposal observes the expected cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->