### PR TITLE
feat: add AutomationProperties.Name to icon-only controls

### DIFF
--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -144,11 +144,13 @@
                 </Style>
             </StackPanel.Styles>
             <Button Click="SocialClick"
+                    AutomationProperties.Name="GitHub"
                     Tag="GitHub"
                     ToolTip.Tip="GitHub">
                 <Image x:Name="githubLogo" RenderOptions.BitmapInterpolationMode="HighQuality" />
             </Button>
             <Button Click="SocialClick"
+                    AutomationProperties.Name="X"
                     Tag="X"
                     ToolTip.Tip="X">
                 <Image x:Name="xLogo"
@@ -156,6 +158,7 @@
                        RenderOptions.BitmapInterpolationMode="HighQuality" />
             </Button>
             <Button Click="SocialClick"
+                    AutomationProperties.Name="{x:Static lang:Strings.Website}"
                     Tag="Url"
                     ToolTip.Tip="{x:Static lang:Strings.Website}">
                 <ui:SymbolIcon Width="24"

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -36,16 +36,16 @@
                         <Setter Property="Padding" Value="7,6,5,6" />
                     </Style>
                 </StackPanel.Styles>
-                <RadioButton IsChecked="{Binding IsMoveMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Move}">
+                <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Move}" IsChecked="{Binding IsMoveMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Move}">
                     <icons:SymbolIcon FontSize="16" Symbol="Cursor" />
                 </RadioButton>
-                <RadioButton IsChecked="{Binding IsHandMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Hand}">
+                <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Hand}" IsChecked="{Binding IsHandMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Hand}">
                     <icons:SymbolIcon FontSize="16" Symbol="HandLeft" />
                 </RadioButton>
-                <RadioButton IsChecked="{Binding IsCropMode.Value}" ToolTip.Tip="{x:Static lang:Strings.CropSelection}">
+                <RadioButton AutomationProperties.Name="{x:Static lang:Strings.CropSelection}" IsChecked="{Binding IsCropMode.Value}" ToolTip.Tip="{x:Static lang:Strings.CropSelection}">
                     <icons:SymbolIcon FontSize="16" Symbol="Crop" />
                 </RadioButton>
-                <RadioButton IsChecked="{Binding IsCameraMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Camera3DControl}">
+                <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Camera3DControl}" IsChecked="{Binding IsCameraMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Camera3DControl}">
                     <icons:SymbolIcon FontSize="16" Symbol="Video" />
                 </RadioButton>
                 <!--  Gizmo Mode Selection (visible only in Camera Mode)  -->
@@ -57,18 +57,21 @@
                              GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsTranslate}}"
                              IsVisible="{Binding IsCameraMode.Value}"
+                             AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Translate}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Translate}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowMove" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsRotate}}"
                              IsVisible="{Binding IsCameraMode.Value}"
+                             AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Rotate}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Rotate}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowRotateClockwise" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsScale}}"
                              IsVisible="{Binding IsCameraMode.Value}"
+                             AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Scale}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Scale}">
                     <icons:SymbolIcon FontSize="16" Symbol="ArrowExpand" />
                 </RadioButton>
@@ -82,6 +85,7 @@
                              IsChecked="{Binding PathEditor.Symmetry.Value, Mode=OneWay}"
                              IsVisible="{Binding PathEditor.Context.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                              Tag="Symmetry"
+                             AutomationProperties.Name="{x:Static lang:Strings.Symmetry}"
                              ToolTip.Tip="{x:Static lang:Strings.Symmetry}">
                     <Border VerticalAlignment="Center">
                         <Path Width="16"
@@ -96,6 +100,7 @@
                              IsChecked="{Binding PathEditor.Asymmetry.Value, Mode=OneWay}"
                              IsVisible="{Binding PathEditor.Context.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                              Tag="Asymmetry"
+                             AutomationProperties.Name="{x:Static lang:Strings.Asymmetry}"
                              ToolTip.Tip="{x:Static lang:Strings.Asymmetry}">
                     <Border VerticalAlignment="Center">
                         <Path Width="16"
@@ -110,6 +115,7 @@
                              IsChecked="{Binding PathEditor.Separately.Value, Mode=OneWay}"
                              IsVisible="{Binding PathEditor.Context.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                              Tag="Separately"
+                             AutomationProperties.Name="{x:Static lang:Strings.Separately}"
                              ToolTip.Tip="{x:Static lang:Strings.Separately}">
                     <Border VerticalAlignment="Center">
                         <Path Width="16"
@@ -126,6 +132,7 @@
                     VerticalAlignment="Top"
                     Command="{Binding OpenPreviewSettings}"
                     Theme="{StaticResource TransparentButton}"
+                    AutomationProperties.Name="{x:Static lang:Strings.PreviewSettings}"
                     ToolTip.Tip="{x:Static lang:Strings.PreviewSettings}">
                 <icons:SymbolIcon FontSize="16" Symbol="Settings" />
             </Button>


### PR DESCRIPTION
## Description
- Icon-only buttons and tool-mode radio buttons in `PlayerView` and `EditorHostFallback` exposed no accessible name to assistive technologies — they relied solely on `ToolTip.Tip`, which screen readers do not always announce as the control's name.
- Mirrors each control's existing localized tooltip resource into `AutomationProperties.Name`, so the control's purpose is announced by screen readers and keyboard navigation.
- `PlayerView.axaml`: 11 controls — 4 tool modes (Move/Hand/Crop/Camera), 3 gizmo modes (Translate/Rotate/Scale), 3 path-editor drag modes (Symmetry/Asymmetry/Separately), 1 preview-settings button.
- `EditorHostFallback.axaml`: 3 social buttons (GitHub / X / Website).

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None — purely additive accessibility attributes; no visual or behavioral change.

## Test plan
- This is an XAML-only accessibility-attribute addition; a unit test is not feasible for static attached-property values. Verified via Avalonia docs that `AutomationProperties.Name` is the correct attached property for icon-only control accessible names, and that the XAML compiles (`dotnet build src/Beutl/Beutl.csproj` — 0 errors) and `dotnet format --verify-no-changes` is clean.
- Manual verification: launch the app, focus each icon-only control via keyboard, and confirm the screen reader (VoiceOver / NVDA) announces the localized name (e.g. \"Move\", \"Hand\", \"GitHub\") instead of staying silent or reading only the tooltip.
- The `Player` custom control's built-in transport buttons (Play/Previous/Next/Start/End) are defined in the `Player` control template and are intentionally out of scope for this item (which cites the two View files).

## Fixed issues / References
- Project board: b-editor/projects/9 — アイコンのみ操作にアクセシビリティ名を追加する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility across the editor and player UI by adding descriptive automation labels to several controls and social buttons.
  * Social links and player mode/tool options are now easier to identify with assistive technologies.
* **Bug Fixes**
  * Enhanced UI accessibility metadata without changing existing behavior, visuals, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->