### PR TITLE
fix(ui): make EditorHostFallback recent-items panel responsive

### DIFF
--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -76,54 +76,57 @@
             </WrapPanel>
         </StackPanel>
 
-        <Grid Grid.Row="1"
-              Width="600"
-              Margin="32,0,32,32"
-              HorizontalAlignment="Left"
-              ColumnDefinitions="*,Auto"
-              RowDefinitions="Auto,8,*">
-            <TextBlock Text="{x:Static lang:Strings.Recently}" Theme="{StaticResource SubtitleTextBlockStyle}" />
+        <!-- The * column caps the panel at 600px while letting it shrink on narrow windows; the
+             stretched wrapper keeps it left-anchored (MaxWidth on a stretched grid would centre it). -->
+        <Grid Grid.Row="1" Margin="32,0,32,32">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" MaxWidth="600" />
+            </Grid.ColumnDefinitions>
 
-            <ComboBox x:Name="FilterComboBox"
-                      Grid.Column="1"
-                      VerticalAlignment="Center"
-                      SelectedIndex="1"
-                      Theme="{StaticResource LiteComboBoxStyle}">
-                <ComboBoxItem Content="{x:Static lang:Strings.All}" />
-                <ComboBoxItem Content="{x:Static lang:Strings.Projects}" />
-                <ComboBoxItem Content="{x:Static lang:Strings.Files}" />
-            </ComboBox>
+            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,8,*">
+                <TextBlock Text="{x:Static lang:Strings.Recently}" Theme="{StaticResource SubtitleTextBlockStyle}" />
 
-            <ListBox x:Name="recentList"
-                     Grid.Row="2"
-                     Grid.ColumnSpan="2">
-                <ListBox.Styles>
-                    <Style Selector="ListBoxItem">
-                        <Setter Property="ContextMenu">
-                            <Template>
-                                <ContextMenu>
-                                    <MenuItem Click="DeleteRecentItem_Click" Header="{x:Static lang:Strings.Remove}" />
-                                    <MenuItem Click="OpenRecentItem_Click" Header="{x:Static lang:Strings.Open}" />
-                                </ContextMenu>
-                            </Template>
-                        </Setter>
-                    </Style>
-                </ListBox.Styles>
-                <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="sysIO:FileInfo">
-                        <StackPanel Margin="0,4">
-                            <TextBlock Text="{CompiledBinding Name}" />
-                            <TextBlock FontSize="12"
-                                       Text="{CompiledBinding DirectoryName}"
-                                       Theme="{StaticResource LabelTextBlockStyle}" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
+                <ComboBox x:Name="FilterComboBox"
+                          Grid.Column="1"
+                          VerticalAlignment="Center"
+                          SelectedIndex="1"
+                          Theme="{StaticResource LiteComboBoxStyle}">
+                    <ComboBoxItem Content="{x:Static lang:Strings.All}" />
+                    <ComboBoxItem Content="{x:Static lang:Strings.Projects}" />
+                    <ComboBoxItem Content="{x:Static lang:Strings.Files}" />
+                </ComboBox>
 
-            <TextBlock Grid.Row="2"
-                       IsVisible="{Binding !#recentList.ItemCount}"
-                       Text="{x:Static lang:Strings.NoFilesUsedRecently}" />
+                <ListBox x:Name="recentList"
+                         Grid.Row="2"
+                         Grid.ColumnSpan="2">
+                    <ListBox.Styles>
+                        <Style Selector="ListBoxItem">
+                            <Setter Property="ContextMenu">
+                                <Template>
+                                    <ContextMenu>
+                                        <MenuItem Click="DeleteRecentItem_Click" Header="{x:Static lang:Strings.Remove}" />
+                                        <MenuItem Click="OpenRecentItem_Click" Header="{x:Static lang:Strings.Open}" />
+                                    </ContextMenu>
+                                </Template>
+                            </Setter>
+                        </Style>
+                    </ListBox.Styles>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="sysIO:FileInfo">
+                            <StackPanel Margin="0,4">
+                                <TextBlock Text="{CompiledBinding Name}" />
+                                <TextBlock FontSize="12"
+                                           Text="{CompiledBinding DirectoryName}"
+                                           Theme="{StaticResource LabelTextBlockStyle}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <TextBlock Grid.Row="2"
+                           IsVisible="{Binding !#recentList.ItemCount}"
+                           Text="{x:Static lang:Strings.NoFilesUsedRecently}" />
+            </Grid>
         </Grid>
 
         <StackPanel Grid.Row="2"

--- a/tests/Beutl.HeadlessUITests/EditorHostFallbackTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostFallbackTests.cs
@@ -1,0 +1,95 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Testing.Headless;
+using Beutl.Views;
+
+namespace Beutl.HeadlessUITests;
+
+// Guards the responsive width of EditorHostFallback's "recently used" panel. It must cap at its 600px
+// MaxWidth on wide windows but shrink below that on narrow / high-DPI ones, rather than holding a fixed
+// 600px width that clips. Asserts arranged layout bounds only (no pixel readback): frame capture of an
+// inflated shell view crashes the headless host on software Vulkan.
+[TestFixture]
+public class EditorHostFallbackTests
+{
+    private static Grid GetRecentItemsPanel(EditorHostFallback view)
+    {
+        ListBox recentList = view.GetVisualDescendants()
+            .OfType<ListBox>()
+            .First(x => x.Name == "recentList");
+
+        // The recent-items panel is the Grid that directly hosts the recent-files ListBox.
+        return recentList.GetVisualAncestors().OfType<Grid>().First();
+    }
+
+    private static double LeftRelativeTo(Visual descendant, Visual ancestor)
+    {
+        double x = 0;
+        for (Visual? current = descendant;
+             current is not null && !ReferenceEquals(current, ancestor);
+             current = current.GetVisualParent())
+        {
+            x += current.Bounds.X;
+        }
+
+        return x;
+    }
+
+    [AvaloniaTest]
+    public void Recent_panel_caps_at_600_on_a_wide_window()
+    {
+        var view = new EditorHostFallback();
+        var window = new Window { Content = view, Width = 1200, Height = 800 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Grid panel = GetRecentItemsPanel(view);
+            Assert.That(
+                panel.Bounds.Width,
+                Is.EqualTo(600).Within(1.0),
+                "On a wide window the recent-items panel should cap at its 600px MaxWidth.");
+
+            // The panel must stay left-anchored (consistent with the header / social rows above and
+            // below), not float to the centre of a wide window.
+            Assert.That(
+                LeftRelativeTo(panel, view),
+                Is.LessThan(200),
+                "On a wide window the recent-items panel should remain left-anchored, not centred.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Recent_panel_shrinks_below_600_on_a_narrow_window()
+    {
+        var view = new EditorHostFallback();
+        var window = new Window { Content = view, Width = 320, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Grid panel = GetRecentItemsPanel(view);
+            Assert.That(panel.Bounds.Width, Is.GreaterThan(0));
+            Assert.That(
+                panel.Bounds.Width,
+                Is.LessThan(600),
+                "On a narrow window the recent-items panel must shrink below 600px instead of clipping.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The "recently used" panel in `EditorHostFallback` used a hardcoded `Width="600"`, which clipped/overflowed on narrow windows and high-DPI setups. This makes the panel responsive: it still caps at 600px on wide windows but shrinks below that on narrow ones, staying left-anchored.

## Change

- **`src/Beutl/Views/EditorHostFallback.axaml`** — replaced the fixed `Width="600"` with a stretched wrapper `Grid` whose single `*` column carries `MaxWidth="600"`. This caps the panel at 600px on wide windows and lets it shrink below 600px on narrow ones, while staying left-anchored. (Applying `MaxWidth` + `HorizontalAlignment="Stretch"` directly on the panel was rejected because Avalonia centers a stretched element constrained by `MaxWidth`; the wrapper-column approach keeps it left-anchored. This is documented in an inline comment.)
- **`tests/Beutl.HeadlessUITests/EditorHostFallbackTests.cs`** — new headless layout test (the sole suite referencing `src/Beutl`, following the `ShellViewTests` precedent: `[AvaloniaTest]`, real view inflated in a `Window`, layout-bounds assertions only — no pixel readback). Asserts the panel caps at 600px and stays left-anchored on a wide window, and shrinks below 600px on a narrow one. The narrow-window assertion was **red against the unmodified fixed-width XAML** (panel stuck at 600px) and **green after the fix**, so it captures the bug.

## Test plan

`dotnet test tests/Beutl.HeadlessUITests` — both assertions green after the fix; the narrow-window assertion was verified red against the pre-fix XAML.

## Review notes

Reviewed by `@beutl-reviewer` (NUnit conventions, GPL/MIT, SourceGen) and `@beutl-xaml-binder` (compiled bindings) — both approve, no blocking findings. The root `UserControl` still lacks `x:CompileBindings`/`x:DataType`; this is pre-existing and the change introduces no new bindings, so retrofitting compiled bindings is out of scope (a separate migration). The headless test asserts the inner stretched `Grid` as a proxy for the capped wrapper — it holds today; a future tree change could drift it, noted for follow-up.

---

Board item: Project #9 — *初期画面の固定幅レイアウトを改善する*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the “Recently” section to better adapt to window size.
  * On wider windows, the content stays capped at a comfortable width.
  * On narrower windows, the layout now shrinks gracefully instead of staying fixed.
  * Added a bit more spacing around the panel for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->