### PR TITLE
fix(ui): make OutputView path/value columns flexible with full-path tooltip

### DIFF
--- a/src/Beutl/Views/Tools/OutputView.axaml
+++ b/src/Beutl/Views/Tools/OutputView.axaml
@@ -48,7 +48,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="150" SharedSizeGroup="TextBox_SizeGroup" />
+                <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
 
             <TextBlock HorizontalAlignment="Left"
@@ -62,7 +62,8 @@
             <TextBox Grid.Column="2"
                      MinWidth="120"
                      Margin="0,4"
-                     Text="{Binding DestinationFile.Value, Mode=TwoWay}">
+                     Text="{Binding DestinationFile.Value, Mode=TwoWay}"
+                     ToolTip.Tip="{Binding DestinationFile.Value}">
                 <TextBox.InnerRightContent>
                     <Button Click="SelectDestinationFileClick" Theme="{StaticResource TextBoxOpenButtonStyle}" />
                 </TextBox.InnerRightContent>
@@ -73,7 +74,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="150" SharedSizeGroup="TextBox_SizeGroup" />
+                <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
 
             <TextBlock HorizontalAlignment="Left"
@@ -102,7 +103,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="150" SharedSizeGroup="TextBox_SizeGroup" />
+                <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
 
             <TextBlock HorizontalAlignment="Left"

--- a/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
@@ -1,0 +1,97 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Beutl.Testing.Headless;
+using Beutl.Views.Tools;
+
+namespace Beutl.HeadlessUITests;
+
+// Layout-only assertions for OutputView. The save-destination / Encoder / Supersampling rows used a
+// hard 150px input column, which clipped long file paths and translated labels. These tests pin the
+// fix: the input column is flexible (star-sized) and actually grows with the available width.
+// They inflate the real view headlessly and assert arranged layout (column sizing / bounds) only -
+// never pixels, which crashes the software-Vulkan host when a heavy view is frame-captured.
+[TestFixture]
+public class OutputViewLayoutTests
+{
+    private static List<Grid> LabeledRowGrids(OutputView view)
+    {
+        // The labeled rows are declared 3-column grids (label / splitter / input). Walking the logical
+        // tree (not the visual tree) excludes the control templates' own internal grids.
+        return view.GetLogicalDescendants()
+            .OfType<Grid>()
+            .Where(g => g.ColumnDefinitions.Count == 3)
+            .ToList();
+    }
+
+    [AvaloniaTest]
+    public void Input_columns_are_flexible_not_fixed_width()
+    {
+        var view = new OutputView();
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            List<Grid> rows = LabeledRowGrids(view);
+            Assert.That(
+                rows,
+                Has.Count.GreaterThanOrEqualTo(3),
+                "expected the Destination / Encoder / Supersampling rows as 3-column grids");
+
+            foreach (Grid row in rows)
+            {
+                ColumnDefinition input = row.ColumnDefinitions[2];
+                Assert.That(
+                    input.Width.IsStar,
+                    Is.True,
+                    "the input column must be flexible (star-sized), not a fixed width");
+                Assert.That(
+                    input.Width.IsAbsolute && input.Width.Value == 150,
+                    Is.False,
+                    "the input column must not keep the old 150px fixed width");
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Destination_input_grows_with_available_width()
+    {
+        var view = new OutputView();
+        var window = new Window { Content = view, Width = 420, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            TextBox destination = view.GetLogicalDescendants().OfType<TextBox>().First();
+            double narrow = destination.Bounds.Width;
+
+            window.Width = 1100;
+            HeadlessTestHelpers.Render();
+            double wide = destination.Bounds.Width;
+
+            Assert.That(
+                narrow,
+                Is.GreaterThan(0),
+                "the destination field should be arranged");
+            Assert.That(
+                wide,
+                Is.GreaterThan(narrow + 100),
+                "the destination field must widen with the pane (flexible), not stay fixed");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
@@ -72,7 +72,7 @@ public class OutputViewLayoutTests
             window.Show();
             HeadlessTestHelpers.Render();
 
-            TextBox destination = view.GetLogicalDescendants().OfType<TextBox>().First();
+            TextBox destination = view.GetLogicalDescendants().OfType<TextBox>().Single();
             double narrow = destination.Bounds.Width;
 
             window.Width = 1100;


### PR DESCRIPTION
## Summary

In `OutputView`, the save-destination, Encoder, and Supersampling input columns were fixed at `Width="150"`, which is fragile for long file paths and translated label strings. This makes those input columns flexible and surfaces the full path on hover.

## Change

- **`src/Beutl/Views/Tools/OutputView.axaml`** (5 added / 4 removed lines):
  - The three input columns (Destination / Encoder / Supersampling) are now `Width="3*"` (with the existing `MinWidth`) instead of a fixed `150px`, so they grow with the pane; the label columns stay `2*` with their existing `TextTrimming="CharacterEllipsis"`, tolerant of longer translated strings.
  - Dropped the `SharedSizeGroup="TextBox_SizeGroup"` — it was a **no-op** (no ancestor sets `Grid.IsSharedSizeScope`).
  - Added `ToolTip.Tip="{Binding DestinationFile.Value}"` on the destination `TextBox` so a long, ellipsized path is readable in full on hover.
- **`tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs`** — NEW headless layout test (layout-bounds assertions only, no pixel readback; inflates the real `OutputView` with a null `DataContext`, which is null-safe under its compiled bindings). Asserts the input columns are star-sized and the destination field widens with the pane. Both assertions were **red against the unmodified fixed-150 XAML** and **green after the fix**.

## Test plan

`dotnet test tests/Beutl.HeadlessUITests` — both assertions green after the fix; verified red against the pre-fix XAML.

## Review notes

Reviewed by `@beutl-reviewer` (NUnit conventions, GPL/MIT, SourceGen) and `@beutl-xaml-binder` (compiled bindings) — both approve, no blocking findings. `OutputView` already declares `x:CompileBindings="True"` / `x:DataType`; the new tooltip binding resolves to `OutputViewModel.DestinationFile.Value` (`string?`). The dropped `SharedSizeGroup` is a confirmed no-op.

---

Board item: Project #9 — *出力画面の固定列幅と長いパス表示を改善する*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved layout flexibility in the output settings area by making key input columns adapt using flexible star sizing instead of fixed widths.
  * Added a tooltip to the destination input so the full value/path is visible on hover.

* **Tests**
  * Added headless layout regression tests to verify grid column sizing and that the destination input grows with available window width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->