### PR TITLE
ci: harden release-note format/translate workflows

### DIFF
--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -34,12 +34,13 @@ jobs:
 
       - name: Reformat release notes with Claude
         uses: anthropics/claude-code-action@v1
+        timeout-minutes: 20
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
-          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*)"'
+          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*),Write,Read"'
           prompt: |
             You are reformatting the body of the draft GitHub release `${{ inputs.tag }}` in `${{ github.repository }}` to match the style of https://github.com/b-editor/beutl/releases/tag/v2.0.0-preview.2.
 
@@ -85,8 +86,9 @@ jobs:
 
                e. Preserve the trailing `**Full Changelog**: https://github.com/.../compare/...` line that the auto-generated body provides, on its own paragraph at the very end.
 
-            3. Write the new body to a temp file via `mktemp` + `cat <<'EOF' > "$f"` (do not pass it inline because it has backticks and newlines), then run:
-               `gh release edit ${{ inputs.tag }} -R ${{ github.repository }} --notes-file "$f" --draft=true`
+            3. Create the new body with the `Write` tool — write it to `release-body.md` in the current directory. Do NOT build the body with shell heredocs / `echo` / `printf`: it contains backticks and newlines that break shell quoting and waste turns on denied commands. Then run:
+               `gh release edit ${{ inputs.tag }} -R ${{ github.repository }} --notes-file release-body.md --draft=true`
+               Confirm that command exits 0 (the release body must actually change); if it errors, fix the file and retry.
 
             ## Constraints
 
@@ -94,4 +96,22 @@ jobs:
             - DO NOT add a "日本語のリリースノートはこちら" line — that is appended later by a separate workflow when the corresponding Discussion is created.
             - DO NOT publish the release, edit the tag, modify assets, or open issues/PRs.
             - DO NOT touch any other release.
-            - If the release body already looks reformatted (i.e., contains `## What's Changed` followed by the platform list), exit without changes.
+            - If the fetched body already contains the substring `releases/download/${{ inputs.tag }}/` (the platform download links), it is already reformatted — exit without changes.
+
+      - name: Verify the release notes were reformatted
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! body=$(gh release view "$TAG" -R "$REPO" --json body -q .body); then
+            echo "::error::Failed to fetch release $TAG to verify its notes (gh release view errored)."
+            exit 1
+          fi
+          if printf '%s' "$body" | grep -qF "releases/download/$TAG/"; then
+            echo "Release notes contain the platform download links — reformatting succeeded."
+          else
+            echo "::error::Release notes for $TAG were not reformatted (no download links found). The Claude step finished without editing the body."
+            exit 1
+          fi

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -124,9 +124,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if ! gh release view "$TAG" -R "$REPO" --json url >/dev/null 2>&1; then
-            echo "No release found for $TAG — nothing to translate, skipping verification."
-            exit 0
+          if ! err=$(gh release view "$TAG" -R "$REPO" --json url 2>&1 >/dev/null); then
+            if printf '%s' "$err" | grep -qiE 'release not found|not found|HTTP 404'; then
+              echo "No release found for $TAG — nothing to translate, skipping verification."
+              exit 0
+            fi
+            echo "::error::Failed to look up release $TAG to verify its notes (gh release view errored): $err"
+            exit 1
           fi
           body=$(gh release view "$TAG" -R "$REPO" --json body -q .body)
           if printf '%s' "$body" | grep -qF "日本語のリリースノートは"; then

--- a/.github/workflows/translate-release-notes.yml
+++ b/.github/workflows/translate-release-notes.yml
@@ -35,13 +35,14 @@ jobs:
 
       - name: Translate discussion and link from release
         uses: anthropics/claude-code-action@v1
+        timeout-minutes: 20
         env:
           GH_TOKEN: ${{ secrets.DISCUSSION_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.DISCUSSION_TOKEN }}
           allowed_bots: "github-actions"
-          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(gh api graphql:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*),Bash(jq:*)"'
+          claude_args: '--allowed-tools "Bash(gh release view:*),Bash(gh release edit:*),Bash(gh api graphql:*),Bash(cat:*),Bash(mktemp:*),Bash(printf:*),Bash(jq:*),Write,Read"'
           prompt: |
             A new GitHub Discussion was created in `${{ github.repository }}`. Treat its title as a release tag and:
               1. translate the matching release body into Japanese and post it as a NEW COMMENT on the discussion (do not edit the discussion body itself), and
@@ -87,9 +88,9 @@ jobs:
 
                In either case, ALWAYS continue to step 5 — a previous run may have posted the comment but failed to update the release body, and step 5 must be allowed to repair that.
 
-            4. (Only if `COMMENT_URL` was not set in step 3.) Post the translated body as a NEW comment on the discussion. Write the body to a temp file (it contains backticks, quotes, and newlines) and prepend the marker line `<!-- japanese-release-notes -->` followed by a blank line so future runs can detect it. Then:
+            4. (Only if `COMMENT_URL` was not set in step 3.) Post the translated body as a NEW comment on the discussion. Create the comment body with the `Write` tool — write it to `comment-body.md` (it contains backticks, quotes, and newlines, so do NOT build it with shell heredocs / `echo` / `printf`) and prepend the marker line `<!-- japanese-release-notes -->` followed by a blank line so future runs can detect it. Then:
                ```
-               gh api graphql -F discussionId='${{ inputs.discussion_node_id }}' -F body=@"$comment_file" -f query='
+               gh api graphql -F discussionId='${{ inputs.discussion_node_id }}' -F body=@comment-body.md -f query='
                  mutation($discussionId: ID!, $body: String!) {
                    addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
                      comment { id url }
@@ -104,8 +105,8 @@ jobs:
                ```
                日本語のリリースノートは[こちら](<COMMENT_URL>)です。
                ```
-               Then write the combined body back to a temp file and run:
-               `gh release edit "${{ inputs.discussion_title }}" -R ${{ github.repository }} --notes-file "$f"`
+               Then create the combined body with the `Write` tool — write it to `release-body.md` (not a shell heredoc) and run:
+               `gh release edit "${{ inputs.discussion_title }}" -R ${{ github.repository }} --notes-file release-body.md`
                Preserve `--draft=true` if the release was a draft (use the `isDraft` value you fetched).
                If the substring is already present, do not edit the release.
 
@@ -115,3 +116,22 @@ jobs:
             - Do not publish the release, edit the tag, or touch assets.
             - Do not modify any other discussion or release.
             - If anything is ambiguous (release missing, translation refused, API error), exit without partial writes.
+
+      - name: Verify the translation link was added
+        env:
+          GH_TOKEN: ${{ secrets.DISCUSSION_TOKEN }}
+          TAG: ${{ inputs.discussion_title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" -R "$REPO" --json url >/dev/null 2>&1; then
+            echo "No release found for $TAG — nothing to translate, skipping verification."
+            exit 0
+          fi
+          body=$(gh release view "$TAG" -R "$REPO" --json body -q .body)
+          if printf '%s' "$body" | grep -qF "日本語のリリースノートは"; then
+            echo "Release notes link to the Japanese translation — translation succeeded."
+          else
+            echo "::error::Release $TAG exists but its notes do not link to the Japanese translation. The Claude step finished without updating the release body."
+            exit 1
+          fi


### PR DESCRIPTION
## Description
- Add `timeout-minutes` to the Claude steps so a hung run fails fast instead of burning the job's full budget.
- Allow the `Write`/`Read` tools and switch the prompts to build the release / comment bodies with the `Write` tool instead of fragile shell heredocs (backticks and newlines broke shell quoting and wasted turns on denied commands).
- Add a post-step that verifies the release body was actually reformatted (format workflow) / linked to the Japanese translation (translate workflow), failing the job if the Claude step finished without editing the body.
- Make the idempotency guard check a literal download-link substring (`releases/download/<tag>/`) rather than a loose structural match.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None

## Test plan
- CI-only change; no application logic touched. The workflows are `workflow_call`-triggered (manual / event-driven), so behavior is validated on the next release-note format / translate run.
- The new verification steps are self-checking: they fail the job with an `::error::` annotation if the release body was not actually updated.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release note formatting and translation with stricter verification that confirms the expected download link and the required Japanese content marker are present before completing.
  * Added fail-fast checks to ensure automation does not finish if release notes were not updated correctly.
* **Chores**
  * Increased Claude processing time limits and adjusted allowed tool permissions to improve reliability.
  * Updated the workflows to generate release note bodies and discussion comments via the required write-and-apply flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->