### PR TITLE
fix(ui): bound SearchPage result-card text with trimming and wrapping

### DIFF
--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
@@ -83,29 +83,37 @@
                                                       VerticalAlignment="Stretch"
                                                       ColumnDefinitions="*,Auto"
                                                       RowDefinitions="Auto,Auto,Auto">
-                                                    <TextBlock Text="{Binding Name}" />
+                                                    <TextBlock Text="{Binding Name}"
+                                                               TextTrimming="CharacterEllipsis" />
 
                                                     <TextBlock Grid.Row="1"
-                                                               Grid.ColumnSpan="2"
                                                                Classes="name"
                                                                IsVisible="{Binding DisplayName.Value, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                                               Text="{Binding DisplayName.Value}" />
+                                                               Text="{Binding DisplayName.Value}"
+                                                               TextTrimming="CharacterEllipsis" />
 
                                                     <TextBlock Grid.Row="2"
                                                                Grid.ColumnSpan="2"
                                                                Margin="0,8,0,0"
-                                                               Text="{Binding ShortDescription.Value}" />
+                                                               MaxLines="2"
+                                                               Text="{Binding ShortDescription.Value}"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               TextWrapping="Wrap" />
 
                                                     <TextBlock Grid.Column="1"
+                                                               MaxWidth="120"
                                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                               Text="{Binding Owner.Name}" />
+                                                               Text="{Binding Owner.Name}"
+                                                               TextTrimming="CharacterEllipsis" />
 
                                                     <TextBlock Grid.Row="1"
                                                                Grid.Column="1"
+                                                               MaxWidth="120"
                                                                HorizontalAlignment="Right"
                                                                VerticalAlignment="Center"
                                                                FontWeight="SemiBold"
-                                                               Text="{Binding FormattedPrice.Value, TargetNullValue={x:Static lang:ExtensionsStrings.Free}}" />
+                                                               Text="{Binding FormattedPrice.Value, TargetNullValue={x:Static lang:ExtensionsStrings.Free}}"
+                                                               TextTrimming="CharacterEllipsis" />
                                                 </Grid>
                                             </Grid>
                                         </Button>

--- a/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
@@ -135,6 +135,18 @@ public class SearchPageCardLayoutTests
                 name.Bounds.Width,
                 Is.GreaterThan(0),
                 "the name column must keep positive width even next to a very long author");
+
+            Assert.That(
+                Grid.GetColumnSpan(displayName),
+                Is.EqualTo(1),
+                "the display name must not span into the price column (was the overlap bug)");
+
+            // Only the two secondary-column fields (author, price) are MaxWidth-capped; the
+            // name/display-name in the star column are not, so an ellipsized+capped count of 2 == both.
+            Assert.That(
+                blocks.Count(t => double.IsFinite(t.MaxWidth) && t.TextTrimming == TextTrimming.CharacterEllipsis),
+                Is.GreaterThanOrEqualTo(2),
+                "both the author and price fields must be MaxWidth-capped and ellipsized");
         }
         finally
         {

--- a/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs
@@ -1,0 +1,145 @@
+﻿using System.Net.Http;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.Pages.ExtensionsPages.DiscoverPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
+
+namespace Beutl.HeadlessUITests;
+
+// Layout-only assertions for the extension search result card (SearchPage). Long package/display
+// names, descriptions and author names used to break the card layout because the card's TextBlocks
+// declared no TextTrimming / TextWrapping and the author/price column was an unbounded Auto column.
+// These tests pin the fix: the single-line fields ellipsize, the description wraps with a capped line
+// count, and the author column is bounded so a long author cannot starve the name column or widen the
+// card. They inflate the real card headlessly (a real Package fed into the real ViewModel's Packages
+// list, no network) and assert arranged layout / TextBlock properties only - never pixels, which
+// crashes the software-Vulkan host when a heavy view is frame-captured.
+[TestFixture]
+public class SearchPageCardLayoutTests
+{
+    private const string LongName = "ThisIsAnExtremelyLongPackageNameThatOverflowsTheCardWithoutTrimming";
+    private const string LongDisplayName = "An Extremely Long Human Friendly Display Name That Must Be Ellipsized To Fit";
+    private const string LongDescription =
+        "A very long short description that should wrap to at most a couple of lines and then be "
+        + "ellipsized rather than expanding the card height without bound, going on and on and on and on.";
+    private const string LongOwner = "AnExtremelyLongAuthorAccountNameThatShouldNotPushTheCardWider";
+
+    private static BeutlApiApplication CreateClients() => new(new HttpClient(), new ExtensionProvider());
+
+    private static Package CreatePackage(BeutlApiApplication clients)
+    {
+        var ownerResponse = new ProfileResponse
+        {
+            Id = "owner-id",
+            Name = LongOwner,
+            DisplayName = LongOwner,
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var profile = new Profile(ownerResponse, clients);
+        var response = new PackageResponse
+        {
+            Id = "package-id",
+            Owner = ownerResponse,
+            Name = LongName,
+            DisplayName = LongDisplayName,
+            Description = LongDescription,
+            ShortDescription = LongDescription,
+            WebSite = "",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = "JPY",
+            Price = 999900,
+            Paid = true,
+            Owned = false,
+        };
+        return new Package(profile, response, clients);
+    }
+
+    [AvaloniaTest]
+    public void Long_card_text_ellipsizes_wraps_and_stays_bounded()
+    {
+        BeutlApiApplication clients = CreateClients();
+        var viewModel = new SearchPageViewModel(new DiscoverService(clients), "search");
+        viewModel.Packages.Add(CreatePackage(clients));
+
+        var view = new SearchPage { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            List<TextBlock> blocks = view.GetVisualDescendants().OfType<TextBlock>().ToList();
+            TextBlock? name = blocks.FirstOrDefault(t => t.Text == LongName);
+            TextBlock? displayName = blocks.FirstOrDefault(t => t.Text == LongDisplayName);
+            TextBlock? description = blocks.FirstOrDefault(t => t.Text == LongDescription);
+            TextBlock? owner = blocks.FirstOrDefault(t => t.Text == LongOwner);
+
+            Assert.That(
+                name,
+                Is.Not.Null,
+                "the package card did not materialize headlessly - revisit the test host before trusting it");
+            Assert.That(displayName, Is.Not.Null);
+            Assert.That(description, Is.Not.Null);
+            Assert.That(owner, Is.Not.Null);
+
+            Assert.That(
+                name!.TextTrimming,
+                Is.EqualTo(TextTrimming.CharacterEllipsis),
+                "the package name must ellipsize instead of clipping");
+            Assert.That(
+                displayName!.TextTrimming,
+                Is.EqualTo(TextTrimming.CharacterEllipsis),
+                "the display name must ellipsize instead of clipping");
+            Assert.That(
+                owner!.TextTrimming,
+                Is.EqualTo(TextTrimming.CharacterEllipsis),
+                "the author name must ellipsize instead of clipping");
+
+            Assert.That(
+                description!.TextWrapping,
+                Is.EqualTo(TextWrapping.Wrap),
+                "the description must wrap rather than overflow on one line");
+            Assert.That(
+                description.TextTrimming,
+                Is.EqualTo(TextTrimming.CharacterEllipsis),
+                "the description must ellipsize once it hits its line cap");
+            Assert.That(
+                description.MaxLines,
+                Is.GreaterThan(0),
+                "the description must cap its line count so the card height stays bounded");
+
+            // A long author must not be allowed to grow the Auto column unbounded: the column is now
+            // capped so the name column keeps room and the card does not widen off-screen.
+            Assert.That(
+                double.IsFinite(owner.MaxWidth),
+                Is.True,
+                "the author column must declare an explicit MaxWidth cap");
+            Assert.That(
+                owner.Bounds.Width,
+                Is.LessThanOrEqualTo(owner.MaxWidth + 1),
+                "the arranged author width must respect its MaxWidth cap");
+            Assert.That(
+                name.Bounds.Width,
+                Is.GreaterThan(0),
+                "the name column must keep positive width even next to a very long author");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The extension-search result cards (`SearchPage`) had no text trimming or wrapping, and the author/price sat in an unbounded column, so long package names, descriptions, author names, or prices broke the card layout. This bounds the card's text.

## Change

- **`src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml`** (14 added / 6 removed):
  - `TextTrimming="CharacterEllipsis"` on the single-line fields (`Name`, `DisplayName`, `Owner.Name`, `FormattedPrice`).
  - `TextWrapping="Wrap"` + `MaxLines="2"` + ellipsis on the description, to bound card height.
  - Removed `Grid.ColumnSpan="2"` from the display name — it previously spanned both columns and **overlapped the price**; confining it to column 0 fixes the overlap.
  - Capped the author/price column at `MaxWidth="120"` so a long author/price can't starve the name column or widen the card.
- **`tests/Beutl.HeadlessUITests/SearchPageCardLayoutTests.cs`** — NEW headless layout test. It builds a real `Beutl.Api` `Package` with very long strings (no network — the package is added directly to `SearchPageViewModel.Packages`, so no API call fires), inflates the real card, and asserts the trimming/wrapping/line-cap/width-cap (layout properties + arranged bounds, never pixels). **Red against the unmodified XAML** (`TextTrimming` defaulted to `None`, `MaxLines` to `0`, `MaxWidth` to `Infinity`) and **green after the fix**.

## Test plan

`dotnet test tests/Beutl.HeadlessUITests` — green after the fix; verified red against the pre-fix XAML.

## Review notes

Reviewed by `@beutl-reviewer` (NUnit conventions, GPL/MIT, no-network inflation) and `@beutl-xaml-binder` (compiled bindings) — both approve, no blocking findings. All card bindings resolve on `api:Package` under the template's `x:DataType`; no new `ReflectionBinding`. `Beutl.Api` is the MIT server-API client (no GPL involvement). The unrelated `DummyItem` placeholder template's `ColumnSpan="2"` is untouched (a different element).

---

Board item: Project #9 — *拡張機能検索カードの長文表示を安定させる*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result card layout for long package details (name, display name, owner, price, and description).
  * Added consistent ellipsis truncation and wrapping behavior to prevent text overflow.
  * Constrained owner and price columns to stay bounded while preserving alignment and readability.
* **Tests**
  * Added headless UI layout coverage to verify ellipsis/wrapping, width bounds, and column behavior for long card content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->