### PR TITLE
fix(ui): make ExtensionsPage window responsive with min-size floors

### DIFF
--- a/src/Beutl/Pages/ExtensionsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPage.axaml
@@ -7,6 +7,8 @@
         xmlns:ui="using:FluentAvalonia.UI.Controls"
         Width="800"
         Height="600"
+        MinWidth="480"
+        MinHeight="400"
         Title="{x:Static lang:Strings.Extensions}"
         d:DesignHeight="450"
         d:DesignWidth="800"
@@ -24,9 +26,9 @@
             </ui:NavigationView.Resources>
             <ui:NavigationView.PaneCustomContent>
                 <TextBox x:Name="searchTextBox"
-                         MinWidth="250"
+                         MaxWidth="250"
                          Margin="8,0"
-                         HorizontalAlignment="Right"
+                         HorizontalAlignment="Stretch"
                          VerticalAlignment="Center"
                          Watermark="{x:Static lang:Strings.Search}">
                     <TextBox.InnerRightContent>

--- a/tests/Beutl.HeadlessUITests/ExtensionsPageLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExtensionsPageLayoutTests.cs
@@ -1,0 +1,93 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Pages;
+using Beutl.Testing.Headless;
+
+namespace Beutl.HeadlessUITests;
+
+// Guards that the extensions window adapts to the available space instead of relying on a hard 800x600
+// size with a fixed-width search box. The window must declare MinWidth/MinHeight floors, and the search
+// box must shrink (and stay inside its slot) on a narrow window rather than overflowing it. Asserts
+// arranged layout bounds only (no pixel readback): frame capture of an inflated shell view crashes the
+// headless host on software Vulkan.
+[TestFixture]
+public class ExtensionsPageLayoutTests
+{
+    private static TextBox GetSearchBox(ExtensionsPage page)
+        => page.GetVisualDescendants().OfType<TextBox>().First(x => x.Name == "searchTextBox");
+
+    [AvaloniaTest]
+    public void Window_declares_minimum_size_floors()
+    {
+        var page = new ExtensionsPage();
+        try
+        {
+            Assert.That(page.MinWidth, Is.GreaterThan(0), "window must declare a MinWidth floor so it can shrink without clipping");
+            Assert.That(page.MinHeight, Is.GreaterThan(0), "window must declare a MinHeight floor so it can shrink without clipping");
+        }
+        finally
+        {
+            page.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Search_box_shrinks_and_stays_in_its_slot_on_a_narrow_window()
+    {
+        var page = new ExtensionsPage();
+        // Request a window narrower than the old 800px content width. The MinWidth floor clamps it up to a
+        // usable minimum; the responsive search box must then shrink to fit instead of overflowing.
+        page.Width = 360;
+        page.Height = 600;
+        try
+        {
+            page.Show();
+            HeadlessTestHelpers.Render();
+
+            TextBox tb = GetSearchBox(page);
+            Assert.That(
+                tb.MinWidth,
+                Is.LessThan(250),
+                "search box must no longer pin itself to a 250px floor so it can shrink at narrow widths");
+            Assert.That(
+                tb.Bounds.X,
+                Is.GreaterThanOrEqualTo(0),
+                "search box must stay inside its slot at a narrow width rather than overflowing (clipping) its left edge");
+            Assert.That(
+                tb.Bounds.Width,
+                Is.GreaterThan(0).And.LessThan(250),
+                "search box must shrink below its 250px cap when the top bar is narrow");
+        }
+        finally
+        {
+            page.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Search_box_caps_its_width_on_a_wide_window()
+    {
+        var page = new ExtensionsPage();
+        page.Width = 1200;
+        page.Height = 700;
+        try
+        {
+            page.Show();
+            HeadlessTestHelpers.Render();
+
+            TextBox tb = GetSearchBox(page);
+            Assert.That(
+                tb.Bounds.Width,
+                Is.GreaterThan(0).And.LessThanOrEqualTo(251),
+                "search box must cap at its ~250px MaxWidth on a wide window instead of stretching across the top bar");
+        }
+        finally
+        {
+            page.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ExtensionsPage` was a `Window` hard-coded to `Width="800" Height="600"` with a fixed `MinWidth="250"`, right-aligned search box, so it didn't adapt to small or large screens (the search box clipped on narrow windows). This makes the window responsive.

## Change

- **`src/Beutl/Pages/ExtensionsPage.axaml`** (4 production lines):
  - Added `MinWidth="480"` / `MinHeight="400"` floors, keeping `Width="800" Height="600"` as a **resizable startup default** (an Avalonia `Window`'s `Width`/`Height` are the initial size, not a hard constraint).
  - Changed the search box from `MinWidth="250"` + `HorizontalAlignment="Right"` to `MaxWidth="250"` + `HorizontalAlignment="Stretch"`, so it caps at 250px on wide windows and shrinks on narrow ones instead of clipping (it arranged at X=−78 — overflowing — before the fix).
- **`tests/Beutl.HeadlessUITests/ExtensionsPageLayoutTests.cs`** — NEW: 3 `[AvaloniaTest]` headless layout cases (bounds only). Baseline **red** (2/3 failed: no `MinWidth` floor; search box pinned at 250 + clipping) → **green** after the fix.

## Test plan

`dotnet test tests/Beutl.HeadlessUITests` — green after the fix; verified red against the pre-fix XAML (2/3).

## Review notes

Reviewed by `@beutl-reviewer` (NUnit conventions, GPL/MIT, SourceGen — all N/A or pass) and `@beutl-xaml-binder` (it is a pre-existing `Window`, not a new UserControl; the change is binding-neutral) — both approve, no blocking findings.

**Behavior note for reviewers:** because `MaxWidth` + `HorizontalAlignment="Stretch"` lets the box shrink to fit, on a *wide* window the search box is now **centered** within its top-bar slot (clamped to 250px) rather than right-hugging it as before (`HorizontalAlignment="Right"`). This is the trade-off that enables the shrink-to-fit behavior; if right-alignment on wide windows is preferred, that's a small follow-up tweak. **Out of scope (noted, not implemented):** restoring the last-used window size requires a persistence layer.

---

Board item: Project #9 — *拡張機能ウィンドウの固定サイズを見直す*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Extensions page layout so it has a consistent minimum window size.
  * Adjusted the search box sizing so it fits better in both narrow and wide windows without overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->