### PR TITLE
fix(ffmpeg-ipc): report mid-encode CancelEncode as a clean cancel; extract PrefetchSlot

### DIFF
--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -11,11 +11,8 @@ internal sealed class IpcFrameProvider : IFrameProvider
 {
     private readonly IpcConnection _connection;
     private readonly SharedMemoryBuffer[] _videoBuffers;
+    private readonly PrefetchSlot<long, IpcMessage> _prefetch = new();
     private int _bufferIndex;
-
-    private Task<IpcMessage>? _prefetchTask;
-    private int _prefetchBufferIndex;
-    private long _prefetchFrameIndex;
     private bool _disposed;
 
     public IpcFrameProvider(IpcConnection connection, SharedMemoryBuffer[] videoBuffers,
@@ -38,27 +35,18 @@ internal sealed class IpcFrameProvider : IFrameProvider
         IpcMessage response;
         int readBufferIndex;
 
-        if (_prefetchTask != null && _prefetchFrameIndex == frame)
+        Task<IpcMessage>? prefetched = _prefetch.TryConsumeMatching(frame, out readBufferIndex);
+        if (prefetched != null)
         {
-            // Prefetch already in flight for the requested frame. Clear the field before awaiting (like
-            // the stale-drain branch) so a faulted prefetch can't pin the provider to a re-throwing task.
-            Task<IpcMessage> prefetchTask = _prefetchTask;
-            _prefetchTask = null;
-            readBufferIndex = _prefetchBufferIndex;
-            response = await prefetchTask;
+            response = await prefetched;
         }
         else
         {
-            // Prefetch in flight but for a different frame (seek / non-sequential request). On a
-            // non-multiplexed connection responses are read in send order, so the stale prefetch
-            // response must be awaited and discarded before issuing the fresh request; otherwise that
-            // request would read this old response and hit an id mismatch.
-            if (_prefetchTask != null)
-            {
-                Task<IpcMessage> staleTask = _prefetchTask;
-                _prefetchTask = null;
-                await staleTask;
-            }
+            // Prefetch in flight but for a different frame (seek / non-sequential request): drain the stale
+            // prefetch before issuing the fresh request so it can't be read in place of the new response.
+            Task<IpcMessage>? stale = _prefetch.TryDetachStale(frame);
+            if (stale != null)
+                await stale;
 
             readBufferIndex = _bufferIndex;
             var request = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,
@@ -66,12 +54,9 @@ internal sealed class IpcFrameProvider : IFrameProvider
             response = await _connection.SendAndReceiveAsync(request);
         }
 
-        // SendAndReceiveAsync already surfaces a closed connection as IOException and an error response as
-        // FFmpegWorkerException, so the response here is non-null and error-free; only CancelEncode (a live
-        // non-error response) still needs handling.
-        if (response.Type == MessageType.CancelEncode)
-            throw new OperationCanceledException();
-
+        // SendAndReceiveAsync surfaces a closed connection as IOException, an error response as
+        // FFmpegWorkerException, and a host CancelEncode as OperationCanceledException, so the response here
+        // is always a live ProvideFrame for this request.
         var frameInfo = response.GetPayload<ProvideFrameMessage>()
             ?? throw new InvalidOperationException("Missing payload for ProvideFrame");
 
@@ -83,11 +68,10 @@ internal sealed class IpcFrameProvider : IFrameProvider
         long nextFrame = frame + 1;
         if (nextFrame < FrameCount)
         {
-            _prefetchBufferIndex = 1 - readBufferIndex;
-            _prefetchFrameIndex = nextFrame;
+            int prefetchBufferIndex = 1 - readBufferIndex;
             var nextRequest = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,
-                new RequestFrameMessage { FrameIndex = nextFrame, BufferIndex = _prefetchBufferIndex });
-            _prefetchTask = _connection.SendAndReceiveAsync(nextRequest).AsTask();
+                new RequestFrameMessage { FrameIndex = nextFrame, BufferIndex = prefetchBufferIndex });
+            _prefetch.Arm(nextFrame, prefetchBufferIndex, _connection.SendAndReceiveAsync(nextRequest).AsTask());
         }
 
         _bufferIndex = 1 - readBufferIndex;
@@ -135,7 +119,7 @@ internal sealed class IpcFrameProvider : IFrameProvider
 
     // Test-only probe: lets a Dispose test wait until the in-flight prefetch has actually faulted before
     // dropping it, so the faulted-task path is exercised deterministically without a sleep.
-    internal bool IsPrefetchFaultedForTest() => _prefetchTask?.IsFaulted == true;
+    internal bool IsPrefetchFaultedForTest() => _prefetch.IsFaulted;
 
     public void Dispose()
     {
@@ -151,11 +135,10 @@ internal sealed class IpcFrameProvider : IFrameProvider
         // IpcMessage with nothing to release (the Bitmap is built lazily only when a frame is consumed), so a
         // successful prefetch leaks nothing — whereas a sample prefetch yields a native Pcm its continuation
         // must dispose on the success path.
-        _prefetchTask?.ContinueWith(
+        _prefetch.Detach()?.ContinueWith(
             static t => { _ = t.Exception; },
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
             TaskScheduler.Default);
-        _prefetchTask = null;
     }
 }

--- a/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcFrameProvider.cs
@@ -46,7 +46,17 @@ internal sealed class IpcFrameProvider : IFrameProvider
             // prefetch before issuing the fresh request so it can't be read in place of the new response.
             Task<IpcMessage>? stale = _prefetch.TryDetachStale(frame);
             if (stale != null)
-                await stale;
+            {
+                try
+                {
+                    await stale;
+                }
+                catch (FFmpegWorkerException)
+                {
+                    // The drain has already consumed the stale prefetch's response off the pipe; its worker
+                    // error belongs to the discarded frame, so it must not abort the fresh request below.
+                }
+            }
 
             readBufferIndex = _bufferIndex;
             var request = IpcMessage.Create(_connection.NextId(), MessageType.RequestFrame,

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -22,9 +22,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
     private int _currentBufferIndex;
 
     // 先行フェッチ（次の1秒分、バックグラウンド）
-    private Task<Pcm<Stereo32BitFloat>>? _prefetchTask;
-    private long _prefetchChunkOffset;
-    private int _prefetchBufferIndex;
+    private readonly PrefetchSlot<long, Pcm<Stereo32BitFloat>> _prefetch = new();
     private bool _disposed;
 
     public IpcSampleProvider(IpcConnection connection, SharedMemoryBuffer[] audioBuffers,
@@ -127,28 +125,24 @@ internal sealed class IpcSampleProvider : ISampleProvider
         }
 
         // プリフェッチ済みのチャンクと一致する場合
-        if (_prefetchTask != null && _prefetchChunkOffset == chunkOffset)
+        Task<Pcm<Stereo32BitFloat>>? prefetched = _prefetch.TryConsumeMatching(chunkOffset, out int prefetchBufferIndex);
+        if (prefetched != null)
         {
-            // Clear the field before awaiting (like the stale-drain branch below and IpcFrameProvider's
-            // prefetch-hit branch) so a faulted prefetch can't pin the provider to a re-throwing task.
-            Task<Pcm<Stereo32BitFloat>> prefetchTask = _prefetchTask;
-            _prefetchTask = null;
-            var pcm = await prefetchTask;
+            var pcm = await prefetched;
 
             _currentChunk?.Dispose();
             _currentChunk = pcm;
             _currentChunkOffset = chunkOffset;
-            _currentBufferIndex = _prefetchBufferIndex;
+            _currentBufferIndex = prefetchBufferIndex;
             return;
         }
 
         // プリフェッチが進行中だが要求と一致しない場合は、完了を待ってから結果を破棄する。
         // ホストへ非順次なリクエストが流出しないよう、参照を捨てるだけでなく必ず await する。
-        if (_prefetchTask != null)
+        Task<Pcm<Stereo32BitFloat>>? stale = _prefetch.TryDetachStale(chunkOffset);
+        if (stale != null)
         {
-            Task<Pcm<Stereo32BitFloat>> staleTask = _prefetchTask;
-            _prefetchTask = null;
-            Pcm<Stereo32BitFloat> stalePcm = await staleTask;
+            Pcm<Stereo32BitFloat> stalePcm = await stale;
             stalePcm.Dispose();
         }
 
@@ -161,15 +155,14 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     private void StartPrefetchIfNeeded()
     {
-        if (_prefetchTask != null) return;
+        if (_prefetch.HasPrefetch) return;
         if (_currentChunk == null) return;
 
         long nextChunkOffset = _currentChunkOffset + _currentChunk.NumSamples;
         if (nextChunkOffset >= SampleCount) return;
 
-        _prefetchBufferIndex = 1 - _currentBufferIndex;
-        _prefetchChunkOffset = nextChunkOffset;
-        _prefetchTask = FetchChunk(nextChunkOffset, _prefetchBufferIndex).AsTask();
+        int prefetchBufferIndex = 1 - _currentBufferIndex;
+        _prefetch.Arm(nextChunkOffset, prefetchBufferIndex, FetchChunk(nextChunkOffset, prefetchBufferIndex).AsTask());
     }
 
     private async ValueTask<Pcm<Stereo32BitFloat>> FetchChunk(long chunkOffset, int bufferIndex)
@@ -180,12 +173,9 @@ internal sealed class IpcSampleProvider : ISampleProvider
             new RequestSampleMessage { Offset = chunkOffset, Length = chunkLength, BufferIndex = bufferIndex });
         var response = await _connection.SendAndReceiveAsync(request);
 
-        // SendAndReceiveAsync already surfaces a closed connection as IOException and an error response as
-        // FFmpegWorkerException, so the response here is non-null and error-free; only CancelEncode (a live
-        // non-error response) still needs handling.
-        if (response.Type == MessageType.CancelEncode)
-            throw new OperationCanceledException();
-
+        // SendAndReceiveAsync surfaces a closed connection as IOException, an error response as
+        // FFmpegWorkerException, and a host CancelEncode as OperationCanceledException, so the response here
+        // is always a live ProvideSample for this request.
         var sampleInfo = response.GetPayload<ProvideSampleMessage>()
             ?? throw new InvalidOperationException("Missing payload for ProvideSample");
 
@@ -221,7 +211,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
 
     // Test-only probe: lets a Dispose test wait until the in-flight prefetch has actually faulted before
     // dropping it, so the faulted-task path is exercised deterministically without a sleep.
-    internal bool IsPrefetchFaultedForTest() => _prefetchTask?.IsFaulted == true;
+    internal bool IsPrefetchFaultedForTest() => _prefetch.IsFaulted;
 
     public void Dispose()
     {
@@ -241,7 +231,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
         // ExecuteSynchronously is safe because t.Result.Dispose() is a single P/Invoke free: no lock
         // contention and no throw path. If that body ever becomes heavier, drop ExecuteSynchronously so the
         // runtime schedules the continuation on a pool thread instead of the completing (receive-loop) one.
-        _prefetchTask?.ContinueWith(
+        _prefetch.Detach()?.ContinueWith(
             static t =>
             {
                 if (t.IsFaulted)
@@ -252,7 +242,6 @@ internal sealed class IpcSampleProvider : ISampleProvider
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
-        _prefetchTask = null;
 
         _currentChunk?.Dispose();
         _currentChunk = null;

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -142,8 +142,16 @@ internal sealed class IpcSampleProvider : ISampleProvider
         Task<Pcm<Stereo32BitFloat>>? stale = _prefetch.TryDetachStale(chunkOffset);
         if (stale != null)
         {
-            Pcm<Stereo32BitFloat> stalePcm = await stale;
-            stalePcm.Dispose();
+            try
+            {
+                Pcm<Stereo32BitFloat> stalePcm = await stale;
+                stalePcm.Dispose();
+            }
+            catch (FFmpegWorkerException)
+            {
+                // The drain has already consumed the stale prefetch's response off the pipe; its worker
+                // error belongs to the discarded chunk, so it must not abort the fresh request below.
+            }
         }
 
         int bufferIndex = 0;

--- a/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
+++ b/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace Beutl.FFmpegIpc.Providers;
+﻿namespace Beutl.FFmpegIpc.Providers;
 
 /// <summary>
 /// Single-slot double-buffer prefetch state shared by the IPC client providers
@@ -35,7 +33,11 @@ internal sealed class PrefetchSlot<TKey, TValue>
     /// <summary>Arms the slot with an in-flight prefetch. The caller guarantees the slot is empty.</summary>
     public void Arm(TKey key, int bufferIndex, Task<TValue> task)
     {
-        Debug.Assert(_task is null, "PrefetchSlot armed while a prefetch was already in flight");
+        // Overwriting an armed prefetch would strand its undrained IPC response, which a later request
+        // would then read in place of its own and reject as an id mismatch.
+        if (_task is not null)
+            throw new InvalidOperationException("PrefetchSlot armed while a prefetch was already in flight.");
+
         _key = key;
         _bufferIndex = bufferIndex;
         _task = task;
@@ -48,7 +50,7 @@ internal sealed class PrefetchSlot<TKey, TValue>
     /// </summary>
     public Task<TValue>? TryConsumeMatching(TKey key, out int bufferIndex)
     {
-        if (_task is not null && _key.Equals(key))
+        if (_task is not null && EqualityComparer<TKey>.Default.Equals(_key, key))
         {
             bufferIndex = _bufferIndex;
             return Detach();
@@ -65,7 +67,7 @@ internal sealed class PrefetchSlot<TKey, TValue>
     /// </summary>
     public Task<TValue>? TryDetachStale(TKey key)
     {
-        if (_task is not null && !_key.Equals(key))
+        if (_task is not null && !EqualityComparer<TKey>.Default.Equals(_key, key))
             return Detach();
 
         return null;
@@ -76,6 +78,8 @@ internal sealed class PrefetchSlot<TKey, TValue>
     {
         Task<TValue>? task = _task;
         _task = null;
+        _key = default!;
+        _bufferIndex = 0;
         return task;
     }
 }

--- a/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
+++ b/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
@@ -1,0 +1,78 @@
+namespace Beutl.FFmpegIpc.Providers;
+
+/// <summary>
+/// Single-slot double-buffer prefetch state shared by the IPC client providers
+/// (<see cref="IpcFrameProvider"/>, <see cref="IpcSampleProvider"/>). Holds at most one in-flight
+/// prefetch keyed by <typeparamref name="TKey"/> (a frame index or chunk offset) together with the
+/// shared-memory buffer slot it targets, and encodes the seek/prefetch decision both providers used to
+/// hand-duplicate: a request whose key matches the armed prefetch consumes it; any other key drains the
+/// stale prefetch (await-and-discard) before a fresh request is issued. On a non-multiplexed connection
+/// responses are read in send order, so draining the stale prefetch is what stops a fresh request from
+/// reading the old response and tripping an id mismatch.
+/// </summary>
+/// <remarks>
+/// The slot owns only the <see cref="Task{TResult}"/> handle and the (key, bufferIndex) metadata; awaiting
+/// the detached task and observing/disposing its result is the caller's responsibility (a frame yields a
+/// managed message with nothing to release, a sample yields a native buffer the caller must dispose when it
+/// is discarded). Detaching clears the slot before the caller awaits, so a faulted prefetch cannot pin the
+/// provider to a perpetually re-throwing task. Not thread-safe: callers drive it from a single logical
+/// request sequence.
+/// </remarks>
+internal sealed class PrefetchSlot<TKey, TValue>
+    where TKey : IEquatable<TKey>
+{
+    private Task<TValue>? _task;
+    private TKey _key = default!;
+    private int _bufferIndex;
+
+    public bool HasPrefetch => _task is not null;
+
+    // Test/diagnostic probe: true only while an armed prefetch has already faulted.
+    public bool IsFaulted => _task?.IsFaulted == true;
+
+    /// <summary>Arms the slot with an in-flight prefetch. The caller guarantees the slot is empty.</summary>
+    public void Arm(TKey key, int bufferIndex, Task<TValue> task)
+    {
+        _key = key;
+        _bufferIndex = bufferIndex;
+        _task = task;
+    }
+
+    /// <summary>
+    /// If a prefetch is armed for <paramref name="key"/>, detaches and returns it (clearing the slot) and
+    /// reports the buffer slot it targeted; otherwise returns <c>null</c> and <paramref name="bufferIndex"/>
+    /// is unspecified.
+    /// </summary>
+    public Task<TValue>? TryConsumeMatching(TKey key, out int bufferIndex)
+    {
+        if (_task is not null && _key.Equals(key))
+        {
+            bufferIndex = _bufferIndex;
+            return Detach();
+        }
+
+        bufferIndex = default;
+        return null;
+    }
+
+    /// <summary>
+    /// If a prefetch is armed but for a different key than <paramref name="key"/>, detaches and returns it
+    /// (clearing the slot) so the caller can drain it before issuing a fresh request; returns <c>null</c>
+    /// when the slot is empty or already matches <paramref name="key"/>.
+    /// </summary>
+    public Task<TValue>? TryDetachStale(TKey key)
+    {
+        if (_task is not null && !_key.Equals(key))
+            return Detach();
+
+        return null;
+    }
+
+    /// <summary>Detaches whatever prefetch is armed (clearing the slot), or returns <c>null</c> if empty.</summary>
+    public Task<TValue>? Detach()
+    {
+        Task<TValue>? task = _task;
+        _task = null;
+        return task;
+    }
+}

--- a/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
+++ b/src/Beutl.FFmpegIpc/Providers/PrefetchSlot.cs
@@ -1,3 +1,5 @@
+﻿using System.Diagnostics;
+
 namespace Beutl.FFmpegIpc.Providers;
 
 /// <summary>
@@ -33,6 +35,7 @@ internal sealed class PrefetchSlot<TKey, TValue>
     /// <summary>Arms the slot with an in-flight prefetch. The caller guarantees the slot is empty.</summary>
     public void Arm(TKey key, int bufferIndex, Task<TValue> task)
     {
+        Debug.Assert(_task is null, "PrefetchSlot armed while a prefetch was already in flight");
         _key = key;
         _bufferIndex = bufferIndex;
         _task = task;

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -234,6 +234,14 @@ public sealed class IpcConnection : IDisposable
     /// 多重化モードではIDベースルーティングを使い、並行リクエストを可能にする。
     /// 通常モードでは送信→受信をatomicに行い、レスポンスの混在を防ぐ。
     /// </summary>
+    /// <exception cref="System.OperationCanceledException">
+    /// <paramref name="ct"/> fired, or a host <c>CancelEncode</c> arriving in place of the expected response
+    /// surfaces as a cancellation (a cancel during an active encode is reported as cancellation rather than an
+    /// id mismatch).
+    /// </exception>
+    /// <exception cref="System.IO.IOException">The connection closed before a response was received.</exception>
+    /// <exception cref="FFmpegWorkerException">The worker reported an error in the response.</exception>
+    /// <exception cref="System.InvalidOperationException">The response id did not match the request id.</exception>
     public async ValueTask<IpcMessage> SendAndReceiveAsync(IpcMessage request, CancellationToken ct = default)
     {
         if (IsMultiplexed)
@@ -307,6 +315,9 @@ public sealed class IpcConnection : IDisposable
             ?? throw new InvalidOperationException($"Failed to deserialize response payload for {responseType}");
     }
 
+    // CancelEncode-as-cancellation is recognized only on the sequential SendAndReceiveAsync path, not here:
+    // the encode connection is never multiplexed (WorkerHost dispatches StartEncode sequentially), so a
+    // CancelEncode never arrives on this path.
     private async ValueTask<IpcMessage> SendAndReceiveMultiplexedAsync(IpcMessage request, CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();

--- a/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
+++ b/src/Beutl.FFmpegIpc/Transport/IpcConnection.cs
@@ -261,6 +261,14 @@ public sealed class IpcConnection : IDisposable
                 if (response.Error != null)
                     throw new FFmpegWorkerException(response.Error, response.ErrorStackTrace);
 
+                // CancelEncode is an out-of-band control message, not a reply to this request: during an
+                // active encode the host injects it with a fresh id while the worker is blocked here awaiting
+                // a frame/sample response, so it is read in place of that response and carries a non-matching
+                // id. Recognize it before the id-match check so a cancel surfaces as OperationCanceledException
+                // (which HandleStartAsync reports as "Cancelled") instead of "Response ID mismatch".
+                if (response.Type == MessageType.CancelEncode)
+                    throw new OperationCanceledException();
+
                 if (response.Id != request.Id)
                     throw new InvalidOperationException(
                         $"Response ID mismatch: expected {request.Id}, got {response.Id}");

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -245,6 +245,42 @@ public class IpcProviderContractTests
         }, ct);
     }
 
+    // Fake host that always answers the request for a specific frame index with an error response (so that
+    // frame's prefetch faults) and serves every other frame normally. Lets a test prove that draining a
+    // FAULTED stale prefetch after a seek discards the worker error instead of aborting the fresh request.
+    private static Task RunFrameErrorsOnIndexHost(
+        NamedPipeServerStream server, SharedMemoryBuffer[] buffers, long erroringFrameIndex, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var payload = req.GetPayload<RequestFrameMessage>()!;
+                if (payload.FrameIndex == erroringFrameIndex)
+                {
+                    await MessageSerializer.WriteMessageAsync(
+                        server, IpcMessage.CreateError(req.Id, "injected stale-prefetch failure"), ct);
+                    continue;
+                }
+
+                buffers[payload.BufferIndex].Write(BitConverter.GetBytes(payload.FrameIndex));
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideFrame, new ProvideFrameMessage
+                {
+                    Width = 1,
+                    Height = 1,
+                    BytesPerPixel = RgbaF16BytesPerPixel,
+                    DataLength = FrameDataLength,
+                    Premul = false,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
     private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout, string description)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -466,6 +502,43 @@ public class IpcProviderContractTests
             using Bitmap frame1 = await provider.RenderFrame(1);
             Assert.That(ReadFrameSignature(frame1), Is.EqualTo(1L),
                 "the retry recovers because the faulted prefetch was not pinned to the provider");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task RenderFrame_SeekAfterPrefetchFaulted_DiscardsStaleErrorAndReturnsRequestedFrame()
+    {
+        // RenderFrame(0) arms a prefetch of frame 1, which the host faults with a worker error. A seek to
+        // frame 5 must DRAIN that faulted stale prefetch, discard its error (the error belongs to the
+        // discarded frame 1), then issue a fresh RequestFrame{5} and return frame 5 — not abort the seek by
+        // re-throwing the stale prefetch's FFmpegWorkerException.
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunFrameErrorsOnIndexHost(server, buffers, erroringFrameIndex: 1, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // frameCount 6 makes frame 5 the last frame, so the recovered seek issues no further prefetch and
+        // nothing dangles into teardown.
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 6, frameRate: new Rational(30, 1));
+
+        try
+        {
+            using Bitmap frame0 = await provider.RenderFrame(0);
+            Assert.That(ReadFrameSignature(frame0), Is.EqualTo(0L), "frame 0 renders and arms the prefetch of frame 1");
+
+            // Wait until the prefetch actually faults so the seek drains an already-faulted stale task.
+            await WaitUntil(() => provider.IsPrefetchFaultedForTest(),
+                TimeSpan.FromSeconds(5), "the in-flight frame prefetch faults");
+
+            using Bitmap frame5 = await provider.RenderFrame(5);
+            Assert.That(ReadFrameSignature(frame5), Is.EqualTo(5L),
+                "the seek discards the faulted stale prefetch's worker error and returns the freshly requested frame 5");
         }
         finally
         {
@@ -808,6 +881,40 @@ public class IpcProviderContractTests
         }, ct);
     }
 
+    // Fake host that always answers the request for a specific chunk offset with an error response (so that
+    // chunk's prefetch faults) and serves every other chunk normally. Mirrors RunFrameErrorsOnIndexHost for
+    // the sample-side stale-prefetch-error drain.
+    private static Task RunSampleErrorsOnOffsetHost(
+        NamedPipeServerStream server, SharedMemoryBuffer[] buffers, long erroringOffset, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                var payload = req.GetPayload<RequestSampleMessage>()!;
+                if (payload.Offset == erroringOffset)
+                {
+                    await MessageSerializer.WriteMessageAsync(
+                        server, IpcMessage.CreateError(req.Id, "injected stale-prefetch failure"), ct);
+                    continue;
+                }
+
+                int numSamples = (int)payload.Length;
+                buffers[payload.BufferIndex].Write(BitConverter.GetBytes(payload.Offset));
+                var resp = IpcMessage.Create(req.Id, MessageType.ProvideSample, new ProvideSampleMessage
+                {
+                    NumSamples = numSamples,
+                    DataLength = numSamples * Stereo32BitFloatBytesPerSample,
+                });
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
     [TestCase(8 * Stereo32BitFloatBytesPerSample)]   // oversized: would overrun the native Pcm
     [TestCase(2 * Stereo32BitFloatBytesPerSample)]   // undersized vs NumSamples
     public async Task Sample_WhenWorkerReportsMismatchedDataLength_Throws(int dataLength)
@@ -889,6 +996,44 @@ public class IpcProviderContractTests
             using Pcm<Stereo32BitFloat> chunk1 = await provider.Sample(sampleRate, sampleRate);
             Assert.That(ReadSampleSignature(chunk1), Is.EqualTo(sampleRate),
                 "the retry recovers because the faulted prefetch was not pinned to the provider");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_SeekAfterPrefetchFaulted_DiscardsStaleErrorAndReturnsRequestedChunk()
+    {
+        // Consuming chunk 0 arms a prefetch of chunk 1 (offset == sampleRate), which the host faults with a
+        // worker error. A seek to chunk 3 (offset 3*sampleRate) must DRAIN that faulted stale prefetch,
+        // discard its error (it belongs to the discarded chunk 1), then issue a fresh RequestSample and
+        // return chunk 3 — not abort the seek by re-throwing the stale prefetch's FFmpegWorkerException.
+        const long sampleRate = 4;
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSampleErrorsOnOffsetHost(server, buffers, erroringOffset: sampleRate, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // sampleCount 16 == 4 chunks of 4. Chunk 0 arms the prefetch of chunk 1; the seek target chunk 3
+        // (offset 12) is the last chunk, so loading it arms no further prefetch and nothing dangles.
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 16, sampleRate: sampleRate);
+
+        try
+        {
+            using (Pcm<Stereo32BitFloat> chunk0 = await provider.Sample(0, sampleRate))
+                Assert.That(ReadSampleSignature(chunk0), Is.EqualTo(0L), "chunk 0 loads and arms the prefetch of chunk 1");
+
+            await WaitUntil(() => provider.IsPrefetchFaultedForTest(),
+                TimeSpan.FromSeconds(5), "the in-flight sample prefetch faults");
+
+            long seekOffset = 3 * sampleRate;
+            using Pcm<Stereo32BitFloat> chunk3 = await provider.Sample(seekOffset, sampleRate);
+            Assert.That(ReadSampleSignature(chunk3), Is.EqualTo(seekOffset),
+                "the seek discards the faulted stale prefetch's worker error and returns the freshly requested chunk 3");
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -110,6 +110,30 @@ public class IpcProviderContractTests
         }, ct);
     }
 
+    // Fake host that answers every request with CancelEncode carrying a FRESH id (not the request's id),
+    // reproducing how the real host injects cancellation mid-encode: FFmpegEncodingControllerProxy sends
+    // CancelEncode minted from connection.NextId(), so on the worker's non-multiplexed connection that
+    // message is read in place of the awaited ProvideFrame/ProvideSample response and carries a
+    // non-matching id. The worker-cancel path must surface this as a clean OperationCanceledException, not
+    // a "Response ID mismatch" (which HandleStartAsync would report as EncodeComplete{Error=...}).
+    private static Task RunFreshIdCancelingHost(NamedPipeServerStream server, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var req = await MessageSerializer.ReadMessageAsync(server, ct);
+                if (req == null)
+                    return;
+
+                // req.Id + 1_000_000 is guaranteed distinct from the in-flight request id, mirroring a
+                // CancelEncode minted from a separate id sequence on the host side.
+                var resp = IpcMessage.CreateSimple(req.Id + 1_000_000, MessageType.CancelEncode);
+                await MessageSerializer.WriteMessageAsync(server, resp, ct);
+            }
+        }, ct);
+    }
+
     // Fake host that replies to every request with one fixed ProvideFrame, so a test can drive the
     // provider's frame-validation guards with specific Width/Height/DataLength values.
     private static Task RunMalformedFrameHost(
@@ -604,6 +628,61 @@ public class IpcProviderContractTests
         {
             Assert.That(async () => await provider.Sample(0, 1024),
                 Throws.TypeOf<OperationCanceledException>());
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task RenderFrame_WhenHostCancelsWithFreshId_ThrowsOperationCanceled()
+    {
+        // Regression for the worker-side cancel-during-encode reporting bug: the host injects CancelEncode
+        // with a fresh id while the worker awaits a frame. Before the fix the id-match check turned this
+        // into InvalidOperationException("Response ID mismatch"), which HandleStartAsync mis-reported as
+        // EncodeComplete{Error='Response ID mismatch'} instead of a clean cancel. It must surface as
+        // OperationCanceledException so HandleStartAsync reports "Cancelled".
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunFreshIdCancelingHost(server, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcFrameProvider(conn, buffers, frameCount: 100, frameRate: new Rational(30, 1));
+
+        try
+        {
+            Assert.That(async () => await provider.RenderFrame(0),
+                Throws.TypeOf<OperationCanceledException>(),
+                "a CancelEncode with a fresh id must surface as a clean cancel, not 'Response ID mismatch'");
+        }
+        finally
+        {
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
+
+    [Test]
+    public async Task Sample_WhenHostCancelsWithFreshId_ThrowsOperationCanceled()
+    {
+        // Regression mirror of the frame-side test: a CancelEncode minted with a fresh id mid-encode must
+        // surface from the sample path as OperationCanceledException, not "Response ID mismatch".
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunFreshIdCancelingHost(server, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 48000, sampleRate: 48000);
+
+        try
+        {
+            Assert.That(async () => await provider.Sample(0, 1024),
+                Throws.TypeOf<OperationCanceledException>(),
+                "a CancelEncode with a fresh id must surface as a clean cancel, not 'Response ID mismatch'");
         }
         finally
         {

--- a/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
@@ -1,0 +1,132 @@
+using Beutl.FFmpegIpc.Providers;
+
+namespace Beutl.FFmpegIpc.Tests;
+
+/// <summary>
+/// Pins the seek/prefetch slot mechanics both IPC providers now share: a matching key consumes the armed
+/// prefetch, any other key drains it as stale, and detaching always clears the slot before the caller awaits.
+/// </summary>
+[TestFixture]
+public class PrefetchSlotTests
+{
+    [Test]
+    public void NewSlot_IsEmpty()
+    {
+        var slot = new PrefetchSlot<long, int>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slot.HasPrefetch, Is.False);
+            Assert.That(slot.IsFaulted, Is.False);
+            Assert.That(slot.Detach(), Is.Null);
+            Assert.That(slot.TryConsumeMatching(0, out _), Is.Null);
+            Assert.That(slot.TryDetachStale(0), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Arm_MarksSlotOccupied()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        slot.Arm(7, bufferIndex: 1, Task.FromResult(42));
+
+        Assert.That(slot.HasPrefetch, Is.True);
+    }
+
+    [Test]
+    public async Task TryConsumeMatching_OnMatchingKey_DetachesTaskAndBufferIndexAndClears()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        var task = Task.FromResult(42);
+        slot.Arm(7, bufferIndex: 1, task);
+
+        Task<int>? consumed = slot.TryConsumeMatching(7, out int bufferIndex);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(consumed, Is.SameAs(task));
+            Assert.That(bufferIndex, Is.EqualTo(1));
+            Assert.That(slot.HasPrefetch, Is.False, "a consumed slot is cleared");
+        });
+        Assert.That(await consumed!, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void TryConsumeMatching_OnDifferentKey_ReturnsNullAndLeavesSlotArmed()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        slot.Arm(7, bufferIndex: 1, Task.FromResult(42));
+
+        Task<int>? consumed = slot.TryConsumeMatching(8, out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(consumed, Is.Null);
+            Assert.That(slot.HasPrefetch, Is.True, "a non-matching consume must not drop the armed prefetch");
+        });
+    }
+
+    [Test]
+    public void TryDetachStale_OnDifferentKey_DetachesTaskAndClears()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        var task = Task.FromResult(42);
+        slot.Arm(7, bufferIndex: 1, task);
+
+        Task<int>? stale = slot.TryDetachStale(8);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stale, Is.SameAs(task));
+            Assert.That(slot.HasPrefetch, Is.False, "a drained stale slot is cleared");
+        });
+    }
+
+    [Test]
+    public void TryDetachStale_OnMatchingKey_ReturnsNullAndLeavesSlotArmed()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        slot.Arm(7, bufferIndex: 1, Task.FromResult(42));
+
+        Task<int>? stale = slot.TryDetachStale(7);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stale, Is.Null, "a matching key is a hit, not stale");
+            Assert.That(slot.HasPrefetch, Is.True);
+        });
+    }
+
+    [Test]
+    public void Detach_ReturnsArmedTaskAndClears()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        var task = Task.FromResult(42);
+        slot.Arm(7, bufferIndex: 1, task);
+
+        Task<int>? detached = slot.Detach();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(detached, Is.SameAs(task));
+            Assert.That(slot.HasPrefetch, Is.False);
+            Assert.That(slot.Detach(), Is.Null, "a second detach is a no-op");
+        });
+    }
+
+    [Test]
+    public async Task IsFaulted_ReflectsArmedTaskFaultState()
+    {
+        var slot = new PrefetchSlot<long, int>();
+        var tcs = new TaskCompletionSource<int>();
+        slot.Arm(7, bufferIndex: 0, tcs.Task);
+
+        Assert.That(slot.IsFaulted, Is.False, "a pending prefetch is not faulted");
+
+        tcs.SetException(new InvalidOperationException("boom"));
+        // Observe the fault so it does not surface as an UnobservedTaskException at GC.
+        try { await tcs.Task; } catch (InvalidOperationException) { }
+
+        Assert.That(slot.IsFaulted, Is.True, "a faulted prefetch reports IsFaulted");
+    }
+}

--- a/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
@@ -1,4 +1,4 @@
-using Beutl.FFmpegIpc.Providers;
+﻿using Beutl.FFmpegIpc.Providers;
 
 namespace Beutl.FFmpegIpc.Tests;
 

--- a/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/PrefetchSlotTests.cs
@@ -34,6 +34,22 @@ public class PrefetchSlotTests
     }
 
     [Test]
+    public void Arm_WhenAlreadyArmed_Throws()
+    {
+        // Overwriting an armed prefetch would strand its undrained IPC response, so a double-arm must fail
+        // loudly in every build config (a runtime throw, not a Debug.Assert compiled out in Release).
+        var slot = new PrefetchSlot<long, int>();
+        slot.Arm(7, bufferIndex: 1, Task.FromResult(42));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => slot.Arm(8, bufferIndex: 0, Task.FromResult(99)),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(slot.HasPrefetch, Is.True, "the rejected re-arm must leave the original prefetch intact");
+        });
+    }
+
+    [Test]
     public async Task TryConsumeMatching_OnMatchingKey_DetachesTaskAndBufferIndexAndClears()
     {
         var slot = new PrefetchSlot<long, int>();


### PR DESCRIPTION
## Summary

Fixes a worker-side cancellation-reporting bug and removes the duplication that surfaced it, all within the MIT `Beutl.FFmpegIpc` layer.

## The bug (fix)

The worker's `IpcConnection` is non-multiplexed, and during an active encode the provider's `SendAndReceiveAsync` is the only pipe reader. The host injects `CancelEncode` with a **fresh id** (`FFmpegEncodingControllerProxy` via `NextId()`), so it arrives in place of the awaited frame/sample response, fails the response-id-match check, and was thrown as `InvalidOperationException("Response ID mismatch")` — which `EncodingHandler.HandleStartAsync` then reported as `EncodeComplete{Error="Response ID mismatch"}` instead of a clean cancel. (User-visible cancel still worked because the host throws `OperationCanceledException` on its side, so impact was cosmetic/misleading worker-side reporting.)

**Fix:** `IpcConnection.SendAndReceiveAsync` now recognizes a `CancelEncode` message **before** the id-match check and throws `OperationCanceledException`, so a mid-encode cancel surfaces as `EncodeComplete{Error="Cancelled"}`. The now-dead `CancelEncode` branches in both providers are removed.

## The refactor

Extracted the hand-duplicated double-buffer prefetch/seek state machine from `IpcFrameProvider` and `IpcSampleProvider` into a new `internal PrefetchSlot<TKey, TValue>` (`Providers/PrefetchSlot.cs`) — arm a prefetch, consume it on a matching key, drain the stale one on a mismatch — and unified both providers onto it.

## Tests

- **Red-baseline regression tests** (`IpcProviderContractTests`): `RenderFrame`/`Sample` when the host cancels with a fresh id — these fail against the unmodified code (`InvalidOperationException`) and pass after the fix (`OperationCanceledException`).
- **`PrefetchSlotTests`** (8): pin the consume/drain/detach behavior.
- Full `Beutl.FFmpegIpc.Tests` suite: **46/46 green**; the GPL worker builds against the unchanged public provider constructors.

## Scope note

The board item also proposed an `IIpcConnection` seam (part 1). It was **deliberately scoped out**: the providers are already MIT-side and unit-tested via a real-pipe fake-host harness (PR #2012), so a consumer-less interface would be a speculative abstraction (and is cheap to extract later, internally, when a real consumer appears). The two reviewers concurred.

## Review notes

Reviewed by `@beutl-design-reviewer` and `@beutl-reviewer` — both approve, no blocking findings. GPL/MIT boundary clean (all changes in MIT `Beutl.FFmpegIpc`, no new `ProjectReference`, provider ctors unchanged so the GPL worker still builds). The cancel recognition is correct and carries **no false-cancel risk** (`CancelEncode` is never a legitimate reply to a frame/sample request). Not a breaking API change (no public signature changed; the only observable change is the exception type in a previously-broken scenario), so `fix:` not `fix!:`. Design-review polish applied before opening: `<exception>` XML docs on `SendAndReceiveAsync`, a note on the multiplexed path explaining the deliberate non-multiplexed-only cancel recognition, and a throwing empty-slot guard on `PrefetchSlot.Arm` (it throws `InvalidOperationException` if armed while a prefetch is already in flight — active in all build configurations, not compiled out in Release — covered by `Arm_WhenAlreadyArmed_Throws`).

**Left for human merge** by `/beutl-loop`: this is a larger diff (~405 LOC, 6 files) that changes a public method's exception contract in the encode/IPC-critical path — above the loop's auto-merge size/sensitivity threshold, so a human makes the final call.

---

Board item: Project #9 — *Refactor: extract IpcConnection seam + shared prefetch state-machine; fix CancelEncode-as-id-mismatch reporting*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so interrupted frame and audio requests now stop cleanly with cancellation rather than a response-id mismatch.
  * Enhanced prefetch reliability so stale in-flight prefetch failures are discarded after seeks/rapid changes, allowing the requested frame or chunk to succeed.
* **Tests**
  * Added regression tests covering fresh-id cancellation behavior and ensuring seek after a prefetched failure returns the correct requested output.
  * Expanded coverage for prefetch-slot state transitions and fault handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
