### PR TITLE
feat(ui): show unit suffixes on CreateNewProject numeric inputs

### DIFF
--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -36,13 +36,34 @@
             </StackPanel>
             <StackPanel Spacing="8">
                 <TextBlock Text="{x:Static lang:Strings.Size}" />
-                <TextBox Text="{CompiledBinding Size.Value, Mode=TwoWay, Converter={x:Static converters:AvaloniaPixelSizeConverter.Instance}}" />
+                <TextBox Text="{CompiledBinding Size.Value, Mode=TwoWay, Converter={x:Static converters:AvaloniaPixelSizeConverter.Instance}}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Margin="0,0,8,0"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="px" />
+                    </TextBox.InnerRightContent>
+                </TextBox>
 
                 <TextBlock Margin="0,8,0,0" Text="{x:Static lang:Strings.FrameRate}" />
-                <TextBox Text="{CompiledBinding FrameRate.Value, Mode=TwoWay}" />
+                <TextBox Text="{CompiledBinding FrameRate.Value, Mode=TwoWay}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Margin="0,0,8,0"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="fps" />
+                    </TextBox.InnerRightContent>
+                </TextBox>
 
                 <TextBlock Margin="0,8,0,0" Text="{x:Static lang:Strings.SampleRate}" />
-                <TextBox Text="{CompiledBinding SampleRate.Value, Mode=TwoWay}" />
+                <TextBox Text="{CompiledBinding SampleRate.Value, Mode=TwoWay}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Margin="0,0,8,0"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="Hz" />
+                    </TextBox.InnerRightContent>
+                </TextBox>
             </StackPanel>
         </Carousel.Items>
     </Carousel>

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -11,6 +11,7 @@
                   Title="{x:Static lang:Strings.CreateNewProject}"
                   d:DesignHeight="450"
                   d:DesignWidth="800"
+                  x:CompileBindings="True"
                   x:DataType="vm:CreateNewProjectViewModel"
                   CloseButtonText="{x:Static lang:Strings.Close}"
                   DefaultButton="Secondary"

--- a/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
+++ b/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
@@ -1,0 +1,67 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.Dialogs;
+using Beutl.Views.Dialogs;
+
+namespace Beutl.HeadlessUITests;
+
+// Inflates the real CreateNewProject dialog (src/Beutl) headlessly to characterize the unit-suffix
+// hints on its numeric inputs. The dialog's Carousel virtualizes, so the numeric page is realized
+// only after selecting it; the page transition is cleared to realize it deterministically.
+[TestFixture]
+public class CreateNewProjectDialogTests
+{
+    [AvaloniaTest]
+    public void NumericInputs_show_unit_suffixes()
+    {
+        var vm = new CreateNewProjectViewModel(new ProjectService());
+        var dialog = new CreateNewProject { DataContext = vm };
+        var window = new Window { Content = dialog, Width = 800, Height = 600 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Carousel carousel = HeadlessTestHelpers.FindDescendant<Carousel>(dialog)!;
+            Assert.That(carousel, Is.Not.Null, "dialog should host the wizard Carousel");
+
+            carousel.PageTransition = null;
+            carousel.SelectedIndex = 1;
+            HeadlessTestHelpers.Render();
+
+            List<string> units = CollectDescendants<TextBox>(dialog)
+                .Select(tb => (tb.InnerRightContent as TextBlock)?.Text)
+                .Where(text => text is not null)
+                .ToList()!;
+
+            Assert.That(units, Is.EqualTo(new[] { "px", "fps", "Hz" }),
+                "Size, FrameRate and SampleRate inputs should carry their unit suffixes in order");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static IEnumerable<T> CollectDescendants<T>(Avalonia.Visual root)
+        where T : Avalonia.Visual
+    {
+        foreach (Avalonia.Visual child in root.GetVisualChildren())
+        {
+            if (child is T match)
+            {
+                yield return match;
+            }
+
+            foreach (T descendant in CollectDescendants<T>(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
+++ b/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
@@ -1,16 +1,16 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
-using Avalonia.VisualTree;
+
 using Beutl.Services;
-using Beutl.Testing.Headless;
 using Beutl.ViewModels.Dialogs;
 using Beutl.Views.Dialogs;
 
 namespace Beutl.HeadlessUITests;
 
-// Inflates the real CreateNewProject dialog (src/Beutl) headlessly to characterize the unit-suffix
-// hints on its numeric inputs. The dialog's Carousel virtualizes, so the numeric page is realized
-// only after selecting it; the page transition is cleared to realize it deterministically.
+// Reads the logical content tree rather than showing the dialog: a ContentDialog not opened via
+// ShowAsync keeps its content collapsed (close animation sets LayoutRoot IsVisible=False), so the
+// Carousel pages are never realized in the visual tree. The unit suffixes are static XAML
+// InnerRightContent labels, which exist in the logical tree at construction without any rendering.
 [TestFixture]
 public class CreateNewProjectDialogTests
 {
@@ -19,49 +19,19 @@ public class CreateNewProjectDialogTests
     {
         var vm = new CreateNewProjectViewModel(new ProjectService());
         var dialog = new CreateNewProject { DataContext = vm };
-        var window = new Window { Content = dialog, Width = 800, Height = 600 };
 
-        try
-        {
-            window.Show();
-            HeadlessTestHelpers.Render();
+        var carousel = dialog.Content as Carousel;
+        Assert.That(carousel, Is.Not.Null, "dialog should host the wizard Carousel as its content");
 
-            Carousel carousel = HeadlessTestHelpers.FindDescendant<Carousel>(dialog)!;
-            Assert.That(carousel, Is.Not.Null, "dialog should host the wizard Carousel");
+        // Page 0 is Name/Location; page 1 hosts the Size/FrameRate/SampleRate numeric inputs.
+        var numericPage = carousel!.Items[1] as Panel;
+        Assert.That(numericPage, Is.Not.Null, "the second Carousel page should host the numeric inputs");
 
-            carousel.PageTransition = null;
-            carousel.SelectedIndex = 1;
-            HeadlessTestHelpers.Render();
+        List<string?> units = numericPage!.Children.OfType<TextBox>()
+            .Select(tb => (tb.InnerRightContent as TextBlock)?.Text)
+            .ToList();
 
-            List<string> units = CollectDescendants<TextBox>(dialog)
-                .Select(tb => (tb.InnerRightContent as TextBlock)?.Text)
-                .Where(text => text is not null)
-                .ToList()!;
-
-            Assert.That(units, Is.EqualTo(new[] { "px", "fps", "Hz" }),
-                "Size, FrameRate and SampleRate inputs should carry their unit suffixes in order");
-        }
-        finally
-        {
-            window.Close();
-            HeadlessTestHelpers.Settle();
-        }
-    }
-
-    private static IEnumerable<T> CollectDescendants<T>(Avalonia.Visual root)
-        where T : Avalonia.Visual
-    {
-        foreach (Avalonia.Visual child in root.GetVisualChildren())
-        {
-            if (child is T match)
-            {
-                yield return match;
-            }
-
-            foreach (T descendant in CollectDescendants<T>(child))
-            {
-                yield return descendant;
-            }
-        }
+        Assert.That(units, Is.EqualTo(new[] { "px", "fps", "Hz" }),
+            "Size, FrameRate and SampleRate inputs should carry their unit suffixes in order");
     }
 }


### PR DESCRIPTION
## Summary

The `CreateNewProject` dialog's numeric inputs (Size, FrameRate, SampleRate) were plain TextBoxes with no unit indication. This adds inline unit suffixes (px / fps / Hz) so the expected unit is always visible.

## Change

- **`src/Beutl/Views/Dialogs/CreateNewProject.axaml`**:
  - Added unit-symbol suffixes (`px`, `fps`, `Hz`) to the Size / FrameRate / SampleRate inputs via `TextBox.InnerRightContent` (mirroring the existing Location picker's `InnerRightContent` usage). Purely additive chrome — static text, no bindings, no effect on input or the existing TwoWay/validation bindings.
  - Added `x:CompileBindings="True"` to the ContentDialog root (it declared `x:DataType` and uses `{CompiledBinding}` exclusively, so this enforces compiled bindings without changing behavior).
- **`tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs`** — NEW: asserts the three numeric inputs carry their unit suffixes in order, against the dialog's **logical content tree** (`Content` → `Carousel` → numeric page → `TextBox.InnerRightContent`), with no `Show()`/render/animation dependency. Red against the unmodified XAML (no unit labels) → green after.

## Scope note

The board item proposed five enhancements (numeric-only editors, units, input examples, validation messages, a Carousel step indicator) across both dialogs. This ships the single genuinely-missing, always-visible piece — **unit display** on `CreateNewProject`. A probe confirmed **validation-message display already works** (Avalonia data validation surfaces the ViewModels' `INotifyDataErrorInfo` errors, and both VMs already have full validation + a `CanCreate` gate), so that part was a near-false-positive. Out of scope (follow-up): the same unit treatment for `CreateNewScene`, numeric-only editors, input-example watermarks (low value — fields are pre-populated), and the Carousel step indicator.

## Test plan

`dotnet test tests/Beutl.HeadlessUITests --filter CreateNewProjectDialogTests` — green; verified red against the pre-feature XAML.

## Review notes

Reviewed by `@beutl-reviewer` and `@beutl-xaml-binder` — both approve after rework. Two blocking findings were resolved before opening: (1) the ContentDialog was missing `x:CompileBindings`; (2) the test originally walked the realized visual tree of an un-shown `ContentDialog`, which is fragile (a `ContentDialog` keeps its content collapsed until `ShowAsync`), so it now asserts the logical content tree deterministically.

---

Board item: Project #9 — *新規作成ダイアログの入力支援とバリデーション表示を強化する*. Opened autonomously by `/beutl-loop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the new project dialog to show unit labels for size, frame rate, and sample rate fields.
  * Improved input handling in the dialog with compiled bindings enabled.

* **Tests**
  * Added automated UI coverage to confirm the unit labels appear in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->