### PR TITLE
test(encoding): add FFmpeg-native cancellation regression test for FFmpegEncodingController

### DIFF
--- a/.claude/scripts/check-gpl-mit-boundary-diff.sh
+++ b/.claude/scripts/check-gpl-mit-boundary-diff.sh
@@ -18,7 +18,9 @@
 # <Compile Include>, is forbidden.
 # Also exempts tests/Beutl.FFmpegBenchmarks — a BenchmarkDotNet project that
 # intentionally link-compiles worker source files for direct-call benchmarking
-# (not shipped in the MIT app).
+# (not shipped in the MIT app) — and tests/Beutl.FFmpegWorker.Tests, a
+# non-distributed (IsPackable=false) GPL-side NUnit project that source-links the
+# worker's FFmpeg encoding types under BEUTL_FFMPEG_WORKER for the same reason.
 #
 # Used by: beutl-pre-pr (step 2, --files mode), beutl-loop (step 2.5a, two-ref mode).
 set -euo pipefail
@@ -88,6 +90,11 @@ for f in $CHANGED; do
   case "$f" in
     */Beutl.FFmpegWorker/*|*/Beutl.FFmpegWorker.csproj) continue ;;
     */Beutl.FFmpegBenchmarks/*|*/Beutl.FFmpegBenchmarks.csproj) continue ;;
+    # tests/Beutl.FFmpegWorker.Tests is a non-distributed (IsPackable=false) GPL-side NUnit
+    # test project that source-links the worker's FFmpeg encoding types under BEUTL_FFMPEG_WORKER
+    # — the same firewall pattern as Beutl.FFmpegBenchmarks (no ProjectReference to the worker; the
+    # GPL code stays confined to this never-shipped test assembly), so the boundary is not crossed.
+    */Beutl.FFmpegWorker.Tests/*|*/Beutl.FFmpegWorker.Tests.csproj) continue ;;
   esac
 
   # Flatten the file so multi-line MSBuild elements are caught.

--- a/.claude/scripts/check-gpl-mit-boundary-diff.sh
+++ b/.claude/scripts/check-gpl-mit-boundary-diff.sh
@@ -16,11 +16,11 @@
 # carry a build-order-only <ProjectReference ... ReferenceOutputAssembly="false" />
 # (paired with its CopyFFmpegWorkerForApp target). Every other project, and any
 # <Compile Include>, is forbidden.
-# Also exempts tests/Beutl.FFmpegBenchmarks — a BenchmarkDotNet project that
-# intentionally link-compiles worker source files for direct-call benchmarking
-# (not shipped in the MIT app) — and tests/Beutl.FFmpegWorker.Tests, a
-# non-distributed (IsPackable=false) GPL-side NUnit project that source-links the
-# worker's FFmpeg encoding types under BEUTL_FFMPEG_WORKER for the same reason.
+# tests/Beutl.FFmpegBenchmarks (a BenchmarkDotNet project) and tests/Beutl.FFmpegWorker.Tests (a
+# non-distributed IsPackable=false NUnit project) intentionally source-link worker files under
+# BEUTL_FFMPEG_WORKER for direct-call benchmarking/testing (not shipped in the MIT app), so their
+# <Compile Include> of worker files is allowed. A <ProjectReference> to the worker is still forbidden
+# in them — the exemption covers only the source-link form, never a project dependency.
 #
 # Used by: beutl-pre-pr (step 2, --files mode), beutl-loop (step 2.5a, two-ref mode).
 set -euo pipefail
@@ -83,25 +83,28 @@ for f in $CHANGED; do
     fi
   fi
 
-  # The worker project itself ships FFmpegWorker linkages freely.
-  # tests/Beutl.FFmpegBenchmarks intentionally link-compiles worker source files for
-  # direct-call benchmarking (see its .csproj comments) — it is a BenchmarkDotNet
-  # project, not shipped in the MIT app, so the GPL boundary is not crossed.
+  # The worker project itself ships FFmpegWorker linkages freely, so skip it entirely.
+  # Beutl.FFmpegBenchmarks and Beutl.FFmpegWorker.Tests are non-shipped GPL-side projects that
+  # intentionally source-link worker files via <Compile Include> under BEUTL_FFMPEG_WORKER; allow
+  # that form for them (allow_compile_link) but still run the <ProjectReference> check below, so the
+  # exemption can never silently widen into a forbidden worker project dependency.
+  allow_compile_link=0
   case "$f" in
     */Beutl.FFmpegWorker/*|*/Beutl.FFmpegWorker.csproj) continue ;;
-    */Beutl.FFmpegBenchmarks/*|*/Beutl.FFmpegBenchmarks.csproj) continue ;;
-    # tests/Beutl.FFmpegWorker.Tests is a non-distributed (IsPackable=false) GPL-side NUnit
-    # test project that source-links the worker's FFmpeg encoding types under BEUTL_FFMPEG_WORKER
-    # — the same firewall pattern as Beutl.FFmpegBenchmarks (no ProjectReference to the worker; the
-    # GPL code stays confined to this never-shipped test assembly), so the boundary is not crossed.
-    */Beutl.FFmpegWorker.Tests/*|*/Beutl.FFmpegWorker.Tests.csproj) continue ;;
+    */Beutl.FFmpegBenchmarks/*|*/Beutl.FFmpegBenchmarks.csproj) allow_compile_link=1 ;;
+    */Beutl.FFmpegWorker.Tests/*|*/Beutl.FFmpegWorker.Tests.csproj) allow_compile_link=1 ;;
   esac
 
   # Flatten the file so multi-line MSBuild elements are caught.
   flat=$(printf '%s' "$content" | tr '\n' ' ')
 
-  # <Compile Include="...FFmpegWorker..."> is always forbidden outside the worker.
-  compile_hit=$(printf '%s' "$flat" | grep -oE '<Compile[^>]*Beutl\.FFmpegWorker' || true)
+  # <Compile Include="...FFmpegWorker..."> is forbidden outside the worker and the two sanctioned
+  # source-linking consumers above.
+  if [ "$allow_compile_link" = "1" ]; then
+    compile_hit=""
+  else
+    compile_hit=$(printf '%s' "$flat" | grep -oE '<Compile[^>]*Beutl\.FFmpegWorker' || true)
+  fi
 
   # <ProjectReference> to FFmpegWorker: allow the sanctioned build-order-only
   # form (ReferenceOutputAssembly="false") ONLY in src/Beutl/Beutl.csproj.

--- a/Beutl.slnx
+++ b/Beutl.slnx
@@ -31,6 +31,7 @@
     <Project Path="tests\Beutl.Extensions.MediaFoundation.Tests\Beutl.Extensions.MediaFoundation.Tests.csproj" />
     <Project Path="tests\Beutl.FFmpegBenchmarks\Beutl.FFmpegBenchmarks.csproj" />
     <Project Path="tests\Beutl.FFmpegIpc.Tests\Beutl.FFmpegIpc.Tests.csproj" />
+    <Project Path="tests\Beutl.FFmpegWorker.Tests\Beutl.FFmpegWorker.Tests.csproj" />
     <Project Path="tests\Beutl.UnitTests\Beutl.UnitTests.csproj" />
     <Project Path="tests\Beutl.E2ETests\Beutl.E2ETests.csproj" />
     <Project Path="tests\Beutl.HeadlessUITests\Beutl.HeadlessUITests.csproj" />

--- a/src/Beutl.Core/Properties/AssemblyInfo.cs
+++ b/src/Beutl.Core/Properties/AssemblyInfo.cs
@@ -11,3 +11,4 @@
 [assembly: InternalsVisibleTo("Beutl.Api")]
 [assembly: InternalsVisibleTo("Beutl.NodeGraph")]
 [assembly: InternalsVisibleTo("Beutl.FFmpegWorker")]
+[assembly: InternalsVisibleTo("Beutl.FFmpegWorker.Tests")]

--- a/tests/Beutl.FFmpegWorker.Tests/Beutl.FFmpegWorker.Tests.csproj
+++ b/tests/Beutl.FFmpegWorker.Tests/Beutl.FFmpegWorker.Tests.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    GPL-side, non-distributed NUnit test project. It reaches the GPL worker's FFmpeg-calling
+    encoding types by SOURCE-LINKING them (never a ProjectReference to Beutl.FFmpegWorker), the
+    same firewall-preserving pattern Beutl.FFmpegBenchmarks uses for the decoding side: the linked
+    files compile under BEUTL_FFMPEG_WORKER into this test assembly, which is IsPackable=false and
+    never ships, so the MIT compile closure stays free of the GPL worker. The FFmpeg-native tests
+    self-skip (Assert.Ignore) when the FFmpeg shared libraries are not present.
+  -->
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);BEUTL_FFMPEG_WORKER;FFMPEG_BUILD_IN</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="FFmpeg.AutoGen.Bindings.DynamicallyLoaded" />
+    <PackageReference Include="FFmpeg4Sharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Beutl.Core\Beutl.Core.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.FFmpegIpc\Beutl.FFmpegIpc.csproj" />
+  </ItemGroup>
+
+  <!-- Worker-side FFmpeg-calling encoding types (direct in-process, GPL originals). -->
+  <ItemGroup>
+    <Compile Include="..\..\src\Beutl.FFmpegWorker\Encoding\FFmpegEncodingController.cs" Link="Linked\FFmpegEncodingController.cs" />
+    <Compile Include="..\..\src\Beutl.FFmpegWorker\ColorSpaceHelper.cs" Link="Linked\ColorSpaceHelper.cs" />
+    <Compile Include="..\..\src\Beutl.FFmpegWorker\FFmpegLoaderWorker.cs" Link="Linked\FFmpegLoaderWorker.cs" />
+    <Compile Include="..\..\src\Beutl.FFmpegWorker\WorkerLog.cs" Link="Linked\WorkerLog.cs" />
+  </ItemGroup>
+
+  <!-- Settings/record types shared with the MIT extension (compiled here under BEUTL_FFMPEG_WORKER). -->
+  <ItemGroup>
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Encoding\CodecRecord.cs" Link="Linked\CodecRecord.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Encoding\FFmpegEncodingSettings.cs" Link="Linked\FFmpegEncodingSettings.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Encoding\FFmpegVideoEncoderSettings.cs" Link="Linked\FFmpegVideoEncoderSettings.cs" />
+    <Compile Include="..\..\src\Beutl.Extensions.FFmpeg\Encoding\FFmpegAudioEncoderSettings.cs" Link="Linked\FFmpegAudioEncoderSettings.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -1,0 +1,177 @@
+﻿using Beutl.Extensibility;
+using Beutl.FFmpegIpc;
+using Beutl.FFmpegWorker.Encoding;
+using Beutl.Media;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+
+namespace Beutl.FFmpegWorker.Tests;
+
+// A cancelled Encode must throw OperationCanceledException (both callers already catch it). This
+// pins the shared contract on the FFmpeg-native backend: FFmpegEncodingController got the identical
+// cancellationToken.ThrowIfCancellationRequested() fix as AVFEncodingController (PR #1894) but had
+// no test of its own. Unlike AVFoundation (macOS-only), FFmpeg runs wherever its native libraries
+// are present, so this fixture guards on native availability (Assert.Ignore) rather than a fixed
+// [Platform]: it exercises the real cancellation path where FFmpeg is installed and self-skips
+// where it is not.
+[TestFixture]
+public class EncodingCancellationTests
+{
+    // FFmpegLoaderWorker.Initialize() throws FFmpegLibrariesNotFoundException (or another native-load
+    // error) when the shared libraries are absent. Probe once; the FFmpeg-native tests self-skip if
+    // the natives cannot be loaded on this machine.
+    private static readonly Lazy<bool> s_ffmpegAvailable = new(() =>
+    {
+        try
+        {
+            FFmpegLoaderWorker.Initialize();
+            return true;
+        }
+        catch (FFmpegLibrariesNotFoundException)
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            // A bad architecture / missing transitive dependency also means the FFmpeg-native path
+            // cannot run here — self-skip rather than fail the suite on machines without FFmpeg.
+            return false;
+        }
+    });
+
+    private string _workDir = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), "beutl-ffmpeg-cancel-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_workDir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Test]
+    public void EncodeSurfacesCancellationAsOperationCanceledException()
+    {
+        if (!s_ffmpegAvailable.Value)
+        {
+            Assert.Ignore("FFmpeg native libraries are not available; skipping FFmpeg-native cancellation test.");
+        }
+
+        string outputPath = Path.Combine(_workDir, "cancelled.mp4");
+        var controller = new FFmpegEncodingController(outputPath, new FFmpegEncodingSettings());
+
+        const int width = 64;
+        const int height = 64;
+        const int sampleRate = 44100;
+        const int frameCount = 30;
+        const int frameRateNum = 30;
+        const int frameRateDen = 1;
+
+        controller.VideoSettings.DestinationSize = new PixelSize(width, height);
+        controller.VideoSettings.SourceSize = new PixelSize(width, height);
+        controller.VideoSettings.FrameRate = new Rational(frameRateNum, frameRateDen);
+
+        controller.AudioSettings.SampleRate = sampleRate;
+        controller.AudioSettings.Channels = 2;
+
+        using var cts = new CancellationTokenSource();
+        // Cancel mid-clip (after one frame) so the controller exits its loop on cancellation and
+        // reaches the ThrowIfCancellationRequested() guard rather than completing the encode.
+        var frameProvider = new CancelAfterFirstFrameProvider(
+            cts, frameCount, new Rational(frameRateNum, frameRateDen), width, height);
+        var sampleProvider = new SineSampleProvider(sampleRate, sampleRate);
+
+        Assert.That(
+            async () => await controller.Encode(frameProvider, sampleProvider, cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    // Cancels the token right after the first frame, so the loop's next iteration sees cancellation.
+    private sealed class CancelAfterFirstFrameProvider(
+        CancellationTokenSource cts, long frameCount, Rational frameRate, int width, int height)
+        : IFrameProvider
+    {
+        private readonly GradientFrameProvider _inner = new(frameCount, frameRate, width, height);
+
+        public long FrameCount => _inner.FrameCount;
+
+        public Rational FrameRate => _inner.FrameRate;
+
+        public async ValueTask<Bitmap> RenderFrame(long frame)
+        {
+            Bitmap bitmap = await _inner.RenderFrame(frame);
+            cts.Cancel();
+            return bitmap;
+        }
+
+        public void Dispose() => _inner.Dispose();
+    }
+
+    // Deterministic 64x64 BGRA gradient per frame — a minimal valid frame source for the encoder.
+    private sealed class GradientFrameProvider(long frameCount, Rational frameRate, int width, int height)
+        : IFrameProvider
+    {
+        public long FrameCount { get; } = frameCount;
+
+        public Rational FrameRate { get; } = frameRate;
+
+        public ValueTask<Bitmap> RenderFrame(long frame)
+        {
+            var bitmap = new Bitmap(width, height);
+            unsafe
+            {
+                byte* pixels = (byte*)bitmap.Data;
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        int i = (y * bitmap.RowBytes) + (x * 4);
+                        pixels[i + 0] = (byte)(x * 4 & 0xFF);       // B
+                        pixels[i + 1] = (byte)(y * 4 & 0xFF);       // G
+                        pixels[i + 2] = (byte)((frame * 8) & 0xFF); // R varies per frame
+                        pixels[i + 3] = 0xFF;                       // A
+                    }
+                }
+            }
+            return ValueTask.FromResult(bitmap);
+        }
+
+        public void Dispose()
+        {
+            // Stateless test double — no prefetch or owned resources to drain.
+        }
+    }
+
+    // 440 Hz sine wave, Stereo 32-bit float interleaved.
+    private sealed class SineSampleProvider(long sampleCount, long sampleRate) : ISampleProvider
+    {
+        public long SampleCount { get; } = sampleCount;
+
+        public long SampleRate { get; } = sampleRate;
+
+        public ValueTask<Pcm<Stereo32BitFloat>> Sample(long offset, long length)
+        {
+            var pcm = new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
+            var span = pcm.DataSpan;
+            const float frequency = 440f;
+            float twoPiFOverSr = 2f * MathF.PI * frequency / SampleRate;
+            for (int i = 0; i < length; i++)
+            {
+                float t = MathF.Sin((offset + i) * twoPiFOverSr) * 0.25f;
+                span[i] = new Stereo32BitFloat(t, t);
+            }
+            return ValueTask.FromResult(pcm);
+        }
+
+        public void Dispose()
+        {
+            // Stateless test double — no prefetch or owned resources to drain.
+        }
+    }
+}

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -7,13 +7,9 @@ using Beutl.Media.Music.Samples;
 
 namespace Beutl.FFmpegWorker.Tests;
 
-// A cancelled Encode must throw OperationCanceledException (both callers already catch it). This
-// pins the shared contract on the FFmpeg-native backend: FFmpegEncodingController got the identical
-// cancellationToken.ThrowIfCancellationRequested() fix as AVFEncodingController (PR #1894) but had
-// no test of its own. Unlike AVFoundation (macOS-only), FFmpeg runs wherever its native libraries
-// are present, so this fixture guards on native availability (Assert.Ignore) rather than a fixed
-// [Platform]: it exercises the real cancellation path where FFmpeg is installed and self-skips
-// where it is not.
+// A cancelled Encode must throw OperationCanceledException. FFmpeg runs wherever its native
+// libraries are present, so this fixture guards on native availability (Assert.Ignore) rather than
+// a fixed [Platform].
 [TestFixture]
 public class EncodingCancellationTests
 {
@@ -93,7 +89,6 @@ public class EncodingCancellationTests
             Throws.InstanceOf<OperationCanceledException>());
     }
 
-    // Cancels the token right after the first frame, so the loop's next iteration sees cancellation.
     private sealed class CancelAfterFirstFrameProvider(
         CancellationTokenSource cts, long frameCount, Rational frameRate, int width, int height)
         : IFrameProvider

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -1,9 +1,12 @@
 ﻿using Beutl.Extensibility;
 using Beutl.FFmpegIpc;
 using Beutl.FFmpegWorker.Encoding;
+using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Music;
 using Beutl.Media.Music.Samples;
+using FFmpeg.AutoGen.Abstractions;
+using FFmpegSharp;
 
 namespace Beutl.FFmpegWorker.Tests;
 
@@ -21,7 +24,16 @@ public class EncodingCancellationTests
         try
         {
             FFmpegLoaderWorker.Initialize();
-            return true;
+
+            // Loading the libraries is not enough: the .mp4 cancellation path drives
+            // MediaCodec.FindEncoder for the container's default video+audio codecs, so a build that
+            // loads the libs but lacks those encoders would fail during stream setup instead of
+            // exercising cancellation. Require the same codecs GuessFormat(".mp4") selects.
+            OutputFormat outFormat = OutputFormat.GuessFormat(null, "probe.mp4", null);
+            return (outFormat.VideoCodec == AVCodecID.AV_CODEC_ID_NONE
+                    || MediaCodec.FindEncoder(outFormat.VideoCodec) != null)
+                && (outFormat.AudioCodec == AVCodecID.AV_CODEC_ID_NONE
+                    || MediaCodec.FindEncoder(outFormat.AudioCodec) != null);
         }
         catch (FFmpegLibrariesNotFoundException)
         {
@@ -36,6 +48,16 @@ public class EncodingCancellationTests
     });
 
     private string _workDir = string.Empty;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // FFmpegEncodingController's field initializer calls Log.CreateLogger<T>(), which only falls
+        // back to a temporary factory under #if DEBUG; a Release build dereferences the never-set
+        // s_loggerFactory and throws. The real worker sets this in Program.Main; the in-process test
+        // does not, so seed a no-op factory (the setter is idempotent, so this is safe if already set).
+        Log.LoggerFactory = Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
+    }
 
     [SetUp]
     public void SetUp()

--- a/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
+++ b/tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs
@@ -60,6 +60,7 @@ public class EncodingCancellationTests
     {
         if (!s_ffmpegAvailable.Value)
         {
+            TestContext.WriteLine("FFmpeg native libraries are not available; skipping FFmpeg-native cancellation test.");
             Assert.Ignore("FFmpeg native libraries are not available; skipping FFmpeg-native cancellation test.");
         }
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -10,6 +10,7 @@ Most projects under `tests/` are NUnit (+ Moq where needed); the exceptions are 
 | `src/Beutl.Engine/Graphics3D/` | `tests/Beutl.UnitTests/Engine/Graphics3D/` |
 | `src/Beutl.Engine.SourceGenerators/` | `tests/SourceGeneratorTest/` |
 | `src/Beutl.FFmpegIpc/` and IPC-level contract tests against `Beutl.FFmpegWorker` | `tests/Beutl.FFmpegIpc.Tests/` |
+| `src/Beutl.FFmpegWorker/` direct in-process FFmpeg-native types (e.g. `FFmpegEncodingController`) | `tests/Beutl.FFmpegWorker.Tests/` |
 | `src/Beutl.Editor*/` | `tests/Beutl.UnitTests/Editor*/` |
 | `src/Beutl.NodeGraph/` | `tests/Beutl.UnitTests/NodeGraph/` |
 | `src/Beutl.Extensions.AVFoundation/` (macOS only) | `tests/Beutl.Extensions.AVFoundation.Tests/` |
@@ -19,6 +20,8 @@ Most projects under `tests/` are NUnit (+ Moq where needed); the exceptions are 
 `tests/Beutl.Benchmarks/` and `tests/Beutl.FFmpegBenchmarks/` are BenchmarkDotNet projects, not NUnit — do not add unit tests there.
 
 `tests/Beutl.Graphics3DTests/` is a Vulkan-gated NUnit suite for GPU-backed Graphics3D rendering checks — its tests self-skip (`Assert.Ignore`) when no Vulkan/MoltenVK device is available, so they are safe to run in CI. GPU-free Graphics3D logic tests (hit-testing, render-scale, density, etc.) still go under `tests/Beutl.UnitTests/Engine/Graphics3D/`.
+
+`tests/Beutl.FFmpegWorker.Tests/` covers the GPL worker's direct in-process FFmpeg-calling types (e.g. `FFmpegEncodingController`). Because the worker is GPL-3.0 and MIT projects must not `ProjectReference` it, this project reaches those types by **source-linking** them (`<Compile Include>` under `BEUTL_FFMPEG_WORKER`), the same firewall-preserving pattern `Beutl.FFmpegBenchmarks` uses — never a `ProjectReference`. It is `IsPackable=false` (never distributed), and its native tests self-skip (`Assert.Ignore`) when the FFmpeg shared libraries are not available.
 
 The interactive Avalonia previewers / sample apps no longer live here. The sample extension package `PackageSample` was moved out of `tests/` (and out of `Beutl.slnx`, so CI does not build it) and now lives under `samples/`. Running it launches a window; it is not a test harness.
 


### PR DESCRIPTION
## Description
Adds an FFmpeg-native cancellation regression test for `FFmpegEncodingController`, mirroring the existing AVF backend test. **Test-only change** — no production code is touched.

- `FFmpegEncodingController.Encode` received the same `cancellationToken.ThrowIfCancellationRequested()` fix as `AVFEncodingController` (PR #1894), but only the AVF backend had a test pinning the shared "a cancelled `Encode` throws `OperationCanceledException`" contract. This covers the FFmpeg-native path too, so the FFmpeg-specific finally-block muxer-finalization interaction is verified where FFmpeg natives are present.
- The test mirrors the AVF `EncodingCancellationTests` + `CancelAfterFirstFrameProvider` pattern: it cancels after the first rendered frame so the encode loop exits on cancellation and reaches the `ThrowIfCancellationRequested` guard. Unlike the macOS-only AVF suite it guards on FFmpeg-native availability (`Assert.Ignore`) rather than a fixed `[Platform]`, so it runs for real wherever FFmpeg is installed and self-skips where it is not.

## GPL/MIT boundary
The controller lives in the GPL `Beutl.FFmpegWorker`. Like `tests/Beutl.FFmpegBenchmarks`, the new `tests/Beutl.FFmpegWorker.Tests` is a GPL-side, `IsPackable=false`, never-distributed project that reaches the worker's FFmpeg-calling types by **source-linking them under `BEUTL_FFMPEG_WORKER`** rather than taking a `ProjectReference` — keeping the MIT compile closure free of the GPL worker. The diff-side boundary scanner (`.claude/scripts/check-gpl-mit-boundary-diff.sh`) was updated to exempt this new project, matching the firewall exemption already granted to `Beutl.FFmpegBenchmarks`.

## Affected areas
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Adds `tests/Beutl.FFmpegWorker.Tests/EncodingCancellationTests.cs` — cancels an in-progress FFmpeg-native encode after the first frame and asserts `Encode` throws `OperationCanceledException`; self-skips (`Assert.Ignore`) where FFmpeg natives are unavailable.
- New project `tests/Beutl.FFmpegWorker.Tests/Beutl.FFmpegWorker.Tests.csproj` (`IsPackable=false`, source-links worker types under `BEUTL_FFMPEG_WORKER`, no `ProjectReference`), registered in `Beutl.slnx`; `tests/CLAUDE.md` documents the FFmpeg-gated suite.

## Fixed issues / References
Refs: Project #9 board item "Add FFmpeg-native cancellation regression test for FFmpegEncodingController"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new FFmpeg worker NUnit test project to the solution.
  * Introduced `EncodingCancellationTests`, verifying that encoding cancellation reliably triggers `OperationCanceledException`, with a native-library availability check and codec-encoder verification when applicable.
* **Documentation**
  * Updated test placement guidance for FFmpeg worker tests, including the project’s source-linked setup and native auto-skip behavior.
* **Chores**
  * Improved license-boundary scanning to avoid false positives for the worker test project while still enforcing project-reference restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->