### PR TITLE
fix(core): create parent directory before saving referenced object file

### DIFF
--- a/src/Beutl.Core/Serialization/JsonSerializationContext.Serialize.cs
+++ b/src/Beutl.Core/Serialization/JsonSerializationContext.Serialize.cs
@@ -159,7 +159,14 @@ public partial class JsonSerializationContext
             value,
             new CoreSerializerOptions { BaseUri = value.Uri });
 
-        using var stream = File.Create(value.Uri!.LocalPath);
+        string path = value.Uri!.LocalPath;
+        string? directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = File.Create(path);
         using var writer = new Utf8JsonWriter(stream, JsonHelper.WriterOptions);
         node.WriteTo(writer);
     }

--- a/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
+++ b/tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs
@@ -29,9 +29,6 @@ public class ProjectPersistenceTests
         var projectUri = new Uri(Path.Combine(_baseDir, "demo.bproj"));
         var sceneUri = new Uri(Path.Combine(_baseDir, "scene0", "scene0.scene"));
         var elementUri = new Uri(Path.Combine(_baseDir, "scene0", "clip.belm"));
-        // The recursive reference save writes each referenced file without creating its parent
-        // directory, so the scene subdirectory has to exist before StoreToUri.
-        Directory.CreateDirectory(Path.Combine(_baseDir, "scene0"));
 
         var project = new Project { Uri = projectUri };
         project.Variables[ProjectVariableKeys.FrameRate] = "30";
@@ -99,10 +96,6 @@ public class ProjectPersistenceTests
         {
             Uri = new Uri(Path.Combine(_baseDir, "b", "b.scene")),
         };
-        // The recursive reference save writes each scene file directly without creating its
-        // directory, mirroring how the app lays the project tree out on disk before saving.
-        Directory.CreateDirectory(Path.Combine(_baseDir, "a"));
-        Directory.CreateDirectory(Path.Combine(_baseDir, "b"));
         project.Items.Add(first);
         project.Items.Add(second);
 
@@ -128,7 +121,6 @@ public class ProjectPersistenceTests
         var projectUri = new Uri(Path.Combine(_baseDir, "resave.bproj"));
         var sceneUri = new Uri(Path.Combine(_baseDir, "s", "s.scene"));
         var elementUri = new Uri(Path.Combine(_baseDir, "s", "e.belm"));
-        Directory.CreateDirectory(Path.Combine(_baseDir, "s"));
 
         var project = new Project { Uri = projectUri };
         var scene = new Scene(1024, 768, "s") { Uri = sceneUri };

--- a/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
+++ b/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
@@ -130,12 +130,8 @@ public class JsonSerializationTest
         Assert.That(elm1, Is.Not.Null);
     }
 
-    // 参照オブジェクト(Uri付きCoreObject)を SaveObjectToFile 経由で保存する際、
-    // その親ディレクトリが未作成でも例外を出さずに保存できることを確認する（回帰テスト）。
-    // 修正前は File.Create が DirectoryNotFoundException を投げていた。
-    // 子要素を持たない Scene を新規サブディレクトリに保存することで、
-    // 子の StoreToUri がディレクトリを先に作ってしまう経路を避け、
-    // SaveObjectToFile 自身のディレクトリ作成責務を検証する。
+    // 子要素を持たない Scene を使うこと。子があると子の StoreToUri が先にディレクトリを
+    // 作ってしまい、SaveObjectToFile 自身のディレクトリ作成責務を検証できなくなる。
     [Test]
     public void SaveReferencedObjects_CreatesMissingParentDirectories()
     {

--- a/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
+++ b/tests/Beutl.UnitTests/Core/JsonSerializationTest.cs
@@ -130,6 +130,42 @@ public class JsonSerializationTest
         Assert.That(elm1, Is.Not.Null);
     }
 
+    // 参照オブジェクト(Uri付きCoreObject)を SaveObjectToFile 経由で保存する際、
+    // その親ディレクトリが未作成でも例外を出さずに保存できることを確認する（回帰テスト）。
+    // 修正前は File.Create が DirectoryNotFoundException を投げていた。
+    // 子要素を持たない Scene を新規サブディレクトリに保存することで、
+    // 子の StoreToUri がディレクトリを先に作ってしまう経路を避け、
+    // SaveObjectToFile 自身のディレクトリ作成責務を検証する。
+    [Test]
+    public void SaveReferencedObjects_CreatesMissingParentDirectories()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"beutl-serialize-mkdir_{Guid.NewGuid():N}");
+        try
+        {
+            var projPath = Path.Combine(baseDir, "project.bproj");
+            // scene0 サブディレクトリは事前に作成しない。
+            var scenePath = Path.Combine(baseDir, "scene0", "scene0.scene");
+
+            BeutlApplication app = BeutlApplication.Current;
+            var proj = new Project { Uri = UriHelper.CreateFromPath(projPath) };
+            var scene = new Scene { Uri = UriHelper.CreateFromPath(scenePath) };
+            proj.Items.Add(scene);
+            app.Project = proj;
+
+            CoreSerializer.StoreToUri(proj, proj.Uri, CoreSerializationMode.Write | CoreSerializationMode.SaveReferencedObjects);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(projPath), Is.True);
+                Assert.That(File.Exists(scenePath), Is.True);
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(baseDir)) Directory.Delete(baseDir, recursive: true);
+        }
+    }
+
     // EmbedReferencedObjectsのテスト
     [Test]
     public void SerializeWithEmbedReferencedObjects()


### PR DESCRIPTION
## Summary

Fixes `SaveObjectToFile` throwing `DirectoryNotFoundException` when the target file's parent directory does not yet exist.

`SaveObjectToFile` called `File.Create` directly without ensuring the target directory existed, so saving a `Project` whose referenced `Scene`/`Element` lives in a not-yet-created subdirectory threw `DirectoryNotFoundException`. The bug was masked whenever a sibling child was written first via `StoreToUri` (which does create the directory), but surfaced for an empty scene or a scene whose `Uri` points to a fresh subdirectory.

## Changes

- Add `Directory.CreateDirectory(Path.GetDirectoryName(path))` before `File.Create`, symmetric with `CoreSerializer.StoreToUri`, guarding against a null/empty directory component.
- Add a red-baseline regression test (empty `Scene` in a fresh subdirectory) in `tests/Beutl.UnitTests/Core/JsonSerializationTest.cs`.
- Remove 3 now-redundant `Directory.CreateDirectory` workarounds in `tests/Beutl.E2ETests/Scenarios/ProjectPersistenceTests.cs`.

This is a serialization **write-path** fix with **no on-disk format change**.

Refs: Project #9 board item "[2026-06-26][diff][medium] SaveObjectToFile: File.Create throws DirectoryNotFoundException when parent dir is absent"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving projects now creates any missing parent folders before writing output files, preventing failures when directories don’t already exist.
  * Improves reliability for project restore and re-save flows involving scenes and referenced items stored in new subfolders.

* **Tests**
  * Added a regression test to confirm referenced object saves succeed even when parent directories are missing.
  * Updated end-to-end project persistence scenarios to remove redundant manual folder setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->