### PR TITLE
fix: parse and format numeric property editors with CurrentCulture

### DIFF
--- a/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
@@ -57,7 +57,7 @@ public class NumberEditor<TValue> : StringEditor
         {
             if (SetAndRaise(ValueProperty, ref _value, value))
             {
-                Text = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                Text = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -175,9 +175,9 @@ public class NumberEditor<TValue> : StringEditor
     protected override void OnTextBoxTextChanged(string newValue, string oldValue)
     {
         if (InnerTextBox?.IsKeyboardFocusWithin == true
-            && TValue.TryParse(newValue, CultureInfo.CurrentUICulture, out TValue newValue2))
+            && TValue.TryParse(newValue, CultureInfo.CurrentCulture, out TValue newValue2))
         {
-            bool invalidOldValue = !TValue.TryParse(oldValue, CultureInfo.CurrentUICulture, out TValue oldValue2);
+            bool invalidOldValue = !TValue.TryParse(oldValue, CultureInfo.CurrentCulture, out TValue oldValue2);
             if (invalidOldValue)
             {
                 oldValue2 = newValue2;
@@ -195,7 +195,7 @@ public class NumberEditor<TValue> : StringEditor
 
     private void UpdateErrors()
     {
-        if (TValue.TryParse(InnerTextBox.Text, CultureInfo.CurrentUICulture, out _))
+        if (TValue.TryParse(InnerTextBox.Text, CultureInfo.CurrentCulture, out _))
         {
             DataValidationErrors.ClearErrors(InnerTextBox);
         }
@@ -209,7 +209,7 @@ public class NumberEditor<TValue> : StringEditor
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox)
             && InnerTextBox.IsKeyboardFocusWithin
-            && TValue.TryParse(InnerTextBox.Text, CultureInfo.CurrentUICulture, out TValue value))
+            && TValue.TryParse(InnerTextBox.Text, CultureInfo.CurrentCulture, out TValue value))
         {
             TValue delta = LargeChange;
             double wheelDelta = e.Delta.Y;

--- a/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
@@ -140,9 +140,9 @@ public class RationalEditor : StringEditor
     protected override void OnTextBoxTextChanged(string newValue, string oldValue)
     {
         if (InnerTextBox?.IsKeyboardFocusWithin == true
-            && Rational.TryParse(newValue, CultureInfo.CurrentUICulture, out Rational newValue2))
+            && Rational.TryParse(newValue, CultureInfo.CurrentCulture, out Rational newValue2))
         {
-            bool invalidOldValue = !Rational.TryParse(oldValue, CultureInfo.CurrentUICulture, out Rational oldValue2);
+            bool invalidOldValue = !Rational.TryParse(oldValue, CultureInfo.CurrentCulture, out Rational oldValue2);
             if (invalidOldValue)
             {
                 oldValue2 = newValue2;
@@ -160,7 +160,7 @@ public class RationalEditor : StringEditor
 
     private void UpdateErrors()
     {
-        if (Rational.TryParse(InnerTextBox.Text, CultureInfo.CurrentUICulture, out _))
+        if (Rational.TryParse(InnerTextBox.Text, CultureInfo.CurrentCulture, out _))
         {
             DataValidationErrors.ClearErrors(InnerTextBox);
         }
@@ -174,7 +174,7 @@ public class RationalEditor : StringEditor
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox)
             && InnerTextBox.IsKeyboardFocusWithin
-            && Rational.TryParse(InnerTextBox.Text, CultureInfo.CurrentUICulture, out Rational value))
+            && Rational.TryParse(InnerTextBox.Text, CultureInfo.CurrentCulture, out Rational value))
         {
             var delta = new Rational(10);
             double wheelDelta = e.Delta.Y;

--- a/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
@@ -55,7 +55,7 @@ public class Vector2Editor<TElement> : Vector2Editor
         {
             if (SetAndRaise(FirstValueProperty, ref _firstValue, value))
             {
-                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -67,7 +67,7 @@ public class Vector2Editor<TElement> : Vector2Editor
         {
             if (SetAndRaise(SecondValueProperty, ref _secondValue, value))
             {
-                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -124,8 +124,8 @@ public class Vector2Editor<TElement> : Vector2Editor
         }
 
         base.OnApplyTemplate(e);
-        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
 
         SubscribeEvents(InnerFirstTextBox);
         SubscribeEvents(InnerSecondTextBox);
@@ -245,9 +245,9 @@ public class Vector2Editor<TElement> : Vector2Editor
     private void OnInnerTextBoxTextChanged(TextBox sender, string newValue, string oldValue)
     {
         if (sender.IsKeyboardFocusWithin
-            && TElement.TryParse(newValue, CultureInfo.CurrentUICulture, out TElement newValue2))
+            && TElement.TryParse(newValue, CultureInfo.CurrentCulture, out TElement newValue2))
         {
-            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentUICulture, out TElement oldValue2);
+            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentCulture, out TElement oldValue2);
             if (invalidOldValue)
             {
                 oldValue2 = newValue2;
@@ -290,9 +290,9 @@ public class Vector2Editor<TElement> : Vector2Editor
 
     private void UpdateErrors()
     {
-        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentUICulture, out _)
+        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentCulture, out _)
             && (IsUniform
-            || TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentUICulture, out _)))
+            || TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentCulture, out _)))
         {
             DataValidationErrors.ClearErrors(this);
         }
@@ -307,7 +307,7 @@ public class Vector2Editor<TElement> : Vector2Editor
         if (!DataValidationErrors.GetHasErrors(this)
             && sender is TextBox textBox
             && textBox.IsKeyboardFocusWithin
-            && TElement.TryParse(textBox.Text, CultureInfo.CurrentUICulture, out TElement value))
+            && TElement.TryParse(textBox.Text, CultureInfo.CurrentCulture, out TElement value))
         {
             TElement delta = LargeChange;
             double wheelDelta = e.Delta.Y;

--- a/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
@@ -64,7 +64,7 @@ public class Vector3Editor<TElement> : Vector3Editor
         {
             if (SetAndRaise(FirstValueProperty, ref _firstValue, value))
             {
-                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -76,7 +76,7 @@ public class Vector3Editor<TElement> : Vector3Editor
         {
             if (SetAndRaise(SecondValueProperty, ref _secondValue, value))
             {
-                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -88,7 +88,7 @@ public class Vector3Editor<TElement> : Vector3Editor
         {
             if (SetAndRaise(ThirdValueProperty, ref _thirdValue, value))
             {
-                ThirdText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                ThirdText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -146,9 +146,9 @@ public class Vector3Editor<TElement> : Vector3Editor
 
         _disposables.Clear();
         base.OnApplyTemplate(e);
-        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        ThirdText = _thirdValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        ThirdText = _thirdValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
 
         SubscribeEvents(InnerFirstTextBox);
         SubscribeEvents(InnerSecondTextBox);
@@ -280,9 +280,9 @@ public class Vector3Editor<TElement> : Vector3Editor
     private void OnInnerTextBoxTextChanged(TextBox sender, string newValue, string oldValue)
     {
         if (sender.IsKeyboardFocusWithin
-            && TElement.TryParse(newValue, CultureInfo.CurrentUICulture, out TElement newValue2))
+            && TElement.TryParse(newValue, CultureInfo.CurrentCulture, out TElement newValue2))
         {
-            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentUICulture, out TElement oldValue2);
+            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentCulture, out TElement oldValue2);
             if (invalidOldValue)
             {
                 oldValue2 = newValue2;
@@ -332,10 +332,10 @@ public class Vector3Editor<TElement> : Vector3Editor
 
     private void UpdateErrors()
     {
-        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentUICulture, out _)
+        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentCulture, out _)
             && (IsUniform
-            || (TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentUICulture, out _)
-            && TElement.TryParse(InnerThirdTextBox.Text, CultureInfo.CurrentUICulture, out _))))
+            || (TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentCulture, out _)
+            && TElement.TryParse(InnerThirdTextBox.Text, CultureInfo.CurrentCulture, out _))))
         {
             DataValidationErrors.ClearErrors(this);
         }
@@ -350,7 +350,7 @@ public class Vector3Editor<TElement> : Vector3Editor
         if (!DataValidationErrors.GetHasErrors(this)
             && sender is TextBox textBox
             && textBox.IsKeyboardFocusWithin
-            && TElement.TryParse(textBox.Text, CultureInfo.CurrentUICulture, out TElement value))
+            && TElement.TryParse(textBox.Text, CultureInfo.CurrentCulture, out TElement value))
         {
             TElement delta = LargeChange;
             double wheelDelta = e.Delta.Y;

--- a/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
@@ -84,7 +84,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         {
             if (SetAndRaise(FirstValueProperty, ref _firstValue, value))
             {
-                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                FirstText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -96,7 +96,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         {
             if (SetAndRaise(SecondValueProperty, ref _secondValue, value))
             {
-                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                SecondText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -108,7 +108,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         {
             if (SetAndRaise(ThirdValueProperty, ref _thirdValue, value))
             {
-                ThirdText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                ThirdText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -120,7 +120,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         {
             if (SetAndRaise(FourthValueProperty, ref _fourthValue, value))
             {
-                FourthText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+                FourthText = value.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
             }
         }
     }
@@ -164,10 +164,10 @@ public class Vector4Editor<TElement> : Vector4Editor
 
         _disposables.Clear();
         base.OnApplyTemplate(e);
-        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        ThirdText = _thirdValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
-        FourthText = _fourthValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentUICulture);
+        FirstText = _firstValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        SecondText = _secondValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        ThirdText = _thirdValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
+        FourthText = _fourthValue.ToString(NumberFormat ?? "G", CultureInfo.CurrentCulture);
 
         SubscribeEvents(InnerFirstTextBox);
         SubscribeEvents(InnerSecondTextBox);
@@ -289,9 +289,9 @@ public class Vector4Editor<TElement> : Vector4Editor
     private void OnInnerTextBoxTextChanged(TextBox sender, string newValue, string oldValue)
     {
         if (sender.IsKeyboardFocusWithin
-            && TElement.TryParse(newValue, CultureInfo.CurrentUICulture, out TElement newValue2))
+            && TElement.TryParse(newValue, CultureInfo.CurrentCulture, out TElement newValue2))
         {
-            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentUICulture, out TElement oldValue2);
+            bool invalidOldValue = !TElement.TryParse(oldValue, CultureInfo.CurrentCulture, out TElement oldValue2);
             if (invalidOldValue)
             {
                 oldValue2 = newValue2;
@@ -346,11 +346,11 @@ public class Vector4Editor<TElement> : Vector4Editor
 
     private void UpdateErrors()
     {
-        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentUICulture, out _)
+        if (TElement.TryParse(InnerFirstTextBox.Text, CultureInfo.CurrentCulture, out _)
             && (IsUniform
-            || (TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentUICulture, out _)
-            && TElement.TryParse(InnerThirdTextBox.Text, CultureInfo.CurrentUICulture, out _)
-            && TElement.TryParse(InnerFourthTextBox.Text, CultureInfo.CurrentUICulture, out _))))
+            || (TElement.TryParse(InnerSecondTextBox.Text, CultureInfo.CurrentCulture, out _)
+            && TElement.TryParse(InnerThirdTextBox.Text, CultureInfo.CurrentCulture, out _)
+            && TElement.TryParse(InnerFourthTextBox.Text, CultureInfo.CurrentCulture, out _))))
         {
             DataValidationErrors.ClearErrors(this);
         }
@@ -365,7 +365,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         if (!DataValidationErrors.GetHasErrors(this)
             && sender is TextBox textBox
             && textBox.IsKeyboardFocusWithin
-            && TElement.TryParse(textBox.Text, CultureInfo.CurrentUICulture, out TElement value))
+            && TElement.TryParse(textBox.Text, CultureInfo.CurrentCulture, out TElement value))
         {
             TElement delta = LargeChange;
             double wheelDelta = e.Delta.Y;

--- a/src/Beutl/ViewModels/Editors/ParsableEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/ParsableEditorViewModel.cs
@@ -35,7 +35,7 @@ public sealed class ParsableEditorViewModel<T> : BaseEditorViewModel<T>, IParsab
 
     public void SetValueString(string? s)
     {
-        if (T.TryParse(s, CultureInfo.CurrentUICulture, out T? newValue))
+        if (T.TryParse(s, CultureInfo.CurrentCulture, out T? newValue))
         {
             SetValue(newValue);
         }
@@ -43,7 +43,7 @@ public sealed class ParsableEditorViewModel<T> : BaseEditorViewModel<T>, IParsab
 
     public void SetCurrentValueString(string? s)
     {
-        if (T.TryParse(s, CultureInfo.CurrentUICulture, out T? newValue))
+        if (T.TryParse(s, CultureInfo.CurrentCulture, out T? newValue))
         {
             SetCurrentValueAndGetCoerced(newValue);
         }

--- a/tests/Beutl.E2ETests/Controls/NumberEditorCultureTests.cs
+++ b/tests/Beutl.E2ETests/Controls/NumberEditorCultureTests.cs
@@ -7,11 +7,8 @@ using Beutl.Controls.PropertyEditors;
 
 namespace Beutl.E2ETests.Controls;
 
-// Regression coverage for the CurrentUICulture-vs-CurrentCulture bug: the numeric property editors
-// must format and parse values with the regional CurrentCulture, not the UI-language
-// CurrentUICulture. These tests model a machine whose UI language is English (en-US) but whose
-// regional format is German (de-DE, comma decimal separator) — a split the earlier tests never
-// exercised because they used a single culture for both the editor and the expected string.
+// Numeric property editors format and parse with the regional CurrentCulture, not the UI-language
+// CurrentUICulture. These tests split the two: UI language en-US, regional format de-DE (comma decimal).
 [TestFixture]
 public class NumberEditorCultureTests
 {

--- a/tests/Beutl.E2ETests/Controls/NumberEditorCultureTests.cs
+++ b/tests/Beutl.E2ETests/Controls/NumberEditorCultureTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Globalization;
+
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+
+using Beutl.Controls.PropertyEditors;
+
+namespace Beutl.E2ETests.Controls;
+
+// Regression coverage for the CurrentUICulture-vs-CurrentCulture bug: the numeric property editors
+// must format and parse values with the regional CurrentCulture, not the UI-language
+// CurrentUICulture. These tests model a machine whose UI language is English (en-US) but whose
+// regional format is German (de-DE, comma decimal separator) — a split the earlier tests never
+// exercised because they used a single culture for both the editor and the expected string.
+[TestFixture]
+public class NumberEditorCultureTests
+{
+    private static readonly CultureInfo s_regional = CultureInfo.GetCultureInfo("de-DE");
+    private static readonly CultureInfo s_uiLanguage = CultureInfo.GetCultureInfo("en-US");
+
+    private static void WithSplitCulture(Action body)
+    {
+        CultureInfo prevCulture = CultureInfo.CurrentCulture;
+        CultureInfo prevUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentCulture = s_regional;
+            CultureInfo.CurrentUICulture = s_uiLanguage;
+            body();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prevCulture;
+            CultureInfo.CurrentUICulture = prevUiCulture;
+        }
+    }
+
+    [AvaloniaTest]
+    public void NumberEditor_formats_value_with_the_regional_culture()
+    {
+        WithSplitCulture(() =>
+        {
+            var editor = new NumberEditor<double> { Header = "Value" };
+            using var host = new EditorTestHost<NumberEditor<double>>(editor);
+
+            editor.Value = 2.5;
+
+            // de-DE renders 2.5 as "2,5"; the UI language (en-US) would render "2.5".
+            Assert.That(editor.Text, Is.EqualTo("2,5"));
+        });
+    }
+
+    [AvaloniaTest]
+    public void NumberEditor_parses_typed_text_with_the_regional_culture()
+    {
+        WithSplitCulture(() =>
+        {
+            var editor = new NumberEditor<double> { Header = "Value" };
+            using var host = new EditorTestHost<NumberEditor<double>>(editor);
+
+            TextBox box = host.Require<TextBox>("PART_InnerTextBox");
+            host.TypeInto(box, "2,5");
+
+            // Parsed under en-US the comma is a group separator, so "2,5" would become 25.
+            Assert.That(editor.Value, Is.EqualTo(2.5));
+        });
+    }
+
+    [AvaloniaTest]
+    public void Vector2Editor_parses_typed_component_with_the_regional_culture()
+    {
+        WithSplitCulture(() =>
+        {
+            var editor = new Vector2Editor<double> { Header = "Size" };
+            using var host = new EditorTestHost<Vector2Editor<double>>(editor);
+
+            TextBox first = host.Require<TextBox>("PART_InnerFirstTextBox");
+            host.TypeInto(first, "2,5");
+
+            Assert.That(editor.FirstValue, Is.EqualTo(2.5));
+        });
+    }
+}

--- a/tests/Beutl.E2ETests/Controls/NumberEditorTests.cs
+++ b/tests/Beutl.E2ETests/Controls/NumberEditorTests.cs
@@ -31,7 +31,7 @@ public class NumberEditorTests
         using var host = new EditorTestHost<NumberEditor<float>>(editor);
 
         TextBox box = host.Require<TextBox>("PART_InnerTextBox");
-        host.TypeInto(box, 2.5f.ToString(CultureInfo.CurrentUICulture));
+        host.TypeInto(box, 2.5f.ToString(CultureInfo.CurrentCulture));
 
         Assert.That(editor.Value, Is.EqualTo(2.5f));
     }
@@ -62,7 +62,7 @@ public class NumberEditorTests
         editor.ValueConfirmed += (_, e) => confirmed.Add(((PropertyEditorValueChangedEventArgs<double>)e).NewValue);
 
         TextBox box = host.Require<TextBox>("PART_InnerTextBox");
-        host.TypeInto(box, 7.25d.ToString(CultureInfo.CurrentUICulture));
+        host.TypeInto(box, 7.25d.ToString(CultureInfo.CurrentCulture));
         host.MoveFocusToSink();
 
         Assert.That(confirmed, Is.EqualTo(new[] { 7.25 }));

--- a/tests/Beutl.E2ETests/Controls/VectorEditorTests.cs
+++ b/tests/Beutl.E2ETests/Controls/VectorEditorTests.cs
@@ -62,9 +62,9 @@ public class VectorEditorTests
         var editor = new Vector3Editor<float> { Header = "XYZ" };
         using var host = new EditorTestHost<Vector3Editor<float>>(editor);
 
-        host.TypeInto(host.Require<TextBox>("PART_InnerFirstTextBox"), 1.5f.ToString(CultureInfo.CurrentUICulture));
-        host.TypeInto(host.Require<TextBox>("PART_InnerSecondTextBox"), 2.5f.ToString(CultureInfo.CurrentUICulture));
-        host.TypeInto(host.Require<TextBox>("PART_InnerThirdTextBox"), 3.5f.ToString(CultureInfo.CurrentUICulture));
+        host.TypeInto(host.Require<TextBox>("PART_InnerFirstTextBox"), 1.5f.ToString(CultureInfo.CurrentCulture));
+        host.TypeInto(host.Require<TextBox>("PART_InnerSecondTextBox"), 2.5f.ToString(CultureInfo.CurrentCulture));
+        host.TypeInto(host.Require<TextBox>("PART_InnerThirdTextBox"), 3.5f.ToString(CultureInfo.CurrentCulture));
 
         Assert.That(editor.FirstValue, Is.EqualTo(1.5f));
         Assert.That(editor.SecondValue, Is.EqualTo(2.5f));


### PR DESCRIPTION
The numeric property editors used CultureInfo.CurrentUICulture for value
formatting and parsing. CurrentUICulture selects UI string resources; the
regional format (decimal / group separators) that governs how a typed number
is parsed and displayed is CurrentCulture. On a machine whose UI language and
region differ (e.g. UI English, region German), the decimal separators did not
match, so entered values failed to parse or round-tripped incorrectly. The
existing E2E tests hid the bug because they formatted their expected strings
with the same culture the editor used.

Replace CurrentUICulture with CurrentCulture at every numeric parse/format site
in NumberEditor, RationalEditor and the Vector2/3/4 editors, and in
ParsableEditorViewModel (whose display string already used the default
CurrentCulture ToString, so parsing must match). Legitimate UI-culture uses
(font-name resource lookup, UI-culture assignment from config) are untouched.

Add NumberEditorCultureTests, which force CurrentCulture=de-DE while
CurrentUICulture=en-US and assert format/parse correctness; these fail against
the unmodified code and pass after the fix. Align the existing editor tests to
CurrentCulture so they no longer mask the split-culture case.

Refs: Project #9 board item "[2026-06-26][diff][medium] NumberEditor<T>: CurrentUICulture used for numeric parsing should be CurrentCulture"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric editors (number, rational, and vector editors) and the parsable editor now display and parse values using the user’s regional numeric format (`CurrentCulture`), ensuring correct decimal separators.
  * Mouse wheel “scrub” adjustments and validation now follow the active regional culture consistently.
* **Tests**
  * Added new end-to-end tests covering culture-specific formatting/parsing for number and vector inputs.
  * Updated existing editor E2E tests to align with regional formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->