### PR TITLE
fix(ffmpeg-ipc): dispose split buffer when a cross-chunk sample load faults

### DIFF
--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -93,18 +93,33 @@ internal sealed class IpcSampleProvider : ISampleProvider
         // チャンク境界をまたぐ場合: 前半を現在のチャンクからコピー
         long firstPartLength = cacheEnd - offset;
         var result2 = new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
-        int start = (int)(offset - _currentChunkOffset);
-        _currentChunk.DataSpan.Slice(start, (int)firstPartLength).CopyTo(result2.DataSpan);
+        try
+        {
+            // Test-only probe (inert in production): capture the freshly-allocated split buffer so a
+            // disposal test can assert it is freed, not leaked, when the second chunk load throws below.
+            CrossChunkSplitAllocatedForTest?.Invoke(result2);
 
-        // 後半を次のチャンクからコピー
-        long remainingOffset = cacheEnd;
-        long remainingLength = length - firstPartLength;
-        await EnsureChunkLoaded(remainingOffset);
-        _currentChunk!.DataSpan[..(int)remainingLength].CopyTo(result2.DataSpan[(int)firstPartLength..]);
+            int start = (int)(offset - _currentChunkOffset);
+            _currentChunk.DataSpan.Slice(start, (int)firstPartLength).CopyTo(result2.DataSpan);
 
-        SamplesProvided += result2.NumSamples;
-        StartPrefetchIfNeeded();
-        return result2;
+            // 後半を次のチャンクからコピー
+            long remainingOffset = cacheEnd;
+            long remainingLength = length - firstPartLength;
+            await EnsureChunkLoaded(remainingOffset);
+            _currentChunk!.DataSpan[..(int)remainingLength].CopyTo(result2.DataSpan[(int)firstPartLength..]);
+
+            SamplesProvided += result2.NumSamples;
+            StartPrefetchIfNeeded();
+            return result2;
+        }
+        catch
+        {
+            // EnsureChunkLoaded can throw (IPC error / cancellation) after result2 is allocated, as can
+            // a DataSpan copy; dispose the native buffer so it is not leaked on the failed split, then
+            // rethrow. The success path above returns result2 undisposed to the caller.
+            result2.Dispose();
+            throw;
+        }
     }
 
     private Pcm<Stereo32BitFloat> CopyFromCache(long offset, long length)
@@ -222,6 +237,11 @@ internal sealed class IpcSampleProvider : ISampleProvider
     // Test-only probe: lets a Dispose test wait until the in-flight prefetch has actually faulted before
     // dropping it, so the faulted-task path is exercised deterministically without a sleep.
     internal bool IsPrefetchFaultedForTest() => _prefetchTask?.IsFaulted == true;
+
+    // Test-only hook (null and inert in production): invoked with the cross-chunk split's freshly
+    // allocated Pcm before the second chunk is loaded, so a disposal test can assert that a mid-split
+    // fault frees that buffer instead of leaking its native memory.
+    internal Action<Pcm<Stereo32BitFloat>>? CrossChunkSplitAllocatedForTest { get; set; }
 
     public void Dispose()
     {

--- a/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
+++ b/src/Beutl.FFmpegIpc/Providers/IpcSampleProvider.cs
@@ -95,8 +95,7 @@ internal sealed class IpcSampleProvider : ISampleProvider
         var result2 = new Pcm<Stereo32BitFloat>((int)SampleRate, (int)length);
         try
         {
-            // Test-only probe (inert in production): capture the freshly-allocated split buffer so a
-            // disposal test can assert it is freed, not leaked, when the second chunk load throws below.
+            // Test-only probe, inert in production (see CrossChunkSplitAllocatedForTest).
             CrossChunkSplitAllocatedForTest?.Invoke(result2);
 
             int start = (int)(offset - _currentChunkOffset);
@@ -114,9 +113,8 @@ internal sealed class IpcSampleProvider : ISampleProvider
         }
         catch
         {
-            // EnsureChunkLoaded can throw (IPC error / cancellation) after result2 is allocated, as can
-            // a DataSpan copy; dispose the native buffer so it is not leaked on the failed split, then
-            // rethrow. The success path above returns result2 undisposed to the caller.
+            // EnsureChunkLoaded can throw (IPC error / cancellation) after result2 is allocated; dispose
+            // its native buffer so a failed split does not leak it. The success path returns it undisposed.
             result2.Dispose();
             throw;
         }

--- a/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/IpcProviderContractTests.cs
@@ -863,4 +863,43 @@ public class IpcProviderContractTests
             DisposeBuffers(buffers);
         }
     }
+
+    [Test]
+    public async Task Sample_WhenSecondChunkLoadFaultsMidSplit_DisposesSplitBufferAndDoesNotLeak()
+    {
+        // A cross-chunk SampleExact allocates result2, copies the first chunk's tail into it, then loads
+        // the SECOND chunk. If that load faults (an IPC error / cancellation, which happens for real mid-
+        // encode), result2 must be disposed — not leaked. Straddling request: offset 2, length 4 over
+        // sampleRate-4 chunks pulls samples 2..3 from chunk 0 and 4..5 from chunk 1; the host faults the
+        // chunk 1 request (offset == sampleRate), so the second load throws after result2 is allocated.
+        const long sampleRate = 4;
+        var (server, client) = ConnectPair();
+        var buffers = CreateBuffers();
+        var hostCts = new CancellationTokenSource();
+        var hostTask = RunSamplePrefetchFaultsOnceHost(server, buffers, sampleRate, hostCts.Token);
+
+        using var conn = new IpcConnection(client);
+        // sampleCount 12 == 3 chunks of 4; offset 2 + length 4 straddles the chunk 0/1 boundary.
+        var provider = new IpcSampleProvider(conn, buffers, sampleCount: 12, sampleRate: sampleRate);
+        Pcm<Stereo32BitFloat>? splitBuffer = null;
+        provider.CrossChunkSplitAllocatedForTest = pcm => splitBuffer = pcm;
+
+        try
+        {
+            Assert.That(async () => await provider.Sample(2, 4),
+                Throws.TypeOf<FFmpegWorkerException>(),
+                "the second chunk load faults mid-split, surfacing the worker error");
+
+            Assert.That(splitBuffer, Is.Not.Null,
+                "the cross-chunk split path allocated result2 before the faulting second load");
+            Assert.That(splitBuffer!.IsDisposed, Is.True,
+                "result2 must be disposed on a mid-split fault so its native buffer is not leaked");
+        }
+        finally
+        {
+            provider.Dispose();
+            await StopHost(hostCts, server, hostTask);
+            DisposeBuffers(buffers);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`IpcSampleProvider.SampleExact` leaked a native `Pcm<Stereo32BitFloat>` on the cross-chunk split path: after the destination buffer was allocated, either the second chunk load (`EnsureChunkLoaded`) or a `DataSpan` copy could throw, and the already-allocated buffer was never disposed.

The post-allocation body is now wrapped in `try/catch` that disposes the buffer on fault and rethrows; the success path returns the buffer undisposed (ownership transfers to the caller).

## Test

Red -> green regression test added via a minimal internal test-only seam (`CrossChunkSplitAllocatedForTest`, inert in production, mirroring the existing `IsPrefetchFaultedForTest` probe). The test fails against the unmodified code (leaked buffer) and passes with the fix.

Refs: Project #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for audio sampling that spans chunk boundaries by ensuring any intermediate split buffer is disposed if the second chunk load fails mid-operation.
  * Further reduces the chance of native memory leaks during partial reads.

* **Tests**
  * Added a contract test covering a mid-split failure on the second chunk, verifying the temporary split buffer is released and the operation throws the expected exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->