### PR TITLE
test(ui): anchor OutputView destination TextBox lookup by x:Name

### DIFF
--- a/src/Beutl/Views/Tools/OutputView.axaml
+++ b/src/Beutl/Views/Tools/OutputView.axaml
@@ -59,7 +59,8 @@
 
             <GridSplitter Grid.Column="1" Background="Transparent" />
 
-            <TextBox Grid.Column="2"
+            <TextBox x:Name="DestinationInputTextBox"
+                     Grid.Column="2"
                      MinWidth="120"
                      Margin="0,4"
                      Text="{Binding DestinationFile.Value, Mode=TwoWay}"

--- a/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/OutputViewLayoutTests.cs
@@ -72,7 +72,9 @@ public class OutputViewLayoutTests
             window.Show();
             HeadlessTestHelpers.Render();
 
-            TextBox destination = view.GetLogicalDescendants().OfType<TextBox>().Single();
+            TextBox destination = view.GetLogicalDescendants()
+                .OfType<TextBox>()
+                .First(x => x.Name == "DestinationInputTextBox");
             double narrow = destination.Bounds.Width;
 
             window.Width = 1100;


### PR DESCRIPTION
OutputViewLayoutTests.Destination_input_grows_with_available_width located
the save-destination TextBox with .Single() over all TextBox descendants.
That passes only while OutputView has exactly one TextBox; adding a second
one would make the test throw InvalidOperationException with a diagnosis
that points at the test rather than the real change.

Give the destination TextBox a stable x:Name ("DestinationInputTextBox")
and select it by name in the test, so the locator stays correct as the view
grows. Layout behavior is unchanged; only the test's element lookup is
hardened.

Refs: Project #9 board item "[2026-06-27][diff][medium] OutputViewLayoutTests uses .Single() without name anchor"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the encoder output view’s destination path field, helping the interface behave more consistently when multiple text fields are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->