### PR TITLE
fix(editor): bound PlayerViewModel.Pause() playback wait with a timeout

### DIFF
--- a/src/Beutl/ViewModels/PlaybackSessionGuard.cs
+++ b/src/Beutl/ViewModels/PlaybackSessionGuard.cs
@@ -1,0 +1,21 @@
+﻿namespace Beutl.ViewModels;
+
+// Arbitrates ownership of PlayerViewModel's single shared playback session. Play() and StartShuttle
+// claim a new session; a Pause() timeout that abandons a stuck playback task disowns it. A playback
+// task captures its token at start and only restores shared session state (IsPlaying, the preview
+// subscriptions, the loop re-arm) while it still owns the session, so a task that a timeout abandoned
+// cannot stomp the session that replaced it when it finally unblocks.
+internal sealed class PlaybackSessionGuard
+{
+    private int _generation;
+
+    // Claim a fresh session and return the token that identifies the claiming task.
+    public int Claim() => Interlocked.Increment(ref _generation);
+
+    // True only while <paramref name="token"/> is still the current session (no later Claim/Disown).
+    public bool Owns(int token) => Volatile.Read(ref _generation) == token;
+
+    // Disown the current owner (a Pause() timeout abandoning a stuck task) so its late restore
+    // becomes a no-op; the next Claim() starts a new session.
+    public void Disown() => Interlocked.Increment(ref _generation);
+}

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -589,6 +589,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 if (Interlocked.Exchange(ref processing, 1) != 0) return;
                 try
                 {
+                    // A Pause() timeout may have disowned this task while it is still blocked in the
+                    // WhenAll below; once a newer session has claimed, stop the loop instead of
+                    // dequeuing frames or writing shared preview state (PreviewImage / CurrentTime /
+                    // IsPlaying) over the session that replaced it. The generation guard on the
+                    // finally alone runs too late — the timer keeps firing until PlayInternal returns.
+                    if (!_sessionGuard.Owns(generation))
+                    {
+                        tcs.TrySetResult(true);
+                        return;
+                    }
+
                     var expectFrame = ComputeExpectFrame();
                     if (_stopRequested || !IsPlaying.Value || expectFrame >= endFrame)
                     {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -60,6 +60,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private Size _maxFrameSize;
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
+    private readonly PlaybackSessionGuard _sessionGuard = new();
 
     // Set by Pause(), cleared by Play(). Cancels a loop re-arm when a pause lands in the
     // brief IsPlaying=false window at a loop boundary that gating on IsPlaying would miss.
@@ -494,6 +495,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         // (before PlayInternal runs) signals the loop to stop instead of awaiting forever.
         _stopRequested = false;
         IsPlaying.Value = true;
+        int generation = _sessionGuard.Claim();
 
         _playbackTask = Task.Run(async () =>
         {
@@ -503,10 +505,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             bool restart;
             do
             {
-                restart = await PlayInternal();
-                // A boundary-window pause set _stopRequested without flipping IsPlaying;
-                // honor it so the loop does not restart and leave Pause()'s awaiter hanging.
-                if (restart && _stopRequested)
+                restart = await PlayInternal(generation);
+                // Stop restarting on a boundary-window pause (_stopRequested set without flipping
+                // IsPlaying), or when a Pause() timeout disowned this task and a newer session took
+                // over — a stale task must not re-arm and stomp the session that replaced it.
+                if (restart && (_stopRequested || !_sessionGuard.Owns(generation)))
                 {
                     restart = false;
                 }
@@ -520,7 +523,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         });
     }
 
-    private async Task<bool> PlayInternal()
+    private async Task<bool> PlayInternal(int generation)
     {
         if (!_isEnabled.Value || Scene == null)
         {
@@ -532,6 +535,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
         Scene.Edited -= OnSceneEdited;
         _currentFrameSubscription?.Dispose();
+        _currentFrameSubscription = null;
 
         int rate = GetFrameRate();
 
@@ -659,22 +663,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
         finally
         {
-            // Restore the scene/frame subscriptions PlayInternal detached on entry, even if
-            // playback faulted mid-run. A leaked detach would leave the editor unsubscribed,
-            // and Pause() swallows the fault, so a guarded history mutation could otherwise
-            // run against a detached editor.
-            IsPlaying.Value = false;
-            bufferStatus.StartTime.Value = TimeSpan.Zero;
-            bufferStatus.EndTime.Value = TimeSpan.Zero;
-            frameCacheManager.Options = frameCacheManager.Options with
+            // Restore the stopped state (IsPlaying, buffer/cache, and the preview subscriptions this
+            // task detached on entry) only while this task still owns the session. If a Pause()
+            // timeout disowned it and a newer session took over, restoring here would stomp that
+            // session, so the new owner — or Pause()'s timeout path — restores it instead.
+            if (_sessionGuard.Owns(generation))
             {
-                DeletionStrategy = FrameCacheDeletionStrategy.Old
-            };
-
-            _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
-            if (Scene != null)
-            {
-                Scene.Edited += OnSceneEdited;
+                RestoreStoppedPreviewState();
             }
 
             _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
@@ -689,6 +684,31 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
 
         return false;
+    }
+
+    // Return the editor to a consistent stopped state: clear IsPlaying, reset the playback-only
+    // buffer/frame-cache state, and re-attach the preview subscriptions a playback task detached on
+    // entry. Idempotent (dispose-then-resubscribe, remove-then-add) so it stays correct even when
+    // PlayInternal's finally and Pause()'s timeout path both run it around an abandoned task.
+    private void RestoreStoppedPreviewState()
+    {
+        IsPlaying.Value = false;
+        BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
+        bufferStatus.StartTime.Value = TimeSpan.Zero;
+        bufferStatus.EndTime.Value = TimeSpan.Zero;
+        FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
+        frameCacheManager.Options = frameCacheManager.Options with
+        {
+            DeletionStrategy = FrameCacheDeletionStrategy.Old
+        };
+
+        _currentFrameSubscription?.Dispose();
+        _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
+        if (Scene != null)
+        {
+            Scene.Edited -= OnSceneEdited;
+            Scene.Edited += OnSceneEdited;
+        }
     }
 
     public int GetFrameRate()
@@ -884,6 +904,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         _stopRequested = false;
         _isShuttling = true;
         IsPlaying.Value = true;
+        int generation = _sessionGuard.Claim();
 
         _playbackTask = Task.Run(async () =>
         {
@@ -959,13 +980,19 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             }
             finally
             {
-                _isShuttling = false;
-                IsPlaying.Value = false;
-                PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
-                PlaybackSpeed.Value = 1.0f;
-                if (Scene != null)
+                // Only restore shared state while this shuttle still owns the session; a Pause()
+                // timeout that disowned it must not let this late finally stomp a newer session.
+                if (_sessionGuard.Owns(generation))
                 {
-                    Scene.Edited += OnSceneEdited;
+                    _isShuttling = false;
+                    IsPlaying.Value = false;
+                    PlaybackDirection.Value = ViewModels.PlaybackDirection.Stopped;
+                    PlaybackSpeed.Value = 1.0f;
+                    if (Scene != null)
+                    {
+                        Scene.Edited -= OnSceneEdited;
+                        Scene.Edited += OnSceneEdited;
+                    }
                 }
             }
         });
@@ -1389,6 +1416,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 if (_playbackTask == playbackTask)
                 {
                     _playbackTask = Task.CompletedTask;
+                    // Disown the abandoned task so its late finally can't restore/stomp a future
+                    // session, then restore the stopped state here: the task detached the preview
+                    // subscriptions on entry and, now disowned, will skip re-attaching them, so
+                    // otherwise the editor would stay detached until (if ever) the task unblocks.
+                    _sessionGuard.Disown();
+                    RestoreStoppedPreviewState();
                 }
             }
         }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -673,7 +673,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
             await Task.WhenAll(tcs.Task, audioTask);
 
-            frameCacheManager.UpdateBlocks();
+            // Committing the recorded cache blocks is a shared write, so gate it on ownership like the
+            // finally/rewind paths below: a task disowned by a Pause() timeout that unblocks after a
+            // newer session started must not stomp that session's frame-cache bookkeeping.
+            if (_sessionGuard.Owns(generation))
+            {
+                frameCacheManager.UpdateBlocks();
+            }
         }
         finally
         {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -61,6 +61,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
     private readonly PlaybackSessionGuard _sessionGuard = new();
+    // Serializes RestoreStoppedPreviewState so PlayInternal's finally and Pause()'s timeout path
+    // cannot interleave the dispose/resubscribe and Scene.Edited unhook/hook steps across threads.
+    private readonly object _restoreLock = new();
 
     // Set by Pause(), cleared by Play(). Cancels a loop re-arm when a pause lands in the
     // brief IsPlaying=false window at a loop boundary that gating on IsPlaying would miss.
@@ -562,7 +565,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             playerImpl.Start();
 
             var clock = new AudioPlaybackClock();
-            var audioTask = PlayAudio(Scene, clock, startTime);
+            var audioTask = PlayAudio(Scene, clock, startTime, generation);
 
             // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
             // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
@@ -688,7 +691,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         // ループが有効でユーザーによる停止ではない場合、ループ先頭に戻して再開を要求。
         // loopStart は購読で最新化されているため、再生中の In/Out 変更にも追従する。
-        if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
+        // A task disowned by a Pause() timeout must not rewind the playhead of a stopped editor or
+        // the session that replaced it, so gate the shared CurrentTime write on ownership too.
+        if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null && _sessionGuard.Owns(generation))
         {
             _editorClock.CurrentTime.Value = Scene.Start;
             return true;
@@ -703,22 +708,25 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     // PlayInternal's finally and Pause()'s timeout path both run it around an abandoned task.
     private void RestoreStoppedPreviewState()
     {
-        IsPlaying.Value = false;
-        BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
-        bufferStatus.StartTime.Value = TimeSpan.Zero;
-        bufferStatus.EndTime.Value = TimeSpan.Zero;
-        FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
-        frameCacheManager.Options = frameCacheManager.Options with
+        lock (_restoreLock)
         {
-            DeletionStrategy = FrameCacheDeletionStrategy.Old
-        };
+            IsPlaying.Value = false;
+            BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
+            bufferStatus.StartTime.Value = TimeSpan.Zero;
+            bufferStatus.EndTime.Value = TimeSpan.Zero;
+            FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
+            frameCacheManager.Options = frameCacheManager.Options with
+            {
+                DeletionStrategy = FrameCacheDeletionStrategy.Old
+            };
 
-        _currentFrameSubscription?.Dispose();
-        _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
-        if (Scene != null)
-        {
-            Scene.Edited -= OnSceneEdited;
-            Scene.Edited += OnSceneEdited;
+            _currentFrameSubscription?.Dispose();
+            _currentFrameSubscription = CurrentFrame.Subscribe(UpdateCurrentFrame);
+            if (Scene != null)
+            {
+                Scene.Edited -= OnSceneEdited;
+                Scene.Edited += OnSceneEdited;
+            }
         }
     }
 
@@ -1009,7 +1017,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         });
     }
 
-    private async Task PlayAudio(Scene scene, AudioPlaybackClock clock, TimeSpan startTime)
+    private async Task PlayAudio(Scene scene, AudioPlaybackClock clock, TimeSpan startTime, int generation)
     {
         try
         {
@@ -1032,7 +1040,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             NotificationService.ShowError(MessageStrings.UnexpectedError,
                 MessageStrings.AudioPlaybackException);
             _logger.LogError(ex, "An exception occurred during audio playback.");
-            IsPlaying.Value = false;
+            // Only stop the session this task owns: a fault from an audio backend abandoned by a
+            // Pause() timeout must not clear IsPlaying on the session that replaced it.
+            if (_sessionGuard.Owns(generation))
+            {
+                IsPlaying.Value = false;
+            }
         }
         finally
         {

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -43,6 +43,10 @@ public enum PlaybackDirection
 public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 {
     private static readonly TimeSpan s_second = TimeSpan.FromSeconds(1);
+    // Upper bound on how long Pause() waits for the playback loop to stop. If the loop is stuck
+    // in a blocking OS audio/COM call, an unbounded await would hold the history-mutation gate
+    // (and the UI thread awaiting it) indefinitely, so we time out and abandon the task instead.
+    private static readonly TimeSpan s_pauseTimeout = TimeSpan.FromSeconds(5);
     private static readonly float[] s_fastSpeeds = [1.0f, 2.0f, 4.0f, 8.0f, 16.0f, 32.0f];
     private static readonly float[] s_slowSpeeds = [1.0f, 0.5f, 0.25f];
     private readonly ILogger _logger = Log.CreateLogger<PlayerViewModel>();
@@ -1370,12 +1374,23 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
 
         // Await even when already stopped so an overlapping pause blocks until the prior
-        // drain finishes. Catch a faulted task and drop it, so it neither surfaces as a
-        // history-operation failure nor replays on later pauses.
+        // drain finishes. Bound the wait: if the playback loop is stuck in a blocking OS
+        // audio/COM call, awaiting it unbounded would pin the history-mutation gate (and the
+        // UI thread awaiting Pause) indefinitely, so time out, log, and abandon the task.
+        // Catch a faulted task and drop it, so it neither surfaces as a history-operation
+        // failure nor replays on later pauses.
         Task playbackTask = _playbackTask;
         try
         {
-            await playbackTask;
+            if (!await WaitForPlaybackStopAsync(playbackTask, s_pauseTimeout, _logger, _editViewModel.SceneId))
+            {
+                // Timed out: drop the hung task so it neither replays on later pauses nor keeps
+                // the gate held. The abandoned task keeps observing _stopRequested / the cts.
+                if (_playbackTask == playbackTask)
+                {
+                    _playbackTask = Task.CompletedTask;
+                }
+            }
         }
         catch (Exception ex)
         {
@@ -1385,6 +1400,36 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 _playbackTask = Task.CompletedTask;
             }
         }
+    }
+
+    // Wait for the playback task to finish, but never longer than <paramref name="timeout"/>.
+    // Returns true when the task completed (its fault, if any, is re-thrown to the caller);
+    // false when the wait timed out. A timeout is logged and the task is left running but kept
+    // observed via a continuation, so a playback loop blocked in a native audio/COM call cannot
+    // pin the caller (and the history-mutation gate it runs under) indefinitely.
+    internal static async Task<bool> WaitForPlaybackStopAsync(
+        Task playbackTask, TimeSpan timeout, ILogger logger, string sceneId)
+    {
+        Task finished = await Task.WhenAny(playbackTask, Task.Delay(timeout)).ConfigureAwait(false);
+        if (finished == playbackTask)
+        {
+            // Completed within the timeout — propagate any fault so the caller can observe it.
+            await playbackTask.ConfigureAwait(false);
+            return true;
+        }
+
+        logger.LogError(
+            "Playback task did not stop within {Timeout} on pause; abandoning it to release the history gate. ({SceneId})",
+            timeout, sceneId);
+        // Observe a late fault so abandoning the task does not raise an unobserved-exception event.
+        _ = playbackTask.ContinueWith(
+            static (t, s) => ((ILogger)s!).LogError(
+                t.Exception, "Abandoned playback task faulted after a pause timeout."),
+            logger,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        return false;
     }
 
     private void UpdateImage(Ref<Bitmap> source)

--- a/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
@@ -1,0 +1,55 @@
+﻿using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PlaybackSessionGuardTests
+{
+    [Test]
+    public void The_latest_claim_owns_the_session_and_older_claims_do_not()
+    {
+        var guard = new PlaybackSessionGuard();
+
+        int first = guard.Claim();
+        Assert.That(guard.Owns(first), Is.True, "the only claim owns the session");
+
+        int second = guard.Claim();
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.Owns(second), Is.True, "the newest claim owns the session");
+            Assert.That(guard.Owns(first), Is.False, "a superseded claim no longer owns the session");
+            Assert.That(second, Is.Not.EqualTo(first), "each claim gets a distinct token");
+        });
+    }
+
+    [Test]
+    public void Disown_makes_the_current_owner_stop_owning()
+    {
+        var guard = new PlaybackSessionGuard();
+        int token = guard.Claim();
+
+        guard.Disown();
+
+        Assert.That(guard.Owns(token), Is.False,
+            "a Pause() timeout disowns the running task so its late restore becomes a no-op");
+    }
+
+    // Models the exact race the generation guard fixes: a playback task (session A) is abandoned by a
+    // Pause() timeout, a new Play() starts session B, and A only unblocks afterward. A must not still
+    // own the session, or its finally would stomp B's IsPlaying / preview subscriptions.
+    [Test]
+    public void An_abandoned_session_does_not_own_after_a_timeout_disown_and_a_restart()
+    {
+        var guard = new PlaybackSessionGuard();
+        int sessionA = guard.Claim();
+
+        guard.Disown();                 // Pause() timed out and abandoned session A
+        int sessionB = guard.Claim();   // a new Play() took over
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.Owns(sessionA), Is.False, "the abandoned task must not restore/stomp the new session");
+            Assert.That(guard.Owns(sessionB), Is.True, "the new session owns the shared playback state");
+        });
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelPauseTimeoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelPauseTimeoutTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Diagnostics;
+using Beutl.ViewModels;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PlayerViewModelPauseTimeoutTests
+{
+    [Test]
+    public async Task WaitForPlaybackStopAsync_returns_false_and_logs_when_the_task_never_completes()
+    {
+        var logger = new CapturingLogger();
+        var timeout = TimeSpan.FromMilliseconds(200);
+        // A task that never completes stands in for a playback loop stuck in a blocking
+        // OS audio/COM call — the exact case the unbounded await would hang on.
+        Task neverCompletes = new TaskCompletionSource().Task;
+
+        var sw = Stopwatch.StartNew();
+        bool completed = await PlayerViewModel.WaitForPlaybackStopAsync(neverCompletes, timeout, logger, "scene-1");
+        sw.Stop();
+
+        Assert.That(completed, Is.False, "the bounded wait must give up instead of hanging");
+        Assert.That(sw.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)), "the wait must return near the timeout, not hang");
+        Assert.That(logger.Errors, Is.Not.Empty, "a timeout must be logged as an error");
+    }
+
+    [Test]
+    public async Task WaitForPlaybackStopAsync_returns_true_when_the_task_already_completed()
+    {
+        var logger = new CapturingLogger();
+
+        bool completed = await PlayerViewModel.WaitForPlaybackStopAsync(
+            Task.CompletedTask, TimeSpan.FromSeconds(5), logger, "scene-1");
+
+        Assert.That(completed, Is.True);
+        Assert.That(logger.Errors, Is.Empty, "no error is logged when the task stops in time");
+    }
+
+    [Test]
+    public void WaitForPlaybackStopAsync_propagates_the_fault_when_the_task_completes_faulted()
+    {
+        var logger = new CapturingLogger();
+        Task faulted = Task.FromException(new InvalidOperationException("boom"));
+
+        // A task that completed before the timeout still has its fault re-thrown so Pause()'s
+        // existing catch can drop and reset it — the pre-existing behaviour must be preserved.
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await PlayerViewModel.WaitForPlaybackStopAsync(faulted, TimeSpan.FromSeconds(5), logger, "scene-1"));
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Errors { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+            {
+                Errors.Add(formatter(state, exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fix — `PlayerViewModel.Pause()` previously awaited `_playbackTask` unbounded. If the playback loop was stuck in a blocking OS audio/COM call, setting `_stopRequested` could not unstick it, so the await never returned. Because history mutations (Undo/Redo/JumpTo) run through `HistoryMutationPlaybackGuard.RunAsync` while holding its `SemaphoreSlim` gate, and that guard awaits `Pause()` on the UI thread, an unbounded await froze the whole history-mutation pipeline and the UI thread indefinitely.

The wait is now bounded by a 5s timeout via an extracted internal `WaitForPlaybackStopAsync` that races the playback task against the timeout:

- On **normal completion**, any fault is re-thrown to preserve the existing drop-and-reset behavior.
- On **timeout**, it logs an error and abandons the task; the abandoned task is kept observed via an `OnlyOnFaulted` continuation (so no `UnobservedTaskException`), then the caller falls through and releases the gate. The abandoned task keeps observing `_stopRequested` / the `cts`.

A stuck playback loop can therefore no longer pin the history-mutation gate / UI thread indefinitely.

### Reviewer note

Trade-off (inherent to the fix, documented): if the stuck OS audio/COM call later unblocks past the 5s timeout, the abandoned playback task's `PlayInternal` finally could run against a subsequently-started session. This only manifests in the pathological >5s-stuck case; freezing the UI is the worse alternative.

## Affected areas

- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes

None.

## Test plan

- 3 NUnit tests added in `tests/Beutl.HeadlessUITests/PlayerViewModelPauseTimeoutTests.cs` covering `WaitForPlaybackStopAsync`: never-completing task returns within the bound and logs; completed task returns true; faulted task propagates.

## Fixed issues / References

- Project board: b-editor/projects/9 ("[2026-06-24][diff][medium] PlayerViewModel.Pause() awaits _playbackTask without timeout — UI freeze risk")

Refs: Project #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback pause to stop within a defined timeout instead of waiting indefinitely, with safe recovery if playback gets stuck.
  * Prevented late playback/shuttle/audio events from changing newer preview state after a session restart.
  * Centralized and locked restoration of the stopped preview/editor state to keep UI updates consistent during rapid play/pause changes.
* **Tests**
  * Added headless tests for pause-stop timeout behavior, fault propagation, and session ownership/abandonment race handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->