### PR TITLE
refactor!: resolve editor host services by type through IEditorContextServices

### DIFF
--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -14,11 +14,10 @@ public interface IEditorContextServices
 
     /// <summary>
     /// Resolves a host-provided service of type <typeparamref name="T"/> by type. This is the
-    /// abstraction's escape hatch for capabilities that live downstream of
-    /// <c>Beutl.Extensibility</c> (for example the host's editor service), so an extension can reach
-    /// them without downcasting to the host's concrete implementation of
-    /// <see cref="IEditorContextServices"/>. Downcasting would defeat the abstraction — a hand-written fake could never
-    /// satisfy it — so implementers must honor this by-type lookup instead.
+    /// escape hatch for capabilities that live downstream of <c>Beutl.Extensibility</c> (for example
+    /// the host's editor service), letting an extension reach them without downcasting to the host's
+    /// concrete implementation of <see cref="IEditorContextServices"/>. Implementers must honor this
+    /// by-type lookup rather than assume the concrete host type.
     /// </summary>
     /// <typeparam name="T">The reference type of the requested service.</typeparam>
     /// <param name="service">The resolved service when the method returns <see langword="true"/>.</param>

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -1,4 +1,6 @@
-﻿namespace Beutl.Extensibility;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Beutl.Extensibility;
 
 /// <summary>
 /// Host services supplied to <see cref="EditorExtension.TryCreateContext"/> so a created
@@ -9,4 +11,18 @@ public interface IEditorContextServices
 {
     /// <summary>Gets the host's extension provider, for querying other registered extensions.</summary>
     IExtensionProvider ExtensionProvider { get; }
+
+    /// <summary>
+    /// Resolves a host-provided service of type <typeparamref name="T"/> by type. This is the
+    /// abstraction's escape hatch for capabilities that live downstream of
+    /// <c>Beutl.Extensibility</c> (for example the host's editor service), so an extension can reach
+    /// them without downcasting to the host's concrete <see cref="IEditorContextServices"/>
+    /// implementation. Downcasting would defeat the abstraction — a hand-written fake could never
+    /// satisfy it — so implementers must honor this by-type lookup instead.
+    /// </summary>
+    /// <typeparam name="T">The reference type of the requested service.</typeparam>
+    /// <param name="service">The resolved service when the method returns <see langword="true"/>.</param>
+    /// <returns><see langword="true"/> if a service of type <typeparamref name="T"/> was found.</returns>
+    bool TryGetService<T>([NotNullWhen(true)] out T? service)
+        where T : class;
 }

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -16,8 +16,8 @@ public interface IEditorContextServices
     /// Resolves a host-provided service of type <typeparamref name="T"/> by type. This is the
     /// abstraction's escape hatch for capabilities that live downstream of
     /// <c>Beutl.Extensibility</c> (for example the host's editor service), so an extension can reach
-    /// them without downcasting to the host's concrete <see cref="IEditorContextServices"/>
-    /// implementation. Downcasting would defeat the abstraction — a hand-written fake could never
+    /// them without downcasting to the host's concrete implementation of
+    /// <see cref="IEditorContextServices"/>. Downcasting would defeat the abstraction — a hand-written fake could never
     /// satisfy it — so implementers must honor this by-type lookup instead.
     /// </summary>
     /// <typeparam name="T">The reference type of the requested service.</typeparam>

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -4,11 +4,9 @@ using Beutl.Extensibility;
 
 namespace Beutl.Services;
 
-// Host services handed to EditorExtension.TryCreateContext so a created editor context can
-// receive the services it needs. Extensions resolve host capabilities through the abstract
-// IEditorContextServices.TryGetService<T> lookup (including the host-internal EditorService,
-// which is downstream of Beutl.Extensibility and so cannot be a typed interface member) rather
-// than downcasting to this concrete type — that keeps the abstraction testable with a fake.
+// Host services handed to EditorExtension.TryCreateContext. The host-internal EditorService is
+// downstream of Beutl.Extensibility and so cannot be a typed interface member; extensions reach it
+// through the IEditorContextServices.TryGetService<T> lookup rather than downcasting to this type.
 internal sealed class EditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
     : IEditorContextServices
 {

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -1,18 +1,25 @@
-﻿using Beutl.Api.Services;
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Api.Services;
 using Beutl.Extensibility;
 
 namespace Beutl.Services;
 
 // Host services handed to EditorExtension.TryCreateContext so a created editor context can
-// receive the services it needs. Plugins consume the typed IEditorContextServices surface;
-// in-tree extensions (e.g. SceneEditorExtension) cast to this concrete type to also obtain
-// the host-internal EditorService.
+// receive the services it needs. Extensions resolve host capabilities through the abstract
+// IEditorContextServices.TryGetService<T> lookup (including the host-internal EditorService,
+// which is downstream of Beutl.Extensibility and so cannot be a typed interface member) rather
+// than downcasting to this concrete type — that keeps the abstraction testable with a fake.
 internal sealed class EditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
     : IEditorContextServices
 {
-    public ExtensionProvider ExtensionProvider => extensionProvider;
-
-    public EditorService EditorService => editorService;
-
     IExtensionProvider IEditorContextServices.ExtensionProvider => extensionProvider;
+
+    public bool TryGetService<T>([NotNullWhen(true)] out T? service)
+        where T : class
+    {
+        // Resolve by assignability so both the concrete ExtensionProvider and its IExtensionProvider
+        // interface (and the host-internal EditorService) are reachable by type.
+        service = editorService as T ?? extensionProvider as T;
+        return service is not null;
+    }
 }

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -120,10 +120,8 @@ public sealed class SceneEditorExtension : EditorExtension
     public override bool TryCreateContext(
         CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
     {
-        // TryCreate* must not throw: only build the context when the host actually supplies the
-        // services EditViewModel needs. Resolve them through the IEditorContextServices abstraction
-        // (not a concrete downcast) so any implementation — including a test fake — is accepted;
-        // otherwise fail (return false) rather than pushing nulls into EditViewModel.
+        // TryCreate* must not throw: when the host does not supply the services EditViewModel needs,
+        // fail (return false) rather than pushing nulls into EditViewModel.
         if (obj is Scene scene
             && services.TryGetService<EditorService>(out EditorService? editorService)
             && services.TryGetService<ExtensionProvider>(out ExtensionProvider? extensionProvider))

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
+using Beutl.Api.Services;
 using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 using Beutl.Views;
@@ -119,11 +120,15 @@ public sealed class SceneEditorExtension : EditorExtension
     public override bool TryCreateContext(
         CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
     {
-        // TryCreate* must not throw: only build the context for the host-provided services we
-        // recognize, otherwise fail (return false) rather than pushing nulls into EditViewModel.
-        if (obj is Scene scene && services is EditorContextServices ctx)
+        // TryCreate* must not throw: only build the context when the host actually supplies the
+        // services EditViewModel needs. Resolve them through the IEditorContextServices abstraction
+        // (not a concrete downcast) so any implementation — including a test fake — is accepted;
+        // otherwise fail (return false) rather than pushing nulls into EditViewModel.
+        if (obj is Scene scene
+            && services.TryGetService<EditorService>(out EditorService? editorService)
+            && services.TryGetService<ExtensionProvider>(out ExtensionProvider? extensionProvider))
         {
-            context = new EditViewModel(scene, ctx.ExtensionProvider, ctx.EditorService);
+            context = new EditViewModel(scene, extensionProvider, editorService);
             return true;
         }
 

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -1,0 +1,98 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+// Guards that the editor-context abstraction is honored by type, not by a concrete downcast.
+// SceneEditorExtension.TryCreateContext used to gate on `services is EditorContextServices`, so any
+// other IEditorContextServices implementation (a test fake, a plugin's own) silently returned false
+// and the extension could not be unit-tested. The fix routes host-service lookup through
+// IEditorContextServices.TryGetService<T>, which a hand-written fake can satisfy.
+[TestFixture]
+public class SceneEditorContextServicesTests
+{
+    // A hand-written IEditorContextServices that is deliberately NOT the host's concrete
+    // EditorContextServices. Before the fix, TryCreateContext downcast to that concrete type and
+    // rejected this implementation; after the fix it resolves services purely through TryGetService.
+    private sealed class FakeEditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
+        : IEditorContextServices
+    {
+        public IExtensionProvider ExtensionProvider => extensionProvider;
+
+        public bool TryGetService<T>([NotNullWhen(true)] out T? service)
+            where T : class
+        {
+            service = editorService as T ?? extensionProvider as T;
+            return service is not null;
+        }
+    }
+
+    // Focused resolution test for the host's concrete implementation: it must expose the
+    // host-internal EditorService and both the concrete and interface extension-provider shapes.
+    [Test]
+    public void EditorContextServices_TryGetService_resolves_by_type()
+    {
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.TryGetService<EditorService>(out EditorService? resolvedEditor), Is.True);
+            Assert.That(resolvedEditor, Is.SameAs(editorService));
+
+            Assert.That(services.TryGetService<ExtensionProvider>(out ExtensionProvider? resolvedProvider), Is.True);
+            Assert.That(resolvedProvider, Is.SameAs(extensionProvider));
+
+            Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
+            Assert.That(resolvedInterface, Is.SameAs(extensionProvider));
+
+            // An unrelated reference type resolves to nothing (and reports false / null).
+            Assert.That(services.TryGetService<string>(out string? missing), Is.False);
+            Assert.That(missing, Is.Null);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task TryCreateContext_accepts_a_non_concrete_IEditorContextServices()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "trycreatecontext");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "trycreatecontext")
+        {
+            Uri = new Uri(Path.Combine(workspace, "trycreatecontext.scene"))
+        };
+
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new FakeEditorContextServices(editorService, extensionProvider);
+
+        bool created = SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context);
+
+        try
+        {
+            Assert.That(
+                created,
+                Is.True,
+                "TryCreateContext must accept any IEditorContextServices, not only the host's concrete type.");
+            Assert.That(context, Is.Not.Null);
+            Assert.That(context, Is.InstanceOf<EditViewModel>());
+        }
+        finally
+        {
+            if (context is not null)
+            {
+                await context.DisposeAsync();
+            }
+
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -10,17 +10,14 @@ using Beutl.ViewModels;
 
 namespace Beutl.HeadlessUITests;
 
-// Guards that the editor-context abstraction is honored by type, not by a concrete downcast.
-// SceneEditorExtension.TryCreateContext used to gate on `services is EditorContextServices`, so any
-// other IEditorContextServices implementation (a test fake, a plugin's own) silently returned false
-// and the extension could not be unit-tested. The fix routes host-service lookup through
-// IEditorContextServices.TryGetService<T>, which a hand-written fake can satisfy.
+// Guards that SceneEditorExtension.TryCreateContext resolves host services by type through
+// IEditorContextServices, so any implementation (including a test fake) is accepted, not only the
+// host's concrete EditorContextServices.
 [TestFixture]
 public class SceneEditorContextServicesTests
 {
-    // A hand-written IEditorContextServices that is deliberately NOT the host's concrete
-    // EditorContextServices. Before the fix, TryCreateContext downcast to that concrete type and
-    // rejected this implementation; after the fix it resolves services purely through TryGetService.
+    // An IEditorContextServices that is deliberately NOT the host's concrete EditorContextServices,
+    // so the test exercises the by-type TryGetService path instead of a concrete downcast.
     private sealed class FakeEditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
         : IEditorContextServices
     {
@@ -34,8 +31,6 @@ public class SceneEditorContextServicesTests
         }
     }
 
-    // Focused resolution test for the host's concrete implementation: it must expose the
-    // host-internal EditorService and both the concrete and interface extension-provider shapes.
     [Test]
     public void EditorContextServices_TryGetService_resolves_by_type()
     {
@@ -54,7 +49,6 @@ public class SceneEditorContextServicesTests
             Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
             Assert.That(resolvedInterface, Is.SameAs(extensionProvider));
 
-            // An unrelated reference type resolves to nothing (and reports false / null).
             Assert.That(services.TryGetService<string>(out string? missing), Is.False);
             Assert.That(missing, Is.Null);
         });


### PR DESCRIPTION
## Description

`refactor!` — `SceneEditorExtension.TryCreateContext` resolved host services by downcasting the
public `IEditorContextServices` to the internal concrete `EditorContextServices`, which made the
abstraction untestable/unusable by any non-host implementation (a `services is EditorContextServices`
check silently failed for a test fake or a plugin's own implementation and returned `false`).

Now `IEditorContextServices` exposes `bool TryGetService<T>(out T? service) where T : class` — a
bounded, per-instance, typed host-service lookup — and `SceneEditorExtension` resolves the
`EditorService` and `ExtensionProvider` through it. The concrete-only properties on
`EditorContextServices` that existed solely for the downcast were removed; the sole in-tree consumer
was migrated in the same change (no `[Obsolete]` shim, no duplicate "v2" type).

A `HeadlessUITests` fixture proves a non-host (fake) `IEditorContextServices` is now accepted:
it is RED against the concrete-downcast baseline and GREEN after this change.

## Affected areas

- [x] `Beutl.Extensibility` (plugin abstractions)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`) — host-side `EditorContextServices` / `SceneEditorExtension`

## Breaking changes

**BREAKING CHANGE:** `IEditorContextServices` (`Beutl.Extensibility`) gains a required
`TryGetService<T>` member. It is **host-implemented and plugin-consumed**, so plugin *consumers* of
the interface are unaffected; only out-of-tree **implementers** of the interface must now provide
`TryGetService<T>`. The sole in-tree implementer (`EditorContextServices`) was migrated in this same
change. The commit is a `refactor!:` with the `BREAKING CHANGE:` footer.

## Design review

`@beutl-design-reviewer` reviewed and endorsed `TryGetService<T>` over a typed `IEditorService` seam
(which would leak the host tab-model into the plugin layer). Verdict: sound to ship, no blocking
findings, no rework required.

## Test plan

- Added `tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs`: constructs a hand-written
  fake `IEditorContextServices` and asserts `SceneEditorExtension.TryCreateContext` accepts it and
  resolves the host services through `TryGetService<T>`. RED against the concrete-downcast baseline,
  GREEN after this change.
- `dotnet build Beutl.slnx`, `dotnet test Beutl.slnx -f net10.0`, and
  `dotnet format Beutl.slnx --verify-no-changes` all pass.

## Fixed issues / References

- Project board: b-editor/projects/9 — "[2026-06-26][diff][medium] SceneEditorExtension: casts IEditorContextServices to concrete EditorContextServices, breaking testability"

Refs: Project #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a type-based service lookup API to editor context services (`TryGetService<T>`), reporting success and providing a safe nullable result.
  * Scene editor context creation now resolves its required dependencies via this API, enabling broader compatible service providers.

* **Bug Fixes**
  * Improved resolution behavior to clearly return failure when requested services aren’t available, with stronger null-safety.

* **Tests**
  * Added NUnit coverage validating type-based service resolution (including interface types) and verifying scene context creation with a non-concrete service provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->