### PR TITLE
test(ffmpeg-ipc): pin audio-only ReadVideo -> FFmpegWorkerException contract

### DIFF
--- a/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
+++ b/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
@@ -18,6 +18,26 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Beutl.FFmpegIpc\Beutl.FFmpegIpc.csproj" />
+    <!-- MIT->MIT reference: the IPC proxy (FFmpegReaderProxy) and worker launcher
+         (FFmpegWorkerProcess) live in the MIT extension, which does NOT reference the GPL
+         Beutl.FFmpegWorker. The worker is reached only as a spawned process over IPC. -->
+    <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
   </ItemGroup>
+
+  <!-- Make the built GPL worker BINARY available at test runtime WITHOUT a compile-closure
+       reference to it, mirroring tests/Beutl.FFmpegBenchmarks' precedent. The worker is copied
+       (not referenced or link-compiled), so the GPL/MIT boundary stays intact: the audio-only
+       ReadVideo contract test spawns this binary as a separate process via IPC. When the worker
+       has not been built (or its output is absent), nothing is copied and the process-level test
+       self-skips via Assert.Ignore. -->
+  <Target Name="CopyWorkerBinary" AfterTargets="Build">
+    <PropertyGroup>
+      <WorkerOutputDir>..\..\src\Beutl.FFmpegWorker\bin\$(Configuration)\$(TargetFramework)\</WorkerOutputDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <WorkerFiles Include="$(WorkerOutputDir)**\*" Exclude="$(WorkerOutputDir)**\*.dev.runtimeconfig.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WorkerFiles)" DestinationFiles="@(WorkerFiles->'$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
+++ b/tests/Beutl.FFmpegIpc.Tests/Beutl.FFmpegIpc.Tests.csproj
@@ -24,12 +24,21 @@
     <ProjectReference Include="..\..\src\Beutl.Extensions.FFmpeg\Beutl.Extensions.FFmpeg.csproj" />
   </ItemGroup>
 
+  <!-- Order the GPL worker's build before the copy below so the copy is deterministic even on a clean
+       or parallel build, where the solution may not have produced the worker output yet. This is an
+       ordering-only <MSBuild> invocation, NOT a <ProjectReference>: the worker assembly never enters
+       this MIT project's compile closure, so the GPL/MIT boundary stays intact. -->
+  <Target Name="BuildWorkerForCopy" BeforeTargets="CopyWorkerBinary">
+    <MSBuild Projects="..\..\src\Beutl.FFmpegWorker\Beutl.FFmpegWorker.csproj"
+             Targets="Build"
+             Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
+  </Target>
+
   <!-- Make the built GPL worker BINARY available at test runtime WITHOUT a compile-closure
        reference to it, mirroring tests/Beutl.FFmpegBenchmarks' precedent. The worker is copied
        (not referenced or link-compiled), so the GPL/MIT boundary stays intact: the audio-only
-       ReadVideo contract test spawns this binary as a separate process via IPC. When the worker
-       has not been built (or its output is absent), nothing is copied and the process-level test
-       self-skips via Assert.Ignore. -->
+       ReadVideo contract test spawns this binary as a separate process via IPC. If the worker build
+       still yields no output, nothing is copied and the process-level test self-skips via Assert.Ignore. -->
   <Target Name="CopyWorkerBinary" AfterTargets="Build">
     <PropertyGroup>
       <WorkerOutputDir>..\..\src\Beutl.FFmpegWorker\bin\$(Configuration)\$(TargetFramework)\</WorkerOutputDir>

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
@@ -1,0 +1,131 @@
+﻿using Beutl.Extensions.FFmpeg.Decoding;
+using Beutl.Media.Decoding;
+
+namespace Beutl.FFmpegIpc.Tests;
+
+/// <summary>
+/// Process-level IPC contract test: spawns the real GPL <c>Beutl.FFmpegWorker</c> (via the MIT
+/// <see cref="FFmpegDecoderInfo"/> / <c>FFmpegReaderProxy</c> path) and pins the audio-only
+/// <c>ReadVideo</c> error contract.
+/// <para>
+/// <c>DecodingHandler.HandleReadVideo</c> answers a <c>ReadVideo</c> request against an audio-only
+/// reader with <c>IpcMessage.CreateError(...)</c> (no ring buffer, <c>HasVideo == false</c>). The
+/// transport surfaces that error message as a thrown <see cref="FFmpegWorkerException"/>, so
+/// <c>FFmpegReaderProxy.ReadVideo</c> throws rather than silently returning <c>false</c>. This test
+/// pins that end-to-end contract so a future regression (e.g. swapping the error for a
+/// <c>Success = false</c> response) is caught.
+/// </para>
+/// <para>
+/// The worker binary is copied into the test output by the <c>CopyWorkerBinary</c> MSBuild target
+/// (no compile-closure reference to the GPL project). When the worker binary or its FFmpeg natives
+/// are unavailable (e.g. CI without FFmpeg), the test self-skips via <see cref="Assert.Ignore(string)"/>.
+/// </para>
+/// </summary>
+[TestFixture, NonParallelizable]
+public class FFmpegReaderProxyReadVideoContractTests
+{
+    private string _audioOnlyPath = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _audioOnlyPath = Path.Combine(
+            Path.GetTempPath(), $"beutl-ffmpeg-audioonly-{Guid.NewGuid():N}.wav");
+        WriteSilentPcmWav(_audioOnlyPath);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        try
+        {
+            if (_audioOnlyPath != null && File.Exists(_audioOnlyPath))
+                File.Delete(_audioOnlyPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of the temp fixture; a leftover file must not fail the run.
+        }
+    }
+
+    [Test]
+    public void ReadVideo_OnAudioOnlyFile_ThrowsFFmpegWorkerException()
+    {
+        if (!WorkerBinaryPresent())
+        {
+            Assert.Ignore(
+                "FFmpeg worker binary not present in the test output; skipping the process-level contract test.");
+        }
+
+        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
+
+        // Open spawns the worker over IPC and returns the FFmpegReaderProxy. A null result means the
+        // worker could not start (binary missing or FFmpeg natives absent) -> self-skip on CI.
+        using MediaReader? reader = decoderInfo.Open(_audioOnlyPath, new MediaOptions(MediaMode.AudioVideo));
+        if (reader is null)
+        {
+            Assert.Ignore(
+                "FFmpeg worker/natives unavailable (could not open the audio fixture); skipping the process-level contract test.");
+            return;
+        }
+
+        // Sanity: the fixture must be audio-only, so the reader exercises the HandleReadVideo
+        // audio-only error branch (not the "unknown reader" or ring-buffer paths).
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.HasAudio, Is.True, "the WAV fixture must expose an audio stream");
+            Assert.That(reader.HasVideo, Is.False, "the WAV fixture must be audio-only (no video stream)");
+        });
+
+        Assert.That(
+            () => reader.ReadVideo(0, out _),
+            Throws.TypeOf<FFmpegWorkerException>(),
+            "ReadVideo on an audio-only reader must surface the worker's CreateError as a thrown FFmpegWorkerException, not a silent false");
+    }
+
+    // The CopyWorkerBinary target lays the worker's output flat into the test bin dir. Nuke publishes
+    // isolate it under an FFmpegWorker/ subdir, so probe both — mirroring FFmpegWorkerProcess.ResolveWorkerCommand.
+    private static bool WorkerBinaryPresent()
+    {
+        string baseDir = AppContext.BaseDirectory;
+        return File.Exists(Path.Combine(baseDir, "Beutl.FFmpegWorker.dll"))
+            || File.Exists(Path.Combine(baseDir, "FFmpegWorker", "Beutl.FFmpegWorker.dll"));
+    }
+
+    // Writes a tiny, valid audio-only PCM WAV (0.1s of 8 kHz mono 16-bit silence). FFmpeg decodes WAV
+    // with its base demuxer, so no extra codec/native beyond the worker's FFmpeg load is required, and
+    // no binary fixture is committed.
+    private static void WriteSilentPcmWav(string path)
+    {
+        const int sampleRate = 8000;
+        const short channels = 1;
+        const short bitsPerSample = 16;
+        const int numSamples = 800; // 0.1 second
+        int blockAlign = channels * (bitsPerSample / 8);
+        int byteRate = sampleRate * blockAlign;
+        int dataSize = numSamples * blockAlign;
+
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        using var writer = new BinaryWriter(stream);
+
+        // RIFF header
+        writer.Write("RIFF"u8);
+        writer.Write(36 + dataSize); // ChunkSize
+        writer.Write("WAVE"u8);
+
+        // fmt sub-chunk
+        writer.Write("fmt "u8);
+        writer.Write(16);                    // Subchunk1Size (PCM)
+        writer.Write((short)1);              // AudioFormat = PCM
+        writer.Write(channels);
+        writer.Write(sampleRate);
+        writer.Write(byteRate);
+        writer.Write((short)blockAlign);
+        writer.Write(bitsPerSample);
+
+        // data sub-chunk (silence)
+        writer.Write("data"u8);
+        writer.Write(dataSize);
+        writer.Write(new byte[dataSize]);
+    }
+}

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
@@ -97,8 +97,8 @@ public class FFmpegReaderProxyReadVideoContractTests
             "ReadVideo on an audio-only reader must surface the worker's CreateError as a thrown FFmpegWorkerException, not a silent false");
     }
 
-    // The CopyWorkerBinary target lays the worker's output flat into the test bin dir. Nuke publishes
-    // isolate it under an FFmpegWorker/ subdir, so probe both — mirroring FFmpegWorkerProcess.ResolveWorkerCommand.
+    // CopyWorkerBinary lays the worker flat into the test bin dir, but Nuke publish isolates it under an
+    // FFmpegWorker/ subdir, so probe both — mirroring FFmpegWorkerProcess.ResolveWorkerCommand.
     private static bool WorkerBinaryPresent()
     {
         string baseDir = AppContext.BaseDirectory;

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Extensions.FFmpeg.Decoding;
+﻿using Beutl.Extensions.FFmpeg;
+using Beutl.Extensions.FFmpeg.Decoding;
 using Beutl.Media.Decoding;
 
 namespace Beutl.FFmpegIpc.Tests;
@@ -17,8 +18,11 @@ namespace Beutl.FFmpegIpc.Tests;
 /// </para>
 /// <para>
 /// The worker binary is copied into the test output by the <c>CopyWorkerBinary</c> MSBuild target
-/// (no compile-closure reference to the GPL project). When the worker binary or its FFmpeg natives
-/// are unavailable (e.g. CI without FFmpeg), the test self-skips via <see cref="Assert.Ignore(string)"/>.
+/// (no compile-closure reference to the GPL project). Only a genuinely unavailable prerequisite
+/// self-skips: a missing worker binary, or a worker that exits because the FFmpeg natives are absent
+/// (surfaced as <see cref="FFmpegLibrariesNotFoundException"/>). Once the worker has started with its
+/// natives loaded, any failure to open the fixture is a real worker/proxy regression and fails the
+/// test rather than being masked as "unavailable".
 /// </para>
 /// </summary>
 [TestFixture, NonParallelizable]
@@ -57,28 +61,38 @@ public class FFmpegReaderProxyReadVideoContractTests
                 "FFmpeg worker binary not present in the test output; skipping the process-level contract test.");
         }
 
-        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
-
-        // Open spawns the worker over IPC and returns the FFmpegReaderProxy. A null result means the
-        // worker could not start (binary missing or FFmpeg natives absent) -> self-skip on CI.
-        using MediaReader? reader = decoderInfo.Open(_audioOnlyPath, new MediaOptions(MediaMode.AudioVideo));
-        if (reader is null)
+        // Native-availability probe kept separate from the contract call: the worker loads the FFmpeg
+        // natives at startup and only completes the IPC handshake when they are present (otherwise it
+        // exits and EnsureStarted surfaces FFmpegLibrariesNotFoundException). Skipping only on that
+        // exception means a later null from Open — the worker is up, natives loaded — is a real
+        // OpenFile/proxy regression that must fail the test, not be masked as "unavailable".
+        try
+        {
+            FFmpegWorkerProcess.DecodingInstance.EnsureStarted();
+        }
+        catch (FFmpegLibrariesNotFoundException ex)
         {
             Assert.Ignore(
-                "FFmpeg worker/natives unavailable (could not open the audio fixture); skipping the process-level contract test.");
-            return;
+                $"FFmpeg natives unavailable ({ex.Message}); skipping the process-level contract test.");
         }
+
+        var decoderInfo = new FFmpegDecoderInfo(new FFmpegDecodingSettings());
+
+        using MediaReader? reader = decoderInfo.Open(_audioOnlyPath, new MediaOptions(MediaMode.AudioVideo));
+        Assert.That(
+            reader, Is.Not.Null,
+            "the worker started with FFmpeg natives loaded, so Open must succeed; a null result is a real OpenFile/proxy regression, not an unavailable prerequisite");
 
         // Sanity: the fixture must be audio-only, so the reader exercises the HandleReadVideo
         // audio-only error branch (not the "unknown reader" or ring-buffer paths).
         Assert.Multiple(() =>
         {
-            Assert.That(reader.HasAudio, Is.True, "the WAV fixture must expose an audio stream");
+            Assert.That(reader!.HasAudio, Is.True, "the WAV fixture must expose an audio stream");
             Assert.That(reader.HasVideo, Is.False, "the WAV fixture must be audio-only (no video stream)");
         });
 
         Assert.That(
-            () => reader.ReadVideo(0, out _),
+            () => reader!.ReadVideo(0, out _),
             Throws.TypeOf<FFmpegWorkerException>(),
             "ReadVideo on an audio-only reader must surface the worker's CreateError as a thrown FFmpegWorkerException, not a silent false");
     }

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
@@ -42,7 +42,7 @@ public class FFmpegReaderProxyReadVideoContractTests
             if (_audioOnlyPath != null && File.Exists(_audioOnlyPath))
                 File.Delete(_audioOnlyPath);
         }
-        catch (IOException)
+        catch (Exception)
         {
             // Best-effort cleanup of the temp fixture; a leftover file must not fail the run.
         }


### PR DESCRIPTION
Add a process-level IPC contract test that spawns the real Beutl.FFmpegWorker via
the MIT FFmpegReaderProxy path (FFmpegDecoderInfo.Open) and asserts that ReadVideo
on an audio-only reader throws FFmpegWorkerException. This pins
DecodingHandler.HandleReadVideo's audio-only error branch (CreateError when a
ReadVideo request hits a reader with no video stream) and the worker-error ->
thrown-exception surfacing contract, so a future regression (e.g. swapping the
error for a Success=false response) is caught. The unreachable-by-construction
invariant branch (HasVideo && RingBuffer == null) is intentionally left untested.

The fixture is a tiny audio-only PCM WAV generated at test setup (no committed
binary). The worker binary is made available at runtime by a copy-only
CopyWorkerBinary MSBuild target mirroring tests/Beutl.FFmpegBenchmarks, with no
compile-closure reference to the GPL worker, so the GPL/MIT boundary stays intact.
The test self-skips (Assert.Ignore) when the worker binary or FFmpeg natives are
unavailable (e.g. CI without FFmpeg).

Refs: Project #9 board item "FFmpegWorker: add worker-spawning IPC contract test for FFmpegReaderProxy ReadVideo error paths"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new process-level IPC contract test that starts the FFmpeg worker and verifies `ReadVideo` on an audio-only input throws the expected worker exception (instead of silent failure).
  * The test self-skips when the worker binary or required FFmpeg natives/fixtures aren’t available.
* **Chores**
  * Updated the test project build to deterministically build and copy the FFmpeg worker binaries into test output so runtime execution is consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->