### PR TITLE
chore: Bump FluentIcons.FluentAvalonia to FluentIcons.Avalonia.Fluent 2.0.330

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="FFmpeg.AutoGen.Bindings.DynamicallyLoaded" Version="8.1.0" />
     <PackageVersion Include="FFmpeg4Sharp" Version="7.0.1" />
     <PackageVersion Include="FluentAvaloniaUI" Version="2.5.1" />
-    <PackageVersion Include="FluentIcons.FluentAvalonia" Version="1.1.224" />
+    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.330" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,28 +1,28 @@
 ## .NET Runtime
 https://github.com/dotnet/runtime
 
-The MIT License (MIT) 
-  
-Copyright (c) .NET Foundation and Contributors 
-  
-All rights reserved. 
-  
-Permission is hereby granted, free of charge, to any person obtaining a copy 
-of this software and associated documentation files (the "Software"), to deal 
-in the Software without restriction, including without limitation the rights 
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is 
-furnished to do so, subject to the following conditions: 
-  
-The above copyright notice and this permission notice shall be included in all 
-copies or substantial portions of the Software. 
-  
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ## Avalonia
@@ -1128,7 +1128,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## FluentIcons.FluentAvalonia
+## FluentIcons.Avalonia.Fluent
 https://github.com/davidxuang/FluentIcons
 
 MIT License
@@ -1602,7 +1602,7 @@ subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER

--- a/src/Beutl.Controls/Beutl.Controls.csproj
+++ b/src/Beutl.Controls/Beutl.Controls.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Xaml.Behaviors.Interactivity" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
-    <PackageReference Include="FluentIcons.FluentAvalonia" />
+    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
 

--- a/src/Beutl.Controls/Styling/FileInputArea.axaml
+++ b/src/Beutl.Controls/Styling/FileInputArea.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/NavigationView.axaml
+++ b/src/Beutl.Controls/Styling/NavigationView.axaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:icons="using:FluentIcons.FluentAvalonia"
+        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
         xmlns:local="using:Beutl.Controls"
         xmlns:ui="using:FluentAvalonia.UI.Controls"
         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Beutl.Controls"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/AlignmentXEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/AlignmentXEditor.axaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">

--- a/src/Beutl.Controls/Styling/PropertyEditors/BooleanEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/BooleanEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ColorComponentsEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ColorComponentsEditor.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Beutl.Controls"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="clr-namespace:FluentIcons.FluentAvalonia;assembly=FluentIcons.FluentAvalonia"
+                    xmlns:icons="clr-namespace:FluentIcons.Avalonia.Fluent;assembly=FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/CornerRadiusEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/CornerRadiusEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/EnumEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/EnumEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>
@@ -55,7 +55,7 @@
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="local:EnumItem">
                                         <TextBlock ToolTip.Tip="{Binding Description}"
-                                                   Text="{Binding DisplayName}" 
+                                                   Text="{Binding DisplayName}"
                                                    Background="Transparent" />
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
@@ -161,7 +161,7 @@
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="local:EnumItem">
                                         <TextBlock ToolTip.Tip="{Binding Description}"
-                                                   Text="{Binding DisplayName}" 
+                                                   Text="{Binding DisplayName}"
                                                    Background="Transparent" />
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
@@ -206,7 +206,7 @@
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="local:EnumItem">
                                         <TextBlock ToolTip.Tip="{Binding Description}"
-                                                   Text="{Binding DisplayName}" 
+                                                   Text="{Binding DisplayName}"
                                                    Background="Transparent" />
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>

--- a/src/Beutl.Controls/Styling/PropertyEditors/FontFamilyEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/FontFamilyEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/GradingColorComponentsEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/GradingColorComponentsEditor.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Beutl.Controls"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="clr-namespace:FluentIcons.FluentAvalonia;assembly=FluentIcons.FluentAvalonia"
+                    xmlns:icons="clr-namespace:FluentIcons.Avalonia.Fluent;assembly=FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/PropertyEditorResources.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/PropertyEditorResources.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:i="using:Avalonia.Xaml.Interactions.Core"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:intv="using:Avalonia.Xaml.Interactivity"
                     xmlns:local="using:Beutl.Controls.Styling.PropertyEditors"
                     xmlns:pe="using:Beutl.Controls.PropertyEditors"

--- a/src/Beutl.Controls/Styling/PropertyEditors/ReferenceEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ReferenceEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors">
     <Design.PreviewWith>
         <Border Width="300">

--- a/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/StringEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/StringEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ThicknessEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ThicknessEditor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector3Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector3Editor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector4Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector4Editor.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>

--- a/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
+++ b/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="clr-namespace:FluentIcons.FluentAvalonia;assembly=FluentIcons.FluentAvalonia"
+                    xmlns:icons="clr-namespace:FluentIcons.Avalonia.Fluent;assembly=FluentIcons.Avalonia.Fluent"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
     <Design.PreviewWith>

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="using:Beutl.Editor.Components.AudioVisualizerTab.ViewModels"

--- a/src/Beutl.Editor.Components/Beutl.Editor.Components.csproj
+++ b/src/Beutl.Editor.Components/Beutl.Editor.Components.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="PanAndZoom" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
-    <PackageReference Include="FluentIcons.FluentAvalonia" />
+    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="ReactiveProperty" />

--- a/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml
+++ b/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Editor.Components.ColorGradingProperties.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
+++ b/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:icons="clr-namespace:FluentIcons.FluentAvalonia;assembly=FluentIcons.FluentAvalonia"
+                    xmlns:icons="clr-namespace:FluentIcons.Avalonia.Fluent;assembly=FluentIcons.Avalonia.Fluent"
                     xmlns:pe="using:Beutl.Controls.PropertyEditors">
     <ControlTheme x:Key="MinimalNumberEditor"
                   BasedOn="{StaticResource {x:Type pe:StringEditor}}"

--- a/src/Beutl.Editor.Components/ColorGradingTab/Views/ColorGradingTabView.axaml
+++ b/src/Beutl.Editor.Components/ColorGradingTab/Views/ColorGradingTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="clr-namespace:FluentIcons.FluentAvalonia;assembly=FluentIcons.FluentAvalonia"
+             xmlns:icons="clr-namespace:FluentIcons.Avalonia.Fluent;assembly=FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:scopes="using:Beutl.Editor.Components.ColorScopesTab.Views.Scopes"

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModel="using:Beutl.Editor.Components.ElementPropertyTab.ViewModels"

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Editor.Components.FileBrowserTab.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -174,7 +174,7 @@
                         <Panel>
                             <icons:SymbolIcon FontSize="16"
                                               IsVisible="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.IsList}}"
-                                              Symbol="TextBulletListLtr" />
+                                              Symbol="TextBulletList" />
                             <icons:SymbolIcon FontSize="16"
                                               IsVisible="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.IsTree}}"
                                               Symbol="TextBulletListTree" />
@@ -234,7 +234,7 @@
                                                           Symbol="Grid" />
                                         <icons:SymbolIcon FontSize="14"
                                                           IsVisible="{Binding !IsFavoritesIconView.Value}"
-                                                          Symbol="TextBulletListLtr" />
+                                                          Symbol="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>
@@ -301,7 +301,7 @@
                                                           Symbol="Grid" />
                                         <icons:SymbolIcon FontSize="14"
                                                           IsVisible="{Binding !IsProjectDirIconView.Value}"
-                                                          Symbol="TextBulletListLtr" />
+                                                          Symbol="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>
@@ -363,7 +363,7 @@
                                                           Symbol="Grid" />
                                         <icons:SymbolIcon FontSize="14"
                                                           IsVisible="{Binding !IsMediaFilesIconView.Value}"
-                                                          Symbol="TextBulletListLtr" />
+                                                          Symbol="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>

--- a/src/Beutl.Editor.Components/GraphEditorTab/Resources/GraphEditorResources.axaml
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Resources/GraphEditorResources.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:view="using:Beutl.Editor.Components.GraphEditorTab.Views"
-                    xmlns:icons="using:FluentIcons.FluentAvalonia"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:viewModel="using:Beutl.Editor.Components.GraphEditorTab.ViewModels">
     <ResourceDictionary.ThemeDictionaries>

--- a/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:convert="using:Beutl.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Editor.Components.GraphEditorTab.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
@@ -15,7 +15,7 @@ using Beutl.Utilities;
 using FluentAvalonia.UI.Controls;
 
 using Symbol = FluentIcons.Common.Symbol;
-using SymbolIcon = FluentIcons.FluentAvalonia.SymbolIcon;
+using SymbolIcon = FluentIcons.Avalonia.Fluent.SymbolIcon;
 
 namespace Beutl.Editor.Components.LibraryTab.Views;
 

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/EasingsView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/EasingsView.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/LibraryView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/LibraryView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/NodesView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/NodesView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/SearchView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/SearchView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/NodePortView.axaml.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/NodePortView.axaml.cs
@@ -9,8 +9,8 @@ using Beutl.Controls.PropertyEditors;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Components.NodeGraphTab.ViewModels;
 using Beutl.NodeGraph;
+using FluentIcons.Avalonia.Fluent;
 using FluentIcons.Common;
-using FluentIcons.FluentAvalonia;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:convert="using:Beutl.Editor.Components.PathEditorTab.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:paz="using:Avalonia.Controls.PanAndZoom"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:h="using:Beutl.Editor.Components.Helpers"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:p="using:Beutl.Services.PrimitiveImpls"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:convert="using:Beutl.Editor.Components.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:views="using:Beutl.Editor.Components.TimelineTab.Views"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:local="using:Beutl.Editor.Components.TimelineTab.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -4,7 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ecv="using:Beutl.Editor.Components.Views"
              xmlns:h="using:Beutl.Editor.Components.Helpers"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Editor.Components.TimelineTab.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -20,7 +20,7 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
-    <PackageReference Include="FluentIcons.FluentAvalonia" />
+    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="AsyncImageLoader.Avalonia" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="FluentAvaloniaUI" />
-    <PackageReference Include="FluentIcons.FluentAvalonia" />
+    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 

--- a/src/Beutl.WaitingDialog/MainWindow.axaml.cs
+++ b/src/Beutl.WaitingDialog/MainWindow.axaml.cs
@@ -70,7 +70,7 @@ public partial class MainWindow : AppWindow
         {
             subheaderRoot.IsVisible = true;
             iconHost.IsVisible = true;
-            iconSourceElement.IconSource = new FluentIcons.FluentAvalonia.SymbolIconSource
+            iconSourceElement.IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource
             {
                 Symbol = iconSymbol,
             };

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Dotnet.Bundle" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
-    <PackageReference Include="FluentIcons.FluentAvalonia" />
+    <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="OpenTelemetry" />

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml
@@ -4,7 +4,7 @@
              xmlns:api="using:Beutl.Api.Objects"
              xmlns:asyncImageLoader="using:AsyncImageLoader"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:asyncImageLoader="using:AsyncImageLoader"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="using:Beutl.ViewModels.ExtensionsPages.DiscoverPages"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
@@ -5,7 +5,7 @@
              xmlns:asyncImageLoader="using:AsyncImageLoader"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:extensionsPage="using:Beutl.ViewModels.ExtensionsPages"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:panelx="using:PanelExtension"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
@@ -5,7 +5,7 @@
              xmlns:asyncImageLoader="using:AsyncImageLoader"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:extensionsPage="using:Beutl.ViewModels.ExtensionsPages"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:panelx="using:PanelExtension"

--- a/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:asyncImageLoader="using:AsyncImageLoader"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsDialog.axaml.cs
+++ b/src/Beutl/Pages/SettingsDialog.axaml.cs
@@ -119,7 +119,7 @@ public sealed partial class SettingsDialog : AppWindow
             {
                 Content = Strings.Extensions,
                 Tag = typeof(ExtensionsSettingsPage),
-                IconSource = new FluentIcons.FluentAvalonia.SymbolIconSource()
+                IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource()
                 {
                     Symbol = FluentIcons.Common.Symbol.PuzzlePiece
                 }
@@ -128,7 +128,7 @@ public sealed partial class SettingsDialog : AppWindow
             {
                 Content = Strings.Info,
                 Tag = typeof(InformationPage),
-                IconSource = new FluentIcons.FluentAvalonia.SymbolIconSource()
+                IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource()
                 {
                     Symbol = FluentIcons.Common.Symbol.Info
                 }

--- a/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
+++ b/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
@@ -4,7 +4,7 @@
              xmlns:asyncImage="using:AsyncImageLoader"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/AnExtensionSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/AnExtensionSettingsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Pages.SettingsPages"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Pages/SettingsPages/DecoderPriorityPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/DecoderPriorityPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"

--- a/src/Beutl/Pages/SettingsPages/InformationPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/InformationPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/PropertyEditorGroup.axaml
+++ b/src/Beutl/Pages/SettingsPages/PropertyEditorGroup.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="450"

--- a/src/Beutl/Pages/SettingsPages/TelemetrySettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/TelemetrySettingsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
@@ -5,7 +5,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Beutl.ViewModels;
 using FluentAvalonia.UI.Controls;
 using Symbol = FluentIcons.Common.Symbol;
-using SymbolIconSource = FluentIcons.FluentAvalonia.SymbolIconSource;
+using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
 
 namespace Beutl.Services.PrimitiveImpls;
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -7,7 +7,7 @@ using Beutl.ViewModels;
 using Beutl.Views;
 using FluentAvalonia.UI.Controls;
 using Symbol = FluentIcons.Common.Symbol;
-using SymbolIconSource = FluentIcons.FluentAvalonia.SymbolIconSource;
+using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
 
 namespace Beutl.Services.PrimitiveImpls;
 

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -169,7 +169,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     public ReadOnlyReactiveProperty<bool> HasExpression { get; }
 
-    public ReactivePropertySlim<bool> IsSymbolIconFilled { get; } = new();
+    public ReactivePropertySlim<FluentIcons.Common.IconVariant> SymbolIconVariant { get; } = new();
 
     public ReactivePropertySlim<IKeyFrame?> EditingKeyFrame { get; } = new();
 
@@ -252,11 +252,13 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
                                 TimeSpan keyTime = animation.UseGlobalClock ? globalkeyTime : localKeyTime;
                                 keyTime = keyTime.RoundToRate(rate);
 
-                                IsSymbolIconFilled.Value = t.Second?.Any(obj => obj.KeyTime == keyTime) ?? false;
+                                SymbolIconVariant.Value = t.Second?.Any(obj => obj.KeyTime == keyTime) ?? false
+                                    ? FluentIcons.Common.IconVariant.Filled
+                                    : FluentIcons.Common.IconVariant.Regular;
                                 if (t.Second != null)
                                 {
                                     float kfIndex = t.Second.IndexAtOrCount(keyTime);
-                                    if (!IsSymbolIconFilled.Value)
+                                    if (SymbolIconVariant.Value != FluentIcons.Common.IconVariant.Filled)
                                         kfIndex -= 0.5f;
 
                                     _skipKeyFrameIndexSubscription = KeyFrameIndex.Value != kfIndex;

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -169,7 +169,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     public ReadOnlyReactiveProperty<bool> HasExpression { get; }
 
-    public ReactivePropertySlim<FluentIcons.Common.IconVariant> SymbolIconVariant { get; } = new();
+public ReactivePropertySlim<FluentIcons.Common.IconVariant> SymbolIconVariant { get; } = new(FluentIcons.Common.IconVariant.Regular);
 
     public ReactivePropertySlim<IKeyFrame?> EditingKeyFrame { get; } = new();
 

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -3,7 +3,7 @@
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:converters="clr-namespace:Beutl.Converters;assembly=Beutl"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                  xmlns:icons="using:FluentIcons.FluentAvalonia"
+                  xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                   xmlns:lang="using:Beutl.Language"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml
@@ -3,7 +3,7 @@
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:converters="clr-namespace:Beutl.Converters;assembly=Beutl"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                  xmlns:icons="using:FluentIcons.FluentAvalonia"
+                  xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                   xmlns:lang="using:Beutl.Language"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sysIO="using:System.IO"

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:intv="using:Avalonia.Xaml.Interactivity"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/CurveMapEditor.axaml
+++ b/src/Beutl/Views/Editors/CurveMapEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/GraphModelEditor.axaml
+++ b/src/Beutl/Views/Editors/GraphModelEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml
+++ b/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"

--- a/src/Beutl/Views/Editors/ListEditor.axaml
+++ b/src/Beutl/Views/Editors/ListEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/ListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/ListItemEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:interactions="using:Avalonia.Xaml.Interactions.Core"
              xmlns:interactivity="using:Avalonia.Xaml.Interactivity"
              xmlns:lang="using:Beutl.Language"

--- a/src/Beutl/Views/Editors/ListItemEditorHost.axaml
+++ b/src/Beutl/Views/Editors/ListItemEditorHost.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModel="using:Beutl.ViewModels.Editors"

--- a/src/Beutl/Views/Editors/NavigateButton.axaml
+++ b/src/Beutl/Views/Editors/NavigateButton.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="450"

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
@@ -70,7 +70,7 @@
         <icons:SymbolIcon x:Name="symbolIcon"
                           Classes.hasAnimation="{Binding HasAnimation.Value}"
                           Classes.hasExpression="{Binding HasExpression.Value}"
-                          IsFilled="{Binding IsSymbolIconFilled.Value}">
+                          IconVariant="{Binding SymbolIconVariant.Value}">
             <icons:SymbolIcon.Styles>
                 <Style Selector="icons|SymbolIcon">
                     <Setter Property="Symbol" Value="MoreVertical" />

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
@@ -67,7 +67,7 @@ public sealed partial class PropertyEditorMenu : UserControl
             else if (viewModel.HasAnimation.Value && viewModel.GetService<IEditorClock>() is { } editorClock)
             {
                 TimeSpan keyTime = editorClock.CurrentTime.Value;
-                if (symbolIcon.IsFilled)
+                if (symbolIcon.IconVariant == FluentIcons.Common.IconVariant.Filled)
                 {
                     viewModel.RemoveKeyFrame(keyTime);
                 }

--- a/src/Beutl/Views/Editors/SceneEditor.axaml
+++ b/src/Beutl/Views/Editors/SceneEditor.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="Beutl.Views.Editors.SceneEditor"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"
              xmlns:ui="using:FluentAvalonia.UI.Controls"

--- a/src/Beutl/Views/Editors/TextureSourceEditor.axaml
+++ b/src/Beutl/Views/Editors/TextureSourceEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:editor="using:Beutl.Controls.PropertyEditors"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:h="using:Beutl.Editor.Components.Helpers"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:p="using:Beutl.Services.PrimitiveImpls"
@@ -121,7 +121,7 @@
                               Header="{x:Static lang:Strings.ExportProject}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="ArrowExportLtr" />
+                            <icons:SymbolIcon Symbol="ArrowExport" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <!--  プロジェクトをインポート  -->

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -4,7 +4,7 @@
              xmlns:controls="using:Beutl.Controls"
              xmlns:converters="clr-namespace:Beutl.Converters;assembly=Beutl"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.FluentAvalonia"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:local="using:Beutl.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Beutl/Views/Tutorial/TutorialListDialog.axaml
+++ b/src/Beutl/Views/Tutorial/TutorialListDialog.axaml
@@ -2,7 +2,7 @@
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                  xmlns:icons="using:FluentIcons.FluentAvalonia"
+                  xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                   xmlns:lang="using:Beutl.Language"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"


### PR DESCRIPTION
## Description
<!-- What does this PR do and why? Bullet points encouraged. -->
Update the icon control dependency. This introduces more available icons, as well as the compatibility (with v2.1) with FluentAvalonia 3 / Avalonia 12 in the future.

## Affected areas
<!-- Check the modules this PR touches. These map to the `area-*` labels. -->
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
<!-- Public API / behavior changes that downstream code must adapt to.
     Write "None" if there are none. Breaking PRs use a `feat!:` / `refactor!:`
     title and a `BREAKING CHANGE:` commit footer. -->
None

## Test plan
<!-- - Unit/integration tests added or updated (path + brief intent)
     - Manual repro steps for behavior changes
     - For UI changes: screenshots or short screen recording (before/after if applicable) -->
Blank project screen after the changes:
![screenshot](https://github.com/user-attachments/assets/3631fc05-9e70-433a-b82b-0aa8cc0786ab)

## Fixed issues / References
<!-- - Closes #1234
     - Project board: b-editor/projects/9 ("item title")
     - Leave blank if none -->
Relates to https://github.com/b-editor/beutl/issues/563.

---

<!--
Reminders (see CONTRIBUTING.md / AGENTS.md):
- New logic ships with a NUnit test under `tests/`.
- New XAML uses compiled bindings (`x:CompileBindings="True"` + `x:DataType`).
- Do not cross the GPL/MIT boundary: MIT projects must not reference `Beutl.FFmpegWorker`.
- Do not defer work: everything this change surfaced is finished here — no `## Follow-ups`
  pile, no leftover `// TODO`. Anything genuinely out of scope or blocked was raised with a
  maintainer, not quietly filed away (AGENTS.md "Do not defer work").
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Bug Fixes**
  * Updated the app to use the newer Fluent Icons package throughout the UI for consistent icon resolution.
  * Refreshed icons across menus, toolbars, and editor panels, including correcting a few icon symbol selections in the UI.
  * Updated icon “filled/regular” behavior to use the current icon variant state consistently across editor interactions.

* **Chores**
  * Reformatted and refreshed third-party license/notice text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->