### PR TITLE
feat: Add a terminal tool tab

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -50,6 +50,8 @@ jobs:
         run: echo "run-id=${{ github.run_id }}" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
+      with:
+        submodules: recursive
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "external/XTerm.NET"]
+	path = external/XTerm.NET
+	url = https://github.com/b-editor/XTerm.NET.git
+	branch = beutl
+[submodule "external/Iciclecreek.Avalonia.Terminal"]
+	path = external/Iciclecreek.Avalonia.Terminal
+	url = https://github.com/b-editor/Iciclecreek.Avalonia.Terminal.git
+	branch = beutl

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1757,3 +1757,53 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## XTerm.NET
+https://github.com/b-editor/XTerm.NET
+
+MIT License
+
+Copyright (c) 2025 Tom Laird-McConnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Iciclecreek.Avalonia.Terminal
+https://github.com/b-editor/Iciclecreek.Avalonia.Terminal
+
+MIT License
+
+Copyright (c) 2025 Tom Laird-McConnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external/.editorconfig
+++ b/external/.editorconfig
@@ -1,0 +1,8 @@
+# Vendored submodules (XTerm.NET, Iciclecreek.Avalonia.Terminal).
+# root = true stops these from inheriting Beutl's repo-root .editorconfig, and
+# generated_code = true excludes them from `dotnet format` so their upstream
+# style is preserved instead of being reformatted to Beutl's conventions.
+root = true
+
+[*]
+generated_code = true

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -1,0 +1,2 @@
+<!-- Stops Beutl's root Directory.Build.props from applying to the vendored submodules. -->
+<Project />

--- a/external/Directory.Build.targets
+++ b/external/Directory.Build.targets
@@ -1,0 +1,2 @@
+<!-- Stops Beutl's root Directory.Build.targets from applying to the vendored submodules. -->
+<Project />

--- a/external/Directory.Packages.props
+++ b/external/Directory.Packages.props
@@ -1,0 +1,7 @@
+<!-- The vendored submodules pin their own package versions; keep Beutl's central
+     package management from rejecting their versioned PackageReferences. -->
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/src/Beutl.Editor.Components/Beutl.Editor.Components.csproj
+++ b/src/Beutl.Editor.Components/Beutl.Editor.Components.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Beutl.Configuration\Beutl.Configuration.csproj" />
     <ProjectReference Include="..\Beutl.Language\Beutl.Language.csproj" />
     <ProjectReference Include="..\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
+    <ProjectReference Include="..\..\external\Iciclecreek.Avalonia.Terminal\src\Iciclecreek.Avalonia.TerminalWindow\Iciclecreek.Avalonia.Terminal.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Beutl.Editor.Components/Properties/AssemblyInfo.cs
+++ b/src/Beutl.Editor.Components/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Beutl")]
+[assembly: InternalsVisibleTo("Beutl.UnitTests")]

--- a/src/Beutl.Editor.Components/TerminalTab/TerminalTabExtension.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/TerminalTabExtension.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Avalonia.Controls;
+
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+using Beutl.Editor.Components.TerminalTab.Views;
+
+namespace Beutl.Editor.Components.TerminalTab;
+
+[PrimitiveImpl]
+public sealed class TerminalTabExtension : ToolTabExtension
+{
+    public static readonly TerminalTabExtension Instance = new();
+
+    public override string Name => "Terminal";
+
+    public override string DisplayName => Strings.Terminal;
+
+    public override string? Header => Strings.Terminal;
+
+    public override bool CanMultiple => true;
+
+    public override DockAnchor DefaultAnchor => DockAnchor.Bottom;
+
+    public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
+    {
+        control = new TerminalTabView();
+        return true;
+    }
+
+    public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
+    {
+        context = new TerminalTabViewModel(editorContext);
+        return true;
+    }
+}

--- a/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
@@ -78,8 +78,13 @@ public sealed class TerminalTabViewModel : IToolContext
 
         // GUI-launched macOS/Linux apps carry no locale in their environment, which drops
         // shells and TUI apps into the C locale and garbles multi-byte output.
-        return cultureName.Contains('-')
-            ? cultureName.Replace('-', '_') + ".UTF-8"
+        // POSIX locale names are language[_TERRITORY]; keep the language and the ISO-3166 territory
+        // (a two-letter uppercase subtag), skipping any script subtag such as "Hant" in zh-Hant-TW,
+        // which would otherwise produce an invalid locale like zh_Hant_TW.UTF-8.
+        string[] parts = cultureName.Split('-');
+        string? region = Array.FindLast(parts, static p => p.Length == 2 && p.All(char.IsAsciiLetterUpper));
+        return parts.Length > 0 && !string.IsNullOrEmpty(parts[0]) && region is not null
+            ? $"{parts[0]}_{region}.UTF-8"
             : "en_US.UTF-8";
     }
 

--- a/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
@@ -106,6 +106,9 @@ public sealed class TerminalTabViewModel : IToolContext
     {
         Disposed?.Invoke(this, EventArgs.Empty);
         Disposed = null;
+        IsSelected.Dispose();
+        IsProcessExited.Dispose();
+        ExitCode.Dispose();
     }
 
     public void ReadFromJson(JsonObject json)

--- a/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
@@ -1,0 +1,120 @@
+﻿using System.Text.Json.Nodes;
+
+using Beutl.ProjectSystem;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Reactive.Bindings;
+
+namespace Beutl.Editor.Components.TerminalTab.ViewModels;
+
+public sealed class TerminalTabViewModel : IToolContext
+{
+    public TerminalTabViewModel(IEditorContext editorContext)
+    {
+        WorkingDirectory = ResolveWorkingDirectory(editorContext);
+        (ShellPath, ShellArgs) = ResolveShell(
+            Environment.GetEnvironmentVariable,
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS());
+        LangFallback = ResolveLangFallback(
+            Environment.GetEnvironmentVariable,
+            CultureInfo.CurrentCulture.Name,
+            OperatingSystem.IsWindows());
+    }
+
+    public ToolTabExtension Extension => TerminalTabExtension.Instance;
+
+    public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
+
+    public string Header => Strings.Terminal;
+
+    public string ShellPath { get; }
+
+    public string[] ShellArgs { get; }
+
+    public string? WorkingDirectory { get; }
+
+    public string? LangFallback { get; }
+
+    public ReactivePropertySlim<bool> IsProcessExited { get; } = new();
+
+    public ReactivePropertySlim<int> ExitCode { get; } = new();
+
+    internal event EventHandler? Disposed;
+
+    internal static (string Path, string[] Args) ResolveShell(
+        Func<string, string?> getEnvironmentVariable, bool isWindows, bool isMacOS)
+    {
+        if (isWindows)
+        {
+            return (getEnvironmentVariable("COMSPEC") ?? "cmd.exe", []);
+        }
+
+        string? shell = getEnvironmentVariable("SHELL");
+        if (string.IsNullOrWhiteSpace(shell))
+        {
+            shell = isMacOS ? "/bin/zsh" : "/bin/bash";
+        }
+
+        // A login shell picks up the user's profile (PATH etc.), which a bare PTY shell would not.
+        return (shell, ["-l"]);
+    }
+
+    internal static string? ResolveLangFallback(
+        Func<string, string?> getEnvironmentVariable, string cultureName, bool isWindows)
+    {
+        if (isWindows)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(getEnvironmentVariable("LC_ALL"))
+            || !string.IsNullOrEmpty(getEnvironmentVariable("LC_CTYPE"))
+            || !string.IsNullOrEmpty(getEnvironmentVariable("LANG")))
+        {
+            return null;
+        }
+
+        // GUI-launched macOS/Linux apps carry no locale in their environment, which drops
+        // shells and TUI apps into the C locale and garbles multi-byte output.
+        return cultureName.Contains('-')
+            ? cultureName.Replace('-', '_') + ".UTF-8"
+            : "en_US.UTF-8";
+    }
+
+    internal static string? ResolveWorkingDirectory(IEditorContext editorContext)
+    {
+        Scene? scene = editorContext.GetService<Scene>();
+        Project? project = scene?.FindHierarchicalParent<Project>();
+        if (project?.Uri is { } projectUri
+            && Path.GetDirectoryName(projectUri.LocalPath) is { Length: > 0 } projectDirectory)
+        {
+            return projectDirectory;
+        }
+
+        if (scene?.Uri is { } sceneUri
+            && Path.GetDirectoryName(sceneUri.LocalPath) is { Length: > 0 } sceneDirectory)
+        {
+            return sceneDirectory;
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        Disposed?.Invoke(this, EventArgs.Empty);
+        Disposed = null;
+    }
+
+    public void ReadFromJson(JsonObject json)
+    {
+    }
+
+    public void WriteToJson(JsonObject json)
+    {
+    }
+
+    public object? GetService(Type serviceType) => null;
+}

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="Beutl.Editor.Components.TerminalTab.Views.TerminalTabView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:lang="using:Beutl.Language"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:terminal="using:Iciclecreek.Terminal"
+             xmlns:vm="using:Beutl.Editor.Components.TerminalTab.ViewModels"
+             d:DesignHeight="300"
+             d:DesignWidth="600"
+             x:CompileBindings="True"
+             x:DataType="vm:TerminalTabViewModel"
+             mc:Ignorable="d">
+    <DockPanel>
+        <Border Background="{DynamicResource SolidBackgroundFillColorSecondaryBrush}"
+                DockPanel.Dock="Top"
+                IsVisible="{Binding IsProcessExited.Value}"
+                Padding="8,4">
+            <DockPanel>
+                <Button Click="OnRestartClick"
+                        Content="{x:Static lang:Strings.Restart}"
+                        DockPanel.Dock="Right" />
+                <TextBlock VerticalAlignment="Center" Text="{x:Static lang:Strings.TerminalSessionEnded}" />
+            </DockPanel>
+        </Border>
+        <terminal:TerminalControl Name="Terminal"
+                                  BufferSize="5000"
+                                  FontFamily="Consolas, Menlo, monospace"
+                                  Process=""
+                                  ProcessExited="OnProcessExited" />
+    </DockPanel>
+</UserControl>

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -24,19 +24,24 @@ public partial class TerminalTabView : UserControl
     {
         base.OnDataContextChanged(e);
 
-        if (_viewModel != null)
+        TerminalTabViewModel? previous = _viewModel;
+        if (previous != null)
         {
-            _viewModel.Disposed -= OnViewModelDisposed;
+            previous.Disposed -= OnViewModelDisposed;
         }
 
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
-            // Reset the lifecycle flags so a recycled view bound to a fresh view-model relaunches
-            // rather than staying suppressed by the previous binding's state.
-            _launched = false;
-            _launching = false;
-            _disposed = false;
+            if (!ReferenceEquals(previous, _viewModel))
+            {
+                // Reset the lifecycle flags only when a recycled view is bound to a DIFFERENT
+                // view-model. A same-view-model re-fire (e.g. DataContext cleared and restored
+                // during a dock/reparent) must not relaunch and kill the live PTY session.
+                _launched = false;
+                _launching = false;
+                _disposed = false;
+            }
 
             // Pass the locale per spawn so it never mutates the shared process environment
             // (which would race across concurrent terminals and leak into other subprocesses).

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -10,7 +10,9 @@ namespace Beutl.Editor.Components.TerminalTab.Views;
 public partial class TerminalTabView : UserControl
 {
     private TerminalTabViewModel? _viewModel;
+    private bool _launching;
     private bool _launched;
+    private bool _disposed;
 
     public TerminalTabView()
     {
@@ -42,19 +44,64 @@ public partial class TerminalTabView : UserControl
 
     private async void TryLaunch()
     {
-        if (_launched || _viewModel == null || !IsLoaded)
+        if (_launched || _launching || _viewModel == null || !IsLoaded)
         {
             return;
         }
 
-        _launched = true;
+        _launching = true;
+
+        string? previousLang = null;
+        bool langOverridden = false;
         if (_viewModel.LangFallback is { } lang)
         {
             // The PTY inherits this process' environment; there is no per-launch override.
+            // Set LANG only around the spawn and restore it afterwards so the terminal-only
+            // locale does not leak into later child processes (e.g. the FFmpeg worker).
+            previousLang = Environment.GetEnvironmentVariable("LANG");
             Environment.SetEnvironmentVariable("LANG", lang);
+            langOverridden = true;
         }
 
-        await Terminal.LaunchProcess(_viewModel.WorkingDirectory, _viewModel.ShellPath, _viewModel.ShellArgs);
+        try
+        {
+            await Terminal.LaunchProcess(_viewModel.WorkingDirectory, _viewModel.ShellPath, _viewModel.ShellArgs);
+        }
+        catch
+        {
+            // async void: an unhandled launch failure would terminate the app. Leaving
+            // _launched false lets the restart UI retry.
+            _viewModel.IsProcessExited.Value = true;
+            return;
+        }
+        finally
+        {
+            if (langOverridden)
+            {
+                Environment.SetEnvironmentVariable("LANG", previousLang);
+            }
+
+            _launching = false;
+        }
+
+        // Set only after a successful spawn so OnViewModelDisposed knows a PTY exists to kill.
+        _launched = true;
+
+        if (_disposed)
+        {
+            // Torn down mid-launch: OnViewModelDisposed ran before the PTY existed, so kill
+            // it here rather than reattaching a session with no live tab.
+            try
+            {
+                Terminal.Kill();
+            }
+            catch
+            {
+                // The PTY may already be gone; tearing down must not throw.
+            }
+
+            return;
+        }
 
         // Keep the PTY session alive while the tab is re-docked; the process is
         // killed explicitly when the view-model (i.e. the tab) is disposed.
@@ -84,6 +131,7 @@ public partial class TerminalTabView : UserControl
 
     private void OnViewModelDisposed(object? sender, EventArgs e)
     {
+        _disposed = true;
         Terminal.EndReparent();
         if (_launched)
         {

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -32,6 +32,13 @@ public partial class TerminalTabView : UserControl
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
+            if (_viewModel.LangFallback is { } lang)
+            {
+                // Pass the locale per spawn so it never mutates the shared process environment
+                // (which would race across concurrent terminals and leak into other subprocesses).
+                Terminal.EnvironmentOverrides = new Dictionary<string, string> { ["LANG"] = lang };
+            }
+
             _viewModel.Disposed += OnViewModelDisposed;
             TryLaunch();
         }
@@ -70,18 +77,8 @@ public partial class TerminalTabView : UserControl
         _launching = true;
         viewModel.IsProcessExited.Value = false;
 
-        string? previousLang = null;
-        bool langOverridden = false;
-        if (viewModel.LangFallback is { } lang)
-        {
-            // The PTY inherits this process' environment; there is no per-launch override.
-            // Set LANG only around the spawn and restore it afterwards so the terminal-only
-            // locale does not leak into later child processes (e.g. the FFmpeg worker).
-            previousLang = Environment.GetEnvironmentVariable("LANG");
-            Environment.SetEnvironmentVariable("LANG", lang);
-            langOverridden = true;
-        }
-
+        // The locale fallback is applied per spawn via Terminal.EnvironmentOverrides (set when the
+        // view-model is attached), so no process-wide environment mutation happens here.
         try
         {
             if (reuseConfiguredProcess)
@@ -95,11 +92,6 @@ public partial class TerminalTabView : UserControl
         }
         finally
         {
-            if (langOverridden)
-            {
-                Environment.SetEnvironmentVariable("LANG", previousLang);
-            }
-
             _launching = false;
         }
 

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -32,12 +32,12 @@ public partial class TerminalTabView : UserControl
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
-            if (_viewModel.LangFallback is { } lang)
-            {
-                // Pass the locale per spawn so it never mutates the shared process environment
-                // (which would race across concurrent terminals and leak into other subprocesses).
-                Terminal.EnvironmentOverrides = new Dictionary<string, string> { ["LANG"] = lang };
-            }
+            // Pass the locale per spawn so it never mutates the shared process environment
+            // (which would race across concurrent terminals and leak into other subprocesses).
+            // Cleared when the fallback is absent so a recycled view drops a prior view-model's LANG.
+            Terminal.EnvironmentOverrides = _viewModel.LangFallback is { } lang
+                ? new Dictionary<string, string> { ["LANG"] = lang }
+                : null;
 
             _viewModel.Disposed += OnViewModelDisposed;
             TryLaunch();
@@ -95,6 +95,25 @@ public partial class TerminalTabView : UserControl
             _launching = false;
         }
 
+        if (_disposed)
+        {
+            // Torn down mid-launch: OnViewModelDisposed already ran (before any PTY existed), so it
+            // could not kill one. Kill a PTY that did spawn and never touch the disposed view-model.
+            if (Terminal.HasProcess)
+            {
+                try
+                {
+                    Terminal.Kill();
+                }
+                catch
+                {
+                    // The PTY may already be gone; tearing down must not throw.
+                }
+            }
+
+            return;
+        }
+
         if (!Terminal.HasProcess)
         {
             // The terminal control swallows spawn failures (e.g. a missing SHELL/COMSPEC), so no
@@ -106,22 +125,6 @@ public partial class TerminalTabView : UserControl
 
         // Set only after a confirmed live PTY so OnViewModelDisposed knows there is one to kill.
         _launched = true;
-
-        if (_disposed)
-        {
-            // Torn down mid-launch: OnViewModelDisposed ran before the PTY existed, so kill it
-            // here rather than reattaching a session with no live tab.
-            try
-            {
-                Terminal.Kill();
-            }
-            catch
-            {
-                // The PTY may already be gone; tearing down must not throw.
-            }
-
-            return;
-        }
 
         // Keep the PTY session alive while the tab is re-docked; the process is
         // killed explicitly when the view-model (i.e. the tab) is disposed.

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -42,18 +42,37 @@ public partial class TerminalTabView : UserControl
         TryLaunch();
     }
 
-    private async void TryLaunch()
+    private void TryLaunch()
     {
         if (_launched || _launching || _viewModel == null || !IsLoaded)
         {
             return;
         }
 
+        // The first launch resolves the shell/args/working directory from the view-model.
+        _ = LaunchAsync(reuseConfiguredProcess: false);
+    }
+
+    private void OnRestartClick(object? sender, RoutedEventArgs e)
+    {
+        if (_launching || _viewModel == null)
+        {
+            return;
+        }
+
+        // Restart reuses the shell/args/working directory the first launch already configured.
+        _ = LaunchAsync(reuseConfiguredProcess: true);
+    }
+
+    private async Task LaunchAsync(bool reuseConfiguredProcess)
+    {
+        TerminalTabViewModel viewModel = _viewModel!;
         _launching = true;
+        viewModel.IsProcessExited.Value = false;
 
         string? previousLang = null;
         bool langOverridden = false;
-        if (_viewModel.LangFallback is { } lang)
+        if (viewModel.LangFallback is { } lang)
         {
             // The PTY inherits this process' environment; there is no per-launch override.
             // Set LANG only around the spawn and restore it afterwards so the terminal-only
@@ -65,14 +84,14 @@ public partial class TerminalTabView : UserControl
 
         try
         {
-            await Terminal.LaunchProcess(_viewModel.WorkingDirectory, _viewModel.ShellPath, _viewModel.ShellArgs);
-        }
-        catch
-        {
-            // async void: an unhandled launch failure would terminate the app. Leaving
-            // _launched false lets the restart UI retry.
-            _viewModel.IsProcessExited.Value = true;
-            return;
+            if (reuseConfiguredProcess)
+            {
+                await Terminal.LaunchProcess();
+            }
+            else
+            {
+                await Terminal.LaunchProcess(viewModel.WorkingDirectory, viewModel.ShellPath, viewModel.ShellArgs);
+            }
         }
         finally
         {
@@ -84,13 +103,22 @@ public partial class TerminalTabView : UserControl
             _launching = false;
         }
 
-        // Set only after a successful spawn so OnViewModelDisposed knows a PTY exists to kill.
+        if (!Terminal.HasProcess)
+        {
+            // The terminal control swallows spawn failures (e.g. a missing SHELL/COMSPEC), so no
+            // PTY exists. Surface it through the restart UI and leave the tab relaunchable.
+            _launched = false;
+            viewModel.IsProcessExited.Value = true;
+            return;
+        }
+
+        // Set only after a confirmed live PTY so OnViewModelDisposed knows there is one to kill.
         _launched = true;
 
         if (_disposed)
         {
-            // Torn down mid-launch: OnViewModelDisposed ran before the PTY existed, so kill
-            // it here rather than reattaching a session with no live tab.
+            // Torn down mid-launch: OnViewModelDisposed ran before the PTY existed, so kill it
+            // here rather than reattaching a session with no live tab.
             try
             {
                 Terminal.Kill();
@@ -108,21 +136,9 @@ public partial class TerminalTabView : UserControl
         Terminal.BeginReparent();
     }
 
-    private async void OnRestartClick(object? sender, RoutedEventArgs e)
-    {
-        if (_viewModel == null)
-        {
-            return;
-        }
-
-        _viewModel.IsProcessExited.Value = false;
-        await Terminal.LaunchProcess();
-        Terminal.BeginReparent();
-    }
-
     private void OnProcessExited(object? sender, ProcessExitedEventArgs e)
     {
-        if (_viewModel != null)
+        if (_viewModel != null && !_disposed)
         {
             _viewModel.ExitCode.Value = e.ExitCode;
             _viewModel.IsProcessExited.Value = true;

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -32,6 +32,12 @@ public partial class TerminalTabView : UserControl
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
+            // Reset the lifecycle flags so a recycled view bound to a fresh view-model relaunches
+            // rather than staying suppressed by the previous binding's state.
+            _launched = false;
+            _launching = false;
+            _disposed = false;
+
             // Pass the locale per spawn so it never mutates the shared process environment
             // (which would race across concurrent terminals and leak into other subprocesses).
             // Cleared when the fallback is absent so a recycled view drops a prior view-model's LANG.
@@ -51,7 +57,7 @@ public partial class TerminalTabView : UserControl
 
     private void TryLaunch()
     {
-        if (_launched || _launching || _viewModel == null || !IsLoaded)
+        if (_launched || _launching || _disposed || _viewModel == null || !IsLoaded)
         {
             return;
         }
@@ -62,7 +68,7 @@ public partial class TerminalTabView : UserControl
 
     private void OnRestartClick(object? sender, RoutedEventArgs e)
     {
-        if (_launching || _viewModel == null)
+        if (_launching || _disposed || _viewModel == null)
         {
             return;
         }
@@ -77,8 +83,12 @@ public partial class TerminalTabView : UserControl
         _launching = true;
         viewModel.IsProcessExited.Value = false;
 
-        // The locale fallback is applied per spawn via Terminal.EnvironmentOverrides (set when the
-        // view-model is attached), so no process-wide environment mutation happens here.
+        // Suppress detach-cleanup before spawning so switching away mid-launch re-docks the tab
+        // instead of killing the just-spawned PTY. Kept on for the tab's life; disposal calls
+        // EndReparent + Shutdown. The locale fallback is applied per spawn via
+        // Terminal.EnvironmentOverrides, so no process-wide environment mutation happens here.
+        Terminal.BeginReparent();
+
         try
         {
             if (reuseConfiguredProcess)
@@ -97,24 +107,13 @@ public partial class TerminalTabView : UserControl
 
         if (_disposed)
         {
-            // Torn down mid-launch: OnViewModelDisposed already ran (before any PTY existed), so it
-            // could not kill one. Kill a PTY that did spawn and never touch the disposed view-model.
-            if (Terminal.HasProcess)
-            {
-                try
-                {
-                    Terminal.Kill();
-                }
-                catch
-                {
-                    // The PTY may already be gone; tearing down must not throw.
-                }
-            }
-
+            // Torn down mid-launch: tear down any PTY that did spawn and never touch the disposed
+            // view-model. Shutdown is idempotent with the teardown OnViewModelDisposed already ran.
+            Terminal.Shutdown();
             return;
         }
 
-        if (!Terminal.HasProcess)
+        if (!Terminal.HasPtyConnection)
         {
             // The terminal control swallows spawn failures (e.g. a missing SHELL/COMSPEC), so no
             // PTY exists. Surface it through the restart UI and leave the tab relaunchable.
@@ -123,12 +122,7 @@ public partial class TerminalTabView : UserControl
             return;
         }
 
-        // Set only after a confirmed live PTY so OnViewModelDisposed knows there is one to kill.
         _launched = true;
-
-        // Keep the PTY session alive while the tab is re-docked; the process is
-        // killed explicitly when the view-model (i.e. the tab) is disposed.
-        Terminal.BeginReparent();
     }
 
     private void OnProcessExited(object? sender, ProcessExitedEventArgs e)
@@ -143,17 +137,16 @@ public partial class TerminalTabView : UserControl
     private void OnViewModelDisposed(object? sender, EventArgs e)
     {
         _disposed = true;
+        // Shutdown (not just Kill) so the connection and read-cancellation source are disposed even
+        // when no later detach runs the cleanup — an inactive tab is already detached when closed.
         Terminal.EndReparent();
-        if (_launched)
+        try
         {
-            try
-            {
-                Terminal.Kill();
-            }
-            catch
-            {
-                // The PTY may already be gone; tearing down the tab must not throw.
-            }
+            Terminal.Shutdown();
+        }
+        catch
+        {
+            // The PTY may already be gone; tearing down the tab must not throw.
         }
     }
 }

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -25,12 +25,6 @@ public partial class TerminalTabView : UserControl
     {
         base.OnDataContextChanged(e);
 
-        TerminalTabViewModel? previous = _viewModel;
-        if (previous != null)
-        {
-            previous.Disposed -= OnViewModelDisposed;
-        }
-
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
@@ -38,7 +32,7 @@ public partial class TerminalTabView : UserControl
             {
                 // Reset the lifecycle flags only when a recycled view is bound to a DIFFERENT
                 // view-model than the one it launched a PTY for. Comparing against the launched
-                // view-model (not the previous DataContext) also preserves the session across a
+                // view-model (not the current DataContext) also preserves the session across a
                 // VM -> null -> same-VM re-fire, where the DataContext momentarily goes null during
                 // a dock/reparent.
                 _launched = false;
@@ -53,7 +47,6 @@ public partial class TerminalTabView : UserControl
                 ? new Dictionary<string, string> { ["LANG"] = lang }
                 : null;
 
-            _viewModel.Disposed += OnViewModelDisposed;
             TryLaunch();
         }
     }
@@ -89,9 +82,9 @@ public partial class TerminalTabView : UserControl
     {
         TerminalTabViewModel viewModel = _viewModel!;
         _launching = true;
-        // Remember which view-model this PTY serves so a later same-VM rebind (even through null)
-        // is recognized and does not reset the flags and respawn.
-        _launchedViewModel = viewModel;
+        // Bind the dispose subscription to the view-model this PTY serves so it survives a same-VM
+        // rebind through null and still tears the PTY down when that view-model is disposed.
+        SetLaunchedViewModel(viewModel);
         viewModel.IsProcessExited.Value = false;
 
         // Suppress detach-cleanup before spawning so switching away mid-launch re-docks the tab
@@ -102,46 +95,82 @@ public partial class TerminalTabView : UserControl
 
         try
         {
-            if (reuseConfiguredProcess)
+            try
             {
-                await Terminal.LaunchProcess();
+                if (reuseConfiguredProcess)
+                {
+                    await Terminal.LaunchProcess();
+                }
+                else
+                {
+                    await Terminal.LaunchProcess(viewModel.WorkingDirectory, viewModel.ShellPath, viewModel.ShellArgs);
+                }
+            }
+            finally
+            {
+                _launching = false;
+            }
+
+            if (_disposed)
+            {
+                // Torn down mid-launch: tear down any PTY that did spawn and never touch the disposed
+                // view-model. Shutdown is idempotent with the teardown OnViewModelDisposed already ran.
+                Terminal.Shutdown();
+                return;
+            }
+
+            if (!Terminal.HasPtyConnection)
+            {
+                // The terminal control swallows spawn failures (e.g. a missing SHELL/COMSPEC), so no
+                // PTY exists. Surface it through the restart UI and leave the tab relaunchable.
+                _launched = false;
+                viewModel.IsProcessExited.Value = true;
+                return;
+            }
+
+            _launched = true;
+        }
+        catch
+        {
+            // LaunchAsync is fire-and-forget, and LaunchProcess throws if the template is not applied.
+            // Contain any fault so it never becomes an unobserved task exception; surface it through
+            // the restart UI when the tab is live, or tear down when it is already disposed.
+            _launched = false;
+            if (_disposed)
+            {
+                Terminal.Shutdown();
             }
             else
             {
-                await Terminal.LaunchProcess(viewModel.WorkingDirectory, viewModel.ShellPath, viewModel.ShellArgs);
+                viewModel.IsProcessExited.Value = true;
             }
         }
-        finally
-        {
-            _launching = false;
-        }
+    }
 
-        if (_disposed)
+    private void SetLaunchedViewModel(TerminalTabViewModel viewModel)
+    {
+        if (ReferenceEquals(_launchedViewModel, viewModel))
         {
-            // Torn down mid-launch: tear down any PTY that did spawn and never touch the disposed
-            // view-model. Shutdown is idempotent with the teardown OnViewModelDisposed already ran.
-            Terminal.Shutdown();
             return;
         }
 
-        if (!Terminal.HasPtyConnection)
+        if (_launchedViewModel != null)
         {
-            // The terminal control swallows spawn failures (e.g. a missing SHELL/COMSPEC), so no
-            // PTY exists. Surface it through the restart UI and leave the tab relaunchable.
-            _launched = false;
-            viewModel.IsProcessExited.Value = true;
-            return;
+            _launchedViewModel.Disposed -= OnViewModelDisposed;
         }
 
-        _launched = true;
+        _launchedViewModel = viewModel;
+        _launchedViewModel.Disposed += OnViewModelDisposed;
     }
 
     private void OnProcessExited(object? sender, ProcessExitedEventArgs e)
     {
-        if (_viewModel != null && !_disposed)
+        // Report on the view-model that owns the PTY, not the current DataContext, so a process exit
+        // while the view is transiently unbound still reaches the right view-model.
+        if (_launchedViewModel != null && !_disposed)
         {
-            _viewModel.ExitCode.Value = e.ExitCode;
-            _viewModel.IsProcessExited.Value = true;
+            _launchedViewModel.ExitCode.Value = e.ExitCode;
+            _launchedViewModel.IsProcessExited.Value = true;
         }
     }
 

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -138,7 +138,14 @@ public partial class TerminalTabView : UserControl
             _launched = false;
             if (_disposed)
             {
-                Terminal.Shutdown();
+                try
+                {
+                    Terminal.Shutdown();
+                }
+                catch
+                {
+                    // Best-effort teardown; the fire-and-forget catch must not rethrow.
+                }
             }
             else
             {

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -1,0 +1,100 @@
+﻿using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+
+using Iciclecreek.Terminal;
+
+namespace Beutl.Editor.Components.TerminalTab.Views;
+
+public partial class TerminalTabView : UserControl
+{
+    private TerminalTabViewModel? _viewModel;
+    private bool _launched;
+
+    public TerminalTabView()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if (_viewModel != null)
+        {
+            _viewModel.Disposed -= OnViewModelDisposed;
+        }
+
+        _viewModel = DataContext as TerminalTabViewModel;
+        if (_viewModel != null)
+        {
+            _viewModel.Disposed += OnViewModelDisposed;
+            TryLaunch();
+        }
+    }
+
+    private void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        TryLaunch();
+    }
+
+    private async void TryLaunch()
+    {
+        if (_launched || _viewModel == null || !IsLoaded)
+        {
+            return;
+        }
+
+        _launched = true;
+        if (_viewModel.LangFallback is { } lang)
+        {
+            // The PTY inherits this process' environment; there is no per-launch override.
+            Environment.SetEnvironmentVariable("LANG", lang);
+        }
+
+        await Terminal.LaunchProcess(_viewModel.WorkingDirectory, _viewModel.ShellPath, _viewModel.ShellArgs);
+
+        // Keep the PTY session alive while the tab is re-docked; the process is
+        // killed explicitly when the view-model (i.e. the tab) is disposed.
+        Terminal.BeginReparent();
+    }
+
+    private async void OnRestartClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel == null)
+        {
+            return;
+        }
+
+        _viewModel.IsProcessExited.Value = false;
+        await Terminal.LaunchProcess();
+        Terminal.BeginReparent();
+    }
+
+    private void OnProcessExited(object? sender, ProcessExitedEventArgs e)
+    {
+        if (_viewModel != null)
+        {
+            _viewModel.ExitCode.Value = e.ExitCode;
+            _viewModel.IsProcessExited.Value = true;
+        }
+    }
+
+    private void OnViewModelDisposed(object? sender, EventArgs e)
+    {
+        Terminal.EndReparent();
+        if (_launched)
+        {
+            try
+            {
+                Terminal.Kill();
+            }
+            catch
+            {
+                // The PTY may already be gone; tearing down the tab must not throw.
+            }
+        }
+    }
+}

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -10,6 +10,7 @@ namespace Beutl.Editor.Components.TerminalTab.Views;
 public partial class TerminalTabView : UserControl
 {
     private TerminalTabViewModel? _viewModel;
+    private TerminalTabViewModel? _launchedViewModel;
     private bool _launching;
     private bool _launched;
     private bool _disposed;
@@ -33,11 +34,13 @@ public partial class TerminalTabView : UserControl
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
         {
-            if (!ReferenceEquals(previous, _viewModel))
+            if (!ReferenceEquals(_launchedViewModel, _viewModel))
             {
                 // Reset the lifecycle flags only when a recycled view is bound to a DIFFERENT
-                // view-model. A same-view-model re-fire (e.g. DataContext cleared and restored
-                // during a dock/reparent) must not relaunch and kill the live PTY session.
+                // view-model than the one it launched a PTY for. Comparing against the launched
+                // view-model (not the previous DataContext) also preserves the session across a
+                // VM -> null -> same-VM re-fire, where the DataContext momentarily goes null during
+                // a dock/reparent.
                 _launched = false;
                 _launching = false;
                 _disposed = false;
@@ -86,6 +89,9 @@ public partial class TerminalTabView : UserControl
     {
         TerminalTabViewModel viewModel = _viewModel!;
         _launching = true;
+        // Remember which view-model this PTY serves so a later same-VM rebind (even through null)
+        // is recognized and does not reset the flags and respawn.
+        _launchedViewModel = viewModel;
         viewModel.IsProcessExited.Value = false;
 
         // Suppress detach-cleanup before spawning so switching away mid-launch re-docks the tab

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -1288,4 +1288,13 @@ GetProperty&lt;T&gt;("path") または GetProperty&lt;T&gt;(guid, "propertyName"
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
     <value>プレビューに合わせる</value>
   </data>
+  <data name="Terminal" xml:space="preserve">
+    <value>ターミナル</value>
+  </data>
+  <data name="TerminalSessionEnded" xml:space="preserve">
+    <value>ターミナルセッションは終了しました。</value>
+  </data>
+  <data name="Restart" xml:space="preserve">
+    <value>再起動</value>
+  </data>
 </root>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -1294,4 +1294,13 @@ Example: GetProperty&lt;double&gt;("{GUID}.Opacity")</value>
   <data name="RenderScale_FitToPreviewer" xml:space="preserve">
     <value>Fit to previewer</value>
   </data>
+  <data name="Terminal" xml:space="preserve">
+    <value>Terminal</value>
+  </data>
+  <data name="TerminalSessionEnded" xml:space="preserve">
+    <value>The terminal session has ended.</value>
+  </data>
+  <data name="Restart" xml:space="preserve">
+    <value>Restart</value>
+  </data>
 </root>

--- a/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
+++ b/src/Beutl/Services/StartupTasks/LoadPrimitiveExtensionTask.cs
@@ -14,6 +14,7 @@ using Beutl.Editor.Components.ObjectPropertyTab;
 using Beutl.Editor.Components.PathEditorTab;
 using Beutl.Editor.Components.PreviewSettingsTab;
 using Beutl.Editor.Components.SceneSettingsTab;
+using Beutl.Editor.Components.TerminalTab;
 using Beutl.Logging;
 using Beutl.Services.PrimitiveImpls;
 using Microsoft.Extensions.Logging;
@@ -54,7 +55,8 @@ public sealed class LoadPrimitiveExtensionTask : StartupTask
         EqualizerPropertiesExtension.Instance,
         ScriptEditorExtension.Instance,
         FileBrowserTabExtension.Instance,
-        HistoryTabExtension.Instance
+        HistoryTabExtension.Instance,
+        TerminalTabExtension.Instance
     ];
 
     public LoadPrimitiveExtensionTask(PackageManager manager, ExtensionProvider provider,

--- a/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/BaseEditorViewModel.cs
@@ -169,7 +169,7 @@ public abstract class BaseEditorViewModel : IPropertyEditorContext, IServiceProv
 
     public ReadOnlyReactiveProperty<bool> HasExpression { get; }
 
-public ReactivePropertySlim<FluentIcons.Common.IconVariant> SymbolIconVariant { get; } = new(FluentIcons.Common.IconVariant.Regular);
+    public ReactivePropertySlim<FluentIcons.Common.IconVariant> SymbolIconVariant { get; } = new(FluentIcons.Common.IconVariant.Regular);
 
     public ReactivePropertySlim<IKeyFrame?> EditingKeyFrame { get; } = new();
 

--- a/tests/Beutl.E2ETests/Controls/TerminalControlInputTests.cs
+++ b/tests/Beutl.E2ETests/Controls/TerminalControlInputTests.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;

--- a/tests/Beutl.E2ETests/Controls/TerminalControlInputTests.cs
+++ b/tests/Beutl.E2ETests/Controls/TerminalControlInputTests.cs
@@ -1,0 +1,88 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Beutl.Testing.Headless;
+using Iciclecreek.Terminal;
+
+namespace Beutl.E2ETests.Controls;
+
+[TestFixture]
+public class TerminalControlInputTests
+{
+    [AvaloniaTest]
+    public void ShiftedLetter_IsSentOnce_ViaTextInput()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Uses a Unix PTY (/bin/cat); the Windows ConPTY path is not exercised here.");
+        }
+
+        var terminal = new TerminalControl { Process = "/bin/cat" };
+        var window = new Window { Width = 640, Height = 320, Content = terminal };
+        window.Show();
+        HeadlessTestHelpers.Settle();
+
+        try
+        {
+            terminal.Focus();
+            WaitUntil(() => terminal.Pid > 0, "the PTY process did not start");
+
+            // A real desktop keystroke of Shift+A arrives as KeyDown (KeySymbol is the
+            // unshifted "a" on macOS) followed by a TextInput event carrying "A".
+            window.KeyPress(Key.A, RawInputModifiers.Shift, PhysicalKey.A, "a");
+            window.KeyTextInput("A");
+            HeadlessTestHelpers.Settle();
+
+            // /bin/cat runs with tty echo on, so what the control writes to the PTY
+            // comes straight back into the terminal buffer.
+            WaitUntil(() => ScreenText(terminal).Contains('A'), "the echoed input never appeared");
+
+            string text = ScreenText(terminal);
+            Assert.That(text.Trim(), Is.EqualTo("A"),
+                "Shift+A must reach the PTY exactly once and as an uppercase letter");
+        }
+        finally
+        {
+            try
+            {
+                terminal.Kill();
+            }
+            catch
+            {
+                // The PTY may never have started; closing the window is what matters.
+            }
+
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static string ScreenText(TerminalControl control)
+    {
+        var buffer = control.Terminal.Buffer;
+        var lines = new List<string>();
+        for (int y = 0; y < control.Terminal.Rows; y++)
+        {
+            lines.Add(buffer.GetLine(buffer.YBase + y)?.TranslateToString(trimRight: true) ?? "");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static void WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 5000)
+    {
+        for (int elapsed = 0; elapsed < timeoutMs; elapsed += 50)
+        {
+            HeadlessTestHelpers.Settle();
+            if (condition())
+            {
+                return;
+            }
+
+            Thread.Sleep(50);
+        }
+
+        Assert.Fail(failureMessage);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/MainViewModelExtensionTests.cs
+++ b/tests/Beutl.HeadlessUITests/MainViewModelExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.TerminalTab;
 using Beutl.Services.PrimitiveImpls;
 using Beutl.ViewModels;
 
@@ -19,6 +20,15 @@ public class MainViewModelExtensionTests
 
         Assert.That(vm.ToolTabExtensions, Is.Not.Empty);
         Assert.That(vm.ToolTabExtensions, Does.Contain(TimelineTabExtension.Instance));
+    }
+
+    [AvaloniaTest]
+    public async Task ToolTabExtensions_include_the_built_in_terminal_tab()
+    {
+        await ResetProjectAsync();
+        MainViewModel vm = SharedMainViewModel;
+
+        Assert.That(vm.ToolTabExtensions, Does.Contain(TerminalTabExtension.Instance));
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
@@ -96,6 +96,10 @@ public class TerminalTabViewModelTests
     [TestCase("ja-JP", "ja_JP.UTF-8")]
     [TestCase("en-US", "en_US.UTF-8")]
     [TestCase("", "en_US.UTF-8")]
+    [TestCase("zh-Hant-TW", "zh_TW.UTF-8")]
+    [TestCase("zh-Hans-CN", "zh_CN.UTF-8")]
+    [TestCase("sr-Latn-RS", "sr_RS.UTF-8")]
+    [TestCase("en", "en_US.UTF-8")]
     public void ResolveLangFallback_BuildsUtf8Locale_WhenEnvironmentHasNoLocale(
         string cultureName, string expected)
     {

--- a/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
@@ -1,0 +1,220 @@
+﻿using Beutl.Editor.Components.TerminalTab;
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class TerminalTabViewModelTests
+{
+    [Test]
+    public void ResolveShell_OnWindows_UsesComSpec()
+    {
+        (string path, string[] args) = TerminalTabViewModel.ResolveShell(
+            name => name == "COMSPEC" ? @"C:\Windows\System32\cmd.exe" : null,
+            isWindows: true,
+            isMacOS: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(path, Is.EqualTo(@"C:\Windows\System32\cmd.exe"));
+            Assert.That(args, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ResolveShell_OnWindows_FallsBackToCmdExe()
+    {
+        (string path, string[] args) = TerminalTabViewModel.ResolveShell(
+            _ => null,
+            isWindows: true,
+            isMacOS: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(path, Is.EqualTo("cmd.exe"));
+            Assert.That(args, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ResolveShell_OnUnix_UsesShellEnvironmentVariableAsLoginShell()
+    {
+        (string path, string[] args) = TerminalTabViewModel.ResolveShell(
+            name => name == "SHELL" ? "/opt/homebrew/bin/fish" : null,
+            isWindows: false,
+            isMacOS: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(path, Is.EqualTo("/opt/homebrew/bin/fish"));
+            Assert.That(args, Is.EqualTo(new[] { "-l" }));
+        });
+    }
+
+    [TestCase(true, "/bin/zsh")]
+    [TestCase(false, "/bin/bash")]
+    public void ResolveShell_OnUnix_FallsBackToPlatformDefault(bool isMacOS, string expected)
+    {
+        (string path, string[] args) = TerminalTabViewModel.ResolveShell(
+            _ => null,
+            isWindows: false,
+            isMacOS: isMacOS);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(path, Is.EqualTo(expected));
+            Assert.That(args, Is.EqualTo(new[] { "-l" }));
+        });
+    }
+
+    [Test]
+    public void ResolveLangFallback_OnWindows_ReturnsNull()
+    {
+        string? result = TerminalTabViewModel.ResolveLangFallback(
+            _ => null, "ja-JP", isWindows: true);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [TestCase("LANG")]
+    [TestCase("LC_ALL")]
+    [TestCase("LC_CTYPE")]
+    public void ResolveLangFallback_ReturnsNull_WhenLocaleIsAlreadyConfigured(string variable)
+    {
+        string? result = TerminalTabViewModel.ResolveLangFallback(
+            name => name == variable ? "ja_JP.UTF-8" : null,
+            "ja-JP",
+            isWindows: false);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [TestCase("ja-JP", "ja_JP.UTF-8")]
+    [TestCase("en-US", "en_US.UTF-8")]
+    [TestCase("", "en_US.UTF-8")]
+    public void ResolveLangFallback_BuildsUtf8Locale_WhenEnvironmentHasNoLocale(
+        string cultureName, string expected)
+    {
+        string? result = TerminalTabViewModel.ResolveLangFallback(
+            _ => null, cultureName, isWindows: false);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ResolveWorkingDirectory_PrefersProjectDirectory()
+    {
+        string projectDir = Path.Combine(Path.GetTempPath(), "beutl-terminal-test", "proj");
+        string sceneDir = Path.Combine(projectDir, "scenes", "scene1");
+        var scene = new Scene(640, 480, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(sceneDir, "scene1.scene")),
+        };
+        var project = new Project
+        {
+            Uri = new Uri(Path.Combine(projectDir, "proj.bproj")),
+        };
+        project.Items.Add(scene);
+        var editorContext = new TestEditorContext(scene);
+        editorContext.AddService(scene);
+
+        string? result = TerminalTabViewModel.ResolveWorkingDirectory(editorContext);
+
+        Assert.That(result, Is.EqualTo(projectDir));
+    }
+
+    [Test]
+    public void ResolveWorkingDirectory_FallsBackToSceneDirectory()
+    {
+        string sceneDir = Path.Combine(Path.GetTempPath(), "beutl-terminal-test", "scene-only");
+        var scene = new Scene(640, 480, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(sceneDir, "scene1.scene")),
+        };
+        var editorContext = new TestEditorContext(scene);
+        editorContext.AddService(scene);
+
+        string? result = TerminalTabViewModel.ResolveWorkingDirectory(editorContext);
+
+        Assert.That(result, Is.EqualTo(sceneDir));
+    }
+
+    [Test]
+    public void ResolveWorkingDirectory_ReturnsNull_WhenSceneIsUnavailable()
+    {
+        var scene = new Scene(640, 480, string.Empty);
+        var editorContext = new TestEditorContext(scene);
+
+        string? result = TerminalTabViewModel.ResolveWorkingDirectory(editorContext);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void Dispose_RaisesDisposedOnce()
+    {
+        var scene = new Scene(640, 480, string.Empty);
+        var editorContext = new TestEditorContext(scene);
+        var viewModel = new TerminalTabViewModel(editorContext);
+        int disposedCount = 0;
+        viewModel.Disposed += (_, _) => disposedCount++;
+
+        viewModel.Dispose();
+        viewModel.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disposedCount, Is.EqualTo(1));
+            Assert.That(viewModel.Extension, Is.SameAs(TerminalTabExtension.Instance));
+        });
+    }
+
+    private sealed class TestEditorContext(CoreObject obj) : IEditorContext
+    {
+        private readonly Dictionary<Type, object> _services = [];
+
+        public CoreObject Object { get; } = obj;
+
+        public EditorExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public void AddService<T>(T service)
+            where T : notnull
+        {
+            _services[typeof(T)] = service;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            return _services.GetValueOrDefault(serviceType);
+        }
+
+        public T? FindToolTab<T>(Func<T, bool> condition)
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public T? FindToolTab<T>()
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public bool OpenToolTab(IToolContext item)
+        {
+            return false;
+        }
+
+        public void CloseToolTab(IToolContext item)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Add `TerminalTabExtension`, a dockable tool tab hosting a full PTY terminal (VT100/xterm emulation), so builds, scripts, and TUI tools can run inside the editor. The shell starts as a login shell resolved from `COMSPEC`/`SHELL`, in the project (or scene) directory, with a UTF-8 `LANG` fallback when the GUI-launched process carries no locale. The PTY session survives dock re-parenting and is killed when the tab is disposed; a restart bar appears when the shell exits.
- Vendor the terminal stack as git submodules under `external/` (b-editor forks of [tomlm/Iciclecreek.Avalonia.Terminal](https://github.com/b-editor/Iciclecreek.Avalonia.Terminal) and [tomlm/XTerm.NET](https://github.com/b-editor/XTerm.NET), `beutl` branches) instead of the NuGet packages. Real-world TUIs (lazygit, Claude Code) surfaced four upstream bugs, each fixed on the forks with regression tests:
  1. **XTerm.NET parser**: collect bytes leaked across escape sequences, so the zsh/tcell startup pair `ESC(B ESC)0` re-designated G0 to DEC graphics and ASCII rendered as line-drawing glyphs (lazygit mojibake).
  2. **XTerm.NET erase ops** filled blanks with the full SGR attribute set instead of background-only (BCE), underlining whole blank regions.
  3. **XTerm.NET routed prefixed CSI** (xterm modifyOtherKeys `CSI > 4;2 m`, kitty keyboard `CSI > u` / `CSI < u`) to the plain SGR/cursor handlers, underlining and dimming everything Claude Code printed.
  4. **TerminalView consumed printable keys in KeyDown** from `e.KeySymbol`, which ignores Shift on macOS and suppresses `TextInput`, making uppercase input impossible; plain keys now flow through `TextInput`.
- A stateful UTF-8 decoder on the fork also fixes `U+FFFD` from multi-byte characters split across PTY read chunks.
- `external/Directory.*.props` stubs shield the submodules from Beutl's root MSBuild configuration and central package management. Each fork carries per-fix branches based on upstream `main` so the fixes can be offered upstream and the submodules replaced by NuGet packages once released.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None for public API. Developer workflow: the repo now uses git submodules — clone with `--recursive` or run `git submodule update --init` (CI checkout steps were updated accordingly).

## Test plan
- `tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs` — shell resolution (COMSPEC/SHELL/platform fallbacks), working-directory resolution (project → scene → null), LANG fallback matrix, dispose semantics (16 tests).
- `tests/Beutl.HeadlessUITests/MainViewModelExtensionTests.cs` — the terminal tab is enumerated by the shell.
- `tests/Beutl.E2ETests/Controls/TerminalControlInputTests.cs` — real PTY (`/bin/cat`) + headless keyboard: Shift+A reaches the PTY exactly once as `A` (fails with `aA` on the unpatched control; self-skips on Windows).
- Fork test suites: XTerm.NET 613/613 green (603 upstream + 10 new xUnit regression tests for the parser/BCE/prefixed-CSI fixes).
- Manual: lazygit and Claude Code render clean (no mojibake, no phantom underlines) and Shift input works; verified via a PTY harness driving the exact library pipeline and in the app.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in Terminal tool tab with a **Restart** button and a session-ended indicator.
  * Terminal tab now automatically selects the working directory and shell/arguments, with UTF-8 language fallback on non-Windows.
  * Added localized UI text for **Terminal**, **Restart**, and session end (including Japanese).
* **Bug Fixes / CI**
  * Updated CI checkouts to initialize submodules recursively and avoid credential persistence; improved isolation for vendored builds.
* **Tests**
  * Added unit, E2E, and headless UI tests covering terminal input and tab/view-model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->