### PR TITLE
feat: add gap close and gap navigation commands for timeline scenes

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -121,6 +121,22 @@ public sealed class TimelineTabExtension : ToolTabExtension
         [
             new ContextCommandKeyGesture("B"),
         ]),
+        new ContextCommandDefinition("CloseGap", Strings.CloseGap, "",
+        [
+            new ContextCommandKeyGesture("OemSemicolon"),
+        ]),
+        new ContextCommandDefinition("CloseAllGaps", Strings.CloseAllGaps, "",
+        [
+            new ContextCommandKeyGesture("Shift+Alt+OemSemicolon"),
+        ]),
+        new ContextCommandDefinition("GoToNextGap", Strings.GoToNextGap, "",
+        [
+            new ContextCommandKeyGesture("Shift+OemSemicolon"),
+        ]),
+        new ContextCommandDefinition("GoToPreviousGap", Strings.GoToPreviousGap, "",
+        [
+            new ContextCommandKeyGesture("Alt+OemSemicolon"),
+        ]),
     ];
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -144,6 +144,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         SetStartTimeToCurrentTime.Subscribe(OnSetStartTimeToCurrentTime);
         SetEndTimeToCurrentTime.Subscribe(OnSetEndTimeToCurrentTime);
         CloseGap = new ReactiveCommandSlim().WithSubscribe(CloseSelectedGap).DisposeWith(_disposables);
+        CloseGapAtPointerPosition = new ReactiveCommandSlim().WithSubscribe(CloseGapAtPointer).DisposeWith(_disposables);
         CloseAllGaps = new ReactiveCommandSlim().WithSubscribe(CloseAllSceneGaps).DisposeWith(_disposables);
         GoToNextGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: true)).DisposeWith(_disposables);
         GoToPreviousGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: false)).DisposeWith(_disposables);
@@ -315,6 +316,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public ReactiveCommandSlim SetEndTimeToCurrentTime { get; } = new();
 
     public ReactiveCommandSlim CloseGap { get; }
+
+    public ReactiveCommandSlim CloseGapAtPointerPosition { get; }
 
     public ReactiveCommandSlim CloseAllGaps { get; }
 
@@ -1165,6 +1168,20 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
+    // Context-menu Close Gap acts on the right-clicked position, not the selection, so the gap the
+    // user pointed at is the one that closes.
+    private void CloseGapAtPointer()
+    {
+        FlushPendingNudgeCommit();
+        if (Scene.FindGapAt(ClickedFrame, CalculateClickedLayer()) is { } gap
+            && EditorContext.GetRequiredService<IElementGapService>().CloseGapAfter(Scene, gap.Anchor))
+        {
+            return;
+        }
+
+        NotificationService.ShowInformation(Strings.CloseGap, Strings.NoGapsToClose);
+    }
+
     private void CloseAllSceneGaps()
     {
         FlushPendingNudgeCommit();
@@ -1178,7 +1195,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
-            CurrentTime.Value = target;
+            CurrentTime.Value = target.Target;
+            SelectGapAnchor(target.Anchor);
         }
         else
         {
@@ -1188,22 +1206,35 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
+    // Moving to a gap selects its anchor so the selection-based Close Gap then acts on that same gap.
+    private void SelectGapAnchor(Element anchor)
+    {
+        ElementViewModel? vm = Elements.FirstOrDefault(e => ReferenceEquals(e.Model, anchor));
+        if (vm is null) return;
+
+        ClearSelected();
+        SelectElement(vm);
+    }
+
     // The search is bounded to the active scene range by searchRange, so a playhead parked outside the
     // scene still navigates within it. currentTime is passed through unclamped: clamping the origin to
-    // the boundary would make the strict > / < searches skip an in-range gap that touches Scene.Start
-    // or Scene.Start + Duration exactly.
-    internal static TimeSpan? FindGapNavigationTarget(Scene scene, TimeSpan currentTime, bool forward)
+    // the boundary would make the >= / <= searches skip an in-range gap that touches Scene.Start or
+    // Scene.Start + Duration exactly. Returns the target playhead time (the gap center, clamped to the
+    // scene) together with the gap's anchor so the caller can both move and select.
+    internal static (TimeSpan Target, Element Anchor)? FindGapNavigationTarget(
+        Scene scene, TimeSpan currentTime, bool forward)
     {
         TimeSpan sceneStart = scene.Start;
         TimeSpan sceneEnd = scene.Start + scene.Duration;
         var range = new TimeRange(sceneStart, scene.Duration);
-        TimeRange? gap = forward
+        SceneGap? gap = forward
             ? scene.FindNextGap(currentTime, range)
             : scene.FindPreviousGap(currentTime, range);
         if (gap is not { } g) return null;
 
-        TimeSpan target = g.Start + new TimeSpan(g.Duration.Ticks / 2);
-        return target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target;
+        TimeSpan target = g.Range.Start + new TimeSpan(g.Range.Duration.Ticks / 2);
+        target = target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target;
+        return (target, g.Anchor);
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1151,7 +1151,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .ThenBy(e => e.Model.ZIndex)
             .Select(e => e.Model)
             .FirstOrDefault();
-        if (anchor is null) return;
+        if (anchor is null)
+        {
+            // Reachable from the flyout menu, which unlike the shortcut path has no selection gate.
+            NotificationService.ShowInformation(Strings.CloseGap, Strings.NoElementSelected);
+            return;
+        }
 
         FlushPendingNudgeCommit();
         if (!EditorContext.GetRequiredService<IElementGapService>().CloseGap(Scene, anchor))
@@ -1171,21 +1176,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void GoToGap(bool forward)
     {
-        TimeSpan sceneStart = Scene.Start;
-        TimeSpan sceneEnd = Scene.Start + Scene.Duration;
-        var range = new TimeRange(sceneStart, Scene.Duration);
-        TimeSpan origin = CurrentTime.Value < sceneStart
-            ? sceneStart
-            : CurrentTime.Value > sceneEnd ? sceneEnd : CurrentTime.Value;
-        TimeSpan? center = forward
-            ? Scene.FindNextGapCenter(origin, range)
-            : Scene.FindPreviousGapCenter(origin, range);
-
-        if (center is { } target)
+        if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
-            CurrentTime.Value = target < sceneStart
-                ? sceneStart
-                : target > sceneEnd ? sceneEnd : target;
+            CurrentTime.Value = target;
         }
         else
         {
@@ -1193,6 +1186,25 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 forward ? Strings.GoToNextGap : Strings.GoToPreviousGap,
                 Strings.NoGapsToGoTo);
         }
+    }
+
+    // Both the search origin and the returned target are clamped to the active scene range, so a
+    // playhead parked outside the scene still navigates within it and never lands outside it.
+    internal static TimeSpan? FindGapNavigationTarget(Scene scene, TimeSpan currentTime, bool forward)
+    {
+        TimeSpan sceneStart = scene.Start;
+        TimeSpan sceneEnd = scene.Start + scene.Duration;
+        var range = new TimeRange(sceneStart, scene.Duration);
+        TimeSpan origin = currentTime < sceneStart
+            ? sceneStart
+            : currentTime > sceneEnd ? sceneEnd : currentTime;
+        TimeSpan? center = forward
+            ? scene.FindNextGapCenter(origin, range)
+            : scene.FindPreviousGapCenter(origin, range);
+
+        return center is { } target
+            ? target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target
+            : null;
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1170,15 +1170,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void GoToGap(bool forward)
     {
+        TimeSpan sceneStart = Scene.Start;
+        TimeSpan sceneEnd = Scene.Start + Scene.Duration;
         TimeSpan? center = forward
-            ? Scene.FindNextGapCenter(CurrentTime.Value)
-            : Scene.FindPreviousGapCenter(CurrentTime.Value);
+            ? Scene.FindNextGapCenter(CurrentTime.Value, sceneEnd)
+            : Scene.FindPreviousGapCenter(CurrentTime.Value, sceneStart);
 
         if (center is { } target)
         {
-            TimeSpan sceneEnd = Scene.Start + Scene.Duration;
-            CurrentTime.Value = target < Scene.Start
-                ? Scene.Start
+            CurrentTime.Value = target < sceneStart
+                ? sceneStart
                 : target > sceneEnd ? sceneEnd : target;
         }
         else

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1159,7 +1159,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
 
         FlushPendingNudgeCommit();
-        if (!EditorContext.GetRequiredService<IElementGapService>().CloseGap(Scene, anchor))
+        if (!EditorContext.GetRequiredService<IElementGapService>().CloseGapAfter(Scene, anchor))
         {
             NotificationService.ShowInformation(Strings.CloseGap, Strings.NoGapsToClose);
         }
@@ -1198,13 +1198,13 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         TimeSpan origin = currentTime < sceneStart
             ? sceneStart
             : currentTime > sceneEnd ? sceneEnd : currentTime;
-        TimeSpan? center = forward
-            ? scene.FindNextGapCenter(origin, range)
-            : scene.FindPreviousGapCenter(origin, range);
+        TimeRange? gap = forward
+            ? scene.FindNextGap(origin, range)
+            : scene.FindPreviousGap(origin, range);
+        if (gap is not { } g) return null;
 
-        return center is { } target
-            ? target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target
-            : null;
+        TimeSpan target = g.Start + new TimeSpan(g.Duration.Ticks / 2);
+        return target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target;
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1173,7 +1173,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private void CloseGapAtPointer()
     {
         FlushPendingNudgeCommit();
-        if (ResolvePointerGapToClose(Scene, ClickedFrame, CalculateClickedLayer()) is { } gap
+        // Hit-test with the raw pointer time, not the frame-rounded ClickedFrame: rounding can push a
+        // click in the latter half of a one-frame gap onto the next clip's start, which the half-open
+        // gap range then reports as no gap.
+        TimeSpan clickedTime = ClickedPosition.X.PixelToTimeSpan(Options.Value.Scale);
+        if (ResolvePointerGapToClose(Scene, clickedTime, CalculateClickedLayer()) is { } gap
             && EditorContext.GetRequiredService<IElementGapService>().CloseGapAfter(Scene, gap.Anchor))
         {
             return;

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1196,7 +1196,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
             CurrentTime.Value = target.Target;
-            SelectGapAnchor(target.Anchor);
+            if (target.Anchor is { } anchor)
+            {
+                SelectGapAnchor(anchor);
+            }
         }
         else
         {
@@ -1220,8 +1223,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // scene still navigates within it. currentTime is passed through unclamped: clamping the origin to
     // the boundary would make the >= / <= searches skip an in-range gap that touches Scene.Start or
     // Scene.Start + Duration exactly. Returns the target playhead time (the gap center, clamped to the
-    // scene) together with the gap's anchor so the caller can both move and select.
-    internal static (TimeSpan Target, Element Anchor)? FindGapNavigationTarget(
+    // scene) together with the gap's anchor so the caller can both move and select. The anchor is null
+    // when the search range clipped the gap's start: the anchor then ends off-scene and no longer abuts
+    // the visible gap, so selecting it would make Close Gap collapse the whole raw gap.
+    internal static (TimeSpan Target, Element? Anchor)? FindGapNavigationTarget(
         Scene scene, TimeSpan currentTime, bool forward)
     {
         TimeSpan sceneStart = scene.Start;
@@ -1234,7 +1239,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         TimeSpan target = g.Range.Start + new TimeSpan(g.Range.Duration.Ticks / 2);
         target = target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target;
-        return (target, g.Anchor);
+        Element? anchor = g.Anchor.Range.End == g.Range.Start ? g.Anchor : null;
+        return (target, anchor);
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -143,10 +143,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         SetEndTimeToPointerPosition.Subscribe(OnSetEndTimeToPointerPosition);
         SetStartTimeToCurrentTime.Subscribe(OnSetStartTimeToCurrentTime);
         SetEndTimeToCurrentTime.Subscribe(OnSetEndTimeToCurrentTime);
-        CloseGap = new ReactiveCommandSlim().WithSubscribe(CloseSelectedGap);
-        CloseAllGaps = new ReactiveCommandSlim().WithSubscribe(CloseAllSceneGaps);
-        GoToNextGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: true));
-        GoToPreviousGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: false));
+        CloseGap = new ReactiveCommandSlim().WithSubscribe(CloseSelectedGap).DisposeWith(_disposables);
+        CloseAllGaps = new ReactiveCommandSlim().WithSubscribe(CloseAllSceneGaps).DisposeWith(_disposables);
+        GoToNextGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: true)).DisposeWith(_disposables);
+        GoToPreviousGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: false)).DisposeWith(_disposables);
         EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
 
         AutoAdjustSceneDuration = editorConfig.GetObservable(EditorConfig.AutoAdjustSceneDurationProperty)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1130,10 +1130,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    // ナッジ・ToggleRazorMode 系のショートカットがテキスト入力中に発火しないようにする。
-    // TextBox を直接見るだけでは AutoCompleteBox/NumericUpDown/MaskedTextBox 等の
-    // ラッパー経由でフォーカスされた埋め込み TextBox を検知できないので、Source の
-    // ancestor 連鎖を辿って TextBox を探す。
+    // Timeline shortcuts that use printable keys must not fire while a text input has focus.
+    // Checking only TextBox misses embedded text boxes inside wrappers such as AutoCompleteBox,
+    // NumericUpDown, and MaskedTextBox, so inspect the Source visual ancestor chain.
     private static bool IsTextInputFocused(KeyEventArgs? args)
     {
         return IsTextInputSource(args?.Source);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1188,19 +1188,18 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         }
     }
 
-    // Both the search origin and the returned target are clamped to the active scene range, so a
-    // playhead parked outside the scene still navigates within it and never lands outside it.
+    // The search is bounded to the active scene range by searchRange, so a playhead parked outside the
+    // scene still navigates within it. currentTime is passed through unclamped: clamping the origin to
+    // the boundary would make the strict > / < searches skip an in-range gap that touches Scene.Start
+    // or Scene.Start + Duration exactly.
     internal static TimeSpan? FindGapNavigationTarget(Scene scene, TimeSpan currentTime, bool forward)
     {
         TimeSpan sceneStart = scene.Start;
         TimeSpan sceneEnd = scene.Start + scene.Duration;
         var range = new TimeRange(sceneStart, scene.Duration);
-        TimeSpan origin = currentTime < sceneStart
-            ? sceneStart
-            : currentTime > sceneEnd ? sceneEnd : currentTime;
         TimeRange? gap = forward
-            ? scene.FindNextGap(origin, range)
-            : scene.FindPreviousGap(origin, range);
+            ? scene.FindNextGap(currentTime, range)
+            : scene.FindPreviousGap(currentTime, range);
         if (gap is not { } g) return null;
 
         TimeSpan target = g.Start + new TimeSpan(g.Duration.Ticks / 2);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1152,6 +1152,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             .FirstOrDefault();
         if (anchor is null) return;
 
+        FlushPendingNudgeCommit();
         if (!EditorContext.GetRequiredService<IElementGapService>().CloseGap(Scene, anchor))
         {
             NotificationService.ShowInformation(Strings.CloseGap, Strings.NoGapsToClose);
@@ -1160,6 +1161,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     private void CloseAllSceneGaps()
     {
+        FlushPendingNudgeCommit();
         if (EditorContext.GetRequiredService<IElementGapService>().CloseAllGaps(Scene) == 0)
         {
             NotificationService.ShowInformation(Strings.CloseAllGaps, Strings.NoGapsToClose);

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1148,6 +1148,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         Element? anchor = SelectedElements
             .OrderBy(e => e.Model.Start)
+            .ThenBy(e => e.Model.ZIndex)
             .Select(e => e.Model)
             .FirstOrDefault();
         if (anchor is null) return;
@@ -1172,9 +1173,13 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         TimeSpan sceneStart = Scene.Start;
         TimeSpan sceneEnd = Scene.Start + Scene.Duration;
+        var range = new TimeRange(sceneStart, Scene.Duration);
+        TimeSpan origin = CurrentTime.Value < sceneStart
+            ? sceneStart
+            : CurrentTime.Value > sceneEnd ? sceneEnd : CurrentTime.Value;
         TimeSpan? center = forward
-            ? Scene.FindNextGapCenter(CurrentTime.Value, sceneEnd)
-            : Scene.FindPreviousGapCenter(CurrentTime.Value, sceneStart);
+            ? Scene.FindNextGapCenter(origin, range)
+            : Scene.FindPreviousGapCenter(origin, range);
 
         if (center is { } target)
         {

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1208,6 +1208,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
             CurrentTime.Value = target.Target;
+            // The playhead move alone does not scroll while playback is stopped, so bring the gap into
+            // view like the other seek-style commands do.
+            ScrollTo.Execute((target.VisibleGap, target.ZIndex));
             // A null anchor (start-clipped gap) has no element to select; clear any prior selection so
             // the selection-based Close Gap cannot act on a stale, unrelated gap after the jump.
             if (target.Anchor is { } anchor)
@@ -1217,6 +1220,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             else
             {
                 ClearSelected();
+                EditorContext.GetRequiredService<IEditorSelection>().SelectedObject.Value = null;
             }
         }
         else
@@ -1228,6 +1232,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     }
 
     // Moving to a gap selects its anchor so the selection-based Close Gap then acts on that same gap.
+    // The global editor selection is updated too, matching click selection, so the inspector and other
+    // tabs follow the gap anchor instead of the previously selected element.
     private void SelectGapAnchor(Element anchor)
     {
         ElementViewModel? vm = Elements.FirstOrDefault(e => ReferenceEquals(e.Model, anchor));
@@ -1235,6 +1241,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         ClearSelected();
         SelectElement(vm);
+        EditorContext.GetRequiredService<IEditorSelection>().SelectedObject.Value = anchor;
     }
 
     // The search is bounded to the active scene range by searchRange, so a playhead parked outside the
@@ -1244,7 +1251,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // (scene-clamped) portion — together with the gap's anchor. The anchor is null unless the raw gap is
     // wholly inside the scene: a clipped gap's anchor sits off-scene, so selecting it would make Close
     // Gap collapse the raw gap and move a clip the user cannot see.
-    internal static (TimeSpan Target, Element? Anchor)? FindGapNavigationTarget(
+    internal static (TimeSpan Target, TimeRange VisibleGap, int ZIndex, Element? Anchor)? FindGapNavigationTarget(
         Scene scene, TimeSpan currentTime, bool forward)
     {
         TimeSpan sceneStart = scene.Start;
@@ -1257,9 +1264,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         TimeSpan visibleStart = g.Range.Start > sceneStart ? g.Range.Start : sceneStart;
         TimeSpan visibleEnd = g.Range.End < sceneEnd ? g.Range.End : sceneEnd;
+        var visibleGap = new TimeRange(visibleStart, visibleEnd - visibleStart);
         TimeSpan target = visibleStart + new TimeSpan((visibleEnd - visibleStart).Ticks / 2);
         bool whollyInside = g.Range.Start >= sceneStart && g.Range.End <= sceneEnd;
-        return (target, whollyInside ? g.Anchor : null);
+        return (target, visibleGap, g.ZIndex, whollyInside ? g.Anchor : null);
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1208,9 +1208,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
             CurrentTime.Value = target.Target;
-            // The playhead move alone does not scroll while playback is stopped, so bring the gap into
-            // view like the other seek-style commands do.
-            ScrollTo.Execute((target.VisibleGap, target.ZIndex));
+            // The playhead move alone does not scroll while stopped, so bring the target into view like
+            // the other seek commands. Scroll around the target, not the whole gap: a gap wider than the
+            // viewport always intersects it and the view would skip the scroll. The 1-tick width keeps
+            // the range non-empty so the view's "already visible" check reads it as the target point.
+            ScrollTo.Execute((new TimeRange(target.Target, TimeSpan.FromTicks(1)), target.ZIndex));
             // A null anchor (start-clipped gap) has no element to select; clear any prior selection so
             // the selection-based Close Gap cannot act on a stale, unrelated gap after the jump.
             if (target.Anchor is { } anchor)
@@ -1251,7 +1253,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // (scene-clamped) portion — together with the gap's anchor. The anchor is null unless the raw gap is
     // wholly inside the scene: a clipped gap's anchor sits off-scene, so selecting it would make Close
     // Gap collapse the raw gap and move a clip the user cannot see.
-    internal static (TimeSpan Target, TimeRange VisibleGap, int ZIndex, Element? Anchor)? FindGapNavigationTarget(
+    internal static (TimeSpan Target, int ZIndex, Element? Anchor)? FindGapNavigationTarget(
         Scene scene, TimeSpan currentTime, bool forward)
     {
         TimeSpan sceneStart = scene.Start;
@@ -1264,10 +1266,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
         TimeSpan visibleStart = g.Range.Start > sceneStart ? g.Range.Start : sceneStart;
         TimeSpan visibleEnd = g.Range.End < sceneEnd ? g.Range.End : sceneEnd;
-        var visibleGap = new TimeRange(visibleStart, visibleEnd - visibleStart);
         TimeSpan target = visibleStart + new TimeSpan((visibleEnd - visibleStart).Ticks / 2);
         bool whollyInside = g.Range.Start >= sceneStart && g.Range.End <= sceneEnd;
-        return (target, visibleGap, g.ZIndex, whollyInside ? g.Anchor : null);
+        return (target, g.ZIndex, whollyInside ? g.Anchor : null);
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1240,10 +1240,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // The search is bounded to the active scene range by searchRange, so a playhead parked outside the
     // scene still navigates within it. currentTime is passed through unclamped: clamping the origin to
     // the boundary would make the >= / <= searches skip an in-range gap that touches Scene.Start or
-    // Scene.Start + Duration exactly. Returns the target playhead time (the gap center, clamped to the
-    // scene) together with the gap's anchor so the caller can both move and select. The anchor is null
-    // when the search range clipped the gap's start: the anchor then ends off-scene and no longer abuts
-    // the visible gap, so selecting it would make Close Gap collapse the whole raw gap.
+    // Scene.Start + Duration exactly. Returns the target playhead time — the centre of the gap's visible
+    // (scene-clamped) portion — together with the gap's anchor. The anchor is null unless the raw gap is
+    // wholly inside the scene: a clipped gap's anchor sits off-scene, so selecting it would make Close
+    // Gap collapse the raw gap and move a clip the user cannot see.
     internal static (TimeSpan Target, Element? Anchor)? FindGapNavigationTarget(
         Scene scene, TimeSpan currentTime, bool forward)
     {
@@ -1255,10 +1255,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             : scene.FindPreviousGap(currentTime, range);
         if (gap is not { } g) return null;
 
-        TimeSpan target = g.Range.Start + new TimeSpan(g.Range.Duration.Ticks / 2);
-        target = target < sceneStart ? sceneStart : target > sceneEnd ? sceneEnd : target;
-        Element? anchor = g.Anchor.Range.End == g.Range.Start ? g.Anchor : null;
-        return (target, anchor);
+        TimeSpan visibleStart = g.Range.Start > sceneStart ? g.Range.Start : sceneStart;
+        TimeSpan visibleEnd = g.Range.End < sceneEnd ? g.Range.End : sceneEnd;
+        TimeSpan target = visibleStart + new TimeSpan((visibleEnd - visibleStart).Ticks / 2);
+        bool whollyInside = g.Range.Start >= sceneStart && g.Range.End <= sceneEnd;
+        return (target, whollyInside ? g.Anchor : null);
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -992,7 +992,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             case "Exclude":
                 SelectedElements.FirstOrDefault()?.Exclude.Execute();
                 break;
-            case "SetStartTime":
+            case "SetStartTime" when !IsTextInputFocused(execution.KeyEventArgs):
                 SetStartTimeToCurrentTime.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1000,7 +1000,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "SetEndTime":
+            case "SetEndTime" when !IsTextInputFocused(execution.KeyEventArgs):
                 SetEndTimeToCurrentTime.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1095,7 +1095,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "CloseGap":
+            case "CloseGap" when !IsTextInputFocused(execution.KeyEventArgs):
                 CloseGap.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1103,7 +1103,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "CloseAllGaps":
+            case "CloseAllGaps" when !IsTextInputFocused(execution.KeyEventArgs):
                 CloseAllGaps.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1111,7 +1111,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "GoToNextGap":
+            case "GoToNextGap" when !IsTextInputFocused(execution.KeyEventArgs):
                 GoToNextGap.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1119,7 +1119,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
-            case "GoToPreviousGap":
+            case "GoToPreviousGap" when !IsTextInputFocused(execution.KeyEventArgs):
                 GoToPreviousGap.Execute();
                 if (execution.KeyEventArgs != null)
                 {
@@ -1136,7 +1136,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     // ancestor 連鎖を辿って TextBox を探す。
     private static bool IsTextInputFocused(KeyEventArgs? args)
     {
-        if (args?.Source is not Visual visual) return false;
+        return IsTextInputSource(args?.Source);
+    }
+
+    internal static bool IsTextInputSource(object? source)
+    {
+        if (source is not Visual visual) return false;
         return visual.FindAncestorOfType<TextBox>(includeSelf: true) is not null;
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1173,16 +1173,25 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private void CloseGapAtPointer()
     {
         FlushPendingNudgeCommit();
-        // Only close a gap whose start lies inside the active scene; a raw gap starting before
-        // Scene.Start would collapse an off-scene interval and jump a clip the user cannot see.
-        if (Scene.FindGapAt(ClickedFrame, CalculateClickedLayer()) is { } gap
-            && gap.Range.Start >= Scene.Start
+        if (ResolvePointerGapToClose(Scene, ClickedFrame, CalculateClickedLayer()) is { } gap
             && EditorContext.GetRequiredService<IElementGapService>().CloseGapAfter(Scene, gap.Anchor))
         {
             return;
         }
 
         NotificationService.ShowInformation(Strings.CloseGap, Strings.NoGapsToClose);
+    }
+
+    // The gap under a right-click, but only when it lies wholly inside the active scene. ClickedFrame
+    // is not clamped to the scene, so a click past either edge can land in a gap that straddles the
+    // boundary; closing that raw gap would shift clips by off-scene space the user cannot see.
+    internal static SceneGap? ResolvePointerGapToClose(Scene scene, TimeSpan clickedTime, int layer)
+    {
+        TimeSpan sceneEnd = scene.Start + scene.Duration;
+        return scene.FindGapAt(clickedTime, layer) is { } gap
+               && gap.Range.Start >= scene.Start && gap.Range.End <= sceneEnd
+            ? gap
+            : null;
     }
 
     private void CloseAllSceneGaps()

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -143,6 +143,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         SetEndTimeToPointerPosition.Subscribe(OnSetEndTimeToPointerPosition);
         SetStartTimeToCurrentTime.Subscribe(OnSetStartTimeToCurrentTime);
         SetEndTimeToCurrentTime.Subscribe(OnSetEndTimeToCurrentTime);
+        CloseGap = new ReactiveCommandSlim().WithSubscribe(CloseSelectedGap);
+        CloseAllGaps = new ReactiveCommandSlim().WithSubscribe(CloseAllSceneGaps);
+        GoToNextGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: true));
+        GoToPreviousGap = new ReactiveCommandSlim().WithSubscribe(() => GoToGap(forward: false));
         EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
 
         AutoAdjustSceneDuration = editorConfig.GetObservable(EditorConfig.AutoAdjustSceneDurationProperty)
@@ -309,6 +313,14 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public ReactiveCommandSlim SetStartTimeToCurrentTime { get; } = new();
 
     public ReactiveCommandSlim SetEndTimeToCurrentTime { get; } = new();
+
+    public ReactiveCommandSlim CloseGap { get; }
+
+    public ReactiveCommandSlim CloseAllGaps { get; }
+
+    public ReactiveCommandSlim GoToNextGap { get; }
+
+    public ReactiveCommandSlim GoToPreviousGap { get; }
 
     public CoreList<SceneMarker> Markers => Scene.Markers;
 
@@ -925,10 +937,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             "NudgeLeftFrame" or "NudgeRightFrame"
                 or "NudgeLeftLarge" or "NudgeRightLarge"
                 or "NudgeLeftSecond" or "NudgeRightSecond" => SelectedElements.Count > 0,
+            "CloseGap" => SelectedElements.Count > 0,
             "ToggleGroup" => SelectedElements.FirstOrDefault() is { } first
                 && (first.CanUngroupSelectedElements() || first.CanGroupSelectedElements()),
             "ExitRazorMode" => IsRazorMode.Value,
-            "Paste" or "SetStartTime" or "SetEndTime" or "ToggleRazorMode" or "ToggleRippleMode" => true,
+            "Paste" or "SetStartTime" or "SetEndTime" or "ToggleRazorMode" or "ToggleRippleMode"
+                or "CloseAllGaps" or "GoToNextGap" or "GoToPreviousGap" => true,
             // Rename / Split など Execute で対応 case が無いコマンドは false を返し、
             // パレットやショートカット経路で誤って enabled として扱われないようにする。
             _ => false,
@@ -1081,6 +1095,38 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 }
 
                 break;
+            case "CloseGap":
+                CloseGap.Execute();
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "CloseAllGaps":
+                CloseAllGaps.Execute();
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "GoToNextGap":
+                GoToNextGap.Execute();
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "GoToPreviousGap":
+                GoToPreviousGap.Execute();
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
         }
     }
 
@@ -1092,6 +1138,49 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         if (args?.Source is not Visual visual) return false;
         return visual.FindAncestorOfType<TextBox>(includeSelf: true) is not null;
+    }
+
+    private void CloseSelectedGap()
+    {
+        Element? anchor = SelectedElements
+            .OrderBy(e => e.Model.Start)
+            .Select(e => e.Model)
+            .FirstOrDefault();
+        if (anchor is null) return;
+
+        if (!EditorContext.GetRequiredService<IElementGapService>().CloseGap(Scene, anchor))
+        {
+            NotificationService.ShowInformation(Strings.CloseGap, Strings.NoGapsToClose);
+        }
+    }
+
+    private void CloseAllSceneGaps()
+    {
+        if (EditorContext.GetRequiredService<IElementGapService>().CloseAllGaps(Scene) == 0)
+        {
+            NotificationService.ShowInformation(Strings.CloseAllGaps, Strings.NoGapsToClose);
+        }
+    }
+
+    private void GoToGap(bool forward)
+    {
+        TimeSpan? center = forward
+            ? Scene.FindNextGapCenter(CurrentTime.Value)
+            : Scene.FindPreviousGapCenter(CurrentTime.Value);
+
+        if (center is { } target)
+        {
+            TimeSpan sceneEnd = Scene.Start + Scene.Duration;
+            CurrentTime.Value = target < Scene.Start
+                ? Scene.Start
+                : target > sceneEnd ? sceneEnd : target;
+        }
+        else
+        {
+            NotificationService.ShowInformation(
+                forward ? Strings.GoToNextGap : Strings.GoToPreviousGap,
+                Strings.NoGapsToGoTo);
+        }
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -1173,7 +1173,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private void CloseGapAtPointer()
     {
         FlushPendingNudgeCommit();
+        // Only close a gap whose start lies inside the active scene; a raw gap starting before
+        // Scene.Start would collapse an off-scene interval and jump a clip the user cannot see.
         if (Scene.FindGapAt(ClickedFrame, CalculateClickedLayer()) is { } gap
+            && gap.Range.Start >= Scene.Start
             && EditorContext.GetRequiredService<IElementGapService>().CloseGapAfter(Scene, gap.Anchor))
         {
             return;
@@ -1196,9 +1199,15 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (FindGapNavigationTarget(Scene, CurrentTime.Value, forward) is { } target)
         {
             CurrentTime.Value = target.Target;
+            // A null anchor (start-clipped gap) has no element to select; clear any prior selection so
+            // the selection-based Close Gap cannot act on a stale, unrelated gap after the jump.
             if (target.Anchor is { } anchor)
             {
                 SelectGapAnchor(anchor);
+            }
+            else
+            {
+                ClearSelected();
             }
         }
         else

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -171,7 +171,7 @@
                         <ui:MenuFlyoutItem Command="{Binding SetEndTimeToPointerPosition}"
                                            InputGesture="{h:GetCommandGesture SetEndTime}"
                                            Text="{x:Static lang:Strings.SetEndTime}" />
-                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.CloseGap}">
+                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.Gaps}">
                             <ui:MenuFlyoutSubItem.IconSource>
                                 <icons:SymbolIconSource Symbol="ArrowMoveInward" />
                             </ui:MenuFlyoutSubItem.IconSource>

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -175,16 +175,16 @@
                             <ui:MenuFlyoutSubItem.IconSource>
                                 <icons:SymbolIconSource Symbol="ArrowMoveInward" />
                             </ui:MenuFlyoutSubItem.IconSource>
-                            <ui:MenuFlyoutItem Command="{Binding CloseGapAtPointerPosition}"
+                            <ui:MenuFlyoutItem Command="{CompiledBinding CloseGapAtPointerPosition}"
                                                Text="{x:Static lang:Strings.CloseGap}" />
-                            <ui:MenuFlyoutItem Command="{Binding CloseAllGaps}"
+                            <ui:MenuFlyoutItem Command="{CompiledBinding CloseAllGaps}"
                                                InputGesture="{h:GetCommandGesture CloseAllGaps, ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.CloseAllGaps}" />
                             <ui:MenuFlyoutSeparator />
-                            <ui:MenuFlyoutItem Command="{Binding GoToNextGap}"
+                            <ui:MenuFlyoutItem Command="{CompiledBinding GoToNextGap}"
                                                InputGesture="{h:GetCommandGesture GoToNextGap, ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.GoToNextGap}" />
-                            <ui:MenuFlyoutItem Command="{Binding GoToPreviousGap}"
+                            <ui:MenuFlyoutItem Command="{CompiledBinding GoToPreviousGap}"
                                                InputGesture="{h:GetCommandGesture GoToPreviousGap, ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.GoToPreviousGap}" />
                         </ui:MenuFlyoutSubItem>

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -171,6 +171,24 @@
                         <ui:MenuFlyoutItem Command="{Binding SetEndTimeToPointerPosition}"
                                            InputGesture="{h:GetCommandGesture SetEndTime}"
                                            Text="{x:Static lang:Strings.SetEndTime}" />
+                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.CloseGap}">
+                            <ui:MenuFlyoutSubItem.IconSource>
+                                <icons:SymbolIconSource Symbol="ArrowMoveInward" />
+                            </ui:MenuFlyoutSubItem.IconSource>
+                            <ui:MenuFlyoutItem Command="{Binding CloseGap}"
+                                               InputGesture="{h:GetCommandGesture CloseGap, ExtensionType={x:Type p:TimelineTabExtension}}"
+                                               Text="{x:Static lang:Strings.CloseGap}" />
+                            <ui:MenuFlyoutItem Command="{Binding CloseAllGaps}"
+                                               InputGesture="{h:GetCommandGesture CloseAllGaps, ExtensionType={x:Type p:TimelineTabExtension}}"
+                                               Text="{x:Static lang:Strings.CloseAllGaps}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:MenuFlyoutItem Command="{Binding GoToNextGap}"
+                                               InputGesture="{h:GetCommandGesture GoToNextGap, ExtensionType={x:Type p:TimelineTabExtension}}"
+                                               Text="{x:Static lang:Strings.GoToNextGap}" />
+                            <ui:MenuFlyoutItem Command="{Binding GoToPreviousGap}"
+                                               InputGesture="{h:GetCommandGesture GoToPreviousGap, ExtensionType={x:Type p:TimelineTabExtension}}"
+                                               Text="{x:Static lang:Strings.GoToPreviousGap}" />
+                        </ui:MenuFlyoutSubItem>
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsStrings.AutoAdjustSceneDuration}" />
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding IsSnapEnabled.Value, Mode=TwoWay}" Text="{x:Static lang:Strings.TimelineSnap}" />
                         <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRippleEnabled.Value, Mode=TwoWay}"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -175,8 +175,7 @@
                             <ui:MenuFlyoutSubItem.IconSource>
                                 <icons:SymbolIconSource Symbol="ArrowMoveInward" />
                             </ui:MenuFlyoutSubItem.IconSource>
-                            <ui:MenuFlyoutItem Command="{Binding CloseGap}"
-                                               InputGesture="{h:GetCommandGesture CloseGap, ExtensionType={x:Type p:TimelineTabExtension}}"
+                            <ui:MenuFlyoutItem Command="{Binding CloseGapAtPointerPosition}"
                                                Text="{x:Static lang:Strings.CloseGap}" />
                             <ui:MenuFlyoutItem Command="{Binding CloseAllGaps}"
                                                InputGesture="{h:GetCommandGesture CloseAllGaps, ExtensionType={x:Type p:TimelineTabExtension}}"

--- a/src/Beutl.Editor/Services/ElementGapService.cs
+++ b/src/Beutl.Editor/Services/ElementGapService.cs
@@ -1,0 +1,33 @@
+﻿using Beutl.Language;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+public sealed class ElementGapService : IElementGapService
+{
+    private readonly HistoryManager _historyManager;
+
+    public ElementGapService(HistoryManager historyManager)
+    {
+        _historyManager = historyManager ?? throw new ArgumentNullException(nameof(historyManager));
+    }
+
+    public bool CloseGap(Scene scene, Element anchor)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(anchor);
+
+        if (!scene.CloseGap(anchor)) return false;
+        _historyManager.Commit(CommandNames.CloseGap);
+        return true;
+    }
+
+    public int CloseAllGaps(Scene scene)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+
+        int closed = scene.CloseAllGaps();
+        if (closed > 0) _historyManager.Commit(CommandNames.CloseAllGaps);
+        return closed;
+    }
+}

--- a/src/Beutl.Editor/Services/ElementGapService.cs
+++ b/src/Beutl.Editor/Services/ElementGapService.cs
@@ -12,12 +12,12 @@ public sealed class ElementGapService : IElementGapService
         _historyManager = historyManager ?? throw new ArgumentNullException(nameof(historyManager));
     }
 
-    public bool CloseGap(Scene scene, Element anchor)
+    public bool CloseGapAfter(Scene scene, Element anchor)
     {
         ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(anchor);
 
-        if (!scene.CloseGap(anchor)) return false;
+        if (!scene.CloseGapAfter(anchor)) return false;
         _historyManager.Commit(CommandNames.CloseGap);
         return true;
     }

--- a/src/Beutl.Editor/Services/IElementGapService.cs
+++ b/src/Beutl.Editor/Services/IElementGapService.cs
@@ -1,0 +1,18 @@
+﻿using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+/// <summary>
+/// Closes timeline gaps between <see cref="Element"/>s on a <see cref="Scene"/>, owning the
+/// history commit. Commits one undo entry only when the scene actually changes.
+/// </summary>
+public interface IElementGapService
+{
+    /// <summary>Closes the gap immediately after <paramref name="anchor"/> on its ZIndex layer.
+    /// Returns <see langword="false"/> (no commit) when there is no gap to close.</summary>
+    bool CloseGap(Scene scene, Element anchor);
+
+    /// <summary>Closes every gap across all ZIndex layers. Returns the number of gaps closed;
+    /// commits one undo entry only when that number is greater than zero.</summary>
+    int CloseAllGaps(Scene scene);
+}

--- a/src/Beutl.Editor/Services/IElementGapService.cs
+++ b/src/Beutl.Editor/Services/IElementGapService.cs
@@ -10,7 +10,7 @@ public interface IElementGapService
 {
     /// <summary>Closes the gap immediately after <paramref name="anchor"/> on its ZIndex layer.
     /// Returns <see langword="false"/> (no commit) when there is no gap to close.</summary>
-    bool CloseGap(Scene scene, Element anchor);
+    bool CloseGapAfter(Scene scene, Element anchor);
 
     /// <summary>Closes every gap across all ZIndex layers. Returns the number of gaps closed;
     /// commits one undo entry only when that number is greater than zero.</summary>

--- a/src/Beutl.Language/CommandNames.ja.resx
+++ b/src/Beutl.Language/CommandNames.ja.resx
@@ -51,6 +51,12 @@
   <data name="UngroupElements" xml:space="preserve">
     <value>グループを解除</value>
   </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>隙間を詰める</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>すべての隙間を詰める</value>
+  </data>
   <data name="ChangeSceneDuration" xml:space="preserve">
     <value>シーンの長さを変更</value>
   </data>

--- a/src/Beutl.Language/CommandNames.resx
+++ b/src/Beutl.Language/CommandNames.resx
@@ -56,6 +56,12 @@
   <data name="UngroupElements" xml:space="preserve">
     <value>Ungroup Elements</value>
   </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>Close Gap</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>Close All Gaps</value>
+  </data>
   <data name="ChangeSceneDuration" xml:space="preserve">
     <value>Change Scene Duration</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -591,6 +591,9 @@
   <data name="CloseGap" xml:space="preserve">
     <value>隙間を詰める</value>
   </data>
+  <data name="Gaps" xml:space="preserve">
+    <value>隙間</value>
+  </data>
   <data name="CloseAllGaps" xml:space="preserve">
     <value>すべての隙間を詰める</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -609,6 +609,9 @@
   <data name="NoGapsToGoTo" xml:space="preserve">
     <value>移動できる隙間がありません</value>
   </data>
+  <data name="NoElementSelected" xml:space="preserve">
+    <value>要素が選択されていません</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>エディター</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -588,6 +588,24 @@
   <data name="NudgeRightSecond" xml:space="preserve">
     <value>1 秒右へ移動</value>
   </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>隙間を詰める</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>すべての隙間を詰める</value>
+  </data>
+  <data name="GoToNextGap" xml:space="preserve">
+    <value>次の隙間へ移動</value>
+  </data>
+  <data name="GoToPreviousGap" xml:space="preserve">
+    <value>前の隙間へ移動</value>
+  </data>
+  <data name="NoGapsToClose" xml:space="preserve">
+    <value>詰める隙間がありません</value>
+  </data>
+  <data name="NoGapsToGoTo" xml:space="preserve">
+    <value>移動できる隙間がありません</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>エディター</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -614,6 +614,9 @@
   <data name="NoGapsToGoTo" xml:space="preserve">
     <value>There are no gaps to go to</value>
   </data>
+  <data name="NoElementSelected" xml:space="preserve">
+    <value>No element is selected</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>Editor</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -596,6 +596,9 @@
   <data name="CloseGap" xml:space="preserve">
     <value>Close Gap</value>
   </data>
+  <data name="Gaps" xml:space="preserve">
+    <value>Gaps</value>
+  </data>
   <data name="CloseAllGaps" xml:space="preserve">
     <value>Close All Gaps</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -593,6 +593,24 @@
   <data name="NudgeRightSecond" xml:space="preserve">
     <value>Nudge right (1 second)</value>
   </data>
+  <data name="CloseGap" xml:space="preserve">
+    <value>Close Gap</value>
+  </data>
+  <data name="CloseAllGaps" xml:space="preserve">
+    <value>Close All Gaps</value>
+  </data>
+  <data name="GoToNextGap" xml:space="preserve">
+    <value>Go to Next Gap</value>
+  </data>
+  <data name="GoToPreviousGap" xml:space="preserve">
+    <value>Go to Previous Gap</value>
+  </data>
+  <data name="NoGapsToClose" xml:space="preserve">
+    <value>There are no gaps to close</value>
+  </data>
+  <data name="NoGapsToGoTo" xml:space="preserve">
+    <value>There are no gaps to go to</value>
+  </data>
   <data name="Editor" xml:space="preserve">
     <value>Editor</value>
   </data>

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -442,16 +442,17 @@ public class Scene : ProjectItem, INotifyEdited
     /// gap exists.
     /// </summary>
     /// <param name="searchRange">
-    /// When set, only gaps that lie entirely within this range are considered, so
-    /// navigation stays within the active scene range and does not target the
-    /// trailing space left by elements beyond a shortened or offset scene.
+    /// When set, each gap is clamped to its intersection with this range and gaps that do not
+    /// intersect it are dropped, so navigation stays within the active scene range yet a gap that
+    /// merely straddles the range (its ends lie beyond a shortened or offset scene) is still reachable
+    /// through its visible portion. The returned range is the clamped, visible gap.
     /// </param>
     public TimeRange? FindNextGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Range.Start > currentTime && Contains(searchRange, g.Range))
-            .OrderBy(g => g.Range.Start)
-            .Select(g => (TimeRange?)g.Range)
+            .Select(g => ClampToRange(g.Range, searchRange))
+            .Where(r => r is { } v && v.Start > currentTime)
+            .OrderBy(r => r!.Value.Start)
             .FirstOrDefault();
     }
 
@@ -461,22 +462,30 @@ public class Scene : ProjectItem, INotifyEdited
     /// gap exists.
     /// </summary>
     /// <param name="searchRange">
-    /// When set, only gaps that lie entirely within this range are considered, so
-    /// navigation stays within the active scene range.
+    /// When set, each gap is clamped to its intersection with this range and gaps that do not
+    /// intersect it are dropped, so a gap straddling the range stays reachable through its visible
+    /// portion. The returned range is the clamped, visible gap.
     /// </param>
     public TimeRange? FindPreviousGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Range.End < currentTime && Contains(searchRange, g.Range))
-            .OrderByDescending(g => g.Range.End)
-            .Select(g => (TimeRange?)g.Range)
+            .Select(g => ClampToRange(g.Range, searchRange))
+            .Where(r => r is { } v && v.End < currentTime)
+            .OrderByDescending(r => r!.Value.End)
             .FirstOrDefault();
     }
 
-    // Inclusive at both ends, unlike the half-open TimeRange.Contains: a gap touching
-    // the searched range's end must still count as inside it.
-    private static bool Contains(TimeRange? range, TimeRange gap)
-        => range is not { } r || (gap.Start >= r.Start && gap.End <= r.End);
+    // The part of gap visible inside range, or null when they do not overlap. Boundaries are inclusive
+    // at the endpoints (a gap touching an edge keeps that touch), so a straddling gap contributes only
+    // its in-range slice rather than being dropped for not being wholly contained.
+    private static TimeRange? ClampToRange(TimeRange gap, TimeRange? range)
+    {
+        if (range is not { } r) return gap;
+
+        TimeSpan start = gap.Start > r.Start ? gap.Start : r.Start;
+        TimeSpan end = gap.End < r.End ? gap.End : r.End;
+        return end > start ? new TimeRange(start, end - start) : null;
+    }
 
     public override void Serialize(ICoreSerializationContext context)
     {

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -420,15 +420,15 @@ public class Scene : ProjectItem, INotifyEdited
     /// strictly after <paramref name="currentTime"/>, or <see langword="null"/>
     /// when no such gap exists. The leading gap is excluded.
     /// </summary>
-    /// <param name="searchEnd">
-    /// When set, gaps that end after this time are ignored, so navigation stays
-    /// within the active scene range and does not target the trailing space left
-    /// by elements beyond a shortened scene.
+    /// <param name="searchRange">
+    /// When set, only gaps that lie entirely within this range are considered, so
+    /// navigation stays within the active scene range and does not target the
+    /// trailing space left by elements beyond a shortened or offset scene.
     /// </param>
-    public TimeSpan? FindNextGapCenter(TimeSpan currentTime, TimeSpan? searchEnd = null)
+    public TimeSpan? FindNextGapCenter(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.Start > currentTime && (searchEnd is not { } end || g.Gap.End <= end))
+            .Where(g => g.Gap.Start > currentTime && Contains(searchRange, g.Gap))
             .OrderBy(g => g.Gap.Start)
             .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
             .FirstOrDefault();
@@ -439,18 +439,21 @@ public class Scene : ProjectItem, INotifyEdited
     /// strictly before <paramref name="currentTime"/>, or <see langword="null"/>
     /// when no such gap exists. The leading gap is excluded.
     /// </summary>
-    /// <param name="searchStart">
-    /// When set, gaps that start before this time are ignored, so navigation
-    /// stays within the active scene range.
+    /// <param name="searchRange">
+    /// When set, only gaps that lie entirely within this range are considered, so
+    /// navigation stays within the active scene range.
     /// </param>
-    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime, TimeSpan? searchStart = null)
+    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.End < currentTime && (searchStart is not { } start || g.Gap.Start >= start))
+            .Where(g => g.Gap.End < currentTime && Contains(searchRange, g.Gap))
             .OrderByDescending(g => g.Gap.End)
             .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
             .FirstOrDefault();
     }
+
+    private static bool Contains(TimeRange? range, TimeRange gap)
+        => range is not { } r || (gap.Start >= r.Start && gap.End <= r.End);
 
     public override void Serialize(ICoreSerializationContext context)
     {

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -326,28 +326,41 @@ public class Scene : ProjectItem, INotifyEdited
             return false;
 
         int z = anchor.ZIndex;
-        TimeSpan anchorEnd = anchor.Range.End;
-
         List<Element> sorted = Children
             .Where(e => e.ZIndex == z)
             .OrderBy(e => e.Start)
             .ThenBy(e => e.Range.End)
             .ToList();
-        int anchorIndex = sorted.IndexOf(anchor);
-        if (anchorIndex < 0) return false;
+        if (sorted.Count == 0) return false;
 
-        Element? next = sorted.Skip(anchorIndex + 1).FirstOrDefault();
-        if (next is null) return false;
+        // The gap to close is the first empty interval after the continuous coverage run that
+        // contains the anchor, so an earlier element covering past the anchor means no gap exists.
+        TimeSpan coveredEnd = sorted[0].Range.End;
+        bool anchorInRun = ReferenceEquals(sorted[0], anchor);
+        for (int i = 1; i < sorted.Count; i++)
+        {
+            Element cur = sorted[i];
+            if (cur.Start > coveredEnd)
+            {
+                if (anchorInRun)
+                {
+                    Element[] toShift = Children
+                        .Where(e => e.ZIndex == z && e.Start >= cur.Start)
+                        .ToArray();
+                    return toShift.Length != 0 && MoveChildrenAndDetectChange(toShift, coveredEnd - cur.Start);
+                }
 
-        TimeSpan gapSize = next.Start - anchorEnd;
-        if (gapSize <= TimeSpan.Zero) return false;
+                coveredEnd = cur.Range.End;
+                anchorInRun = ReferenceEquals(cur, anchor);
+            }
+            else
+            {
+                if (cur.Range.End > coveredEnd) coveredEnd = cur.Range.End;
+                if (ReferenceEquals(cur, anchor)) anchorInRun = true;
+            }
+        }
 
-        Element[] toShift = Children
-            .Where(e => e != anchor && e.ZIndex == z && e.Start >= next.Start)
-            .ToArray();
-        if (toShift.Length == 0) return false;
-
-        return MoveChildrenAndDetectChange(toShift, -gapSize);
+        return false;
     }
 
     /// <summary>
@@ -407,10 +420,15 @@ public class Scene : ProjectItem, INotifyEdited
     /// strictly after <paramref name="currentTime"/>, or <see langword="null"/>
     /// when no such gap exists. The leading gap is excluded.
     /// </summary>
-    public TimeSpan? FindNextGapCenter(TimeSpan currentTime)
+    /// <param name="searchEnd">
+    /// When set, gaps that end after this time are ignored, so navigation stays
+    /// within the active scene range and does not target the trailing space left
+    /// by elements beyond a shortened scene.
+    /// </param>
+    public TimeSpan? FindNextGapCenter(TimeSpan currentTime, TimeSpan? searchEnd = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.Start > currentTime)
+            .Where(g => g.Gap.Start > currentTime && (searchEnd is not { } end || g.Gap.End <= end))
             .OrderBy(g => g.Gap.Start)
             .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
             .FirstOrDefault();
@@ -421,10 +439,14 @@ public class Scene : ProjectItem, INotifyEdited
     /// strictly before <paramref name="currentTime"/>, or <see langword="null"/>
     /// when no such gap exists. The leading gap is excluded.
     /// </summary>
-    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime)
+    /// <param name="searchStart">
+    /// When set, gaps that start before this time are ignored, so navigation
+    /// stays within the active scene range.
+    /// </param>
+    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime, TimeSpan? searchStart = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.End < currentTime)
+            .Where(g => g.Gap.End < currentTime && (searchStart is not { } start || g.Gap.Start >= start))
             .OrderByDescending(g => g.Gap.End)
             .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
             .FirstOrDefault();

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -294,13 +294,18 @@ public class Scene : ProjectItem, INotifyEdited
                 yield return (zGroup.Key, new TimeRange(TimeSpan.Zero, sorted[0].Start));
             }
 
-            for (int i = 0; i < sorted.Count - 1; i++)
+            TimeSpan coveredEnd = sorted[0].Range.End;
+            for (int i = 1; i < sorted.Count; i++)
             {
-                TimeSpan gapStart = sorted[i].Range.End;
-                TimeSpan gapEnd = sorted[i + 1].Start;
-                if (gapEnd > gapStart)
+                Element next = sorted[i];
+                if (next.Start > coveredEnd)
                 {
-                    yield return (zGroup.Key, new TimeRange(gapStart, gapEnd - gapStart));
+                    yield return (zGroup.Key, new TimeRange(coveredEnd, next.Start - coveredEnd));
+                }
+
+                if (next.Range.End > coveredEnd)
+                {
+                    coveredEnd = next.Range.End;
                 }
             }
         }
@@ -323,10 +328,15 @@ public class Scene : ProjectItem, INotifyEdited
         int z = anchor.ZIndex;
         TimeSpan anchorEnd = anchor.Range.End;
 
-        Element? next = Children
-            .Where(e => e != anchor && e.ZIndex == z && e.Start >= anchorEnd)
+        List<Element> sorted = Children
+            .Where(e => e.ZIndex == z)
             .OrderBy(e => e.Start)
-            .FirstOrDefault();
+            .ThenBy(e => e.Range.End)
+            .ToList();
+        int anchorIndex = sorted.IndexOf(anchor);
+        if (anchorIndex < 0) return false;
+
+        Element? next = sorted.Skip(anchorIndex + 1).FirstOrDefault();
         if (next is null) return false;
 
         TimeSpan gapSize = next.Start - anchorEnd;
@@ -337,8 +347,7 @@ public class Scene : ProjectItem, INotifyEdited
             .ToArray();
         if (toShift.Length == 0) return false;
 
-        MoveChildren(0, -gapSize, toShift);
-        return true;
+        return MoveChildrenAndDetectChange(toShift, -gapSize);
     }
 
     /// <summary>
@@ -366,12 +375,31 @@ public class Scene : ProjectItem, INotifyEdited
                 TimeSpan delta = -gap.Gap.Duration;
                 if (delta == TimeSpan.Zero) continue;
 
-                MoveChildren(0, delta, toShift);
-                closed++;
+                if (MoveChildrenAndDetectChange(toShift, delta))
+                {
+                    closed++;
+                }
             }
         }
 
         return closed;
+    }
+
+    private bool MoveChildrenAndDetectChange(Element[] elements, TimeSpan deltaStart)
+    {
+        TimeSpan[] originalStarts = elements.Select(e => e.Start).ToArray();
+
+        MoveChildren(0, deltaStart, elements);
+
+        for (int i = 0; i < elements.Length; i++)
+        {
+            if (elements[i].Start != originalStarts[i])
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -425,7 +425,7 @@ public class Scene : ProjectItem, INotifyEdited
     {
         return EnumerateGaps()
             .Where(g => g.Gap.End < currentTime)
-            .OrderByDescending(g => g.Gap.Start)
+            .OrderByDescending(g => g.Gap.End)
             .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
             .FirstOrDefault();
     }

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -275,24 +275,15 @@ public class Scene : ProjectItem, INotifyEdited
     /// interval between one element's <see cref="Element.Range.End"/> and the
     /// next element's <see cref="Element.Start"/> on the same ZIndex when the
     /// next element starts strictly after the previous one ends. Overlapping
-    /// or touching elements produce no gap.
+    /// or touching elements produce no gap, and the space before the first
+    /// element on a ZIndex is not a gap.
     /// </summary>
-    /// <param name="includeLeadingGap">
-    /// When <see langword="true"/>, also yields the leading gap on each ZIndex:
-    /// the interval from <see cref="TimeSpan.Zero"/> to the first element's
-    /// <see cref="Element.Start"/> when the first element starts after zero.
-    /// </param>
-    public IEnumerable<(int ZIndex, TimeRange Gap)> EnumerateGaps(bool includeLeadingGap = false)
+    public IEnumerable<SceneGap> EnumerateGaps()
     {
         foreach (IGrouping<int, Element> zGroup in Children.GroupBy(e => e.ZIndex).OrderBy(g => g.Key))
         {
             List<Element> sorted = zGroup.OrderBy(e => e.Start).ThenBy(e => e.Range.End).ToList();
             if (sorted.Count == 0) continue;
-
-            if (includeLeadingGap && sorted[0].Start > TimeSpan.Zero)
-            {
-                yield return (zGroup.Key, new TimeRange(TimeSpan.Zero, sorted[0].Start));
-            }
 
             TimeSpan coveredEnd = sorted[0].Range.End;
             for (int i = 1; i < sorted.Count; i++)
@@ -300,7 +291,7 @@ public class Scene : ProjectItem, INotifyEdited
                 Element next = sorted[i];
                 if (next.Start > coveredEnd)
                 {
-                    yield return (zGroup.Key, new TimeRange(coveredEnd, next.Start - coveredEnd));
+                    yield return new SceneGap(zGroup.Key, new TimeRange(coveredEnd, next.Start - coveredEnd));
                 }
 
                 if (next.Range.End > coveredEnd)
@@ -319,7 +310,7 @@ public class Scene : ProjectItem, INotifyEdited
     /// touches or overlaps the anchor). Does not commit history; the caller owns
     /// the single <c>HistoryManager.Commit</c> boundary.
     /// </summary>
-    public bool CloseGap(Element anchor)
+    public bool CloseGapAfter(Element anchor)
     {
         ArgumentNullException.ThrowIfNull(anchor);
         if (anchor.HierarchicalParent is not Scene scene || !ReferenceEquals(scene, this))
@@ -364,28 +355,28 @@ public class Scene : ProjectItem, INotifyEdited
     }
 
     /// <summary>
-    /// Closes every gap between elements on every ZIndex (the leading gap from
-    /// zero to the first element is not closed). Returns the number of gaps
+    /// Closes every gap between elements on every ZIndex (the space before the
+    /// first element on a ZIndex is not closed). Returns the number of gaps
     /// closed. Gaps are closed right-to-left within each ZIndex so earlier
     /// closes do not shift elements that later closes depend on. Does not
     /// commit history; the caller owns the single commit boundary.
     /// </summary>
     public int CloseAllGaps()
     {
-        List<(int ZIndex, TimeRange Gap)> gaps = EnumerateGaps().ToList();
+        List<SceneGap> gaps = EnumerateGaps().ToList();
         if (gaps.Count == 0) return 0;
 
         int closed = 0;
-        foreach (IGrouping<int, (int ZIndex, TimeRange Gap)> zGroup in gaps.GroupBy(g => g.ZIndex))
+        foreach (IGrouping<int, SceneGap> zGroup in gaps.GroupBy(g => g.ZIndex))
         {
-            foreach ((int ZIndex, TimeRange Gap) gap in zGroup.OrderByDescending(g => g.Gap.Start))
+            foreach (SceneGap gap in zGroup.OrderByDescending(g => g.Range.Start))
             {
                 Element[] toShift = Children
-                    .Where(e => e.ZIndex == zGroup.Key && e.Start >= gap.Gap.End)
+                    .Where(e => e.ZIndex == zGroup.Key && e.Start >= gap.Range.End)
                     .ToArray();
                 if (toShift.Length == 0) continue;
 
-                TimeSpan delta = -gap.Gap.Duration;
+                TimeSpan delta = -gap.Range.Duration;
                 if (delta == TimeSpan.Zero) continue;
 
                 if (MoveChildrenAndDetectChange(toShift, delta))
@@ -416,42 +407,44 @@ public class Scene : ProjectItem, INotifyEdited
     }
 
     /// <summary>
-    /// Returns the center of the first gap (across all ZIndexes) that starts
-    /// strictly after <paramref name="currentTime"/>, or <see langword="null"/>
-    /// when no such gap exists. The leading gap is excluded.
+    /// Returns the first gap (across all ZIndexes) that starts strictly after
+    /// <paramref name="currentTime"/>, or <see langword="null"/> when no such
+    /// gap exists.
     /// </summary>
     /// <param name="searchRange">
     /// When set, only gaps that lie entirely within this range are considered, so
     /// navigation stays within the active scene range and does not target the
     /// trailing space left by elements beyond a shortened or offset scene.
     /// </param>
-    public TimeSpan? FindNextGapCenter(TimeSpan currentTime, TimeRange? searchRange = null)
+    public TimeRange? FindNextGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.Start > currentTime && Contains(searchRange, g.Gap))
-            .OrderBy(g => g.Gap.Start)
-            .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
+            .Where(g => g.Range.Start > currentTime && Contains(searchRange, g.Range))
+            .OrderBy(g => g.Range.Start)
+            .Select(g => (TimeRange?)g.Range)
             .FirstOrDefault();
     }
 
     /// <summary>
-    /// Returns the center of the last gap (across all ZIndexes) that ends
-    /// strictly before <paramref name="currentTime"/>, or <see langword="null"/>
-    /// when no such gap exists. The leading gap is excluded.
+    /// Returns the last gap (across all ZIndexes) that ends strictly before
+    /// <paramref name="currentTime"/>, or <see langword="null"/> when no such
+    /// gap exists.
     /// </summary>
     /// <param name="searchRange">
     /// When set, only gaps that lie entirely within this range are considered, so
     /// navigation stays within the active scene range.
     /// </param>
-    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime, TimeRange? searchRange = null)
+    public TimeRange? FindPreviousGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Where(g => g.Gap.End < currentTime && Contains(searchRange, g.Gap))
-            .OrderByDescending(g => g.Gap.End)
-            .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
+            .Where(g => g.Range.End < currentTime && Contains(searchRange, g.Range))
+            .OrderByDescending(g => g.Range.End)
+            .Select(g => (TimeRange?)g.Range)
             .FirstOrDefault();
     }
 
+    // Inclusive at both ends, unlike the half-open TimeRange.Contains: a gap touching
+    // the searched range's end must still count as inside it.
     private static bool Contains(TimeRange? range, TimeRange gap)
         => range is not { } r || (gap.Start >= r.Start && gap.End <= r.End);
 

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -410,14 +410,21 @@ public class Scene : ProjectItem, INotifyEdited
             .ToArray();
 
         var result = new List<Element>();
-        foreach (Element e in Children
+        // Same-start elements move as one cohort: if any of them would land on a locked element the
+        // whole group stops, so the shiftable set never depends on Children enumeration order.
+        foreach (IGrouping<TimeSpan, Element> startGroup in Children
             .Where(e => e.ZIndex == zIndex && !e.IsLocked && e.Start >= fromStart)
-            .OrderBy(e => e.Start))
+            .GroupBy(e => e.Start)
+            .OrderBy(g => g.Key))
         {
-            TimeRange shifted = e.Range.WithStart(e.Start + deltaStart);
-            if (Array.Exists(lockedOnLayer, l => shifted.Intersects(l.Range))) break;
+            bool blocked = startGroup.Any(e =>
+            {
+                TimeRange shifted = e.Range.WithStart(e.Start + deltaStart);
+                return Array.Exists(lockedOnLayer, l => shifted.Intersects(l.Range));
+            });
+            if (blocked) break;
 
-            result.Add(e);
+            result.AddRange(startGroup);
         }
 
         return [.. result];

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -343,7 +343,7 @@ public class Scene : ProjectItem, INotifyEdited
             {
                 if (anchorInRun)
                 {
-                    Element[] toShift = ShiftableAfter(z, cur.Start, coveredEnd - cur.Start);
+                    Element[] toShift = ShiftableAfter(z, cur.Start);
                     return toShift.Length != 0 && MoveChildrenAndDetectChange(toShift, coveredEnd - cur.Start);
                 }
 
@@ -384,7 +384,7 @@ public class Scene : ProjectItem, INotifyEdited
                 TimeSpan delta = -gap.Range.Duration;
                 if (delta == TimeSpan.Zero) continue;
 
-                Element[] toShift = ShiftableAfter(zGroup.Key, gap.Range.End, delta);
+                Element[] toShift = ShiftableAfter(zGroup.Key, gap.Range.End);
                 if (toShift.Length == 0) continue;
 
                 if (MoveChildrenAndDetectChange(toShift, delta))
@@ -397,32 +397,21 @@ public class Scene : ProjectItem, INotifyEdited
         return closed;
     }
 
-    // The unlocked elements on the layer at or after fromStart that can slide by deltaStart without
-    // any of them landing on a locked element, in shift order. A locked element is an immovable
-    // barrier: once a follower's shifted range would intersect one, the shift stops there. Mirrors
-    // RippleHelper so gap-close honors the same lock guarantees as the other timeline mutations.
-    private Element[] ShiftableAfter(int zIndex, TimeSpan fromStart, TimeSpan deltaStart)
+    // The elements at or after fromStart that a gap close may slide left, in timeline order. A locked
+    // element is a hard wall: iteration stops at the first locked start-group, so nothing at or beyond
+    // it shifts across the lock (elements before it only move further left, never onto a lock).
+    // Grouping by Start keeps same-start elements atomic, independent of Children enumeration order.
+    private Element[] ShiftableAfter(int zIndex, TimeSpan fromStart)
     {
         if (IsLayerLocked(zIndex)) return [];
 
-        Element[] lockedOnLayer = Children
-            .Where(e => e.ZIndex == zIndex && e.IsLocked)
-            .ToArray();
-
         var result = new List<Element>();
-        // Same-start elements move as one cohort: if any of them would land on a locked element the
-        // whole group stops, so the shiftable set never depends on Children enumeration order.
         foreach (IGrouping<TimeSpan, Element> startGroup in Children
-            .Where(e => e.ZIndex == zIndex && !e.IsLocked && e.Start >= fromStart)
+            .Where(e => e.ZIndex == zIndex && e.Start >= fromStart)
             .GroupBy(e => e.Start)
             .OrderBy(g => g.Key))
         {
-            bool blocked = startGroup.Any(e =>
-            {
-                TimeRange shifted = e.Range.WithStart(e.Start + deltaStart);
-                return Array.Exists(lockedOnLayer, l => shifted.Intersects(l.Range));
-            });
-            if (blocked) break;
+            if (startGroup.Any(e => e.IsLocked)) break;
 
             result.AddRange(startGroup);
         }

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -457,6 +457,7 @@ public class Scene : ProjectItem, INotifyEdited
             .Select(g => ClampGap(g, searchRange))
             .Where(g => g is { } v && v.Range.Start >= currentTime)
             .OrderBy(g => g!.Value.Range.Start)
+            .ThenBy(g => g!.Value.Range.End)
             .FirstOrDefault();
     }
 
@@ -477,6 +478,7 @@ public class Scene : ProjectItem, INotifyEdited
             .Select(g => ClampGap(g, searchRange))
             .Where(g => g is { } v && v.Range.End <= currentTime)
             .OrderByDescending(g => g!.Value.Range.End)
+            .ThenByDescending(g => g!.Value.Range.Start)
             .FirstOrDefault();
     }
 

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -437,9 +437,10 @@ public class Scene : ProjectItem, INotifyEdited
     }
 
     /// <summary>
-    /// Returns the first gap (across all ZIndexes) that starts strictly after
+    /// Returns the first gap (across all ZIndexes) that starts at or after
     /// <paramref name="currentTime"/>, or <see langword="null"/> when no such
-    /// gap exists.
+    /// gap exists. A playhead sitting inside a gap starts past that gap, so it is
+    /// skipped, but one resting exactly on a gap's start still finds it.
     /// </summary>
     /// <param name="searchRange">
     /// When set, each gap is clamped to its intersection with this range and gaps that do not
@@ -451,15 +452,16 @@ public class Scene : ProjectItem, INotifyEdited
     {
         return EnumerateGaps()
             .Select(g => ClampToRange(g.Range, searchRange))
-            .Where(r => r is { } v && v.Start > currentTime)
+            .Where(r => r is { } v && v.Start >= currentTime)
             .OrderBy(r => r!.Value.Start)
             .FirstOrDefault();
     }
 
     /// <summary>
-    /// Returns the last gap (across all ZIndexes) that ends strictly before
+    /// Returns the last gap (across all ZIndexes) that ends at or before
     /// <paramref name="currentTime"/>, or <see langword="null"/> when no such
-    /// gap exists.
+    /// gap exists. A playhead sitting inside a gap ends before that gap, so it is
+    /// skipped, but one resting exactly on a gap's end still finds it.
     /// </summary>
     /// <param name="searchRange">
     /// When set, each gap is clamped to its intersection with this range and gaps that do not
@@ -470,14 +472,14 @@ public class Scene : ProjectItem, INotifyEdited
     {
         return EnumerateGaps()
             .Select(g => ClampToRange(g.Range, searchRange))
-            .Where(r => r is { } v && v.End < currentTime)
+            .Where(r => r is { } v && v.End <= currentTime)
             .OrderByDescending(r => r!.Value.End)
             .FirstOrDefault();
     }
 
-    // The part of gap visible inside range, or null when they do not overlap. Boundaries are inclusive
-    // at the endpoints (a gap touching an edge keeps that touch), so a straddling gap contributes only
-    // its in-range slice rather than being dropped for not being wholly contained.
+    // The part of gap visible inside range, or null when they do not overlap with positive width —
+    // half-open, matching TimeRange, so a point-only touch at an edge yields no gap. A straddling gap
+    // contributes its in-range slice instead of being dropped for not being wholly contained.
     private static TimeRange? ClampToRange(TimeRange gap, TimeRange? range)
     {
         if (range is not { } r) return gap;

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -446,18 +446,19 @@ public class Scene : ProjectItem, INotifyEdited
     /// skipped, but one resting exactly on a gap's start still finds it.
     /// </summary>
     /// <param name="searchRange">
-    /// When set, each gap is clamped to its intersection with this range and gaps that do not
-    /// intersect it are dropped, so navigation stays within the active scene range yet a gap that
-    /// merely straddles the range (its ends lie beyond a shortened or offset scene) is still reachable
-    /// through its visible portion. The returned range is the clamped, visible gap.
+    /// When set, a gap that does not intersect this range is dropped, and the filter/ordering use the
+    /// gap's intersection with the range, so a gap that merely straddles the range (its ends lie beyond
+    /// a shortened or offset scene) is still reachable through its visible portion. The returned gap is
+    /// the raw gap, unclamped — the caller decides how to clamp it for display.
     /// </param>
     public SceneGap? FindNextGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Select(g => ClampGap(g, searchRange))
-            .Where(g => g is { } v && v.Range.Start >= currentTime)
-            .OrderBy(g => g!.Value.Range.Start)
-            .ThenBy(g => g!.Value.Range.End)
+            .Select(g => (Raw: g, Visible: ClampGap(g, searchRange)))
+            .Where(x => x.Visible is { } v && v.Range.Start >= currentTime)
+            .OrderBy(x => x.Visible!.Value.Range.Start)
+            .ThenBy(x => x.Visible!.Value.Range.End)
+            .Select(x => (SceneGap?)x.Raw)
             .FirstOrDefault();
     }
 
@@ -468,17 +469,18 @@ public class Scene : ProjectItem, INotifyEdited
     /// skipped, but one resting exactly on a gap's end still finds it.
     /// </summary>
     /// <param name="searchRange">
-    /// When set, each gap is clamped to its intersection with this range and gaps that do not
-    /// intersect it are dropped, so a gap straddling the range stays reachable through its visible
-    /// portion. The returned range is the clamped, visible gap.
+    /// When set, a gap that does not intersect this range is dropped, and the filter/ordering use the
+    /// gap's intersection with the range, so a gap straddling the range stays reachable through its
+    /// visible portion. The returned gap is the raw gap, unclamped.
     /// </param>
     public SceneGap? FindPreviousGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Select(g => ClampGap(g, searchRange))
-            .Where(g => g is { } v && v.Range.End <= currentTime)
-            .OrderByDescending(g => g!.Value.Range.End)
-            .ThenByDescending(g => g!.Value.Range.Start)
+            .Select(g => (Raw: g, Visible: ClampGap(g, searchRange)))
+            .Where(x => x.Visible is { } v && v.Range.End <= currentTime)
+            .OrderByDescending(x => x.Visible!.Value.Range.End)
+            .ThenByDescending(x => x.Visible!.Value.Range.Start)
+            .Select(x => (SceneGap?)x.Raw)
             .FirstOrDefault();
     }
 

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -269,6 +269,139 @@ public class Scene : ProjectItem, INotifyEdited
         new MultipleMoveCommand(this, elements, deltaIndex, deltaStart).Do();
     }
 
+    /// <summary>
+    /// Enumerates the gaps between adjacent elements on each ZIndex, ordered by
+    /// ZIndex (ascending) then by gap start (ascending). A gap is the empty
+    /// interval between one element's <see cref="Element.Range.End"/> and the
+    /// next element's <see cref="Element.Start"/> on the same ZIndex when the
+    /// next element starts strictly after the previous one ends. Overlapping
+    /// or touching elements produce no gap.
+    /// </summary>
+    /// <param name="includeLeadingGap">
+    /// When <see langword="true"/>, also yields the leading gap on each ZIndex:
+    /// the interval from <see cref="TimeSpan.Zero"/> to the first element's
+    /// <see cref="Element.Start"/> when the first element starts after zero.
+    /// </param>
+    public IEnumerable<(int ZIndex, TimeRange Gap)> EnumerateGaps(bool includeLeadingGap = false)
+    {
+        foreach (IGrouping<int, Element> zGroup in Children.GroupBy(e => e.ZIndex).OrderBy(g => g.Key))
+        {
+            List<Element> sorted = zGroup.OrderBy(e => e.Start).ThenBy(e => e.Range.End).ToList();
+            if (sorted.Count == 0) continue;
+
+            if (includeLeadingGap && sorted[0].Start > TimeSpan.Zero)
+            {
+                yield return (zGroup.Key, new TimeRange(TimeSpan.Zero, sorted[0].Start));
+            }
+
+            for (int i = 0; i < sorted.Count - 1; i++)
+            {
+                TimeSpan gapStart = sorted[i].Range.End;
+                TimeSpan gapEnd = sorted[i + 1].Start;
+                if (gapEnd > gapStart)
+                {
+                    yield return (zGroup.Key, new TimeRange(gapStart, gapEnd - gapStart));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Closes the gap immediately after <paramref name="anchor"/> on
+    /// <paramref name="anchor"/>'s ZIndex by shifting all subsequent elements on
+    /// that ZIndex left by the gap size. Returns <see langword="false"/> when
+    /// there is no gap after the anchor (no next element, or the next element
+    /// touches or overlaps the anchor). Does not commit history; the caller owns
+    /// the single <c>HistoryManager.Commit</c> boundary.
+    /// </summary>
+    public bool CloseGap(Element anchor)
+    {
+        ArgumentNullException.ThrowIfNull(anchor);
+        if (anchor.HierarchicalParent is not Scene scene || !ReferenceEquals(scene, this))
+            return false;
+
+        int z = anchor.ZIndex;
+        TimeSpan anchorEnd = anchor.Range.End;
+
+        Element? next = Children
+            .Where(e => e != anchor && e.ZIndex == z && e.Start >= anchorEnd)
+            .OrderBy(e => e.Start)
+            .FirstOrDefault();
+        if (next is null) return false;
+
+        TimeSpan gapSize = next.Start - anchorEnd;
+        if (gapSize <= TimeSpan.Zero) return false;
+
+        Element[] toShift = Children
+            .Where(e => e != anchor && e.ZIndex == z && e.Start >= next.Start)
+            .ToArray();
+        if (toShift.Length == 0) return false;
+
+        MoveChildren(0, -gapSize, toShift);
+        return true;
+    }
+
+    /// <summary>
+    /// Closes every gap between elements on every ZIndex (the leading gap from
+    /// zero to the first element is not closed). Returns the number of gaps
+    /// closed. Gaps are closed right-to-left within each ZIndex so earlier
+    /// closes do not shift elements that later closes depend on. Does not
+    /// commit history; the caller owns the single commit boundary.
+    /// </summary>
+    public int CloseAllGaps()
+    {
+        List<(int ZIndex, TimeRange Gap)> gaps = EnumerateGaps().ToList();
+        if (gaps.Count == 0) return 0;
+
+        int closed = 0;
+        foreach (IGrouping<int, (int ZIndex, TimeRange Gap)> zGroup in gaps.GroupBy(g => g.ZIndex))
+        {
+            foreach ((int ZIndex, TimeRange Gap) gap in zGroup.OrderByDescending(g => g.Gap.Start))
+            {
+                Element[] toShift = Children
+                    .Where(e => e.ZIndex == zGroup.Key && e.Start >= gap.Gap.End)
+                    .ToArray();
+                if (toShift.Length == 0) continue;
+
+                TimeSpan delta = -gap.Gap.Duration;
+                if (delta == TimeSpan.Zero) continue;
+
+                MoveChildren(0, delta, toShift);
+                closed++;
+            }
+        }
+
+        return closed;
+    }
+
+    /// <summary>
+    /// Returns the center of the first gap (across all ZIndexes) that starts
+    /// strictly after <paramref name="currentTime"/>, or <see langword="null"/>
+    /// when no such gap exists. The leading gap is excluded.
+    /// </summary>
+    public TimeSpan? FindNextGapCenter(TimeSpan currentTime)
+    {
+        return EnumerateGaps()
+            .Where(g => g.Gap.Start > currentTime)
+            .OrderBy(g => g.Gap.Start)
+            .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Returns the center of the last gap (across all ZIndexes) that ends
+    /// strictly before <paramref name="currentTime"/>, or <see langword="null"/>
+    /// when no such gap exists. The leading gap is excluded.
+    /// </summary>
+    public TimeSpan? FindPreviousGapCenter(TimeSpan currentTime)
+    {
+        return EnumerateGaps()
+            .Where(g => g.Gap.End < currentTime)
+            .OrderByDescending(g => g.Gap.Start)
+            .Select(g => (TimeSpan?)(g.Gap.Start + new TimeSpan(g.Gap.Duration.Ticks / 2)))
+            .FirstOrDefault();
+    }
+
     public override void Serialize(ICoreSerializationContext context)
     {
         base.Serialize(context);

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -303,12 +303,17 @@ public class Scene : ProjectItem, INotifyEdited
     }
 
     /// <summary>
-    /// Closes the gap immediately after <paramref name="anchor"/> on
-    /// <paramref name="anchor"/>'s ZIndex by shifting all subsequent elements on
-    /// that ZIndex left by the gap size. Returns <see langword="false"/> when
-    /// there is no gap after the anchor (no next element, or the next element
-    /// touches or overlaps the anchor). Does not commit history; the caller owns
-    /// the single <c>HistoryManager.Commit</c> boundary.
+    /// Closes the first gap after the continuous-coverage run containing
+    /// <paramref name="anchor"/> on <paramref name="anchor"/>'s ZIndex by
+    /// shifting the subsequent unlocked elements on that ZIndex left by the gap
+    /// size. An overlapping peer that extends the run past the anchor moves the
+    /// target gap to the run's covered end. Returns <see langword="false"/> when
+    /// there is no gap after the run (no next element, or the next element
+    /// touches or overlaps the run), when the layer is locked, or when a locked
+    /// element blocks every shiftable follower. Locked layers and locked
+    /// elements are never moved; a locked element acts as an immovable barrier
+    /// that halts the shift. Does not commit history; the caller owns the single
+    /// <c>HistoryManager.Commit</c> boundary.
     /// </summary>
     public bool CloseGapAfter(Element anchor)
     {
@@ -317,6 +322,9 @@ public class Scene : ProjectItem, INotifyEdited
             return false;
 
         int z = anchor.ZIndex;
+        // A locked layer's elements must not move, matching the other timeline mutation services.
+        if (IsLayerLocked(z)) return false;
+
         List<Element> sorted = Children
             .Where(e => e.ZIndex == z)
             .OrderBy(e => e.Start)
@@ -335,9 +343,7 @@ public class Scene : ProjectItem, INotifyEdited
             {
                 if (anchorInRun)
                 {
-                    Element[] toShift = Children
-                        .Where(e => e.ZIndex == z && e.Start >= cur.Start)
-                        .ToArray();
+                    Element[] toShift = ShiftableAfter(z, cur.Start, coveredEnd - cur.Start);
                     return toShift.Length != 0 && MoveChildrenAndDetectChange(toShift, coveredEnd - cur.Start);
                 }
 
@@ -358,8 +364,10 @@ public class Scene : ProjectItem, INotifyEdited
     /// Closes every gap between elements on every ZIndex (the space before the
     /// first element on a ZIndex is not closed). Returns the number of gaps
     /// closed. Gaps are closed right-to-left within each ZIndex so earlier
-    /// closes do not shift elements that later closes depend on. Does not
-    /// commit history; the caller owns the single commit boundary.
+    /// closes do not shift elements that later closes depend on. Locked layers
+    /// are skipped and locked elements are never moved; a locked element acts as
+    /// an immovable barrier that halts the shift. Does not commit history; the
+    /// caller owns the single commit boundary.
     /// </summary>
     public int CloseAllGaps()
     {
@@ -369,15 +377,15 @@ public class Scene : ProjectItem, INotifyEdited
         int closed = 0;
         foreach (IGrouping<int, SceneGap> zGroup in gaps.GroupBy(g => g.ZIndex))
         {
+            if (IsLayerLocked(zGroup.Key)) continue;
+
             foreach (SceneGap gap in zGroup.OrderByDescending(g => g.Range.Start))
             {
-                Element[] toShift = Children
-                    .Where(e => e.ZIndex == zGroup.Key && e.Start >= gap.Range.End)
-                    .ToArray();
-                if (toShift.Length == 0) continue;
-
                 TimeSpan delta = -gap.Range.Duration;
                 if (delta == TimeSpan.Zero) continue;
+
+                Element[] toShift = ShiftableAfter(zGroup.Key, gap.Range.End, delta);
+                if (toShift.Length == 0) continue;
 
                 if (MoveChildrenAndDetectChange(toShift, delta))
                 {
@@ -387,6 +395,32 @@ public class Scene : ProjectItem, INotifyEdited
         }
 
         return closed;
+    }
+
+    // The unlocked elements on the layer at or after fromStart that can slide by deltaStart without
+    // any of them landing on a locked element, in shift order. A locked element is an immovable
+    // barrier: once a follower's shifted range would intersect one, the shift stops there. Mirrors
+    // RippleHelper so gap-close honors the same lock guarantees as the other timeline mutations.
+    private Element[] ShiftableAfter(int zIndex, TimeSpan fromStart, TimeSpan deltaStart)
+    {
+        if (IsLayerLocked(zIndex)) return [];
+
+        Element[] lockedOnLayer = Children
+            .Where(e => e.ZIndex == zIndex && e.IsLocked)
+            .ToArray();
+
+        var result = new List<Element>();
+        foreach (Element e in Children
+            .Where(e => e.ZIndex == zIndex && !e.IsLocked && e.Start >= fromStart)
+            .OrderBy(e => e.Start))
+        {
+            TimeRange shifted = e.Range.WithStart(e.Start + deltaStart);
+            if (Array.Exists(lockedOnLayer, l => shifted.Intersects(l.Range))) break;
+
+            result.Add(e);
+        }
+
+        return [.. result];
     }
 
     private bool MoveChildrenAndDetectChange(Element[] elements, TimeSpan deltaStart)

--- a/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/Scene.cs
@@ -285,18 +285,21 @@ public class Scene : ProjectItem, INotifyEdited
             List<Element> sorted = zGroup.OrderBy(e => e.Start).ThenBy(e => e.Range.End).ToList();
             if (sorted.Count == 0) continue;
 
-            TimeSpan coveredEnd = sorted[0].Range.End;
+            // The anchor is the run's furthest-ending element, so it ends exactly at the gap start.
+            Element coveredEndElement = sorted[0];
+            TimeSpan coveredEnd = coveredEndElement.Range.End;
             for (int i = 1; i < sorted.Count; i++)
             {
                 Element next = sorted[i];
                 if (next.Start > coveredEnd)
                 {
-                    yield return new SceneGap(zGroup.Key, new TimeRange(coveredEnd, next.Start - coveredEnd));
+                    yield return new SceneGap(zGroup.Key, new TimeRange(coveredEnd, next.Start - coveredEnd), coveredEndElement);
                 }
 
                 if (next.Range.End > coveredEnd)
                 {
                     coveredEnd = next.Range.End;
+                    coveredEndElement = next;
                 }
             }
         }
@@ -448,12 +451,12 @@ public class Scene : ProjectItem, INotifyEdited
     /// merely straddles the range (its ends lie beyond a shortened or offset scene) is still reachable
     /// through its visible portion. The returned range is the clamped, visible gap.
     /// </param>
-    public TimeRange? FindNextGap(TimeSpan currentTime, TimeRange? searchRange = null)
+    public SceneGap? FindNextGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Select(g => ClampToRange(g.Range, searchRange))
-            .Where(r => r is { } v && v.Start >= currentTime)
-            .OrderBy(r => r!.Value.Start)
+            .Select(g => ClampGap(g, searchRange))
+            .Where(g => g is { } v && v.Range.Start >= currentTime)
+            .OrderBy(g => g!.Value.Range.Start)
             .FirstOrDefault();
     }
 
@@ -468,25 +471,38 @@ public class Scene : ProjectItem, INotifyEdited
     /// intersect it are dropped, so a gap straddling the range stays reachable through its visible
     /// portion. The returned range is the clamped, visible gap.
     /// </param>
-    public TimeRange? FindPreviousGap(TimeSpan currentTime, TimeRange? searchRange = null)
+    public SceneGap? FindPreviousGap(TimeSpan currentTime, TimeRange? searchRange = null)
     {
         return EnumerateGaps()
-            .Select(g => ClampToRange(g.Range, searchRange))
-            .Where(r => r is { } v && v.End <= currentTime)
-            .OrderByDescending(r => r!.Value.End)
+            .Select(g => ClampGap(g, searchRange))
+            .Where(g => g is { } v && v.Range.End <= currentTime)
+            .OrderByDescending(g => g!.Value.Range.End)
             .FirstOrDefault();
     }
 
-    // The part of gap visible inside range, or null when they do not overlap with positive width —
-    // half-open, matching TimeRange, so a point-only touch at an edge yields no gap. A straddling gap
-    // contributes its in-range slice instead of being dropped for not being wholly contained.
-    private static TimeRange? ClampToRange(TimeRange gap, TimeRange? range)
+    /// <summary>
+    /// Returns the gap on <paramref name="zIndex"/> that contains <paramref name="time"/> (half-open,
+    /// like <see cref="TimeRange.Contains(TimeSpan)"/>), or <see langword="null"/> when the point is
+    /// not inside a gap on that layer. Used to close the gap under a right-click position.
+    /// </summary>
+    public SceneGap? FindGapAt(TimeSpan time, int zIndex)
+    {
+        return EnumerateGaps()
+            .Where(g => g.ZIndex == zIndex && g.Range.Contains(time))
+            .Select(g => (SceneGap?)g)
+            .FirstOrDefault();
+    }
+
+    // The gap clamped to its intersection with range (ZIndex and Anchor preserved), or null when they
+    // do not overlap with positive width — half-open, matching TimeRange, so a point-only touch at an
+    // edge yields no gap. A straddling gap contributes its in-range slice instead of being dropped.
+    private static SceneGap? ClampGap(SceneGap gap, TimeRange? range)
     {
         if (range is not { } r) return gap;
 
-        TimeSpan start = gap.Start > r.Start ? gap.Start : r.Start;
-        TimeSpan end = gap.End < r.End ? gap.End : r.End;
-        return end > start ? new TimeRange(start, end - start) : null;
+        TimeSpan start = gap.Range.Start > r.Start ? gap.Range.Start : r.Start;
+        TimeSpan end = gap.Range.End < r.End ? gap.Range.End : r.End;
+        return end > start ? gap with { Range = new TimeRange(start, end - start) } : null;
     }
 
     public override void Serialize(ICoreSerializationContext context)

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneGap.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneGap.cs
@@ -1,0 +1,9 @@
+﻿using Beutl.Media;
+
+namespace Beutl.ProjectSystem;
+
+/// <summary>
+/// An empty interval between adjacent <see cref="Element"/>s on a single ZIndex
+/// layer of a <see cref="Scene"/>. See <see cref="Scene.EnumerateGaps"/>.
+/// </summary>
+public readonly record struct SceneGap(int ZIndex, TimeRange Range);

--- a/src/Beutl.ProjectSystem/ProjectSystem/SceneGap.cs
+++ b/src/Beutl.ProjectSystem/ProjectSystem/SceneGap.cs
@@ -6,4 +6,9 @@ namespace Beutl.ProjectSystem;
 /// An empty interval between adjacent <see cref="Element"/>s on a single ZIndex
 /// layer of a <see cref="Scene"/>. See <see cref="Scene.EnumerateGaps"/>.
 /// </summary>
-public readonly record struct SceneGap(int ZIndex, TimeRange Range);
+/// <param name="Anchor">
+/// The element ending at <see cref="Range"/>'s start — the last element of the covered run before the
+/// gap. Passing it to <see cref="Scene.CloseGapAfter"/> closes this gap, and it is the element gap
+/// navigation selects so a follow-up Close Gap acts on the gap the playhead moved to.
+/// </param>
+public readonly record struct SceneGap(int ZIndex, TimeRange Range, Element Anchor);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -39,6 +39,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     private ElementResizeService? _elementResizeService;
     private ElementDuplicateService? _elementDuplicateService;
     private ElementMoveService? _elementMoveService;
+    private ElementGapService? _elementGapService;
     private ElementClipboardService? _elementClipboardService;
     private ElementStructureService? _elementStructureService;
     private ElementAttributeService? _elementAttributeService;
@@ -755,6 +756,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
             return _elementMoveService ??= new ElementMoveService(
                 HistoryManager,
                 (IElementDuplicateService)GetService(typeof(IElementDuplicateService))!);
+
+        if (serviceType.IsAssignableTo(typeof(IElementGapService)))
+            return _elementGapService ??= new ElementGapService(HistoryManager);
 
         if (serviceType.IsAssignableTo(typeof(IClipboardGateway)))
             return _clipboardGateway;

--- a/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
@@ -1,0 +1,181 @@
+﻿using Beutl.Editor;
+using Beutl.Editor.Services;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.UnitTests.TestInfrastructure;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class ElementGapServiceTests
+{
+    private SceneHistoryHarness _harness = null!;
+    private Scene _scene = null!;
+    private HistoryManager _history = null!;
+    private ElementGapService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _harness = new SceneHistoryHarness("beutl_gap", start: TimeSpan.Zero, duration: TimeSpan.FromSeconds(30));
+        _scene = _harness.Scene;
+        _history = _harness.History;
+        _service = new ElementGapService(_history);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _harness.Dispose();
+    }
+
+    private Element AddElement(TimeSpan start, TimeSpan length, int zIndex = 0)
+        => _harness.AddElement(start, length, zIndex);
+
+    [Test]
+    public void Constructor_NullHistoryManager_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ElementGapService(null!));
+    }
+
+    [Test]
+    public void CloseGap_NullArguments_Throw()
+    {
+        Element placeholder = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentNullException>(() => _service.CloseGap(null!, placeholder));
+            Assert.Throws<ArgumentNullException>(() => _service.CloseGap(_scene, null!));
+        });
+    }
+
+    [Test]
+    public void CloseGap_ClosesGapAndCommitsOnce()
+    {
+        Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool result = _service.CloseGap(_scene, a);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void CloseGap_NoGap_ReturnsFalse_NoCommit()
+    {
+        Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool result = _service.CloseGap(_scene, a);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void CloseGap_AnchorIsLastElement_ReturnsFalse_NoCommit()
+    {
+        Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool result = _service.CloseGap(_scene, b);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void CloseAllGaps_NullScene_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _service.CloseAllGaps(null!));
+    }
+
+    [Test]
+    public void CloseAllGaps_ClosesAllAndCommitsOnce()
+    {
+        AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 0);
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), 0);
+        Element c = AddElement(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2), 0);
+        int before = _history.UndoCount;
+
+        int closed = _service.CloseAllGaps(_scene);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(closed, Is.EqualTo(2));
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void CloseAllGaps_NoGaps_ReturnsZero_NoCommit()
+    {
+        AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        int closed = _service.CloseAllGaps(_scene);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(closed, Is.EqualTo(0));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void CloseGap_ThenUndo_RestoresLayout()
+    {
+        Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        TimeSpan originalBStart = b.Start;
+        int before = _history.UndoCount;
+
+        _service.CloseGap(_scene, a);
+        _history.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(b.Start, Is.EqualTo(originalBStart));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void CloseAllGaps_ThenUndo_RestoresLayout()
+    {
+        AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 0);
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), 0);
+        Element c = AddElement(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2), 0);
+        TimeSpan originalBStart = b.Start;
+        TimeSpan originalCStart = c.Start;
+        int before = _history.UndoCount;
+
+        _service.CloseAllGaps(_scene);
+        _history.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(b.Start, Is.EqualTo(originalBStart));
+            Assert.That(c.Start, Is.EqualTo(originalCStart));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
@@ -125,6 +125,26 @@ public class ElementGapServiceTests
     }
 
     [Test]
+    public void CloseAllGaps_ClosesGapsAcrossMultipleZIndexes()
+    {
+        AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), 0);
+        Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), 0);
+        AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), 1);
+        Element d = AddElement(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(1), 1);
+        int before = _history.UndoCount;
+
+        int closed = _service.CloseAllGaps(_scene);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(closed, Is.EqualTo(2));
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(d.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
     public void CloseAllGaps_NoGaps_ReturnsZero_NoCommit()
     {
         AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));

--- a/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementGapServiceTests.cs
@@ -39,25 +39,25 @@ public class ElementGapServiceTests
     }
 
     [Test]
-    public void CloseGap_NullArguments_Throw()
+    public void CloseGapAfter_NullArguments_Throw()
     {
         Element placeholder = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
 
         Assert.Multiple(() =>
         {
-            Assert.Throws<ArgumentNullException>(() => _service.CloseGap(null!, placeholder));
-            Assert.Throws<ArgumentNullException>(() => _service.CloseGap(_scene, null!));
+            Assert.Throws<ArgumentNullException>(() => _service.CloseGapAfter(null!, placeholder));
+            Assert.Throws<ArgumentNullException>(() => _service.CloseGapAfter(_scene, null!));
         });
     }
 
     [Test]
-    public void CloseGap_ClosesGapAndCommitsOnce()
+    public void CloseGapAfter_ClosesGapAndCommitsOnce()
     {
         Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool result = _service.CloseGap(_scene, a);
+        bool result = _service.CloseGapAfter(_scene, a);
 
         Assert.Multiple(() =>
         {
@@ -68,13 +68,13 @@ public class ElementGapServiceTests
     }
 
     [Test]
-    public void CloseGap_NoGap_ReturnsFalse_NoCommit()
+    public void CloseGapAfter_NoGap_ReturnsFalse_NoCommit()
     {
         Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool result = _service.CloseGap(_scene, a);
+        bool result = _service.CloseGapAfter(_scene, a);
 
         Assert.Multiple(() =>
         {
@@ -84,13 +84,13 @@ public class ElementGapServiceTests
     }
 
     [Test]
-    public void CloseGap_AnchorIsLastElement_ReturnsFalse_NoCommit()
+    public void CloseGapAfter_AnchorIsLastElement_ReturnsFalse_NoCommit()
     {
         Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool result = _service.CloseGap(_scene, b);
+        bool result = _service.CloseGapAfter(_scene, b);
 
         Assert.Multiple(() =>
         {
@@ -161,14 +161,14 @@ public class ElementGapServiceTests
     }
 
     [Test]
-    public void CloseGap_ThenUndo_RestoresLayout()
+    public void CloseGapAfter_ThenUndo_RestoresLayout()
     {
         Element a = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         Element b = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
         TimeSpan originalBStart = b.Start;
         int before = _history.UndoCount;
 
-        _service.CloseGap(_scene, a);
+        _service.CloseGapAfter(_scene, a);
         _history.Undo();
 
         Assert.Multiple(() =>

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -212,6 +212,28 @@ public class TimelineTabViewModelShortcutTests
     }
 
     [Test]
+    public void FindGapNavigationTarget_ClippedGapStart_DoesNotSelectStaleAnchor()
+    {
+        using var harness = new SceneHistoryHarness(
+            "beutl_timeline_gap_nav",
+            start: TimeSpan.FromSeconds(50),
+            duration: TimeSpan.FromSeconds(30));
+        // The gap 10s-100s straddles the active range 50s-80s; its start is clipped to 50s. The anchor
+        // ends off-scene at 10s, so navigation must not select it (Close Gap would collapse 10s-100s).
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+        harness.AddElement(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(5));
+
+        var result = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.FromSeconds(40), forward: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(65)));
+            Assert.That(result?.Anchor, Is.Null);
+        });
+    }
+
+    [Test]
     public void CloseAllGapsCommand_FlushesPendingNudgeBeforeGapService()
     {
         using var harness = new SceneHistoryHarness("beutl_timeline_gap_command", duration: TimeSpan.FromSeconds(30));

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -13,14 +13,28 @@ using Reactive.Bindings;
 namespace Beutl.UnitTests.Editor;
 
 [TestFixture]
+[NonParallelizable]
 public class TimelineTabViewModelShortcutTests
 {
     private static readonly CaptureNotificationHandler s_notificationHandler = new();
+    private INotificationServiceHandler? _previousHandler;
 
     [OneTimeSetUp]
     public void InstallNotificationHandler()
     {
+        _previousHandler = NotificationService.Handler;
         NotificationService.Handler = s_notificationHandler;
+    }
+
+    [OneTimeTearDown]
+    public void RestoreNotificationHandler()
+    {
+        // The setter rejects null; when no handler existed before, ours stays (Show is null-safe
+        // and no other fixture asserts on Handler identity).
+        if (_previousHandler is not null)
+        {
+            NotificationService.Handler = _previousHandler;
+        }
     }
 
     [SetUp]
@@ -273,7 +287,7 @@ public class TimelineTabViewModelShortcutTests
         public bool CloseAllGapsCalled { get; private set; }
         public bool CloseAllGapsSawFlush { get; private set; }
 
-        public bool CloseGap(Scene scene, Element anchor)
+        public bool CloseGapAfter(Scene scene, Element anchor)
         {
             CloseGapCalled = true;
             CloseGapSawFlush = nudgeService.FlushCount > 0;

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -109,7 +109,7 @@ public class TimelineTabViewModelShortcutTests
         harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
-            harness.Scene, TimeSpan.Zero, forward: true);
+            harness.Scene, TimeSpan.Zero, forward: true)?.Target;
 
         Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(4)));
     }
@@ -122,7 +122,7 @@ public class TimelineTabViewModelShortcutTests
         harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
-            harness.Scene, TimeSpan.FromSeconds(10), forward: true);
+            harness.Scene, TimeSpan.FromSeconds(10), forward: true)?.Target;
 
         Assert.That(target, Is.Null);
     }
@@ -138,7 +138,7 @@ public class TimelineTabViewModelShortcutTests
         harness.AddElement(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(2));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
-            harness.Scene, TimeSpan.Zero, forward: true);
+            harness.Scene, TimeSpan.Zero, forward: true)?.Target;
 
         Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(14)));
     }
@@ -156,7 +156,7 @@ public class TimelineTabViewModelShortcutTests
         harness.AddElement(TimeSpan.FromSeconds(14), TimeSpan.FromSeconds(2));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
-            harness.Scene, TimeSpan.Zero, forward: true);
+            harness.Scene, TimeSpan.Zero, forward: true)?.Target;
 
         Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(12)));
     }
@@ -172,7 +172,7 @@ public class TimelineTabViewModelShortcutTests
         harness.AddElement(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(5));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
-            harness.Scene, TimeSpan.FromSeconds(100), forward: false);
+            harness.Scene, TimeSpan.FromSeconds(100), forward: false)?.Target;
 
         Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(17.5)));
     }
@@ -190,6 +190,24 @@ public class TimelineTabViewModelShortcutTests
             Assert.That(
                 TimelineTabViewModel.FindGapNavigationTarget(harness.Scene, TimeSpan.Zero, forward: false),
                 Is.Null);
+        });
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_ReturnsGapAnchorForSelection()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(30));
+        Element a = harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+
+        var result = TimelineTabViewModel.FindGapNavigationTarget(harness.Scene, TimeSpan.Zero, forward: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            // The anchor is the element ending at the gap start, so GoToGap selects it and a follow-up
+            // Close Gap closes this gap.
+            Assert.That(result?.Anchor, Is.SameAs(a));
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -4,7 +4,9 @@ using Avalonia.Controls;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
 using Beutl.Extensibility;
+using Beutl.Language;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Beutl.UnitTests.TestInfrastructure;
 using Reactive.Bindings;
 
@@ -13,6 +15,20 @@ namespace Beutl.UnitTests.Editor;
 [TestFixture]
 public class TimelineTabViewModelShortcutTests
 {
+    private static readonly CaptureNotificationHandler s_notificationHandler = new();
+
+    [OneTimeSetUp]
+    public void InstallNotificationHandler()
+    {
+        NotificationService.Handler = s_notificationHandler;
+    }
+
+    [SetUp]
+    public void ClearCapturedNotifications()
+    {
+        s_notificationHandler.Notifications.Clear();
+    }
+
     [Test]
     public void IsTextInputSource_ReturnsTrue_ForTextBox()
     {
@@ -48,6 +64,101 @@ public class TimelineTabViewModelShortcutTests
             Assert.That(nudgeService.FlushCount, Is.EqualTo(1));
             Assert.That(gapService.CloseGapCalled, Is.True);
             Assert.That(gapService.CloseGapSawFlush, Is.True);
+        });
+    }
+
+    [Test]
+    public void CloseGapCommand_NoSelection_NotifiesWithoutCallingGapService()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_command", duration: TimeSpan.FromSeconds(30));
+        var nudgeService = new CaptureNudgeService();
+        var gapService = new CaptureGapService(nudgeService);
+        TimelineTabViewModel viewModel = CreateViewModel(harness.Scene, nudgeService, gapService);
+
+        InvokePrivate(viewModel, "CloseSelectedGap");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gapService.CloseGapCalled, Is.False);
+            Assert.That(nudgeService.FlushCount, Is.Zero);
+            Assert.That(s_notificationHandler.Notifications, Has.Count.EqualTo(1));
+            Assert.That(s_notificationHandler.Notifications[0].Title, Is.EqualTo(Strings.CloseGap));
+            Assert.That(s_notificationHandler.Notifications[0].Message, Is.EqualTo(Strings.NoElementSelected));
+        });
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_Forward_ReturnsGapCenter()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(30));
+        harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+
+        TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.Zero, forward: true);
+
+        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(4)));
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_Forward_NoGapAhead_ReturnsNull()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(30));
+        harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+
+        TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.FromSeconds(10), forward: true);
+
+        Assert.That(target, Is.Null);
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_Forward_CurrentBeforeSceneStart_ClampsOriginToSceneStart()
+    {
+        using var harness = new SceneHistoryHarness(
+            "beutl_timeline_gap_nav",
+            start: TimeSpan.FromSeconds(10),
+            duration: TimeSpan.FromSeconds(20));
+        harness.AddElement(TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(2));
+
+        TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.Zero, forward: true);
+
+        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(14)));
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_Backward_CurrentBeyondSceneEnd_ClampsOriginToSceneEnd()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(20));
+        harness.AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(5));
+        harness.AddElement(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+        // Starts exactly at the scene end, so the gap [15s, 20s] touches the boundary. With the
+        // origin clamped to the scene end and the strictly-before filter, that gap is skipped and
+        // navigation lands on the earlier gap [5s, 10s].
+        harness.AddElement(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(5));
+
+        TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.FromSeconds(100), forward: false);
+
+        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_NoElements_ReturnsNull()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(30));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                TimelineTabViewModel.FindGapNavigationTarget(harness.Scene, TimeSpan.Zero, forward: true),
+                Is.Null);
+            Assert.That(
+                TimelineTabViewModel.FindGapNavigationTarget(harness.Scene, TimeSpan.Zero, forward: false),
+                Is.Null);
         });
     }
 
@@ -128,6 +239,13 @@ public class TimelineTabViewModelShortcutTests
             BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new MissingFieldException(typeof(TTarget).FullName, propertyName);
         field.SetValue(target, value);
+    }
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        public List<Notification> Notifications { get; } = [];
+
+        public void Show(Notification notification) => Notifications.Add(notification);
     }
 
     private sealed class CaptureNudgeService : IElementNudgeService

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -230,6 +230,9 @@ public class TimelineTabViewModelShortcutTests
         Assert.Multiple(() =>
         {
             Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(65)));
+            // The scroll target is the visible portion (50s-80s) on the gap's layer, not the raw gap.
+            Assert.That(result?.VisibleGap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30))));
+            Assert.That(result?.ZIndex, Is.EqualTo(0));
             Assert.That(result?.Anchor, Is.Null);
         });
     }

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -1,0 +1,26 @@
+﻿using Avalonia.Controls;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class TimelineTabViewModelShortcutTests
+{
+    [Test]
+    public void IsTextInputSource_ReturnsTrue_ForTextBox()
+    {
+        Assert.That(TimelineTabViewModel.IsTextInputSource(new TextBox()), Is.True);
+    }
+
+    [Test]
+    public void IsTextInputSource_ReturnsFalse_ForNonTextVisual()
+    {
+        Assert.That(TimelineTabViewModel.IsTextInputSource(new Border()), Is.False);
+    }
+
+    [Test]
+    public void IsTextInputSource_ReturnsFalse_ForNull()
+    {
+        Assert.That(TimelineTabViewModel.IsTextInputSource(null), Is.False);
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -82,6 +82,9 @@ public class TimelineTabViewModelShortcutTests
         context.AddService<IElementGapService>(gapService);
 
         var viewModel = (TimelineTabViewModel)RuntimeHelpers.GetUninitializedObject(typeof(TimelineTabViewModel));
+        // GetUninitializedObject skips field initializers, so any finalizer would run against null
+        // fields and crash the finalizer thread (killing the test host). Suppress it.
+        GC.SuppressFinalize(viewModel);
         SetAutoProperty(viewModel, nameof(TimelineTabViewModel.Scene), scene);
         SetAutoProperty(viewModel, nameof(TimelineTabViewModel.EditorContext), context);
         SetAutoProperty(viewModel, nameof(TimelineTabViewModel.SelectedElements), CreateSelection(selectedElement));
@@ -102,6 +105,8 @@ public class TimelineTabViewModelShortcutTests
     private static ElementViewModel CreateElementViewModel(Element element)
     {
         var viewModel = (ElementViewModel)RuntimeHelpers.GetUninitializedObject(typeof(ElementViewModel));
+        // ElementViewModel's finalizer dereferences a field that GetUninitializedObject leaves null.
+        GC.SuppressFinalize(viewModel);
         SetAutoProperty(viewModel, nameof(ElementViewModel.Model), element);
         return viewModel;
     }

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -128,7 +128,7 @@ public class TimelineTabViewModelShortcutTests
     }
 
     [Test]
-    public void FindGapNavigationTarget_Forward_CurrentBeforeSceneStart_ClampsOriginToSceneStart()
+    public void FindGapNavigationTarget_Forward_CurrentBeforeSceneStart_FindsFirstInRangeGap()
     {
         using var harness = new SceneHistoryHarness(
             "beutl_timeline_gap_nav",
@@ -144,20 +144,37 @@ public class TimelineTabViewModelShortcutTests
     }
 
     [Test]
-    public void FindGapNavigationTarget_Backward_CurrentBeyondSceneEnd_ClampsOriginToSceneEnd()
+    public void FindGapNavigationTarget_Forward_CurrentBeforeSceneStart_ReturnsBoundaryTouchingGap()
+    {
+        using var harness = new SceneHistoryHarness(
+            "beutl_timeline_gap_nav",
+            start: TimeSpan.FromSeconds(10),
+            duration: TimeSpan.FromSeconds(20));
+        // Ends exactly at the scene start, so the gap [10s, 14s] begins on the boundary. It lies
+        // wholly in range, so navigating forward from before the scene must land on it.
+        harness.AddElement(TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(1));
+        harness.AddElement(TimeSpan.FromSeconds(14), TimeSpan.FromSeconds(2));
+
+        TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.Zero, forward: true);
+
+        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(12)));
+    }
+
+    [Test]
+    public void FindGapNavigationTarget_Backward_CurrentBeyondSceneEnd_ReturnsBoundaryTouchingGap()
     {
         using var harness = new SceneHistoryHarness("beutl_timeline_gap_nav", duration: TimeSpan.FromSeconds(20));
         harness.AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(5));
         harness.AddElement(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
-        // Starts exactly at the scene end, so the gap [15s, 20s] touches the boundary. With the
-        // origin clamped to the scene end and the strictly-before filter, that gap is skipped and
-        // navigation lands on the earlier gap [5s, 10s].
+        // Starts exactly at the scene end, so the gap [15s, 20s] ends on the boundary. It lies wholly
+        // in range, so navigating back from beyond the scene must land on it, not skip to [5s, 10s].
         harness.AddElement(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(5));
 
         TimeSpan? target = TimelineTabViewModel.FindGapNavigationTarget(
             harness.Scene, TimeSpan.FromSeconds(100), forward: false);
 
-        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
+        Assert.That(target, Is.EqualTo(TimeSpan.FromSeconds(17.5)));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -235,6 +235,29 @@ public class TimelineTabViewModelShortcutTests
     }
 
     [Test]
+    public void FindGapNavigationTarget_ClippedGapEnd_DoesNotSelectAnchor()
+    {
+        using var harness = new SceneHistoryHarness(
+            "beutl_timeline_gap_nav",
+            start: TimeSpan.FromSeconds(50),
+            duration: TimeSpan.FromSeconds(50));
+        // The gap 90s-120s straddles the active range 50s-100s; its end is clipped to 100s. The anchor
+        // (85s clip) abuts the visible start, but closing the gap would move the off-scene 120s clip,
+        // so navigation must not select it.
+        harness.AddElement(TimeSpan.FromSeconds(85), TimeSpan.FromSeconds(5));
+        harness.AddElement(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(5));
+
+        var result = TimelineTabViewModel.FindGapNavigationTarget(
+            harness.Scene, TimeSpan.FromSeconds(60), forward: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(95)));
+            Assert.That(result?.Anchor, Is.Null);
+        });
+    }
+
+    [Test]
     public void ResolvePointerGapToClose_OnlyReturnsGapWhollyInsideScene()
     {
         using var harness = new SceneHistoryHarness(

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -1,5 +1,12 @@
-﻿using Avalonia.Controls;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.UnitTests.TestInfrastructure;
+using Reactive.Bindings;
 
 namespace Beutl.UnitTests.Editor;
 
@@ -22,5 +29,184 @@ public class TimelineTabViewModelShortcutTests
     public void IsTextInputSource_ReturnsFalse_ForNull()
     {
         Assert.That(TimelineTabViewModel.IsTextInputSource(null), Is.False);
+    }
+
+    [Test]
+    public void CloseGapCommand_FlushesPendingNudgeBeforeGapService()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_command", duration: TimeSpan.FromSeconds(30));
+        Element anchor = harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        var nudgeService = new CaptureNudgeService();
+        var gapService = new CaptureGapService(nudgeService);
+        TimelineTabViewModel viewModel = CreateViewModel(harness.Scene, nudgeService, gapService, anchor);
+
+        InvokePrivate(viewModel, "CloseSelectedGap");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nudgeService.FlushCount, Is.EqualTo(1));
+            Assert.That(gapService.CloseGapCalled, Is.True);
+            Assert.That(gapService.CloseGapSawFlush, Is.True);
+        });
+    }
+
+    [Test]
+    public void CloseAllGapsCommand_FlushesPendingNudgeBeforeGapService()
+    {
+        using var harness = new SceneHistoryHarness("beutl_timeline_gap_command", duration: TimeSpan.FromSeconds(30));
+        harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        var nudgeService = new CaptureNudgeService();
+        var gapService = new CaptureGapService(nudgeService);
+        TimelineTabViewModel viewModel = CreateViewModel(harness.Scene, nudgeService, gapService);
+
+        InvokePrivate(viewModel, "CloseAllSceneGaps");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nudgeService.FlushCount, Is.EqualTo(1));
+            Assert.That(gapService.CloseAllGapsCalled, Is.True);
+            Assert.That(gapService.CloseAllGapsSawFlush, Is.True);
+        });
+    }
+
+    private static TimelineTabViewModel CreateViewModel(
+        Scene scene,
+        IElementNudgeService nudgeService,
+        IElementGapService gapService,
+        Element? selectedElement = null)
+    {
+        var context = new TestEditorContext(scene);
+        context.AddService<IElementNudgeService>(nudgeService);
+        context.AddService<IElementGapService>(gapService);
+
+        var viewModel = (TimelineTabViewModel)RuntimeHelpers.GetUninitializedObject(typeof(TimelineTabViewModel));
+        SetAutoProperty(viewModel, nameof(TimelineTabViewModel.Scene), scene);
+        SetAutoProperty(viewModel, nameof(TimelineTabViewModel.EditorContext), context);
+        SetAutoProperty(viewModel, nameof(TimelineTabViewModel.SelectedElements), CreateSelection(selectedElement));
+        return viewModel;
+    }
+
+    private static HashSet<ElementViewModel> CreateSelection(Element? element)
+    {
+        var selection = new HashSet<ElementViewModel>();
+        if (element is not null)
+        {
+            selection.Add(CreateElementViewModel(element));
+        }
+
+        return selection;
+    }
+
+    private static ElementViewModel CreateElementViewModel(Element element)
+    {
+        var viewModel = (ElementViewModel)RuntimeHelpers.GetUninitializedObject(typeof(ElementViewModel));
+        SetAutoProperty(viewModel, nameof(ElementViewModel.Model), element);
+        return viewModel;
+    }
+
+    private static void InvokePrivate(TimelineTabViewModel viewModel, string methodName)
+    {
+        MethodInfo method = typeof(TimelineTabViewModel).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMethodException(typeof(TimelineTabViewModel).FullName, methodName);
+        method.Invoke(viewModel, null);
+    }
+
+    private static void SetAutoProperty<TTarget, TValue>(TTarget target, string propertyName, TValue value)
+        where TTarget : notnull
+    {
+        FieldInfo field = typeof(TTarget).GetField(
+            $"<{propertyName}>k__BackingField",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(typeof(TTarget).FullName, propertyName);
+        field.SetValue(target, value);
+    }
+
+    private sealed class CaptureNudgeService : IElementNudgeService
+    {
+        public int FlushCount { get; private set; }
+
+        public void Nudge(Scene scene, IReadOnlyList<Element> targets, int frames)
+        {
+        }
+
+        public void Flush()
+        {
+            FlushCount++;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CaptureGapService(CaptureNudgeService nudgeService) : IElementGapService
+    {
+        public bool CloseGapCalled { get; private set; }
+        public bool CloseGapSawFlush { get; private set; }
+        public bool CloseAllGapsCalled { get; private set; }
+        public bool CloseAllGapsSawFlush { get; private set; }
+
+        public bool CloseGap(Scene scene, Element anchor)
+        {
+            CloseGapCalled = true;
+            CloseGapSawFlush = nudgeService.FlushCount > 0;
+            return true;
+        }
+
+        public int CloseAllGaps(Scene scene)
+        {
+            CloseAllGapsCalled = true;
+            CloseAllGapsSawFlush = nudgeService.FlushCount > 0;
+            return 1;
+        }
+    }
+
+    private sealed class TestEditorContext(CoreObject obj) : IEditorContext
+    {
+        private readonly Dictionary<Type, object> _services = [];
+
+        public CoreObject Object { get; } = obj;
+
+        public EditorExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public void AddService<T>(T service)
+            where T : notnull
+        {
+            _services[typeof(T)] = service;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            return _services.GetValueOrDefault(serviceType);
+        }
+
+        public T? FindToolTab<T>(Func<T, bool> condition)
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public T? FindToolTab<T>()
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public bool OpenToolTab(IToolContext item)
+        {
+            return false;
+        }
+
+        public void CloseToolTab(IToolContext item)
+        {
+        }
     }
 }

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -5,6 +5,7 @@ using Beutl.Editor.Components.TimelineTab.ViewModels;
 using Beutl.Editor.Services;
 using Beutl.Extensibility;
 using Beutl.Language;
+using Beutl.Media;
 using Beutl.ProjectSystem;
 using Beutl.Services;
 using Beutl.UnitTests.TestInfrastructure;
@@ -230,6 +231,36 @@ public class TimelineTabViewModelShortcutTests
         {
             Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(65)));
             Assert.That(result?.Anchor, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ResolvePointerGapToClose_OnlyReturnsGapWhollyInsideScene()
+    {
+        using var harness = new SceneHistoryHarness(
+            "beutl_timeline_gap_ptr",
+            start: TimeSpan.FromSeconds(50),
+            duration: TimeSpan.FromSeconds(50));
+        // Active scene is 50s-100s. Layer 0 has a gap fully inside (60s-70s); layer 1 has one that
+        // straddles the scene end (90s-120s). Only the fully-inside gap may be closed by a click.
+        harness.AddElement(TimeSpan.FromSeconds(55), TimeSpan.FromSeconds(5), zIndex: 0);
+        harness.AddElement(TimeSpan.FromSeconds(70), TimeSpan.FromSeconds(5), zIndex: 0);
+        harness.AddElement(TimeSpan.FromSeconds(85), TimeSpan.FromSeconds(5), zIndex: 1);
+        harness.AddElement(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(5), zIndex: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                TimelineTabViewModel.ResolvePointerGapToClose(harness.Scene, TimeSpan.FromSeconds(65), layer: 0)?.Range,
+                Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10))));
+            // Clicking the visible part of a gap that runs past the scene end must not close it.
+            Assert.That(
+                TimelineTabViewModel.ResolvePointerGapToClose(harness.Scene, TimeSpan.FromSeconds(95), layer: 1),
+                Is.Null);
+            // A click beyond the scene end lands in the straddling gap but is rejected.
+            Assert.That(
+                TimelineTabViewModel.ResolvePointerGapToClose(harness.Scene, TimeSpan.FromSeconds(110), layer: 1),
+                Is.Null);
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -229,9 +229,8 @@ public class TimelineTabViewModelShortcutTests
 
         Assert.Multiple(() =>
         {
+            // Target is the centre of the visible portion (50s-80s); the scroll uses the gap's layer.
             Assert.That(result?.Target, Is.EqualTo(TimeSpan.FromSeconds(65)));
-            // The scroll target is the visible portion (50s-80s) on the gap's layer, not the raw gap.
-            Assert.That(result?.VisibleGap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30))));
             Assert.That(result?.ZIndex, Is.EqualTo(0));
             Assert.That(result?.Anchor, Is.Null);
         });

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -555,6 +555,131 @@ public class SceneGapTests
     }
 
     [Test]
+    public void CloseGapAfter_LockedLayer_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Layers.Add(new TimelineLayer { ZIndex = 0, IsLocked = true });
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+
+            bool closed = scene.CloseGapAfter(a);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.False);
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGapAfter_LockedFollowerBlocksShift_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Anchor [1s..3s], gap 3s-5s, then a locked block [5s..15s], then [16s..18s]. The only
+            // unlocked follower would land on the locked block when shifted left, so nothing moves.
+            Element anchor = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            Element locked = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
+            locked.IsLocked = true;
+            Element trailing = CreateElement(basePath, TimeSpan.FromSeconds(16), TimeSpan.FromSeconds(2));
+            scene.Children.Add(anchor);
+            scene.Children.Add(locked);
+            scene.Children.Add(trailing);
+
+            bool closed = scene.CloseGapAfter(anchor);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.False);
+                Assert.That(locked.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(trailing.Start, Is.EqualTo(TimeSpan.FromSeconds(16)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_SkipsLockedLayer()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Layers.Add(new TimelineLayer { ZIndex = 0, IsLocked = true });
+            Element locked0 = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element locked1 = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 0);
+            Element open0 = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 1);
+            Element open1 = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 1);
+            scene.Children.Add(locked0);
+            scene.Children.Add(locked1);
+            scene.Children.Add(open0);
+            scene.Children.Add(open1);
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(1));
+                Assert.That(locked1.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(open1.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_LockedElementActsAsBarrier()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // [0s..2s], gap 2s-4s, locked [4s..6s], gap 6s-8s, [8s..10s]. The trailing clip closes
+            // the gap after the locked block (down to 6s) but cannot pass it, so the gap before the
+            // locked block stays open.
+            Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+            Element locked = CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2));
+            locked.IsLocked = true;
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+            scene.Children.Add(locked);
+            scene.Children.Add(c);
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(1));
+                Assert.That(a.Start, Is.EqualTo(TimeSpan.Zero));
+                Assert.That(locked.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(6)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void FindNextGap_ReturnsNextGap()
     {
         string basePath = GetTempPath();

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -973,20 +973,17 @@ public class SceneGapTests
         {
             Scene scene = CreateScene(basePath);
             // A far-right element leaves a gap 10s-100s that straddles a 30s scene end. Its visible
-            // portion 10s-30s is empty space inside the scene, so the search returns the clamped gap;
-            // without a search range the full 10s-90s gap is returned.
+            // portion 10s-30s overlaps the range, so the search still reaches it and returns the raw
+            // gap (clamping for display is the caller's job).
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(9)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(10)));
 
             var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(30));
+            var rawGap = new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90));
             Assert.Multiple(() =>
             {
-                Assert.That(
-                    scene.FindNextGap(TimeSpan.Zero, range)?.Range,
-                    Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20))));
-                Assert.That(
-                    scene.FindNextGap(TimeSpan.Zero)?.Range,
-                    Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90))));
+                Assert.That(scene.FindNextGap(TimeSpan.Zero, range)?.Range, Is.EqualTo(rawGap));
+                Assert.That(scene.FindNextGap(TimeSpan.Zero)?.Range, Is.EqualTo(rawGap));
             });
         }
         finally
@@ -1004,16 +1001,16 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             // The only elements end at 10s and start at 100s, so the gap 10s-100s covers the whole
             // active range 50s-80s. A playhead resting exactly on either boundary must still reach the
-            // clamped visible portion 50s-80s: next from the 50s start, previous from the 80s end.
+            // gap through its visible overlap: next from the 50s start, previous from the 80s end.
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(5)));
             var range = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30));
-            var clamped = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30));
+            var rawGap = new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90));
 
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range)?.Range, Is.EqualTo(clamped));
-                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(80), range)?.Range, Is.EqualTo(clamped));
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range)?.Range, Is.EqualTo(rawGap));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(80), range)?.Range, Is.EqualTo(rawGap));
             });
         }
         finally

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -713,10 +713,42 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(9)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(10)));
 
+            var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(30));
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero, TimeSpan.FromSeconds(30)), Is.Null);
+                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero, range), Is.Null);
                 Assert.That(scene.FindNextGapCenter(TimeSpan.Zero), Is.EqualTo(TimeSpan.FromSeconds(55)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindGapCenter_BoundsBothSides_IgnoresGapsOutsideOffsetScene()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Active scene range is 50s-150s. A gap 10s-40s sits entirely before it and a gap
+            // 200s-260s entirely after it; neither may be selected from either direction.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(9)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(40), TimeSpan.FromSeconds(60)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(80)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(260), TimeSpan.FromSeconds(10)));
+            var range = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(100));
+
+            Assert.Multiple(() =>
+            {
+                // The only in-range gap is 100s-120s (center 110s).
+                Assert.That(scene.FindNextGapCenter(TimeSpan.FromSeconds(50), range), Is.EqualTo(TimeSpan.FromSeconds(110)));
+                Assert.That(scene.FindPreviousGapCenter(TimeSpan.FromSeconds(150), range), Is.EqualTo(TimeSpan.FromSeconds(110)));
+                // Searching from outside the range must not reach the out-of-range gaps.
+                Assert.That(scene.FindNextGapCenter(TimeSpan.FromSeconds(150), range), Is.Null);
+                Assert.That(scene.FindPreviousGapCenter(TimeSpan.FromSeconds(50), range), Is.Null);
             });
         }
         finally

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -918,6 +918,54 @@ public class SceneGapTests
     }
 
     [Test]
+    public void FindNextGap_TiedStart_PicksNearestByEnd()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Two layers both open a gap starting at 2s: layer 0 spans 2s-12s, layer 1 spans 2s-5s.
+            // Next must visit the nearer (shorter) gap first, not whichever ZIndex enumerates first.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 1));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 1));
+
+            TimeRange? gap = scene.FindNextGap(TimeSpan.Zero)?.Range;
+
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3))));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindPreviousGap_TiedEnd_PicksNearestByStart()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Two layers both close a gap ending at 12s: layer 0 spans 2s-12s, layer 1 spans 9s-12s.
+            // Previous must visit the nearer (shorter) gap first, not whichever ZIndex enumerates first.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(1), zIndex: 1));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1), zIndex: 1));
+
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(20))?.Range;
+
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(3))));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void FindNextGap_GapStraddlingSearchEnd_ReturnsClampedVisiblePortion()
     {
         string basePath = GetTempPath();

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -343,8 +343,10 @@ public class SceneGapTests
         try
         {
             Scene scene = CreateScene(basePath);
+            // b overlaps a and extends coverage up to c, so the layer is continuous and there is
+            // no gap after a to close.
             Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(10));
-            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(7));
             Element c = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1));
             scene.Children.Add(a);
             scene.Children.Add(b);
@@ -357,6 +359,66 @@ public class SceneGapTests
                 Assert.That(closed, Is.False);
                 Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
                 Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(12)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_AnchorCoveredByEarlierElement_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // The layer is continuously covered by [0s..100s], so selecting [10s..15s] must not
+            // treat the space before [20s..25s] as a closeable gap.
+            Element cover = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(100));
+            Element anchor = CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+            Element next = CreateElement(basePath, TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(5));
+            scene.Children.Add(cover);
+            scene.Children.Add(anchor);
+            scene.Children.Add(next);
+
+            bool closed = scene.CloseGap(anchor);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.False);
+                Assert.That(next.Start, Is.EqualTo(TimeSpan.FromSeconds(20)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_CoverageExtendsPastAnchor_UsesCoveredEnd()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // [10s..15s] anchor, then [12s..50s] extends coverage to 50s, then [60s..70s]; the real
+            // gap is 50s-60s, so the trailing clip must land at 50s, not be shifted by 45s.
+            Element anchor = CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+            Element mid = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(38));
+            Element next = CreateElement(basePath, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10));
+            scene.Children.Add(anchor);
+            scene.Children.Add(mid);
+            scene.Children.Add(next);
+
+            bool closed = scene.CloseGap(anchor);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.True);
+                Assert.That(next.Start, Is.EqualTo(TimeSpan.FromSeconds(50)));
             });
         }
         finally
@@ -632,6 +694,30 @@ public class SceneGapTests
             TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(201));
 
             Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(140)));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindNextGapCenter_GapBeyondSearchEnd_Ignored()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Elements left beyond a shortened scene form a gap 10s-100s; bounding the search to a
+            // 30s scene end must reject it so navigation reports no gap instead of clamping.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(9)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(10)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero, TimeSpan.FromSeconds(30)), Is.Null);
+                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero), Is.EqualTo(TimeSpan.FromSeconds(55)));
+            });
         }
         finally
         {

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -918,24 +918,54 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindNextGap_GapBeyondSearchEnd_Ignored()
+    public void FindNextGap_GapStraddlingSearchEnd_ReturnsClampedVisiblePortion()
     {
         string basePath = GetTempPath();
         try
         {
             Scene scene = CreateScene(basePath);
-            // Elements left beyond a shortened scene form a gap 10s-100s; bounding the search to a
-            // 30s scene end must reject it so navigation reports no gap instead of clamping.
+            // A far-right element leaves a gap 10s-100s that straddles a 30s scene end. Its visible
+            // portion 10s-30s is empty space inside the scene, so the search returns the clamped gap;
+            // without a search range the full 10s-90s gap is returned.
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(9)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(10)));
 
             var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(30));
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGap(TimeSpan.Zero, range), Is.Null);
+                Assert.That(
+                    scene.FindNextGap(TimeSpan.Zero, range),
+                    Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20))));
                 Assert.That(
                     scene.FindNextGap(TimeSpan.Zero),
                     Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90))));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindGap_GapStraddlingBothEnds_ReturnsClampedVisiblePortion()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // The only elements end at 10s and start at 100s, so the gap 10s-100s covers the whole
+            // active range 50s-80s. Navigation from either side must reach it through the clamped
+            // visible portion 50s-80s rather than reporting no gap.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(5)));
+            var range = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30));
+            var clamped = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(40), range), Is.EqualTo(clamped));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(90), range), Is.EqualTo(clamped));
             });
         }
         finally

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -34,8 +34,8 @@ public class SceneGapTests
         };
     }
 
-    private static List<(int ZIndex, TimeRange Gap)> Gaps(Scene scene, bool includeLeadingGap = false)
-        => scene.EnumerateGaps(includeLeadingGap).ToList();
+    private static List<SceneGap> Gaps(Scene scene)
+        => scene.EnumerateGaps().ToList();
 
     [Test]
     public void EnumerateGaps_NoElements_ReturnsEmpty()
@@ -117,13 +117,13 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1)));
 
-            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+            List<SceneGap> gaps = Gaps(scene);
 
             Assert.That(gaps, Has.Count.EqualTo(1));
             Assert.Multiple(() =>
             {
-                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(10)));
-                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(gaps[0].Range.Start, Is.EqualTo(TimeSpan.FromSeconds(10)));
+                Assert.That(gaps[0].Range.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
             });
         }
         finally
@@ -144,14 +144,14 @@ public class SceneGapTests
             scene.Children.Add(a);
             scene.Children.Add(b);
 
-            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+            List<SceneGap> gaps = Gaps(scene);
 
             Assert.That(gaps, Has.Count.EqualTo(1));
             Assert.Multiple(() =>
             {
                 Assert.That(gaps[0].ZIndex, Is.EqualTo(0));
-                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
-                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(gaps[0].Range.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+                Assert.That(gaps[0].Range.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
             });
         }
         finally
@@ -172,7 +172,7 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(1), zIndex: 1));
 
-            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+            List<SceneGap> gaps = Gaps(scene);
 
             Assert.That(gaps, Has.Count.EqualTo(2));
             Assert.Multiple(() =>
@@ -198,13 +198,13 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(1)));
 
-            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+            List<SceneGap> gaps = Gaps(scene);
 
             Assert.That(gaps, Has.Count.EqualTo(2));
             Assert.Multiple(() =>
             {
-                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
-                Assert.That(gaps[1].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(gaps[0].Range.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(gaps[1].Range.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
             });
         }
         finally
@@ -214,7 +214,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void EnumerateGaps_IncludeLeadingGap_YieldsLeadingGap()
+    public void EnumerateGaps_SpaceBeforeFirstElement_IsNotAGap()
     {
         string basePath = GetTempPath();
         try
@@ -222,14 +222,7 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
 
-            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene, includeLeadingGap: true);
-
-            Assert.That(gaps, Has.Count.EqualTo(1));
-            Assert.Multiple(() =>
-            {
-                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.Zero));
-                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
-            });
+            Assert.That(Gaps(scene), Is.Empty);
         }
         finally
         {
@@ -238,24 +231,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void EnumerateGaps_IncludeLeadingGapFalse_OmitsLeadingGap()
-    {
-        string basePath = GetTempPath();
-        try
-        {
-            Scene scene = CreateScene(basePath);
-            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
-
-            Assert.That(Gaps(scene, includeLeadingGap: false), Is.Empty);
-        }
-        finally
-        {
-            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
-        }
-    }
-
-    [Test]
-    public void CloseGap_ClosesGapAfterAnchor()
+    public void CloseGapAfter_ClosesGapAfterAnchor()
     {
         string basePath = GetTempPath();
         try
@@ -268,9 +244,9 @@ public class SceneGapTests
             scene.Children.Add(b);
             scene.Children.Add(c);
 
-            bool closed = scene.CloseGap(a);
+            bool closed = scene.CloseGapAfter(a);
 
-            // CloseGap closes only the gap immediately after the anchor; subsequent
+            // CloseGapAfter closes only the gap immediately after the anchor; subsequent
             // elements all shift by the same delta, so the gap between b and c is
             // preserved (moved left along with them).
             Assert.Multiple(() =>
@@ -278,10 +254,10 @@ public class SceneGapTests
                 Assert.That(closed, Is.True);
                 Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
                 Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(7)));
-                List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+                List<SceneGap> gaps = Gaps(scene);
                 Assert.That(gaps, Has.Count.EqualTo(1));
-                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
-                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(gaps[0].Range.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(gaps[0].Range.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
             });
         }
         finally
@@ -291,7 +267,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_NoNextElement_ReturnsFalse()
+    public void CloseGapAfter_NoNextElement_ReturnsFalse()
     {
         string basePath = GetTempPath();
         try
@@ -300,7 +276,7 @@ public class SceneGapTests
             Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
             scene.Children.Add(a);
 
-            bool closed = scene.CloseGap(a);
+            bool closed = scene.CloseGapAfter(a);
 
             Assert.That(closed, Is.False);
         }
@@ -311,7 +287,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_TouchingNextElement_ReturnsFalse()
+    public void CloseGapAfter_TouchingNextElement_ReturnsFalse()
     {
         string basePath = GetTempPath();
         try
@@ -322,7 +298,7 @@ public class SceneGapTests
             scene.Children.Add(a);
             scene.Children.Add(b);
 
-            bool closed = scene.CloseGap(a);
+            bool closed = scene.CloseGapAfter(a);
 
             Assert.Multiple(() =>
             {
@@ -337,7 +313,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_OverlappingNextElement_ReturnsFalse()
+    public void CloseGapAfter_OverlappingNextElement_ReturnsFalse()
     {
         string basePath = GetTempPath();
         try
@@ -352,7 +328,7 @@ public class SceneGapTests
             scene.Children.Add(b);
             scene.Children.Add(c);
 
-            bool closed = scene.CloseGap(a);
+            bool closed = scene.CloseGapAfter(a);
 
             Assert.Multiple(() =>
             {
@@ -368,7 +344,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_AnchorCoveredByEarlierElement_ReturnsFalse()
+    public void CloseGapAfter_AnchorCoveredByEarlierElement_ReturnsFalse()
     {
         string basePath = GetTempPath();
         try
@@ -383,7 +359,7 @@ public class SceneGapTests
             scene.Children.Add(anchor);
             scene.Children.Add(next);
 
-            bool closed = scene.CloseGap(anchor);
+            bool closed = scene.CloseGapAfter(anchor);
 
             Assert.Multiple(() =>
             {
@@ -398,7 +374,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_CoverageExtendsPastAnchor_UsesCoveredEnd()
+    public void CloseGapAfter_CoverageExtendsPastAnchor_UsesCoveredEnd()
     {
         string basePath = GetTempPath();
         try
@@ -413,7 +389,7 @@ public class SceneGapTests
             scene.Children.Add(mid);
             scene.Children.Add(next);
 
-            bool closed = scene.CloseGap(anchor);
+            bool closed = scene.CloseGapAfter(anchor);
 
             Assert.Multiple(() =>
             {
@@ -428,7 +404,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_AnchorNotInScene_ReturnsFalse()
+    public void CloseGapAfter_AnchorNotInScene_ReturnsFalse()
     {
         string basePath = GetTempPath();
         try
@@ -436,7 +412,7 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             Element orphan = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
 
-            bool closed = scene.CloseGap(orphan);
+            bool closed = scene.CloseGapAfter(orphan);
 
             Assert.That(closed, Is.False);
         }
@@ -579,7 +555,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindNextGapCenter_ReturnsNextGapCenter()
+    public void FindNextGap_ReturnsNextGap()
     {
         string basePath = GetTempPath();
         try
@@ -588,9 +564,9 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
 
-            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(1));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(1));
 
-            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(3.5)));
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3))));
         }
         finally
         {
@@ -599,7 +575,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindNextGapCenter_NoNextGap_ReturnsNull()
+    public void FindNextGap_NoNextGap_ReturnsNull()
     {
         string basePath = GetTempPath();
         try
@@ -607,9 +583,9 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
 
-            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(5));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(5));
 
-            Assert.That(center, Is.Null);
+            Assert.That(gap, Is.Null);
         }
         finally
         {
@@ -618,7 +594,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindNextGapCenter_WhenInsideGap_SkipsCurrentGap()
+    public void FindNextGap_WhenInsideGap_SkipsCurrentGap()
     {
         string basePath = GetTempPath();
         try
@@ -628,9 +604,9 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1)));
 
-            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(4));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(4));
 
-            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(8)));
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(4))));
         }
         finally
         {
@@ -639,7 +615,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindPreviousGapCenter_ReturnsPreviousGapCenter()
+    public void FindPreviousGap_ReturnsPreviousGap()
     {
         string basePath = GetTempPath();
         try
@@ -648,9 +624,9 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
 
-            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(6));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(6));
 
-            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(3.5)));
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3))));
         }
         finally
         {
@@ -659,7 +635,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindPreviousGapCenter_NoPreviousGap_ReturnsNull()
+    public void FindPreviousGap_NoPreviousGap_ReturnsNull()
     {
         string basePath = GetTempPath();
         try
@@ -667,9 +643,9 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
 
-            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(1));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(1));
 
-            Assert.That(center, Is.Null);
+            Assert.That(gap, Is.Null);
         }
         finally
         {
@@ -678,7 +654,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindPreviousGapCenter_OverlappingCrossLayerGaps_PicksGapEndingClosest()
+    public void FindPreviousGap_OverlappingCrossLayerGaps_PicksGapEndingClosest()
     {
         string basePath = GetTempPath();
         try
@@ -691,9 +667,9 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(89), zIndex: 1));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(91), TimeSpan.FromSeconds(1), zIndex: 1));
 
-            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(201));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(201));
 
-            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(140)));
+            Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(80), TimeSpan.FromSeconds(120))));
         }
         finally
         {
@@ -702,7 +678,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindNextGapCenter_GapBeyondSearchEnd_Ignored()
+    public void FindNextGap_GapBeyondSearchEnd_Ignored()
     {
         string basePath = GetTempPath();
         try
@@ -716,8 +692,10 @@ public class SceneGapTests
             var range = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(30));
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero, range), Is.Null);
-                Assert.That(scene.FindNextGapCenter(TimeSpan.Zero), Is.EqualTo(TimeSpan.FromSeconds(55)));
+                Assert.That(scene.FindNextGap(TimeSpan.Zero, range), Is.Null);
+                Assert.That(
+                    scene.FindNextGap(TimeSpan.Zero),
+                    Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90))));
             });
         }
         finally
@@ -727,7 +705,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void FindGapCenter_BoundsBothSides_IgnoresGapsOutsideOffsetScene()
+    public void FindGap_BoundsBothSides_IgnoresGapsOutsideOffsetScene()
     {
         string basePath = GetTempPath();
         try
@@ -740,15 +718,16 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(80)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(260), TimeSpan.FromSeconds(10)));
             var range = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(100));
+            var inRangeGap = new TimeRange(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(20));
 
             Assert.Multiple(() =>
             {
-                // The only in-range gap is 100s-120s (center 110s).
-                Assert.That(scene.FindNextGapCenter(TimeSpan.FromSeconds(50), range), Is.EqualTo(TimeSpan.FromSeconds(110)));
-                Assert.That(scene.FindPreviousGapCenter(TimeSpan.FromSeconds(150), range), Is.EqualTo(TimeSpan.FromSeconds(110)));
+                // The only in-range gap is 100s-120s.
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range), Is.EqualTo(inRangeGap));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(150), range), Is.EqualTo(inRangeGap));
                 // Searching from outside the range must not reach the out-of-range gaps.
-                Assert.That(scene.FindNextGapCenter(TimeSpan.FromSeconds(150), range), Is.Null);
-                Assert.That(scene.FindPreviousGapCenter(TimeSpan.FromSeconds(50), range), Is.Null);
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(150), range), Is.Null);
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(50), range), Is.Null);
             });
         }
         finally
@@ -758,7 +737,7 @@ public class SceneGapTests
     }
 
     [Test]
-    public void CloseGap_ThenUndo_RestoresPositions()
+    public void CloseGapAfter_ThenUndo_RestoresPositions()
     {
         using var harness = new SceneHistoryHarness("beutl_gap_undo", duration: TimeSpan.FromSeconds(60));
         Scene scene = harness.Scene;
@@ -767,7 +746,7 @@ public class SceneGapTests
         Element c = harness.AddElement(TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(2));
         int beforeUndoCount = harness.History.UndoCount;
 
-        bool closed = scene.CloseGap(a);
+        bool closed = scene.CloseGapAfter(a);
         harness.History.Commit(CommandNames.CloseGap);
 
         Assert.Multiple(() =>

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -1,0 +1,590 @@
+﻿using Beutl.Editor;
+using Beutl.Language;
+using Beutl.Media;
+using Beutl.ProjectSystem;
+using Beutl.UnitTests.TestInfrastructure;
+
+namespace Beutl.UnitTests.ProjectSystem;
+
+[TestFixture]
+public class SceneGapTests
+{
+    private static string GetTempPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"beutl_scene_gaps_{Guid.NewGuid():N}");
+    }
+
+    private static Scene CreateScene(string basePath)
+    {
+        Directory.CreateDirectory(basePath);
+        return new Scene(100, 100, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(basePath, "test.scene")),
+        };
+    }
+
+    private static Element CreateElement(string basePath, TimeSpan start, TimeSpan length, int zIndex = 0)
+    {
+        return new Element
+        {
+            Start = start,
+            Length = length,
+            ZIndex = zIndex,
+            Uri = new Uri(Path.Combine(basePath, $"{Guid.NewGuid():N}.layer")),
+        };
+    }
+
+    private static List<(int ZIndex, TimeRange Gap)> Gaps(Scene scene, bool includeLeadingGap = false)
+        => scene.EnumerateGaps(includeLeadingGap).ToList();
+
+    [Test]
+    public void EnumerateGaps_NoElements_ReturnsEmpty()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Assert.That(Gaps(scene), Is.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_ContiguousElements_NoGaps()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2)));
+
+            Assert.That(Gaps(scene), Is.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_TouchingElements_NoGaps()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+
+            Assert.That(Gaps(scene), Is.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_OverlappingElements_NoGaps()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)));
+
+            Assert.That(Gaps(scene), Is.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_WithGap_YieldsGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+
+            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+
+            Assert.That(gaps, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps[0].ZIndex, Is.EqualTo(0));
+                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_MultipleZIndexes_YieldsPerZIndex()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(1), zIndex: 1));
+
+            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+
+            Assert.That(gaps, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps[0].ZIndex, Is.EqualTo(0));
+                Assert.That(gaps[1].ZIndex, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_MultipleGapsOnSameZIndex_YieldsAllInOrder()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(1)));
+
+            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+
+            Assert.That(gaps, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(gaps[1].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_IncludeLeadingGap_YieldsLeadingGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
+
+            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene, includeLeadingGap: true);
+
+            Assert.That(gaps, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.Zero));
+                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_IncludeLeadingGapFalse_OmitsLeadingGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1)));
+
+            Assert.That(Gaps(scene, includeLeadingGap: false), Is.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_ClosesGapAfterAnchor()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+            scene.Children.Add(c);
+
+            bool closed = scene.CloseGap(a);
+
+            // CloseGap closes only the gap immediately after the anchor; subsequent
+            // elements all shift by the same delta, so the gap between b and c is
+            // preserved (moved left along with them).
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.True);
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(7)));
+                List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+                Assert.That(gaps, Has.Count.EqualTo(1));
+                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_NoNextElement_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+
+            bool closed = scene.CloseGap(a);
+
+            Assert.That(closed, Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_TouchingNextElement_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+
+            bool closed = scene.CloseGap(a);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.False);
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_AnchorNotInScene_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element orphan = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+            bool closed = scene.CloseGap(orphan);
+
+            Assert.That(closed, Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_RemovesAllGapsAcrossZIndexes()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 0));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(1), zIndex: 1));
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(2));
+                Assert.That(Gaps(scene), Is.Empty);
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_NoGaps_ReturnsZero()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.That(closed, Is.EqualTo(0));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_DoesNotCloseLeadingGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)));
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(0));
+                Assert.That(scene.Children[0].Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_ThreeElementsWithTwoGaps_BecomesContiguous()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1));
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(1));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+            scene.Children.Add(c);
+
+            scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(a.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindNextGapCenter_ReturnsNextGapCenter()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
+
+            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(1));
+
+            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(3.5)));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindNextGapCenter_NoNextGap_ReturnsNull()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
+
+            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(5));
+
+            Assert.That(center, Is.Null);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindNextGapCenter_WhenInsideGap_SkipsCurrentGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1)));
+
+            TimeSpan? center = scene.FindNextGapCenter(TimeSpan.FromSeconds(4));
+
+            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(8)));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindPreviousGapCenter_ReturnsPreviousGapCenter()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
+
+            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(6));
+
+            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(3.5)));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindPreviousGapCenter_NoPreviousGap_ReturnsNull()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
+
+            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(1));
+
+            Assert.That(center, Is.Null);
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGap_ThenUndo_RestoresPositions()
+    {
+        using var harness = new SceneHistoryHarness("beutl_gap_undo", duration: TimeSpan.FromSeconds(60));
+        Scene scene = harness.Scene;
+        Element a = harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element b = harness.AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        Element c = harness.AddElement(TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(2));
+        int beforeUndoCount = harness.History.UndoCount;
+
+        bool closed = scene.CloseGap(a);
+        harness.History.Commit(CommandNames.CloseGap);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(closed, Is.True);
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(7)));
+            Assert.That(harness.History.UndoCount, Is.EqualTo(beforeUndoCount + 1));
+        });
+
+        harness.History.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(9)));
+        });
+    }
+
+    [Test]
+    public void CloseAllGaps_ThenUndo_RestoresPositions()
+    {
+        using var harness = new SceneHistoryHarness("beutl_gap_all_undo", duration: TimeSpan.FromSeconds(60));
+        Scene scene = harness.Scene;
+        Element a = harness.AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        Element b = harness.AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1));
+        Element c = harness.AddElement(TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(1));
+        int beforeUndoCount = harness.History.UndoCount;
+
+        int closed = scene.CloseAllGaps();
+        harness.History.Commit(CommandNames.CloseAllGaps);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(closed, Is.EqualTo(2));
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(harness.History.UndoCount, Is.EqualTo(beforeUndoCount + 1));
+        });
+
+        harness.History.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(8)));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -679,6 +679,46 @@ public class SceneGapTests
         }
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public void CloseAllGaps_SameStartCohort_ShiftsTogetherRegardlessOfOrder(bool reversedInsertion)
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Two unlocked elements share Start 6s; the gap-close must move them as one cohort and
+            // reach the same result no matter which order Children enumerates them in.
+            Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+            Element m = CreateElement(basePath, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(1));
+            Element n = CreateElement(basePath, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(3));
+            scene.Children.Add(a);
+            if (reversedInsertion)
+            {
+                scene.Children.Add(n);
+                scene.Children.Add(m);
+            }
+            else
+            {
+                scene.Children.Add(m);
+                scene.Children.Add(n);
+            }
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(1));
+                Assert.That(m.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(n.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
     [Test]
     public void FindNextGap_ReturnsNextGap()
     {

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -616,6 +616,30 @@ public class SceneGapTests
     }
 
     [Test]
+    public void FindPreviousGapCenter_OverlappingCrossLayerGaps_PicksGapEndingClosest()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // The layer-1 gap (90s-91s) starts later than the layer-0 gap (80s-200s) but ends
+            // far earlier; the previous gap must be chosen by end time, so the wide gap wins.
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(79)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(200), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(89), zIndex: 1));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(91), TimeSpan.FromSeconds(1), zIndex: 1));
+
+            TimeSpan? center = scene.FindPreviousGapCenter(TimeSpan.FromSeconds(201));
+
+            Assert.That(center, Is.EqualTo(TimeSpan.FromSeconds(140)));
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void CloseGap_ThenUndo_RestoresPositions()
     {
         using var harness = new SceneHistoryHarness("beutl_gap_undo", duration: TimeSpan.FromSeconds(60));

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -720,6 +720,81 @@ public class SceneGapTests
     }
 
     [Test]
+    public void CloseAllGaps_DoesNotShiftFollowerAcrossLockedElement()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // [0s..1s], locked [5s..6s], [10s..11s]. The gap after the locked clip closes (the trailing
+            // clip lands at 6s), but the gap before it stays open — the follower never crosses the lock.
+            Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            Element locked = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            locked.IsLocked = true;
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
+            scene.Children.Add(a);
+            scene.Children.Add(locked);
+            scene.Children.Add(c);
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(1));
+                Assert.That(a.Start, Is.EqualTo(TimeSpan.Zero));
+                Assert.That(locked.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(6)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseGapAfter_StopsAtLockedWall()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // Anchor [0s..2s]; gap 2s-4s; a same-start cohort at 4s; a locked wall [8s..10s]; another
+            // same-start cohort at 12s beyond the wall. The near cohort shifts left to close the gap,
+            // the wall stops the shift, and the cohort beyond the wall stays put.
+            Element anchor = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+            Element m = CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1));
+            Element n = CreateElement(basePath, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(3));
+            Element locked = CreateElement(basePath, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(2));
+            locked.IsLocked = true;
+            Element c1 = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1));
+            Element c2 = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(4));
+            scene.Children.Add(anchor);
+            scene.Children.Add(m);
+            scene.Children.Add(n);
+            scene.Children.Add(locked);
+            scene.Children.Add(c1);
+            scene.Children.Add(c2);
+
+            bool closed = scene.CloseGapAfter(anchor);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.True);
+                Assert.That(m.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(n.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(locked.Start, Is.EqualTo(TimeSpan.FromSeconds(8)));
+                Assert.That(c1.Start, Is.EqualTo(TimeSpan.FromSeconds(12)));
+                Assert.That(c2.Start, Is.EqualTo(TimeSpan.FromSeconds(12)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void FindNextGap_ReturnsNextGap()
     {
         string basePath = GetTempPath();

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -955,8 +955,8 @@ public class SceneGapTests
         {
             Scene scene = CreateScene(basePath);
             // The only elements end at 10s and start at 100s, so the gap 10s-100s covers the whole
-            // active range 50s-80s. Navigation from either side must reach it through the clamped
-            // visible portion 50s-80s rather than reporting no gap.
+            // active range 50s-80s. A playhead resting exactly on either boundary must still reach the
+            // clamped visible portion 50s-80s: next from the 50s start, previous from the 80s end.
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(5)));
             var range = new TimeRange(TimeSpan.FromSeconds(50), TimeSpan.FromSeconds(30));
@@ -964,8 +964,8 @@ public class SceneGapTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(40), range), Is.EqualTo(clamped));
-                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(90), range), Is.EqualTo(clamped));
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range), Is.EqualTo(clamped));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(80), range), Is.EqualTo(clamped));
             });
         }
         finally

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -107,6 +107,32 @@ public class SceneGapTests
     }
 
     [Test]
+    public void EnumerateGaps_NestedOverlap_UsesCoveredEndForNextGap()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(10)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1)));
+
+            List<(int ZIndex, TimeRange Gap)> gaps = Gaps(scene);
+
+            Assert.That(gaps, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps[0].Gap.Start, Is.EqualTo(TimeSpan.FromSeconds(10)));
+                Assert.That(gaps[0].Gap.Duration, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void EnumerateGaps_WithGap_YieldsGap()
     {
         string basePath = GetTempPath();
@@ -311,6 +337,35 @@ public class SceneGapTests
     }
 
     [Test]
+    public void CloseGap_OverlappingNextElement_ReturnsFalse()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(10));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+            scene.Children.Add(c);
+
+            bool closed = scene.CloseGap(a);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.False);
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(12)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
     public void CloseGap_AnchorNotInScene_ReturnsFalse()
     {
         string basePath = GetTempPath();
@@ -419,6 +474,40 @@ public class SceneGapTests
                 Assert.That(a.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
                 Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
                 Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CloseAllGaps_NestedOverlap_ClosesOnlyRealGaps()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(10));
+            Element b = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            Element c = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1));
+            Element d = CreateElement(basePath, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(1));
+            scene.Children.Add(a);
+            scene.Children.Add(b);
+            scene.Children.Add(c);
+            scene.Children.Add(d);
+
+            int closed = scene.CloseAllGaps();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(closed, Is.EqualTo(2));
+                Assert.That(a.Start, Is.EqualTo(TimeSpan.Zero));
+                Assert.That(b.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+                Assert.That(c.Start, Is.EqualTo(TimeSpan.FromSeconds(10)));
+                Assert.That(d.Start, Is.EqualTo(TimeSpan.FromSeconds(11)));
+                Assert.That(Gaps(scene), Is.Empty);
             });
         }
         finally

--- a/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
+++ b/tests/Beutl.UnitTests/ProjectSystem/SceneGapTests.cs
@@ -804,7 +804,7 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
 
-            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(1));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(1))?.Range;
 
             Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3))));
         }
@@ -823,7 +823,7 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
 
-            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(5));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(5))?.Range;
 
             Assert.That(gap, Is.Null);
         }
@@ -844,7 +844,7 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1)));
 
-            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(4));
+            TimeRange? gap = scene.FindNextGap(TimeSpan.FromSeconds(4))?.Range;
 
             Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(4))));
         }
@@ -864,7 +864,7 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)));
 
-            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(6));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(6))?.Range;
 
             Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3))));
         }
@@ -883,7 +883,7 @@ public class SceneGapTests
             Scene scene = CreateScene(basePath);
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
 
-            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(1));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(1))?.Range;
 
             Assert.That(gap, Is.Null);
         }
@@ -907,7 +907,7 @@ public class SceneGapTests
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(89), zIndex: 1));
             scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(91), TimeSpan.FromSeconds(1), zIndex: 1));
 
-            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(201));
+            TimeRange? gap = scene.FindPreviousGap(TimeSpan.FromSeconds(201))?.Range;
 
             Assert.That(gap, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(80), TimeSpan.FromSeconds(120))));
         }
@@ -934,10 +934,10 @@ public class SceneGapTests
             Assert.Multiple(() =>
             {
                 Assert.That(
-                    scene.FindNextGap(TimeSpan.Zero, range),
+                    scene.FindNextGap(TimeSpan.Zero, range)?.Range,
                     Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20))));
                 Assert.That(
-                    scene.FindNextGap(TimeSpan.Zero),
+                    scene.FindNextGap(TimeSpan.Zero)?.Range,
                     Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(90))));
             });
         }
@@ -964,8 +964,8 @@ public class SceneGapTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range), Is.EqualTo(clamped));
-                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(80), range), Is.EqualTo(clamped));
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range)?.Range, Is.EqualTo(clamped));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(80), range)?.Range, Is.EqualTo(clamped));
             });
         }
         finally
@@ -993,11 +993,72 @@ public class SceneGapTests
             Assert.Multiple(() =>
             {
                 // The only in-range gap is 100s-120s.
-                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range), Is.EqualTo(inRangeGap));
-                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(150), range), Is.EqualTo(inRangeGap));
+                Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(50), range)?.Range, Is.EqualTo(inRangeGap));
+                Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(150), range)?.Range, Is.EqualTo(inRangeGap));
                 // Searching from outside the range must not reach the out-of-range gaps.
                 Assert.That(scene.FindNextGap(TimeSpan.FromSeconds(150), range), Is.Null);
                 Assert.That(scene.FindPreviousGap(TimeSpan.FromSeconds(50), range), Is.Null);
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void EnumerateGaps_AnchorIsElementEndingAtGapStart()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            // A big element covers 0s-10s while a shorter one nests inside; the gap 10s-12s must anchor
+            // on the covering element (it ends at the gap start), not the nested one.
+            Element cover = CreateElement(basePath, TimeSpan.Zero, TimeSpan.FromSeconds(10));
+            Element nested = CreateElement(basePath, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            Element trailing = CreateElement(basePath, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1));
+            scene.Children.Add(cover);
+            scene.Children.Add(nested);
+            scene.Children.Add(trailing);
+
+            List<SceneGap> gaps = Gaps(scene);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(gaps, Has.Count.EqualTo(1));
+                Assert.That(gaps[0].Range, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2))));
+                Assert.That(gaps[0].Anchor, Is.SameAs(cover));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(basePath)) Directory.Delete(basePath, recursive: true);
+        }
+    }
+
+    [Test]
+    public void FindGapAt_ReturnsGapContainingPointOnLayer()
+    {
+        string basePath = GetTempPath();
+        try
+        {
+            Scene scene = CreateScene(basePath);
+            Element a = CreateElement(basePath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+            scene.Children.Add(a);
+            scene.Children.Add(CreateElement(basePath, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(2), zIndex: 0));
+
+            Assert.Multiple(() =>
+            {
+                SceneGap? hit = scene.FindGapAt(TimeSpan.FromSeconds(4), zIndex: 0);
+                Assert.That(hit?.Range, Is.EqualTo(new TimeRange(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3))));
+                Assert.That(hit?.Anchor, Is.SameAs(a));
+                // Half-open: the gap start is inside, the gap end is not.
+                Assert.That(scene.FindGapAt(TimeSpan.FromSeconds(3), zIndex: 0), Is.Not.Null);
+                Assert.That(scene.FindGapAt(TimeSpan.FromSeconds(6), zIndex: 0), Is.Null);
+                // No gap on an empty layer, and no gap when the point sits on an element.
+                Assert.That(scene.FindGapAt(TimeSpan.FromSeconds(4), zIndex: 1), Is.Null);
+                Assert.That(scene.FindGapAt(TimeSpan.FromSeconds(2), zIndex: 0), Is.Null);
             });
         }
         finally


### PR DESCRIPTION
Adds four timeline commands for working with gaps between elements on the
same ZIndex layer:
- Close Gap: closes the gap immediately after the selected anchor element
- Close All Gaps: closes every gap across all ZIndex layers
- Go To Next Gap / Go To Previous Gap: moves the playhead to the center of
  the next or previous gap

Gap detection and shift arithmetic live on Scene (EnumerateGaps, CloseGap,
CloseAllGaps, FindNextGapCenter, FindPreviousGapCenter) as read-only queries
and non-committing mutate primitives, so they are unit-testable without the
UI layer. The mutating close operations are wrapped by IElementGapService
in Beutl.Editor, mirroring IElementMoveService: the service calls the Scene
primitive then owns the single HistoryManager.Commit per user-visible
operation, so the ViewModel never touches HistoryManager directly and a
plugin can replace the close behavior (skip locked elements, sub-threshold
gaps, single-layer restriction, confirmation) by swapping the service. One
undo restores the prior layout (covered by integration tests on both the
Scene primitives and the service). Jump targets are clamped to
[Scene.Start, Scene.Start + Scene.Duration]. A notification is shown when no
gaps are found.

Locked-element guarding is not implemented: Element.IsLocked does not exist
on main, so the guard depends on a separate feature landing first.

Refs: Project #9 board item "ギャップを閉じる / 次のギャップへ移動"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Gaps” timeline actions to close the current gap, close all gaps, and jump to the next/previous gap, with keyboard shortcuts and a new context submenu.
  * Added localized UI labels and messages for gap actions (including Japanese).

* **Bug Fixes**
  * Improved gap navigation/closing behavior with correct empty/no-gap handling and reliable undo support.
  * Prevented time range shortcuts from triggering while text input has focus.
  * Gap actions now flush pending nudge changes first and notify when no gap is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->