### PR TITLE
feat(editor): add Slip / Roll / Slide trim modes with UI invocation

### DIFF
--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -175,9 +175,18 @@ public class ContextCommandManager(
             seen++;
         }
 
-        // platformId が見つからなかった場合、追加する
+        // platformId が見つからなかった場合、次の空きスロット (gestureIndex == 既存数) なら追加する。
+        // それより大きい index は UI が提示していないスロットを黙って生み出し、Save 経由で
+        // 永続化までされてしまうため、呼び出し側のバグとして例外にする。
         if (!changed)
         {
+            if (gestureIndex != seen)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(gestureIndex), gestureIndex,
+                    $"The platform '{platform}' has {seen} gesture slot(s); only an existing slot or the next free slot can be assigned.");
+            }
+
             entry.KeyGestures.Add(new ContextCommandParsedKeyGesture(keyGesture, platform));
         }
 

--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -175,9 +175,9 @@ public class ContextCommandManager(
             seen++;
         }
 
-        // platformId が見つからなかった場合、次の空きスロット (gestureIndex == 既存数) なら追加する。
-        // それより大きい index は UI が提示していないスロットを黙って生み出し、Save 経由で
-        // 永続化までされてしまうため、呼び出し側のバグとして例外にする。
+        // When no slot matched, appending is only valid at the next free slot
+        // (gestureIndex == existing count). A larger index would silently create a slot the
+        // UI never presented — and persist it through Save — so treat it as a caller bug.
         if (!changed)
         {
             if (gestureIndex != seen)
@@ -212,8 +212,8 @@ public class ContextCommandManager(
             foreach ((OSPlatform platform, IReadOnlyList<KeyGesture?> gestures) in
                      settingsStore.Restore(GetFullName(entry)))
             {
-                // 保存されたリストでデフォルトのGestureをスロット順に上書きする。保存された
-                // リストがデフォルトより短い場合、残りのスロットはデフォルトのまま維持する。
+                // Overwrite the default gestures slot-by-slot with the persisted list; slots
+                // beyond a shorter persisted list keep their defaults.
                 int seen = 0;
                 for (int index = 0; index < entry.KeyGestures.Count && seen < gestures.Count; index++)
                 {
@@ -223,7 +223,7 @@ public class ContextCommandManager(
                     seen++;
                 }
 
-                // デフォルトに無いスロットは追加する
+                // Slots the defaults do not have are appended
                 for (; seen < gestures.Count; seen++)
                 {
                     entry.KeyGestures.Add(new ContextCommandParsedKeyGesture(gestures[seen], platform));

--- a/src/Beutl.Api/Services/ContextCommandManager.cs
+++ b/src/Beutl.Api/Services/ContextCommandManager.cs
@@ -151,17 +151,28 @@ public class ContextCommandManager(
         return _entries.Values.SelectMany(i => i);
     }
 
-    public void ChangeKeyGesture(ContextCommandEntry entry, KeyGesture? keyGesture, OSPlatform platform)
+    /// <summary>
+    /// Rebind one gesture slot of a command. <paramref name="gestureIndex"/> addresses the
+    /// N-th gesture of <paramref name="platform"/> (a command may bind several, e.g. V and
+    /// Escape); only that slot changes, so remapping one binding cannot destroy the others.
+    /// </summary>
+    public void ChangeKeyGesture(ContextCommandEntry entry, KeyGesture? keyGesture, OSPlatform platform, int gestureIndex = 0)
     {
+        int seen = 0;
         bool changed = false;
         for (int i = 0; i < entry.KeyGestures.Count; i++)
         {
             var gesture = entry.KeyGestures[i];
-            if (gesture.Platform == platform)
+            if (gesture.Platform != platform) continue;
+
+            if (seen == gestureIndex)
             {
                 entry.KeyGestures[i] = gesture with { KeyGesture = keyGesture };
                 changed = true;
+                break;
             }
+
+            seen++;
         }
 
         // platformId が見つからなかった場合、追加する
@@ -170,7 +181,12 @@ public class ContextCommandManager(
             entry.KeyGestures.Add(new ContextCommandParsedKeyGesture(keyGesture, platform));
         }
 
-        settingsStore.Save(GetFullName(entry), keyGesture, platform);
+        // Persist the whole per-platform list: with multiple gestures per platform a single
+        // (name, platform) → gesture record cannot round-trip the untouched slots.
+        settingsStore.Save(
+            GetFullName(entry),
+            entry.KeyGestures.Where(g => g.Platform == platform).Select(g => g.KeyGesture).ToArray(),
+            platform);
     }
 
     private static string GetFullName(ContextCommandEntry entry)
@@ -184,24 +200,25 @@ public class ContextCommandManager(
     {
         foreach (ContextCommandEntry entry in entries)
         {
-            var keyGestures = settingsStore.Restore(GetFullName(entry));
-            foreach (ContextCommandParsedKeyGesture i in keyGestures)
+            foreach ((OSPlatform platform, IReadOnlyList<KeyGesture?> gestures) in
+                     settingsStore.Restore(GetFullName(entry)))
             {
-                // デフォルトのGestureがある場合、それを上書きする
-                for (int index = 0; index < entry.KeyGestures.Count; index++)
+                // 保存されたリストでデフォルトのGestureをスロット順に上書きする。保存された
+                // リストがデフォルトより短い場合、残りのスロットはデフォルトのまま維持する。
+                int seen = 0;
+                for (int index = 0; index < entry.KeyGestures.Count && seen < gestures.Count; index++)
                 {
-                    ContextCommandParsedKeyGesture j = entry.KeyGestures[index];
-                    if (j.Platform == i.Platform)
-                    {
-                        entry.KeyGestures[index] = i;
-                        goto NextItem;
-                    }
+                    if (entry.KeyGestures[index].Platform != platform) continue;
+
+                    entry.KeyGestures[index] = new ContextCommandParsedKeyGesture(gestures[seen], platform);
+                    seen++;
                 }
 
-                // プラットフォームが指定されていない場合、先頭に追加する
-                entry.KeyGestures.Add(i);
-
-            NextItem:;
+                // デフォルトに無いスロットは追加する
+                for (; seen < gestures.Count; seen++)
+                {
+                    entry.KeyGestures.Add(new ContextCommandParsedKeyGesture(gestures[seen], platform));
+                }
             }
         }
     }
@@ -280,6 +297,7 @@ public class ContextCommandManager(
 public record ContextCommandSettingsStore : IBeutlApiResource
 {
     private readonly ILogger _logger = Log.CreateLogger<ContextCommandSettingsStore>();
+    private readonly bool _persist = true;
     private JsonObject _json = [];
 
     public ContextCommandSettingsStore()
@@ -287,7 +305,14 @@ public record ContextCommandSettingsStore : IBeutlApiResource
         RestoreAll();
     }
 
-    public void Save(string name, KeyGesture? keyGesture, OSPlatform os)
+    // Test seam: start from the given JSON and optionally skip writing keymap.json to disk.
+    internal ContextCommandSettingsStore(JsonObject json, bool persist)
+    {
+        _json = json;
+        _persist = persist;
+    }
+
+    public virtual void Save(string name, IReadOnlyList<KeyGesture?> gestures, OSPlatform os)
     {
         string platform = os.ToString();
         if (!_json.TryGetPropertyValue(platform, out var node)
@@ -297,7 +322,13 @@ public record ContextCommandSettingsStore : IBeutlApiResource
             _json[platform] = obj;
         }
 
-        obj[name] = keyGesture?.ToString();
+        var array = new JsonArray();
+        foreach (KeyGesture? gesture in gestures)
+        {
+            array.Add((JsonNode?)gesture?.ToString());
+        }
+
+        obj[name] = array;
 
         SaveAll();
     }
@@ -309,40 +340,53 @@ public record ContextCommandSettingsStore : IBeutlApiResource
                || key.Equals("OSX", StringComparison.OrdinalIgnoreCase);
     }
 
-    public IEnumerable<ContextCommandParsedKeyGesture> Restore(string name)
+    /// <summary>
+    /// The persisted per-platform gesture lists for a command, slot order preserved. A null
+    /// element is an explicitly cleared binding (distinct from an absent command, which keeps
+    /// its defaults). Entries written before multi-gesture support — a plain string or null
+    /// instead of an array — are read as a single-element list.
+    /// </summary>
+    public virtual IEnumerable<(OSPlatform Platform, IReadOnlyList<KeyGesture?> Gestures)> Restore(string name)
     {
         foreach (var (key, node) in _json)
         {
             if (!ValidateKey(key)) continue;
-            if (node is JsonObject obj && obj.TryGetPropertyValueAsJsonValue(name, out string? value))
-            {
-                ContextCommandParsedKeyGesture? gesture = null;
-                if (string.IsNullOrEmpty(value))
-                {
-                    gesture = new ContextCommandParsedKeyGesture(null, OSPlatform.Create(key));
-                }
-                else
-                {
-                    try
-                    {
-                        gesture = new ContextCommandParsedKeyGesture(KeyGesture.Parse(value), OSPlatform.Create(key));
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to parse key gesture: {KeyGesture}", value);
-                    }
-                }
+            if (node is not JsonObject obj || !obj.TryGetPropertyValue(name, out JsonNode? value)) continue;
 
-                if (gesture != null)
-                {
-                    yield return gesture;
-                }
-            }
+            List<KeyGesture?> gestures = value is JsonArray array
+                ? array.Select(ParseGesture).ToList()
+                : [ParseGesture(value)];
+
+            yield return (OSPlatform.Create(key), gestures);
+        }
+    }
+
+    // A gesture that no longer parses is treated as cleared rather than skipped, so the
+    // slots after it keep their positions.
+    private KeyGesture? ParseGesture(JsonNode? node)
+    {
+        if (node is not JsonValue value
+            || !value.TryGetValue(out string? text)
+            || string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            return KeyGesture.Parse(text);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse key gesture: {KeyGesture}", text);
+            return null;
         }
     }
 
     private void SaveAll()
     {
+        if (!_persist) return;
+
         string fileName = Path.Combine(Helper.AppRoot, "keymap.json");
         _json.JsonSave(fileName);
         _logger.LogInformation("Saved keymap to {FileName}", fileName);

--- a/src/Beutl.Editor.Components/Helpers/TrimDeltaCalculator.cs
+++ b/src/Beutl.Editor.Components/Helpers/TrimDeltaCalculator.cs
@@ -1,0 +1,16 @@
+﻿namespace Beutl.Editor.Components.Helpers;
+
+public static class TrimDeltaCalculator
+{
+    /// <summary>
+    /// The committed delta for a Slip / Roll / Slide drag: the press and release points are
+    /// snapped with the <em>same</em> <paramref name="snap"/> function, then subtracted. Snapping
+    /// both endpoints identically is what makes a no-move click near a cut resolve to a zero delta —
+    /// otherwise only the release endpoint snaps and the operation commits a spurious one-frame trim.
+    /// </summary>
+    public static TimeSpan SnappedDelta(TimeSpan pressTime, TimeSpan releaseTime, Func<TimeSpan, TimeSpan> snap)
+    {
+        ArgumentNullException.ThrowIfNull(snap);
+        return snap(releaseTime) - snap(pressTime);
+    }
+}

--- a/src/Beutl.Editor.Components/Helpers/TrimDeltaCalculator.cs
+++ b/src/Beutl.Editor.Components/Helpers/TrimDeltaCalculator.cs
@@ -13,4 +13,15 @@ public static class TrimDeltaCalculator
         ArgumentNullException.ThrowIfNull(snap);
         return snap(releaseTime) - snap(pressTime);
     }
+
+    /// <summary>
+    /// Clamp a trim delta into the <c>[min, max]</c> window the resize service reported at
+    /// drag start, so the per-pointer-frame preview never overshoots what the release commit
+    /// will apply. Throws when <paramref name="min"/> exceeds <paramref name="max"/> — the
+    /// service guarantees <c>Min ≤ 0 ≤ Max</c>, so an inverted window is a caller bug.
+    /// </summary>
+    public static TimeSpan ClampDelta(TimeSpan delta, TimeSpan min, TimeSpan max)
+    {
+        return TimeSpan.FromTicks(Math.Clamp(delta.Ticks, min.Ticks, max.Ticks));
+    }
 }

--- a/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/TimelineTabExtension.cs
@@ -121,6 +121,33 @@ public sealed class TimelineTabExtension : ToolTabExtension
         [
             new ContextCommandKeyGesture("B"),
         ]),
+        new ContextCommandDefinition("ToggleSlipMode", Strings.SlipTool, Strings.SlipTool_Description,
+        [
+            new ContextCommandKeyGesture("S"),
+        ]),
+        new ContextCommandDefinition("ExitSlipMode", Strings.ExitSlipTool, Strings.ExitSlipTool_Description,
+        [
+            new ContextCommandKeyGesture("V"),
+            new ContextCommandKeyGesture("Escape"),
+        ]),
+        new ContextCommandDefinition("ToggleRollMode", Strings.RollTool, Strings.RollTool_Description,
+        [
+            new ContextCommandKeyGesture("R"),
+        ]),
+        new ContextCommandDefinition("ExitRollMode", Strings.ExitRollTool, Strings.ExitRollTool_Description,
+        [
+            new ContextCommandKeyGesture("V"),
+            new ContextCommandKeyGesture("Escape"),
+        ]),
+        new ContextCommandDefinition("ToggleSlideMode", Strings.SlideTool, Strings.SlideTool_Description,
+        [
+            new ContextCommandKeyGesture("D"),
+        ]),
+        new ContextCommandDefinition("ExitSlideMode", Strings.ExitSlideTool, Strings.ExitSlideTool_Description,
+        [
+            new ContextCommandKeyGesture("V"),
+            new ContextCommandKeyGesture("Escape"),
+        ]),
         new ContextCommandDefinition("CloseGap", Strings.CloseGap, "",
         [
             new ContextCommandKeyGesture("OemSemicolon"),

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -392,7 +392,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public ReactivePropertySlim<bool> IsRazorMode { get; } = new();
 
-    // Tool mode flags are switched through EnterRazorMode/EnterTrimMode.
+    // Mutually exclusive with IsRazorMode and each other; SubscribeToolMode/EnforceSingleToolMode
+    // clears the other flags whenever one becomes true, however it was set.
     public ReactivePropertySlim<bool> IsSlipMode { get; } = new();
     public ReactivePropertySlim<bool> IsRollMode { get; } = new();
     public ReactivePropertySlim<bool> IsSlideMode { get; } = new();

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -33,6 +33,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private readonly Subject<System.Reactive.Unit> _canExecuteChangedSubject = new();
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
     private bool _isDisposed;
+    private bool _updatingToolMode;
 
     public TimelineTabViewModel(IEditorContext editorContext)
     {
@@ -226,19 +227,10 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 BufferStatus.UpdateBlocks();
             });
 
-        // CanExecute がレイザーモード切替に追従するよう変更通知へ流す。
-        IsRazorMode
-            .Subscribe(_ => RaiseCanExecuteChanged())
-            .AddTo(_disposables);
-        IsSlipMode
-            .Subscribe(_ => RaiseCanExecuteChanged())
-            .AddTo(_disposables);
-        IsRollMode
-            .Subscribe(_ => RaiseCanExecuteChanged())
-            .AddTo(_disposables);
-        IsSlideMode
-            .Subscribe(_ => RaiseCanExecuteChanged())
-            .AddTo(_disposables);
+        SubscribeToolMode(IsRazorMode);
+        SubscribeToolMode(IsSlipMode);
+        SubscribeToolMode(IsRollMode);
+        SubscribeToolMode(IsSlideMode);
 
         // The Undo/Redo flush hook now lives in ElementNudgeService, wired to
         // HistoryManager.BeforeMutation by the editor context.
@@ -251,6 +243,38 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         if (!_isDisposed)
         {
             _canExecuteChangedSubject.OnNext(System.Reactive.Unit.Default);
+        }
+    }
+
+    private void SubscribeToolMode(ReactivePropertySlim<bool> mode)
+    {
+        mode.Subscribe(isEnabled =>
+            {
+                if (isEnabled)
+                {
+                    EnforceSingleToolMode(mode);
+                }
+
+                RaiseCanExecuteChanged();
+            })
+            .AddTo(_disposables);
+    }
+
+    private void EnforceSingleToolMode(ReactivePropertySlim<bool> activeMode)
+    {
+        if (_updatingToolMode) return;
+
+        _updatingToolMode = true;
+        try
+        {
+            if (!ReferenceEquals(activeMode, IsRazorMode)) IsRazorMode.Value = false;
+            if (!ReferenceEquals(activeMode, IsSlipMode)) IsSlipMode.Value = false;
+            if (!ReferenceEquals(activeMode, IsRollMode)) IsRollMode.Value = false;
+            if (!ReferenceEquals(activeMode, IsSlideMode)) IsSlideMode.Value = false;
+        }
+        finally
+        {
+            _updatingToolMode = false;
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -368,8 +368,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public ReactivePropertySlim<bool> IsRazorMode { get; } = new();
 
-    // Slip / Roll / Slide trim tool modes. Mutually exclusive with each other and
-    // with IsRazorMode — the Execute cases clear every other flag when one is set.
+    // Tool mode flags are switched through EnterRazorMode/EnterTrimMode.
     public ReactivePropertySlim<bool> IsSlipMode { get; } = new();
     public ReactivePropertySlim<bool> IsRollMode { get; } = new();
     public ReactivePropertySlim<bool> IsSlideMode { get; } = new();
@@ -1044,7 +1043,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
                 break;
             case "ToggleRazorMode" when !IsTextInputFocused(execution.KeyEventArgs):
-                IsRazorMode.Value = !IsRazorMode.Value;
+                EnterRazorMode();
                 if (execution.KeyEventArgs != null)
                 {
                     execution.KeyEventArgs.Handled = true;
@@ -1350,6 +1349,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         TimeSpan target = visibleStart + new TimeSpan((visibleEnd - visibleStart).Ticks / 2);
         bool whollyInside = g.Range.Start >= sceneStart && g.Range.End <= sceneEnd;
         return (target, g.ZIndex, whollyInside ? g.Anchor : null);
+    }
+
+    private void EnterRazorMode()
+    {
+        bool next = !IsRazorMode.Value;
+        IsRazorMode.Value = false;
+        IsSlipMode.Value = false;
+        IsRollMode.Value = false;
+        IsSlideMode.Value = false;
+        IsRazorMode.Value = next;
     }
 
     private void EnterTrimMode(ReactivePropertySlim<bool> mode)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -230,6 +230,15 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         IsRazorMode
             .Subscribe(_ => RaiseCanExecuteChanged())
             .AddTo(_disposables);
+        IsSlipMode
+            .Subscribe(_ => RaiseCanExecuteChanged())
+            .AddTo(_disposables);
+        IsRollMode
+            .Subscribe(_ => RaiseCanExecuteChanged())
+            .AddTo(_disposables);
+        IsSlideMode
+            .Subscribe(_ => RaiseCanExecuteChanged())
+            .AddTo(_disposables);
 
         // The Undo/Redo flush hook now lives in ElementNudgeService, wired to
         // HistoryManager.BeforeMutation by the editor context.
@@ -358,6 +367,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     public HashSet<ElementViewModel> SelectedElements { get; } = [];
 
     public ReactivePropertySlim<bool> IsRazorMode { get; } = new();
+
+    // Slip / Roll / Slide trim tool modes. Mutually exclusive with each other and
+    // with IsRazorMode — the Execute cases clear every other flag when one is set.
+    public ReactivePropertySlim<bool> IsSlipMode { get; } = new();
+    public ReactivePropertySlim<bool> IsRollMode { get; } = new();
+    public ReactivePropertySlim<bool> IsSlideMode { get; } = new();
 
     public ToolTabExtension Extension => TimelineTabExtension.Instance;
 
@@ -944,7 +959,12 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
             "ToggleGroup" => SelectedElements.FirstOrDefault() is { } first
                 && (first.CanUngroupSelectedElements() || first.CanGroupSelectedElements()),
             "ExitRazorMode" => IsRazorMode.Value,
-            "Paste" or "SetStartTime" or "SetEndTime" or "ToggleRazorMode" or "ToggleRippleMode"
+            "ExitSlipMode" => IsSlipMode.Value,
+            "ExitRollMode" => IsRollMode.Value,
+            "ExitSlideMode" => IsSlideMode.Value,
+            "Paste" or "SetStartTime" or "SetEndTime"
+                or "ToggleRazorMode" or "ToggleRippleMode" or "ToggleSlipMode"
+                or "ToggleRollMode" or "ToggleSlideMode"
                 or "CloseAllGaps" or "GoToNextGap" or "GoToPreviousGap" => true,
             // Rename / Split など Execute で対応 case が無いコマンドは false を返し、
             // パレットやショートカット経路で誤って enabled として扱われないようにする。
@@ -1043,6 +1063,63 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
                 if (IsRazorMode.Value)
                 {
                     IsRazorMode.Value = false;
+                    if (execution.KeyEventArgs != null)
+                    {
+                        execution.KeyEventArgs.Handled = true;
+                    }
+                }
+
+                break;
+            case "ToggleSlipMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                EnterTrimMode(IsSlipMode);
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "ToggleRollMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                EnterTrimMode(IsRollMode);
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "ToggleSlideMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                EnterTrimMode(IsSlideMode);
+                if (execution.KeyEventArgs != null)
+                {
+                    execution.KeyEventArgs.Handled = true;
+                }
+
+                break;
+            case "ExitSlipMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                if (IsSlipMode.Value)
+                {
+                    IsSlipMode.Value = false;
+                    if (execution.KeyEventArgs != null)
+                    {
+                        execution.KeyEventArgs.Handled = true;
+                    }
+                }
+
+                break;
+            case "ExitRollMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                if (IsRollMode.Value)
+                {
+                    IsRollMode.Value = false;
+                    if (execution.KeyEventArgs != null)
+                    {
+                        execution.KeyEventArgs.Handled = true;
+                    }
+                }
+
+                break;
+            case "ExitSlideMode" when !IsTextInputFocused(execution.KeyEventArgs):
+                if (IsSlideMode.Value)
+                {
+                    IsSlideMode.Value = false;
                     if (execution.KeyEventArgs != null)
                     {
                         execution.KeyEventArgs.Handled = true;
@@ -1273,6 +1350,16 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         TimeSpan target = visibleStart + new TimeSpan((visibleEnd - visibleStart).Ticks / 2);
         bool whollyInside = g.Range.Start >= sceneStart && g.Range.End <= sceneEnd;
         return (target, g.ZIndex, whollyInside ? g.Anchor : null);
+    }
+
+    private void EnterTrimMode(ReactivePropertySlim<bool> mode)
+    {
+        bool next = !mode.Value;
+        IsRazorMode.Value = false;
+        IsSlipMode.Value = false;
+        IsRollMode.Value = false;
+        IsSlideMode.Value = false;
+        mode.Value = next;
     }
 
     private enum NudgeUnit { Frame, Large, Second }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -74,18 +74,36 @@
                         </Style>
                     </ui:ToggleMenuFlyoutItem.Styles>
                 </ui:ToggleMenuFlyoutItem>
-                <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRazorMode.Value, Mode=TwoWay}"
-                                         InputGesture="{h:GetCommandGesture ToggleRazorMode,
-                                                                            ExtensionType={x:Type p:TimelineTabExtension}}"
-                                         Text="{x:Static lang:Strings.RazorTool}">
-                    <ui:ToggleMenuFlyoutItem.IconSource>
-                        <icons:FluentIconSource Icon="Cut" />
-                    </ui:ToggleMenuFlyoutItem.IconSource>
-                </ui:ToggleMenuFlyoutItem>
-                <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRippleEnabled.Value, Mode=TwoWay}"
-                                         InputGesture="{h:GetCommandGesture ToggleRippleMode,
-                                                                            ExtensionType={x:Type p:TimelineTabExtension}}"
-                                         Text="{x:Static lang:Strings.RippleEdit}" />
+                <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
+                    <ui:MenuFlyoutSubItem.IconSource>
+                        <icons:FluentIconSource Icon="Edit" />
+                    </ui:MenuFlyoutSubItem.IconSource>
+                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRazorMode.Value, Mode=TwoWay}"
+                                             InputGesture="{h:GetCommandGesture ToggleRazorMode,
+                                                                                ExtensionType={x:Type p:TimelineTabExtension}}"
+                                             Text="{x:Static lang:Strings.RazorTool}">
+                        <ui:ToggleMenuFlyoutItem.IconSource>
+                            <icons:FluentIconSource Icon="Cut" />
+                        </ui:ToggleMenuFlyoutItem.IconSource>
+                    </ui:ToggleMenuFlyoutItem>
+                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlipMode.Value, Mode=TwoWay}"
+                                             InputGesture="{h:GetCommandGesture ToggleSlipMode,
+                                                                                ExtensionType={x:Type p:TimelineTabExtension}}"
+                                             Text="{x:Static lang:Strings.SlipTool}" />
+                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRollMode.Value, Mode=TwoWay}"
+                                             InputGesture="{h:GetCommandGesture ToggleRollMode,
+                                                                                ExtensionType={x:Type p:TimelineTabExtension}}"
+                                             Text="{x:Static lang:Strings.RollTool}" />
+                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlideMode.Value, Mode=TwoWay}"
+                                             InputGesture="{h:GetCommandGesture ToggleSlideMode,
+                                                                                ExtensionType={x:Type p:TimelineTabExtension}}"
+                                             Text="{x:Static lang:Strings.SlideTool}" />
+                    <ui:MenuFlyoutSeparator />
+                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRippleEnabled.Value, Mode=TwoWay}"
+                                             InputGesture="{h:GetCommandGesture ToggleRippleMode,
+                                                                                ExtensionType={x:Type p:TimelineTabExtension}}"
+                                             Text="{x:Static lang:Strings.RippleEdit}" />
+                </ui:MenuFlyoutSubItem>
                 <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutItem x:Name="split"
                                    Command="{Binding Split}"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -544,6 +544,13 @@ public sealed partial class ElementView : UserControl
 
                 if (leftButton && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
+                    // In Slip mode an edge press is a slip, handled by _MoveBehavior; leave the
+                    // event unconsumed so a plain edge resize does not run in its place.
+                    if (viewModel.Timeline.IsSlipMode.Value)
+                    {
+                        return;
+                    }
+
                     Point timelinePosition = e.GetPosition(view);
                     if (viewModel.Timeline.IsRollMode.Value)
                     {
@@ -943,18 +950,24 @@ public sealed partial class ElementView : UserControl
                 }
 
                 PointerPoint point = e.GetCurrentPoint(view.border);
-                if (point.Properties.IsLeftButtonPressed
-                    && (view.Cursor == Cursors.Arrow || view.Cursor == null))
+                if (!point.Properties.IsLeftButtonPressed)
                 {
-                    if (viewModel.Timeline.IsSlipMode.Value)
-                    {
-                        _pressed = true;
-                        _isSlipDrag = true;
-                        _start = e.GetPosition(view);
-                        e.Handled = true;
-                        return;
-                    }
+                    return;
+                }
 
+                // Slip shifts the media window, not clip geometry, so it starts anywhere on the clip
+                // — including the resize edge, where a plain resize would otherwise take over.
+                if (viewModel.Timeline.IsSlipMode.Value)
+                {
+                    _pressed = true;
+                    _isSlipDrag = true;
+                    _start = e.GetPosition(view);
+                    e.Handled = true;
+                    return;
+                }
+
+                if (view.Cursor == Cursors.Arrow || view.Cursor == null)
+                {
                     if (viewModel.Timeline.IsRollMode.Value || viewModel.Timeline.IsSlideMode.Value)
                     {
                         e.Handled = true;

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -689,19 +689,14 @@ public sealed partial class ElementView : UserControl
                         float scale = viewModel.Timeline.Options.Value.Scale;
                         int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                         Point released = e.GetPosition(AssociatedObject);
-                        TimeSpan releasedFrame = released.X.PixelToTimeSpan(scale);
-                        releasedFrame = AssociatedObject.RoundStartTime(
-                            releasedFrame,
-                            scale,
-                            e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-                        TimeSpan initialFrame = ctx.InitialPointerX.PixelToTimeSpan(scale);
-                        // Snap the press point the same way as the release, so a no-move click near
-                        // a cut does not snap only one endpoint and commit a spurious one-frame trim.
-                        initialFrame = AssociatedObject.RoundStartTime(
-                            initialFrame,
-                            scale,
-                            e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-                        TimeSpan delta = (releasedFrame - initialFrame).RoundToRate(rate);
+                        bool alt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+                        TimeSpan delta = TrimDeltaCalculator.SnappedDelta(
+                                ctx.InitialPointerX.PixelToTimeSpan(scale),
+                                released.X.PixelToTimeSpan(scale),
+                                t => AssociatedObject.RoundStartTime(t, scale, alt))
+                            .RoundToRate(rate);
+                        // RoundStartTime re-sets the snap guide line as a side effect; clear it.
+                        viewModel.Timeline.SnapBarPosition.Value = null;
 
                         RestoreTrimDragVisuals(ctx);
 
@@ -978,15 +973,14 @@ public sealed partial class ElementView : UserControl
         private void CommitSlipDrag(ElementView view, ElementViewModel viewModel, PointerReleasedEventArgs e)
         {
             float scale = viewModel.Timeline.Options.Value.Scale;
-            int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
             Point released = e.GetPosition(view);
-            TimeSpan pointerFrame = released.X.PixelToTimeSpan(scale);
-            pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-            // Snap the press point the same way, so a no-move click near a cut does not snap only
-            // the release endpoint and shift the media window without any pointer movement.
-            TimeSpan startFrame = view.RoundStartTime(
-                _start.X.PixelToTimeSpan(scale), scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-            TimeSpan delta = pointerFrame - startFrame;
+            bool alt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+            TimeSpan delta = TrimDeltaCalculator.SnappedDelta(
+                _start.X.PixelToTimeSpan(scale),
+                released.X.PixelToTimeSpan(scale),
+                t => view.RoundStartTime(t, scale, alt));
+            // RoundStartTime re-sets the snap guide line as a side effect; clear it.
+            viewModel.Timeline.SnapBarPosition.Value = null;
             if (delta != TimeSpan.Zero)
             {
                 viewModel.Timeline.EditorContext

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -1078,7 +1078,7 @@ public sealed partial class ElementView : UserControl
             {
                 viewModel.Timeline.EditorContext
                     .GetRequiredService<IElementSlipService>()
-                    .Slip(viewModel.Model, delta);
+                    .Slip(viewModel.Scene, viewModel.Model, delta);
             }
         }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -362,9 +362,24 @@ public sealed partial class ElementView : UserControl
             TimeSpan? LeftmostUpstreamStart,
             TimeSpan? OriginalDuration);
 
+        private enum TrimDragKind { None, Roll, Slide }
+
+        private record struct TrimDragContext(
+            TrimDragKind Kind,
+            ElementViewModel Front,
+            ElementViewModel? Middle,
+            ElementViewModel Back,
+            double InitialFrontWidth,
+            double InitialMiddleLeft,
+            double InitialMiddleWidth,
+            double InitialBackLeft,
+            double InitialBackWidth,
+            double InitialPointerX);
+
         private bool _pressed;
         private AlignmentX _resizeType;
         private ElementResizeContext[] _resizeContexts = [];
+        private TrimDragContext _trimDrag;
 
         public void OnLeftCtrlPressed(KeyEventArgs e)
         {
@@ -413,6 +428,13 @@ public sealed partial class ElementView : UserControl
                     point = point.WithX(pointerFrame.TimeToPixel(scale));
                     int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                     double minWidth = TimeSpan.FromSeconds(1d / rate).TimeToPixel(scale);
+
+                    if (_trimDrag.Kind is not TrimDragKind.None)
+                    {
+                        ApplyTrimDragPreview(point.X, minWidth);
+                        e.Handled = true;
+                        return;
+                    }
 
                     if (view.Cursor != Cursors.Arrow && view.Cursor is { })
                     {
@@ -466,6 +488,28 @@ public sealed partial class ElementView : UserControl
             }
         }
 
+        private void ApplyTrimDragPreview(double pointerX, double minWidth)
+        {
+            TrimDragContext ctx = _trimDrag;
+            double delta = pointerX - ctx.InitialPointerX;
+
+            double frontWidth = Math.Max(ctx.InitialFrontWidth + delta, minWidth);
+            double backWidth = Math.Max(ctx.InitialBackWidth - delta, minWidth);
+            double actualDelta = Math.Min(
+                frontWidth - ctx.InitialFrontWidth,
+                ctx.InitialBackWidth - backWidth);
+
+            ctx.Front.Width.Value = ctx.InitialFrontWidth + actualDelta;
+            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft + actualDelta, 0, 0, 0);
+            ctx.Back.Width.Value = ctx.InitialBackWidth - actualDelta;
+
+            if (ctx.Middle is { } middle)
+            {
+                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft + actualDelta, 0, 0, 0);
+                middle.Width.Value = ctx.InitialMiddleWidth;
+            }
+        }
+
         private void OnBorderPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             if (AssociatedObject is { _timeline: not null, ViewModel: { } viewModel } view)
@@ -484,6 +528,20 @@ public sealed partial class ElementView : UserControl
                 if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
+                    if (viewModel.Timeline.IsRollMode.Value && TryStartRollDrag(viewModel, point.Position, view))
+                    {
+                        _pressed = true;
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (viewModel.Timeline.IsSlideMode.Value && TryStartSlideDrag(viewModel, point.Position, view))
+                    {
+                        _pressed = true;
+                        e.Handled = true;
+                        return;
+                    }
+
                     IReadOnlyList<ElementViewModel> relatedElements = viewModel.GetGroupOrSelectedElements()
                         .Where(el => el.IsEditable.Value)
                         .ToArray();
@@ -535,6 +593,73 @@ public sealed partial class ElementView : UserControl
             }
         }
 
+        private bool TryStartRollDrag(ElementViewModel viewModel, Point position, ElementView view)
+        {
+            if (_resizeType is not (AlignmentX.Left or AlignmentX.Right)) return false;
+
+            Element model = viewModel.Model;
+            Element? frontModel;
+            Element? backModel;
+            if (_resizeType == AlignmentX.Right)
+            {
+                frontModel = model;
+                backModel = model.GetAfter(model.ZIndex, model.Range.End);
+            }
+            else
+            {
+                frontModel = model.GetBefore(model.ZIndex, model.Start);
+                backModel = model;
+            }
+
+            if (frontModel is null || backModel is null) return false;
+            if (frontModel.Range.End != backModel.Start) return false;
+
+            ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(frontModel);
+            ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
+            if (frontVm is null || backVm is null) return false;
+
+            _trimDrag = new TrimDragContext(
+                Kind: TrimDragKind.Roll,
+                Front: frontVm,
+                Middle: null,
+                Back: backVm,
+                InitialFrontWidth: frontVm.Width.Value,
+                InitialMiddleLeft: 0,
+                InitialMiddleWidth: 0,
+                InitialBackLeft: backVm.BorderMargin.Value.Left,
+                InitialBackWidth: backVm.Width.Value,
+                InitialPointerX: position.X);
+            return true;
+        }
+
+        private bool TryStartSlideDrag(ElementViewModel viewModel, Point position, ElementView view)
+        {
+            Element middleModel = viewModel.Model;
+            Element? frontModel = middleModel.GetBefore(middleModel.ZIndex, middleModel.Start);
+            Element? backModel = middleModel.GetAfter(middleModel.ZIndex, middleModel.Range.End);
+            if (frontModel is null || backModel is null) return false;
+            if (frontModel.Range.End != middleModel.Start) return false;
+            if (middleModel.Range.End != backModel.Start) return false;
+
+            ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(frontModel);
+            ElementViewModel? middleVm = viewModel.Timeline.GetViewModelFor(middleModel);
+            ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
+            if (frontVm is null || middleVm is null || backVm is null) return false;
+
+            _trimDrag = new TrimDragContext(
+                Kind: TrimDragKind.Slide,
+                Front: frontVm,
+                Middle: middleVm,
+                Back: backVm,
+                InitialFrontWidth: frontVm.Width.Value,
+                InitialMiddleLeft: middleVm.BorderMargin.Value.Left,
+                InitialMiddleWidth: middleVm.Width.Value,
+                InitialBackLeft: backVm.BorderMargin.Value.Left,
+                InitialBackWidth: backVm.Width.Value,
+                InitialPointerX: position.X);
+            return true;
+        }
+
         private async void OnBorderPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
             if (_pressed)
@@ -545,6 +670,35 @@ public sealed partial class ElementView : UserControl
                 {
                     viewModel.Timeline.SnapBarPosition.Value = null;
                     e.Handled = true;
+
+                    if (_trimDrag.Kind is not TrimDragKind.None)
+                    {
+                        TrimDragContext ctx = _trimDrag;
+                        _trimDrag = default;
+
+                        float scale = viewModel.Timeline.Options.Value.Scale;
+                        int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+                        Point released = e.GetPosition(AssociatedObject);
+                        double deltaPixel = released.X - ctx.InitialPointerX;
+                        TimeSpan delta = deltaPixel.PixelToTimeSpan(scale).RoundToRate(rate);
+
+                        if (delta != TimeSpan.Zero)
+                        {
+                            IElementResizeService resizeService = viewModel.Timeline.EditorContext
+                                .GetRequiredService<IElementResizeService>();
+                            if (ctx.Kind == TrimDragKind.Roll)
+                            {
+                                resizeService.Roll(viewModel.Scene, ctx.Front.Model, ctx.Back.Model, delta);
+                            }
+                            else
+                            {
+                                resizeService.Slide(viewModel.Scene, ctx.Front.Model, ctx.Middle!.Model, ctx.Back.Model, delta);
+                            }
+                        }
+
+                        RestoreTrimDragVisuals(ctx);
+                        return;
+                    }
 
                     bool ripple = viewModel.Timeline.IsRippleEnabled.Value
                         && _resizeType is AlignmentX.Right or AlignmentX.Left;
@@ -589,6 +743,18 @@ public sealed partial class ElementView : UserControl
                 }
 
                 _resizeContexts = [];
+            }
+        }
+
+        private static void RestoreTrimDragVisuals(TrimDragContext ctx)
+        {
+            ctx.Front.Width.Value = ctx.InitialFrontWidth;
+            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft, 0, 0, 0);
+            ctx.Back.Width.Value = ctx.InitialBackWidth;
+            if (ctx.Middle is { } middle)
+            {
+                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft, 0, 0, 0);
+                middle.Width.Value = ctx.InitialMiddleWidth;
             }
         }
 
@@ -657,6 +823,7 @@ public sealed partial class ElementView : UserControl
 
         private bool _pressed;
         private bool _duplicateMode;
+        private bool _isSlipDrag;
         private readonly List<Control> _ghosts = [];
         private IReadOnlyList<ElementViewModel> _relatedElements = [];
         private Point _start;
@@ -693,6 +860,15 @@ public sealed partial class ElementView : UserControl
                 TimeSpan pointerFrame = point.X.PixelToTimeSpan(scale);
 
                 pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+
+                if (_isSlipDrag)
+                {
+                    // Slip shifts the media window, not element geometry — there is no
+                    // per-frame geometry preview to apply here. The Player overlay shows
+                    // the media window shift; the service runs once on release.
+                    e.Handled = true;
+                    return;
+                }
 
                 TimeSpan newframe = pointerFrame - _start.X.PixelToTimeSpan(scale);
 
@@ -749,6 +925,15 @@ public sealed partial class ElementView : UserControl
                 if (point.Properties.IsLeftButtonPressed
                     && (view.Cursor == Cursors.Arrow || view.Cursor == null))
                 {
+                    if (viewModel.Timeline.IsSlipMode.Value)
+                    {
+                        _pressed = true;
+                        _isSlipDrag = true;
+                        _start = point.Position;
+                        e.Handled = true;
+                        return;
+                    }
+
                     _pressed = true;
                     _duplicateMode = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
                     _relatedElements = viewModel.GetGroupOrSelectedElements()
@@ -759,6 +944,22 @@ public sealed partial class ElementView : UserControl
                     _start = point.Position;
                     e.Handled = true;
                 }
+            }
+        }
+
+        private void CommitSlipDrag(ElementViewModel viewModel, PointerReleasedEventArgs e)
+        {
+            float scale = viewModel.Timeline.Options.Value.Scale;
+            int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
+            Point released = e.GetPosition(AssociatedObject);
+            TimeSpan pointerFrame = released.X.PixelToTimeSpan(scale);
+            pointerFrame = AssociatedObject.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+            TimeSpan delta = pointerFrame - _start.X.PixelToTimeSpan(scale);
+            if (delta != TimeSpan.Zero)
+            {
+                viewModel.Timeline.EditorContext
+                    .GetRequiredService<IElementSlipService>()
+                    .Slip(viewModel.Model, delta);
             }
         }
 
@@ -800,6 +1001,14 @@ public sealed partial class ElementView : UserControl
 
             viewModel.Timeline.SnapBarPosition.Value = null;
             e.Handled = true;
+
+            if (_isSlipDrag)
+            {
+                _isSlipDrag = false;
+                CommitSlipDrag(viewModel, e);
+                return;
+            }
+
             var elems = relatedElements.Select(x => x.Model).ToArray();
 
             float scale = viewModel.Timeline.Options.Value.Scale;

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -495,6 +495,9 @@ public sealed partial class ElementView : UserControl
 
             double floor = minWidth - ctx.InitialFrontWidth;
             double ceiling = ctx.InitialBackWidth - minWidth;
+            if (floor > ceiling)
+                return;
+
             double actualDelta = Math.Clamp(delta, floor, ceiling);
 
             ctx.Front.Width.Value = ctx.InitialFrontWidth + actualDelta;
@@ -526,9 +529,10 @@ public sealed partial class ElementView : UserControl
                 if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
+                    Point timelinePosition = e.GetPosition(view);
                     if (viewModel.Timeline.IsRollMode.Value)
                     {
-                        if (TryStartRollDrag(viewModel, point.Position, view))
+                        if (TryStartRollDrag(viewModel, timelinePosition, view))
                         {
                             _pressed = true;
                         }
@@ -539,7 +543,7 @@ public sealed partial class ElementView : UserControl
 
                     if (viewModel.Timeline.IsSlideMode.Value)
                     {
-                        if (TryStartSlideDrag(viewModel, point.Position, view))
+                        if (TryStartSlideDrag(viewModel, timelinePosition, view))
                         {
                             _pressed = true;
                         }
@@ -693,6 +697,8 @@ public sealed partial class ElementView : UserControl
                         TimeSpan initialFrame = ctx.InitialPointerX.PixelToTimeSpan(scale);
                         TimeSpan delta = (releasedFrame - initialFrame).RoundToRate(rate);
 
+                        RestoreTrimDragVisuals(ctx);
+
                         if (delta != TimeSpan.Zero)
                         {
                             IElementResizeService resizeService = viewModel.Timeline.EditorContext
@@ -707,7 +713,6 @@ public sealed partial class ElementView : UserControl
                             }
                         }
 
-                        RestoreTrimDragVisuals(ctx);
                         return;
                     }
 
@@ -940,7 +945,13 @@ public sealed partial class ElementView : UserControl
                     {
                         _pressed = true;
                         _isSlipDrag = true;
-                        _start = point.Position;
+                        _start = e.GetPosition(view);
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (viewModel.Timeline.IsRollMode.Value || viewModel.Timeline.IsSlideMode.Value)
+                    {
                         e.Handled = true;
                         return;
                     }
@@ -958,13 +969,13 @@ public sealed partial class ElementView : UserControl
             }
         }
 
-        private void CommitSlipDrag(ElementViewModel viewModel, PointerReleasedEventArgs e)
+        private void CommitSlipDrag(ElementView view, ElementViewModel viewModel, PointerReleasedEventArgs e)
         {
             float scale = viewModel.Timeline.Options.Value.Scale;
             int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-            Point released = e.GetPosition(AssociatedObject);
+            Point released = e.GetPosition(view);
             TimeSpan pointerFrame = released.X.PixelToTimeSpan(scale);
-            pointerFrame = AssociatedObject.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+            pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
             TimeSpan delta = pointerFrame - _start.X.PixelToTimeSpan(scale);
             if (delta != TimeSpan.Zero)
             {
@@ -1006,7 +1017,7 @@ public sealed partial class ElementView : UserControl
             IReadOnlyList<ElementViewModel> relatedElements = _relatedElements;
             _relatedElements = [];
 
-            if (AssociatedObject is not { ViewModel: { } viewModel, _timeline: { } timeline }) return;
+            if (AssociatedObject is not { ViewModel: { } viewModel, _timeline: { } timeline } view) return;
 
             RemoveGhosts(timeline);
 
@@ -1016,7 +1027,7 @@ public sealed partial class ElementView : UserControl
             if (_isSlipDrag)
             {
                 _isSlipDrag = false;
-                CommitSlipDrag(viewModel, e);
+                CommitSlipDrag(view, viewModel, e);
                 return;
             }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -352,13 +352,14 @@ public sealed partial class ElementView : UserControl
     }
 
     // The model-level member set a Slip/Roll/Slide gesture acts on: the pressed clip's
-    // group or multi-selection, minus non-editable members, always including the pressed
-    // clip itself (GetGroupOrSelectedElements returns empty when it is neither grouped
-    // nor selected).
+    // group or multi-selection, always including the pressed clip itself
+    // (GetGroupOrSelectedElements returns empty when it is neither grouped nor selected).
+    // Locked members are deliberately NOT filtered here: TrimGroupCollector needs to see
+    // them to apply its all-or-nothing locked-participant rule for Roll/Slide, and the
+    // slip service drops them itself at the mutation boundary.
     private static Element[] CollectTrimMembers(ElementViewModel viewModel)
     {
         var members = viewModel.GetGroupOrSelectedElements()
-            .Where(el => el.IsEditable.Value)
             .Select(el => el.Model)
             .ToList();
         if (!members.Contains(viewModel.Model))

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -1020,8 +1020,15 @@ public sealed partial class ElementView : UserControl
 
                 // Slip shifts the media window, not clip geometry, so it starts anywhere on the clip
                 // — including the resize edge, where a plain resize would otherwise take over.
+                // Selection-modifier clicks (Ctrl/Shift) belong to _SelectBehavior and must not
+                // start a slip; Alt stays allowed as the snap-disable modifier, like other drags.
                 if (viewModel.Timeline.IsSlipMode.Value)
                 {
+                    if (e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Alt))
+                    {
+                        return;
+                    }
+
                     _pressed = true;
                     _isSlipDrag = true;
                     _start = e.GetPosition(view);

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -402,6 +402,7 @@ public sealed partial class ElementView : UserControl
             AssociatedObject.border.AddHandler(PointerPressedEvent, OnBorderPointerPressed);
             AssociatedObject.border.AddHandler(PointerReleasedEvent, OnBorderPointerReleased);
             AssociatedObject.border.AddHandler(PointerMovedEvent, OnBorderPointerMoved);
+            AssociatedObject.border.AddHandler(PointerCaptureLostEvent, OnBorderPointerCaptureLost);
         }
 
         protected override void OnDetaching()
@@ -413,6 +414,26 @@ public sealed partial class ElementView : UserControl
                 AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
                 AssociatedObject.border.RemoveHandler(PointerReleasedEvent, OnBorderPointerReleased);
                 AssociatedObject.border.RemoveHandler(PointerMovedEvent, OnBorderPointerMoved);
+                AssociatedObject.border.RemoveHandler(PointerCaptureLostEvent, OnBorderPointerCaptureLost);
+            }
+        }
+
+        // A normal release also raises PointerCaptureLost (the implicit capture is released
+        // after PointerReleased), so this only acts when the trim-drag state is still live —
+        // i.e. the capture was stolen mid-drag (window deactivation, another control capturing,
+        // touch cancel). Without the restore, Roll/Slide would leave the neighbour clips frozen
+        // at their previewed geometry, out of sync with the model.
+        private void OnBorderPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            if (_trimDrag.Kind is TrimDragKind.None) return;
+
+            TrimDragContext ctx = _trimDrag;
+            _trimDrag = default;
+            _pressed = false;
+            RestoreTrimDragVisuals(ctx);
+            if (AssociatedObject is { ViewModel: { } viewModel })
+            {
+                viewModel.Timeline.SnapBarPosition.Value = null;
             }
         }
 
@@ -542,6 +563,10 @@ public sealed partial class ElementView : UserControl
                     if (TryStartSlideDrag(viewModel, e.GetPosition(view)))
                     {
                         _pressed = true;
+                        // Re-target Avalonia's implicit capture from the hit-tested child to the
+                        // border: PointerCaptureLost routes Direct (no bubbling), so the reset
+                        // handler below only fires reliably when the border itself is captured.
+                        e.Pointer.Capture(view.border);
                     }
 
                     e.Handled = true;
@@ -563,6 +588,7 @@ public sealed partial class ElementView : UserControl
                         if (TryStartRollDrag(viewModel, timelinePosition))
                         {
                             _pressed = true;
+                            e.Pointer.Capture(view.border);
                         }
 
                         e.Handled = true;
@@ -882,6 +908,7 @@ public sealed partial class ElementView : UserControl
             AssociatedObject.AddHandler(PointerMovedEvent, OnPointerMoved);
             AssociatedObject.border.AddHandler(PointerPressedEvent, OnBorderPointerPressed);
             AssociatedObject.border.AddHandler(PointerReleasedEvent, OnBorderPointerReleased);
+            AssociatedObject.border.AddHandler(PointerCaptureLostEvent, OnBorderPointerCaptureLost);
         }
 
         protected override void OnDetaching()
@@ -895,6 +922,24 @@ public sealed partial class ElementView : UserControl
             AssociatedObject.RemoveHandler(PointerMovedEvent, OnPointerMoved);
             AssociatedObject.border.RemoveHandler(PointerPressedEvent, OnBorderPointerPressed);
             AssociatedObject.border.RemoveHandler(PointerReleasedEvent, OnBorderPointerReleased);
+            AssociatedObject.border.RemoveHandler(PointerCaptureLostEvent, OnBorderPointerCaptureLost);
+        }
+
+        // A normal release also raises PointerCaptureLost (the implicit capture is released
+        // after PointerReleased), so this only acts while a slip drag is still live — i.e.
+        // the capture was stolen mid-drag (window deactivation, another control capturing,
+        // touch cancel). Slip has no geometry preview, so only the flags and the snap guide
+        // need resetting; the pending slip is intentionally dropped, not committed.
+        private void OnBorderPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            if (!_isSlipDrag) return;
+
+            _isSlipDrag = false;
+            _pressed = false;
+            if (AssociatedObject is { ViewModel: { } viewModel })
+            {
+                viewModel.Timeline.SnapBarPosition.Value = null;
+            }
         }
 
         private void OnPointerMoved(object? sender, PointerEventArgs e)
@@ -980,6 +1025,10 @@ public sealed partial class ElementView : UserControl
                     _pressed = true;
                     _isSlipDrag = true;
                     _start = e.GetPosition(view);
+                    // Re-target the implicit capture to the border: PointerCaptureLost routes
+                    // Direct (no bubbling), so the reset handler only fires reliably when the
+                    // border itself holds the capture.
+                    e.Pointer.Capture(view.border);
                     e.Handled = true;
                     return;
                 }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -351,6 +351,24 @@ public sealed partial class ElementView : UserControl
         return result.Time;
     }
 
+    // The model-level member set a Slip/Roll/Slide gesture acts on: the pressed clip's
+    // group or multi-selection, minus non-editable members, always including the pressed
+    // clip itself (GetGroupOrSelectedElements returns empty when it is neither grouped
+    // nor selected).
+    private static Element[] CollectTrimMembers(ElementViewModel viewModel)
+    {
+        var members = viewModel.GetGroupOrSelectedElements()
+            .Where(el => el.IsEditable.Value)
+            .Select(el => el.Model)
+            .ToList();
+        if (!members.Contains(viewModel.Model))
+        {
+            members.Add(viewModel.Model);
+        }
+
+        return [.. members];
+    }
+
     private sealed class _ResizeBehavior : Behavior<ElementView>
     {
         private record struct ElementResizeContext(
@@ -364,16 +382,18 @@ public sealed partial class ElementView : UserControl
 
         private enum TrimDragKind { None, Roll, Slide }
 
+        private record struct TrimSegment(
+            ElementViewModel ViewModel,
+            double InitialLeft,
+            double InitialWidth);
+
         private record struct TrimDragContext(
             TrimDragKind Kind,
-            ElementViewModel Front,
-            ElementViewModel? Middle,
-            ElementViewModel Back,
-            double InitialFrontWidth,
-            double InitialMiddleLeft,
-            double InitialMiddleWidth,
-            double InitialBackLeft,
-            double InitialBackWidth,
+            TrimSegment[] Fronts,
+            TrimSegment[] Middles,
+            TrimSegment[] Backs,
+            ElementTrimPair[] RollPairs,
+            ElementSlideLane[] SlideLanes,
             double InitialPointerX,
             TimeSpan MinDelta,
             TimeSpan MaxDelta);
@@ -528,13 +548,20 @@ public sealed partial class ElementView : UserControl
         {
             TrimDragContext ctx = _trimDrag;
 
-            ctx.Front.Width.Value = ctx.InitialFrontWidth + deltaPixels;
-            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft + deltaPixels, 0, 0, 0);
-            ctx.Back.Width.Value = ctx.InitialBackWidth - deltaPixels;
-
-            if (ctx.Middle is { } middle)
+            foreach (TrimSegment front in ctx.Fronts)
             {
-                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft + deltaPixels, 0, 0, 0);
+                front.ViewModel.Width.Value = front.InitialWidth + deltaPixels;
+            }
+
+            foreach (TrimSegment middle in ctx.Middles)
+            {
+                middle.ViewModel.BorderMargin.Value = new Thickness(middle.InitialLeft + deltaPixels, 0, 0, 0);
+            }
+
+            foreach (TrimSegment back in ctx.Backs)
+            {
+                back.ViewModel.BorderMargin.Value = new Thickness(back.InitialLeft + deltaPixels, 0, 0, 0);
+                back.ViewModel.Width.Value = back.InitialWidth - deltaPixels;
             }
         }
 
@@ -651,40 +678,36 @@ public sealed partial class ElementView : UserControl
             if (_resizeType is not (AlignmentX.Left or AlignmentX.Right)) return false;
 
             Element model = viewModel.Model;
-            Element? frontModel;
-            Element? backModel;
-            if (_resizeType == AlignmentX.Right)
-            {
-                frontModel = model;
-                backModel = model.GetAfter(model.ZIndex, model.Range.End);
-            }
-            else
-            {
-                frontModel = model.GetBefore(model.ZIndex, model.Start);
-                backModel = model;
-            }
+            TimeSpan boundary = _resizeType == AlignmentX.Right ? model.Range.End : model.Start;
 
-            if (frontModel is null || backModel is null) return false;
-            if (frontModel.Range.End != backModel.Start) return false;
+            IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+                viewModel.Scene, CollectTrimMembers(viewModel), boundary);
+            // The pressed clip's own cut must participate; without it the drag would roll
+            // only other group members' cuts, detached from the pointer.
+            if (!pairs.Any(p => p.Front == model || p.Back == model)) return false;
 
-            ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(frontModel);
-            ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
-            if (frontVm is null || backVm is null) return false;
+            var fronts = new TrimSegment[pairs.Count];
+            var backs = new TrimSegment[pairs.Count];
+            for (int i = 0; i < pairs.Count; i++)
+            {
+                ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(pairs[i].Front);
+                ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(pairs[i].Back);
+                if (frontVm is null || backVm is null) return false;
+                fronts[i] = new TrimSegment(frontVm, frontVm.BorderMargin.Value.Left, frontVm.Width.Value);
+                backs[i] = new TrimSegment(backVm, backVm.BorderMargin.Value.Left, backVm.Width.Value);
+            }
 
             (TimeSpan minDelta, TimeSpan maxDelta) = viewModel.Timeline.EditorContext
                 .GetRequiredService<IElementResizeService>()
-                .GetTrimDeltaBounds(viewModel.Scene, frontModel, backModel);
+                .GetTrimDeltaBounds(viewModel.Scene, pairs);
 
             _trimDrag = new TrimDragContext(
                 Kind: TrimDragKind.Roll,
-                Front: frontVm,
-                Middle: null,
-                Back: backVm,
-                InitialFrontWidth: frontVm.Width.Value,
-                InitialMiddleLeft: 0,
-                InitialMiddleWidth: 0,
-                InitialBackLeft: backVm.BorderMargin.Value.Left,
-                InitialBackWidth: backVm.Width.Value,
+                Fronts: fronts,
+                Middles: [],
+                Backs: backs,
+                RollPairs: pairs.ToArray(),
+                SlideLanes: [],
                 InitialPointerX: position.X,
                 MinDelta: minDelta,
                 MaxDelta: maxDelta);
@@ -693,32 +716,42 @@ public sealed partial class ElementView : UserControl
 
         private bool TryStartSlideDrag(ElementViewModel viewModel, Point position)
         {
-            Element middleModel = viewModel.Model;
-            Element? frontModel = middleModel.GetBefore(middleModel.ZIndex, middleModel.Start);
-            Element? backModel = middleModel.GetAfter(middleModel.ZIndex, middleModel.Range.End);
-            if (frontModel is null || backModel is null) return false;
-            if (frontModel.Range.End != middleModel.Start) return false;
-            if (middleModel.Range.End != backModel.Start) return false;
+            IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
+                viewModel.Scene, CollectTrimMembers(viewModel));
+            if (lanes is null) return false;
 
-            ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(frontModel);
-            ElementViewModel? middleVm = viewModel.Timeline.GetViewModelFor(middleModel);
-            ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
-            if (frontVm is null || middleVm is null || backVm is null) return false;
+            var fronts = new TrimSegment[lanes.Count];
+            var backs = new TrimSegment[lanes.Count];
+            var middles = new List<TrimSegment>();
+            for (int i = 0; i < lanes.Count; i++)
+            {
+                ElementViewModel? frontVm = viewModel.Timeline.GetViewModelFor(lanes[i].Front);
+                ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(lanes[i].Back);
+                if (frontVm is null || backVm is null) return false;
+                fronts[i] = new TrimSegment(frontVm, frontVm.BorderMargin.Value.Left, frontVm.Width.Value);
+                backs[i] = new TrimSegment(backVm, backVm.BorderMargin.Value.Left, backVm.Width.Value);
+
+                foreach (Element middle in lanes[i].Middles)
+                {
+                    ElementViewModel? middleVm = viewModel.Timeline.GetViewModelFor(middle);
+                    if (middleVm is null) return false;
+                    middles.Add(new TrimSegment(middleVm, middleVm.BorderMargin.Value.Left, middleVm.Width.Value));
+                }
+            }
 
             (TimeSpan minDelta, TimeSpan maxDelta) = viewModel.Timeline.EditorContext
                 .GetRequiredService<IElementResizeService>()
-                .GetTrimDeltaBounds(viewModel.Scene, frontModel, backModel);
+                .GetTrimDeltaBounds(
+                    viewModel.Scene,
+                    lanes.Select(l => new ElementTrimPair(l.Front, l.Back)).ToArray());
 
             _trimDrag = new TrimDragContext(
                 Kind: TrimDragKind.Slide,
-                Front: frontVm,
-                Middle: middleVm,
-                Back: backVm,
-                InitialFrontWidth: frontVm.Width.Value,
-                InitialMiddleLeft: middleVm.BorderMargin.Value.Left,
-                InitialMiddleWidth: middleVm.Width.Value,
-                InitialBackLeft: backVm.BorderMargin.Value.Left,
-                InitialBackWidth: backVm.Width.Value,
+                Fronts: fronts,
+                Middles: middles.ToArray(),
+                Backs: backs,
+                RollPairs: [],
+                SlideLanes: lanes.ToArray(),
                 InitialPointerX: position.X,
                 MinDelta: minDelta,
                 MaxDelta: maxDelta);
@@ -761,11 +794,11 @@ public sealed partial class ElementView : UserControl
                                 .GetRequiredService<IElementResizeService>();
                             if (ctx.Kind == TrimDragKind.Roll)
                             {
-                                resizeService.Roll(viewModel.Scene, ctx.Front.Model, ctx.Back.Model, delta);
+                                resizeService.Roll(viewModel.Scene, ctx.RollPairs, delta);
                             }
                             else
                             {
-                                resizeService.Slide(viewModel.Scene, ctx.Front.Model, ctx.Middle!.Model, ctx.Back.Model, delta);
+                                resizeService.Slide(viewModel.Scene, ctx.SlideLanes, delta);
                             }
                         }
 
@@ -820,13 +853,21 @@ public sealed partial class ElementView : UserControl
 
         private static void RestoreTrimDragVisuals(TrimDragContext ctx)
         {
-            ctx.Front.Width.Value = ctx.InitialFrontWidth;
-            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft, 0, 0, 0);
-            ctx.Back.Width.Value = ctx.InitialBackWidth;
-            if (ctx.Middle is { } middle)
+            foreach (TrimSegment front in ctx.Fronts)
             {
-                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft, 0, 0, 0);
-                middle.Width.Value = ctx.InitialMiddleWidth;
+                front.ViewModel.Width.Value = front.InitialWidth;
+            }
+
+            foreach (TrimSegment middle in ctx.Middles)
+            {
+                middle.ViewModel.BorderMargin.Value = new Thickness(middle.InitialLeft, 0, 0, 0);
+                middle.ViewModel.Width.Value = middle.InitialWidth;
+            }
+
+            foreach (TrimSegment back in ctx.Backs)
+            {
+                back.ViewModel.BorderMargin.Value = new Thickness(back.InitialLeft, 0, 0, 0);
+                back.ViewModel.Width.Value = back.InitialWidth;
             }
         }
 
@@ -896,6 +937,7 @@ public sealed partial class ElementView : UserControl
         private bool _pressed;
         private bool _duplicateMode;
         private bool _isSlipDrag;
+        private Element[] _slipTargets = [];
         private readonly List<Control> _ghosts = [];
         private IReadOnlyList<ElementViewModel> _relatedElements = [];
         private Point _start;
@@ -936,6 +978,7 @@ public sealed partial class ElementView : UserControl
 
             _isSlipDrag = false;
             _pressed = false;
+            _slipTargets = [];
             if (AssociatedObject is { ViewModel: { } viewModel })
             {
                 viewModel.Timeline.SnapBarPosition.Value = null;
@@ -1031,6 +1074,7 @@ public sealed partial class ElementView : UserControl
 
                     _pressed = true;
                     _isSlipDrag = true;
+                    _slipTargets = CollectTrimMembers(viewModel);
                     _start = e.GetPosition(view);
                     // Re-target the implicit capture to the border: PointerCaptureLost routes
                     // Direct (no bubbling), so the reset handler only fires reliably when the
@@ -1063,6 +1107,9 @@ public sealed partial class ElementView : UserControl
 
         private void CommitSlipDrag(ElementView view, ElementViewModel viewModel, PointerReleasedEventArgs e)
         {
+            Element[] targets = _slipTargets;
+            _slipTargets = [];
+
             float scale = viewModel.Timeline.Options.Value.Scale;
             int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
             Point released = e.GetPosition(view);
@@ -1074,11 +1121,11 @@ public sealed partial class ElementView : UserControl
                 .RoundToRate(rate);
             // RoundStartTime re-sets the snap guide line as a side effect; clear it.
             viewModel.Timeline.SnapBarPosition.Value = null;
-            if (delta != TimeSpan.Zero)
+            if (delta != TimeSpan.Zero && targets.Length > 0)
             {
                 viewModel.Timeline.EditorContext
                     .GetRequiredService<IElementSlipService>()
-                    .Slip(viewModel.Scene, viewModel.Model, delta);
+                    .Slip(viewModel.Scene, targets, delta);
             }
         }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -374,7 +374,9 @@ public sealed partial class ElementView : UserControl
             double InitialMiddleWidth,
             double InitialBackLeft,
             double InitialBackWidth,
-            double InitialPointerX);
+            double InitialPointerX,
+            TimeSpan MinDelta,
+            TimeSpan MaxDelta);
 
         private bool _pressed;
         private AlignmentX _resizeType;
@@ -424,17 +426,30 @@ public sealed partial class ElementView : UserControl
 
                 if (view._timeline is { } timeline && _pressed)
                 {
-                    pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-                    point = point.WithX(pointerFrame.TimeToPixel(scale));
+                    bool alt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
                     int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
-                    double minWidth = TimeSpan.FromSeconds(1d / rate).TimeToPixel(scale);
 
                     if (_trimDrag.Kind is not TrimDragKind.None)
                     {
-                        ApplyTrimDragPreview(point.X, minWidth);
+                        // Mirror the release commit exactly: snap both endpoints with the same
+                        // function, round to the frame rate, clamp to the bounds captured at drag
+                        // start. Snap the press point first so the snap guide (a RoundStartTime
+                        // side effect) ends up reflecting the pointer, not the press point.
+                        TimeSpan pressTime = view.RoundStartTime(
+                            _trimDrag.InitialPointerX.PixelToTimeSpan(scale), scale, alt);
+                        pointerFrame = view.RoundStartTime(pointerFrame, scale, alt);
+                        TimeSpan previewDelta = TrimDeltaCalculator.ClampDelta(
+                            (pointerFrame - pressTime).RoundToRate(rate),
+                            _trimDrag.MinDelta,
+                            _trimDrag.MaxDelta);
+                        ApplyTrimDragPreview(previewDelta.TimeToPixel(scale));
                         e.Handled = true;
                         return;
                     }
+
+                    pointerFrame = view.RoundStartTime(pointerFrame, scale, alt);
+                    point = point.WithX(pointerFrame.TimeToPixel(scale));
+                    double minWidth = TimeSpan.FromSeconds(1d / rate).TimeToPixel(scale);
 
                     if (view.Cursor != Cursors.Arrow && view.Cursor is { })
                     {
@@ -488,26 +503,17 @@ public sealed partial class ElementView : UserControl
             }
         }
 
-        private void ApplyTrimDragPreview(double pointerX, double minWidth)
+        private void ApplyTrimDragPreview(double deltaPixels)
         {
             TrimDragContext ctx = _trimDrag;
-            double delta = pointerX - ctx.InitialPointerX;
 
-            double floor = minWidth - ctx.InitialFrontWidth;
-            double ceiling = ctx.InitialBackWidth - minWidth;
-            if (floor > ceiling)
-                return;
-
-            double actualDelta = Math.Clamp(delta, floor, ceiling);
-
-            ctx.Front.Width.Value = ctx.InitialFrontWidth + actualDelta;
-            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft + actualDelta, 0, 0, 0);
-            ctx.Back.Width.Value = ctx.InitialBackWidth - actualDelta;
+            ctx.Front.Width.Value = ctx.InitialFrontWidth + deltaPixels;
+            ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft + deltaPixels, 0, 0, 0);
+            ctx.Back.Width.Value = ctx.InitialBackWidth - deltaPixels;
 
             if (ctx.Middle is { } middle)
             {
-                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft + actualDelta, 0, 0, 0);
-                middle.Width.Value = ctx.InitialMiddleWidth;
+                middle.BorderMargin.Value = new Thickness(ctx.InitialMiddleLeft + deltaPixels, 0, 0, 0);
             }
         }
 
@@ -533,7 +539,7 @@ public sealed partial class ElementView : UserControl
                 // start on the clip body where the cursor is Arrow, not only on the resize edge.
                 if (leftButton && viewModel.Timeline.IsSlideMode.Value)
                 {
-                    if (TryStartSlideDrag(viewModel, e.GetPosition(view), view))
+                    if (TryStartSlideDrag(viewModel, e.GetPosition(view)))
                     {
                         _pressed = true;
                     }
@@ -554,7 +560,7 @@ public sealed partial class ElementView : UserControl
                     Point timelinePosition = e.GetPosition(view);
                     if (viewModel.Timeline.IsRollMode.Value)
                     {
-                        if (TryStartRollDrag(viewModel, timelinePosition, view))
+                        if (TryStartRollDrag(viewModel, timelinePosition))
                         {
                             _pressed = true;
                         }
@@ -614,7 +620,7 @@ public sealed partial class ElementView : UserControl
             }
         }
 
-        private bool TryStartRollDrag(ElementViewModel viewModel, Point position, ElementView view)
+        private bool TryStartRollDrag(ElementViewModel viewModel, Point position)
         {
             if (_resizeType is not (AlignmentX.Left or AlignmentX.Right)) return false;
 
@@ -639,6 +645,10 @@ public sealed partial class ElementView : UserControl
             ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
             if (frontVm is null || backVm is null) return false;
 
+            (TimeSpan minDelta, TimeSpan maxDelta) = viewModel.Timeline.EditorContext
+                .GetRequiredService<IElementResizeService>()
+                .GetTrimDeltaBounds(viewModel.Scene, frontModel, backModel);
+
             _trimDrag = new TrimDragContext(
                 Kind: TrimDragKind.Roll,
                 Front: frontVm,
@@ -649,11 +659,13 @@ public sealed partial class ElementView : UserControl
                 InitialMiddleWidth: 0,
                 InitialBackLeft: backVm.BorderMargin.Value.Left,
                 InitialBackWidth: backVm.Width.Value,
-                InitialPointerX: position.X);
+                InitialPointerX: position.X,
+                MinDelta: minDelta,
+                MaxDelta: maxDelta);
             return true;
         }
 
-        private bool TryStartSlideDrag(ElementViewModel viewModel, Point position, ElementView view)
+        private bool TryStartSlideDrag(ElementViewModel viewModel, Point position)
         {
             Element middleModel = viewModel.Model;
             Element? frontModel = middleModel.GetBefore(middleModel.ZIndex, middleModel.Start);
@@ -667,6 +679,10 @@ public sealed partial class ElementView : UserControl
             ElementViewModel? backVm = viewModel.Timeline.GetViewModelFor(backModel);
             if (frontVm is null || middleVm is null || backVm is null) return false;
 
+            (TimeSpan minDelta, TimeSpan maxDelta) = viewModel.Timeline.EditorContext
+                .GetRequiredService<IElementResizeService>()
+                .GetTrimDeltaBounds(viewModel.Scene, frontModel, backModel);
+
             _trimDrag = new TrimDragContext(
                 Kind: TrimDragKind.Slide,
                 Front: frontVm,
@@ -677,7 +693,9 @@ public sealed partial class ElementView : UserControl
                 InitialMiddleWidth: middleVm.Width.Value,
                 InitialBackLeft: backVm.BorderMargin.Value.Left,
                 InitialBackWidth: backVm.Width.Value,
-                InitialPointerX: position.X);
+                InitialPointerX: position.X,
+                MinDelta: minDelta,
+                MaxDelta: maxDelta);
             return true;
         }
 
@@ -990,12 +1008,14 @@ public sealed partial class ElementView : UserControl
         private void CommitSlipDrag(ElementView view, ElementViewModel viewModel, PointerReleasedEventArgs e)
         {
             float scale = viewModel.Timeline.Options.Value.Scale;
+            int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
             Point released = e.GetPosition(view);
             bool alt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
             TimeSpan delta = TrimDeltaCalculator.SnappedDelta(
-                _start.X.PixelToTimeSpan(scale),
-                released.X.PixelToTimeSpan(scale),
-                t => view.RoundStartTime(t, scale, alt));
+                    _start.X.PixelToTimeSpan(scale),
+                    released.X.PixelToTimeSpan(scale),
+                    t => view.RoundStartTime(t, scale, alt))
+                .RoundToRate(rate);
             // RoundStartTime re-sets the snap guide line as a side effect; clear it.
             viewModel.Timeline.SnapBarPosition.Value = null;
             if (delta != TimeSpan.Zero)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -680,8 +680,9 @@ public sealed partial class ElementView : UserControl
             Element model = viewModel.Model;
             TimeSpan boundary = _resizeType == AlignmentX.Right ? model.Range.End : model.Start;
 
-            IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
                 viewModel.Scene, CollectTrimMembers(viewModel), boundary);
+            if (pairs is null) return false;
             // The pressed clip's own cut must participate; without it the drag would roll
             // only other group members' cuts, detached from the pointer.
             if (!pairs.Any(p => p.Front == model || p.Back == model)) return false;
@@ -1395,6 +1396,13 @@ public sealed partial class ElementView : UserControl
                             if (!trimMode || !timelineVm.SelectedElements.Contains(obj.ViewModel))
                             {
                                 Select(obj, obj._timeline.ViewModel);
+                            }
+                            else
+                            {
+                                // Keep the multi-selection, but still point the single selection
+                                // (property tab, keyframe scope) at the pressed clip.
+                                timelineVm.EditorContext.GetRequiredService<IEditorSelection>()
+                                    .SelectedObject.Value = obj.ViewModel.Model;
                             }
                         }
                         else

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -1384,7 +1384,18 @@ public sealed partial class ElementView : UserControl
                     {
                         if (e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt)
                         {
-                            Select(obj, obj._timeline.ViewModel);
+                            // In a trim mode, a plain press on an already-selected clip starts a
+                            // multi-selection Slip/Roll/Slide; re-selecting here would collapse
+                            // the selection to the pressed clip before those behaviors (which run
+                            // after this one) collect their targets. Pressing an unselected clip
+                            // still re-selects as usual.
+                            bool trimMode = timelineVm.IsSlipMode.Value
+                                || timelineVm.IsRollMode.Value
+                                || timelineVm.IsSlideMode.Value;
+                            if (!trimMode || !timelineVm.SelectedElements.Contains(obj.ViewModel))
+                            {
+                                Select(obj, obj._timeline.ViewModel);
+                            }
                         }
                         else
                         {

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -695,6 +695,12 @@ public sealed partial class ElementView : UserControl
                             scale,
                             e.KeyModifiers.HasFlag(KeyModifiers.Alt));
                         TimeSpan initialFrame = ctx.InitialPointerX.PixelToTimeSpan(scale);
+                        // Snap the press point the same way as the release, so a no-move click near
+                        // a cut does not snap only one endpoint and commit a spurious one-frame trim.
+                        initialFrame = AssociatedObject.RoundStartTime(
+                            initialFrame,
+                            scale,
+                            e.KeyModifiers.HasFlag(KeyModifiers.Alt));
                         TimeSpan delta = (releasedFrame - initialFrame).RoundToRate(rate);
 
                         RestoreTrimDragVisuals(ctx);
@@ -976,7 +982,11 @@ public sealed partial class ElementView : UserControl
             Point released = e.GetPosition(view);
             TimeSpan pointerFrame = released.X.PixelToTimeSpan(scale);
             pointerFrame = view.RoundStartTime(pointerFrame, scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
-            TimeSpan delta = pointerFrame - _start.X.PixelToTimeSpan(scale);
+            // Snap the press point the same way, so a no-move click near a cut does not snap only
+            // the release endpoint and shift the media window without any pointer movement.
+            TimeSpan startFrame = view.RoundStartTime(
+                _start.X.PixelToTimeSpan(scale), scale, e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+            TimeSpan delta = pointerFrame - startFrame;
             if (delta != TimeSpan.Zero)
             {
                 viewModel.Timeline.EditorContext

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -493,11 +493,9 @@ public sealed partial class ElementView : UserControl
             TrimDragContext ctx = _trimDrag;
             double delta = pointerX - ctx.InitialPointerX;
 
-            double frontWidth = Math.Max(ctx.InitialFrontWidth + delta, minWidth);
-            double backWidth = Math.Max(ctx.InitialBackWidth - delta, minWidth);
-            double actualDelta = Math.Min(
-                frontWidth - ctx.InitialFrontWidth,
-                ctx.InitialBackWidth - backWidth);
+            double floor = minWidth - ctx.InitialFrontWidth;
+            double ceiling = ctx.InitialBackWidth - minWidth;
+            double actualDelta = Math.Clamp(delta, floor, ceiling);
 
             ctx.Front.Width.Value = ctx.InitialFrontWidth + actualDelta;
             ctx.Back.BorderMargin.Value = new Thickness(ctx.InitialBackLeft + actualDelta, 0, 0, 0);
@@ -528,16 +526,24 @@ public sealed partial class ElementView : UserControl
                 if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
                                                          && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
-                    if (viewModel.Timeline.IsRollMode.Value && TryStartRollDrag(viewModel, point.Position, view))
+                    if (viewModel.Timeline.IsRollMode.Value)
                     {
-                        _pressed = true;
+                        if (TryStartRollDrag(viewModel, point.Position, view))
+                        {
+                            _pressed = true;
+                        }
+
                         e.Handled = true;
                         return;
                     }
 
-                    if (viewModel.Timeline.IsSlideMode.Value && TryStartSlideDrag(viewModel, point.Position, view))
+                    if (viewModel.Timeline.IsSlideMode.Value)
                     {
-                        _pressed = true;
+                        if (TryStartSlideDrag(viewModel, point.Position, view))
+                        {
+                            _pressed = true;
+                        }
+
                         e.Handled = true;
                         return;
                     }
@@ -679,8 +685,13 @@ public sealed partial class ElementView : UserControl
                         float scale = viewModel.Timeline.Options.Value.Scale;
                         int rate = viewModel.Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
                         Point released = e.GetPosition(AssociatedObject);
-                        double deltaPixel = released.X - ctx.InitialPointerX;
-                        TimeSpan delta = deltaPixel.PixelToTimeSpan(scale).RoundToRate(rate);
+                        TimeSpan releasedFrame = released.X.PixelToTimeSpan(scale);
+                        releasedFrame = AssociatedObject.RoundStartTime(
+                            releasedFrame,
+                            scale,
+                            e.KeyModifiers.HasFlag(KeyModifiers.Alt));
+                        TimeSpan initialFrame = ctx.InitialPointerX.PixelToTimeSpan(scale);
+                        TimeSpan delta = (releasedFrame - initialFrame).RoundToRate(rate);
 
                         if (delta != TimeSpan.Zero)
                         {

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -526,24 +526,28 @@ public sealed partial class ElementView : UserControl
                 }
 
                 PointerPoint point = e.GetCurrentPoint(view.border);
-                if (point.Properties.IsLeftButtonPressed && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt
-                                                         && view.Cursor != Cursors.Arrow && view.Cursor is not null)
+                bool leftButton = point.Properties.IsLeftButtonPressed
+                                  && e.KeyModifiers is KeyModifiers.None or KeyModifiers.Alt;
+
+                // Slide is a body-drag gesture (SlideTool_Description: "Drag a clip"), so it must
+                // start on the clip body where the cursor is Arrow, not only on the resize edge.
+                if (leftButton && viewModel.Timeline.IsSlideMode.Value)
+                {
+                    if (TryStartSlideDrag(viewModel, e.GetPosition(view), view))
+                    {
+                        _pressed = true;
+                    }
+
+                    e.Handled = true;
+                    return;
+                }
+
+                if (leftButton && view.Cursor != Cursors.Arrow && view.Cursor is not null)
                 {
                     Point timelinePosition = e.GetPosition(view);
                     if (viewModel.Timeline.IsRollMode.Value)
                     {
                         if (TryStartRollDrag(viewModel, timelinePosition, view))
-                        {
-                            _pressed = true;
-                        }
-
-                        e.Handled = true;
-                        return;
-                    }
-
-                    if (viewModel.Timeline.IsSlideMode.Value)
-                    {
-                        if (TryStartSlideDrag(viewModel, timelinePosition, view))
                         {
                             _pressed = true;
                         }

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -123,6 +123,102 @@
             </StackPanel>
         </Border>
 
+        <Border Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="2"
+                BorderBrush="{DynamicResource SystemFillColorSuccessBrush}"
+                BorderThickness="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsSlipMode.Value}"
+                ZIndex="100" />
+
+        <Border Grid.Row="0"
+                Grid.Column="2"
+                Margin="8,4"
+                Padding="8,2"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{DynamicResource SystemFillColorSuccessBrush}"
+                CornerRadius="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsSlipMode.Value}"
+                ZIndex="100">
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <icons:FluentIcon FontSize="14"
+                                  Foreground="White"
+                                  Icon="ArrowSwap" />
+                <TextBlock FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="{x:Static lang:Strings.SlipTool}"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="2"
+                BorderBrush="{DynamicResource SystemFillColorCautionBrush}"
+                BorderThickness="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsRollMode.Value}"
+                ZIndex="100" />
+
+        <Border Grid.Row="0"
+                Grid.Column="2"
+                Margin="8,4"
+                Padding="8,2"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{DynamicResource SystemFillColorCautionBrush}"
+                CornerRadius="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsRollMode.Value}"
+                ZIndex="100">
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <icons:FluentIcon FontSize="14"
+                                  Foreground="White"
+                                  Icon="ArrowAutofitWidth" />
+                <TextBlock FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="{x:Static lang:Strings.RollTool}"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.Column="2"
+                BorderBrush="{DynamicResource SystemFillColorAttentionBrush}"
+                BorderThickness="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsSlideMode.Value}"
+                ZIndex="100" />
+
+        <Border Grid.Row="0"
+                Grid.Column="2"
+                Margin="8,4"
+                Padding="8,2"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{DynamicResource SystemFillColorAttentionBrush}"
+                CornerRadius="4"
+                IsHitTestVisible="False"
+                IsVisible="{CompiledBinding IsSlideMode.Value}"
+                ZIndex="100">
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <icons:FluentIcon FontSize="14"
+                                  Foreground="White"
+                                  Icon="ArrowMove" />
+                <TextBlock FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="White"
+                           Text="{x:Static lang:Strings.SlideTool}"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+        </Border>
+
         <ScrollViewer x:Name="ContentScroll"
                       Grid.Row="1"
                       Grid.Column="2"
@@ -141,14 +237,36 @@
                    PointerReleased="TimelinePanel_PointerReleased">
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
-                        <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRazorMode.Value, Mode=TwoWay}"
-                                                 InputGesture="{h:GetCommandGesture ToggleRazorMode,
-                                                                                    ExtensionType={x:Type p:TimelineTabExtension}}"
-                                                 Text="{x:Static lang:Strings.RazorTool}">
-                            <ui:ToggleMenuFlyoutItem.IconSource>
-                                <icons:FluentIconSource Icon="Cut" />
-                            </ui:ToggleMenuFlyoutItem.IconSource>
-                        </ui:ToggleMenuFlyoutItem>
+                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
+                            <ui:MenuFlyoutSubItem.IconSource>
+                                <icons:FluentIconSource Icon="Edit" />
+                            </ui:MenuFlyoutSubItem.IconSource>
+                            <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRazorMode.Value, Mode=TwoWay}"
+                                                     InputGesture="{h:GetCommandGesture ToggleRazorMode,
+                                                                                        ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                     Text="{x:Static lang:Strings.RazorTool}">
+                                <ui:ToggleMenuFlyoutItem.IconSource>
+                                    <icons:FluentIconSource Icon="Cut" />
+                                </ui:ToggleMenuFlyoutItem.IconSource>
+                            </ui:ToggleMenuFlyoutItem>
+                            <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsSlipMode.Value, Mode=TwoWay}"
+                                                     InputGesture="{h:GetCommandGesture ToggleSlipMode,
+                                                                                        ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                     Text="{x:Static lang:Strings.SlipTool}" />
+                            <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRollMode.Value, Mode=TwoWay}"
+                                                     InputGesture="{h:GetCommandGesture ToggleRollMode,
+                                                                                        ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                     Text="{x:Static lang:Strings.RollTool}" />
+                            <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsSlideMode.Value, Mode=TwoWay}"
+                                                     InputGesture="{h:GetCommandGesture ToggleSlideMode,
+                                                                                        ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                     Text="{x:Static lang:Strings.SlideTool}" />
+                            <ui:MenuFlyoutSeparator />
+                            <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRippleEnabled.Value, Mode=TwoWay}"
+                                                     InputGesture="{h:GetCommandGesture ToggleRippleMode,
+                                                                                        ExtensionType={x:Type p:TimelineTabExtension}}"
+                                                     Text="{x:Static lang:Strings.RippleEdit}" />
+                        </ui:MenuFlyoutSubItem>
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
                         <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
@@ -190,10 +308,6 @@
                         </ui:MenuFlyoutSubItem>
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsStrings.AutoAdjustSceneDuration}" />
                         <ui:ToggleMenuFlyoutItem IsChecked="{Binding IsSnapEnabled.Value, Mode=TwoWay}" Text="{x:Static lang:Strings.TimelineSnap}" />
-                        <ui:ToggleMenuFlyoutItem IsChecked="{CompiledBinding IsRippleEnabled.Value, Mode=TwoWay}"
-                                                 InputGesture="{h:GetCommandGesture ToggleRippleMode,
-                                                                                    ExtensionType={x:Type p:TimelineTabExtension}}"
-                                                 Text="{x:Static lang:Strings.RippleEdit}" />
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutItem Click="ShowSceneSettings" Text="{x:Static lang:Strings.Settings}">
                             <ui:MenuFlyoutItem.IconSource>

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Configuration;
+using Beutl.Engine;
 using Beutl.Language;
 using Beutl.ProjectSystem;
 
@@ -307,6 +308,7 @@ public sealed class ElementResizeService : IElementResizeService
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
+        var applied = new HashSet<IProperty<TimeSpan>>();
         for (int i = 0; i < pairs.Count; i++)
         {
             (Element front, Element back) = pairs[i];
@@ -318,7 +320,7 @@ public sealed class ElementResizeService : IElementResizeService
             back.Length -= clamped;
             // Preserve the back clip's content across the moving cut: its in-point advances
             // by the same delta so the same source frames stay under the same timeline times.
-            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped);
+            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped, applied);
         }
 
         _historyManager.Commit(CommandNames.RollElements);
@@ -384,6 +386,7 @@ public sealed class ElementResizeService : IElementResizeService
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
+        var applied = new HashSet<IProperty<TimeSpan>>();
         for (int i = 0; i < lanes.Count; i++)
         {
             (Element front, IReadOnlyList<Element> middles, Element back) = lanes[i];
@@ -399,7 +402,7 @@ public sealed class ElementResizeService : IElementResizeService
             // The middle clips only shift in time (their in-points are unchanged), but the back
             // clip is trimmed at its head, so advance its media offset by the same delta to keep
             // its content.
-            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped);
+            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped, applied);
         }
 
         _historyManager.Commit(CommandNames.SlideElements);

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -301,19 +301,24 @@ public sealed class ElementResizeService : IElementResizeService
         return true;
     }
 
-    // A positive delta extends the front clip's out-point and pulls the back clip's in-point
-    // forward; a negative delta pulls the back clip's in-point earlier. Each direction can run
-    // past a finite source, so clamp by the front's remaining tail (positive) or the back's
-    // remaining head (negative). Clips without a bounded source impose no limit.
+    // A positive delta extends the front clip's out-point past its source tail; a negative delta
+    // pulls the back clip's in-point earlier, toward its source head.
     private static TimeSpan ClampToSourceBounds(TimeSpan clamped, Element front, Element back)
     {
         if (clamped > TimeSpan.Zero)
         {
-            TimeSpan room = SlippableMedia.OutPointRoom(front);
-            if (room < clamped) clamped = room;
+            // Extending the front out-point past its source honours the same editor preference as
+            // normal edge resize: with clamping off, the clip may run past its original media.
+            if (GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength)
+            {
+                TimeSpan room = SlippableMedia.OutPointRoom(front);
+                if (room < clamped) clamped = room;
+            }
         }
         else if (clamped < TimeSpan.Zero)
         {
+            // The back in-point can never go below zero regardless of the preference: a negative
+            // source offset is an invalid frame request, not an original-length extension.
             TimeSpan room = SlippableMedia.InPointRoom(back);
             if (room < -clamped) clamped = -room;
         }

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -257,6 +257,11 @@ public sealed class ElementResizeService : IElementResizeService
         ArgumentNullException.ThrowIfNull(front);
         ArgumentNullException.ThrowIfNull(back);
         if (front == back) return false;
+        // Coincidental time adjacency across layers is not an editable cut, and elements
+        // outside the supplied scene must not be mutated through this public seam — the
+        // UI guarantees both, direct service callers may not.
+        if (front.ZIndex != back.ZIndex) return false;
+        if (!scene.Children.Contains(front) || !scene.Children.Contains(back)) return false;
         if (front.Range.End != back.Start) return false;
 
         List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
@@ -286,6 +291,9 @@ public sealed class ElementResizeService : IElementResizeService
         ArgumentNullException.ThrowIfNull(middle);
         ArgumentNullException.ThrowIfNull(back);
         if (front == middle || middle == back || front == back) return false;
+        if (front.ZIndex != middle.ZIndex || middle.ZIndex != back.ZIndex) return false;
+        if (!scene.Children.Contains(front) || !scene.Children.Contains(middle) || !scene.Children.Contains(back))
+            return false;
         if (front.Range.End != middle.Start) return false;
         if (middle.Range.End != back.Start) return false;
 

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -241,6 +241,16 @@ public sealed class ElementResizeService : IElementResizeService
         return clampedLength > TimeSpan.Zero ? clampedLength : length;
     }
 
+    public (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, Element front, Element back)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(front);
+        ArgumentNullException.ThrowIfNull(back);
+
+        return ComputeTrimDeltaBounds(scene, front, back,
+            SlippableMedia.Collect(front), SlippableMedia.Collect(back));
+    }
+
     public bool Roll(Scene scene, Element front, Element back, TimeSpan delta)
     {
         ArgumentNullException.ThrowIfNull(scene);
@@ -249,11 +259,10 @@ public sealed class ElementResizeService : IElementResizeService
         if (front == back) return false;
         if (front.Range.End != back.Start) return false;
 
-        int rate = SceneTimeRangeService.GetFrameRate(scene);
-        TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
-
-        TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
-        clamped = ClampToSourceBounds(clamped, front, back);
+        List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
+        List<SlippableMedia.Target> backTargets = SlippableMedia.Collect(back);
+        (TimeSpan min, TimeSpan max) = ComputeTrimDeltaBounds(scene, front, back, frontTargets, backTargets);
+        TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
         // Bypass Scene.MoveChild's overlap handling: Roll intentionally keeps the
@@ -264,7 +273,7 @@ public sealed class ElementResizeService : IElementResizeService
         back.Length -= clamped;
         // Preserve the back clip's content across the moving cut: its in-point advances
         // by the same delta so the same source frames stay under the same timeline times.
-        SlippableMedia.ApplyOffsetDelta(SlippableMedia.Collect(back), clamped);
+        SlippableMedia.ApplyOffsetDelta(backTargets, clamped);
 
         _historyManager.Commit(CommandNames.RollElements);
         return true;
@@ -280,12 +289,11 @@ public sealed class ElementResizeService : IElementResizeService
         if (front.Range.End != middle.Start) return false;
         if (middle.Range.End != back.Start) return false;
 
-        int rate = SceneTimeRangeService.GetFrameRate(scene);
-        TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
-
         // The middle clip's length is unaffected by Slide, so only front and back bound the delta.
-        TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
-        clamped = ClampToSourceBounds(clamped, front, back);
+        List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
+        List<SlippableMedia.Target> backTargets = SlippableMedia.Collect(back);
+        (TimeSpan min, TimeSpan max) = ComputeTrimDeltaBounds(scene, front, back, frontTargets, backTargets);
+        TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
         // Invariant: front.Length + middle.Length + back.Length is unchanged.
@@ -295,48 +303,42 @@ public sealed class ElementResizeService : IElementResizeService
         back.Length -= clamped;
         // The middle clip only shifts in time (its in-point is unchanged), but the back clip is
         // trimmed at its head, so advance its media offset by the same delta to keep its content.
-        SlippableMedia.ApplyOffsetDelta(SlippableMedia.Collect(back), clamped);
+        SlippableMedia.ApplyOffsetDelta(backTargets, clamped);
 
         _historyManager.Commit(CommandNames.SlideElements);
         return true;
     }
 
-    // A positive delta extends the front clip's out-point past its source tail; a negative delta
-    // pulls the back clip's in-point earlier, toward its source head.
-    private static TimeSpan ClampToSourceBounds(TimeSpan clamped, Element front, Element back)
+    // Shared Roll/Slide delta window. Min (≤ 0) is bounded by the shrinking front keeping one
+    // frame and — always, regardless of the clamp preference — by the back in-point staying at
+    // or above zero (a negative source offset is an invalid frame request, not an
+    // original-length extension). Max (≥ 0) is bounded by the shrinking back keeping one frame
+    // and, when ClampResizeToOriginalLength is on, by the front out-point staying within its
+    // source (matching normal edge resize, which may run past the media with the preference off).
+    private static (TimeSpan Min, TimeSpan Max) ComputeTrimDeltaBounds(
+        Scene scene, Element front, Element back,
+        IReadOnlyList<SlippableMedia.Target> frontTargets,
+        IReadOnlyList<SlippableMedia.Target> backTargets)
     {
-        if (clamped > TimeSpan.Zero)
+        int rate = SceneTimeRangeService.GetFrameRate(scene);
+        TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
+
+        if (front.Length < minDuration || back.Length < minDuration)
+            return (TimeSpan.Zero, TimeSpan.Zero);
+
+        TimeSpan min = minDuration - front.Length;
+        TimeSpan max = back.Length - minDuration;
+
+        if (GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength)
         {
-            // Extending the front out-point past its source honours the same editor preference as
-            // normal edge resize: with clamping off, the clip may run past its original media.
-            if (GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength)
-            {
-                TimeSpan room = SlippableMedia.OutPointRoom(front);
-                if (room < clamped) clamped = room;
-            }
-        }
-        else if (clamped < TimeSpan.Zero)
-        {
-            // The back in-point can never go below zero regardless of the preference: a negative
-            // source offset is an invalid frame request, not an original-length extension.
-            TimeSpan room = SlippableMedia.InPointRoom(back);
-            if (room < -clamped) clamped = -room;
+            TimeSpan outRoom = SlippableMedia.OutPointRoom(frontTargets, front.Length);
+            if (outRoom < max) max = outRoom;
         }
 
-        return clamped;
-    }
+        TimeSpan inRoom = SlippableMedia.InPointRoom(backTargets);
+        if (inRoom != TimeSpan.MaxValue && -inRoom > min) min = -inRoom;
 
-    private static TimeSpan ClampTrimDelta(TimeSpan delta, TimeSpan frontLength, TimeSpan backLength, TimeSpan minDuration)
-    {
-        if (frontLength < minDuration || backLength < minDuration)
-            return TimeSpan.Zero;
-
-        TimeSpan minDelta = minDuration - frontLength;
-        TimeSpan maxDelta = backLength - minDuration;
-        if (minDelta > maxDelta)
-            return TimeSpan.Zero;
-
-        return Clamp(delta, minDelta, maxDelta);
+        return (min, max);
     }
 
     private static TimeSpan Clamp(TimeSpan value, TimeSpan min, TimeSpan max)

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -338,6 +338,12 @@ public sealed class ElementResizeService : IElementResizeService
         TimeSpan inRoom = SlippableMedia.InPointRoom(backTargets);
         if (inRoom != TimeSpan.MaxValue && -inRoom > min) min = -inRoom;
 
+        // Enforce the documented Min ≤ 0 ≤ Max contract structurally instead of relying on
+        // every media OffsetPosition being non-negative (an invariant owned by other services);
+        // an inverted window would throw in the View's per-pointer-frame ClampDelta.
+        if (min > TimeSpan.Zero) min = TimeSpan.Zero;
+        if (max < TimeSpan.Zero) max = TimeSpan.Zero;
+
         return (min, max);
     }
 

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -240,4 +240,79 @@ public sealed class ElementResizeService : IElementResizeService
         TimeSpan clampedLength = clampedEnd - start;
         return clampedLength > TimeSpan.Zero ? clampedLength : length;
     }
+
+    public bool Roll(Scene scene, Element front, Element back, TimeSpan delta)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(front);
+        ArgumentNullException.ThrowIfNull(back);
+        if (front == back) return false;
+        if (front.Range.End != back.Start) return false;
+
+        int rate = SceneTimeRangeService.GetFrameRate(scene);
+        TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
+
+        TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
+        if (clamped == TimeSpan.Zero) return false;
+
+        TimeSpan newFrontLength = front.Length + clamped;
+        TimeSpan newBackStart = back.Start + clamped;
+        TimeSpan newBackLength = back.Length - clamped;
+
+        // Bypass Scene.MoveChild's overlap handling: Roll intentionally keeps the
+        // two clips exactly adjacent (front.End == back.Start), which MoveCommand
+        // treats as overlap and refuses. Direct property setters still record.
+        front.Length = newFrontLength;
+        back.Start = newBackStart;
+        back.Length = newBackLength;
+
+        _historyManager.Commit(CommandNames.RollElements);
+        return true;
+    }
+
+    public bool Slide(Scene scene, Element front, Element middle, Element back, TimeSpan delta)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(front);
+        ArgumentNullException.ThrowIfNull(middle);
+        ArgumentNullException.ThrowIfNull(back);
+        if (front == middle || middle == back || front == back) return false;
+        if (front.Range.End != middle.Start) return false;
+        if (middle.Range.End != back.Start) return false;
+
+        int rate = SceneTimeRangeService.GetFrameRate(scene);
+        TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
+
+        // The middle clip's length is unaffected by Slide, so only front and back bound the delta.
+        TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
+        if (clamped == TimeSpan.Zero) return false;
+
+        // Invariant: front.Length + middle.Length + back.Length is unchanged.
+        TimeSpan newFrontLength = front.Length + clamped;
+        TimeSpan newMiddleStart = middle.Start + clamped;
+        TimeSpan newBackStart = back.Start + clamped;
+        TimeSpan newBackLength = back.Length - clamped;
+
+        front.Length = newFrontLength;
+        middle.Start = newMiddleStart;
+        back.Start = newBackStart;
+        back.Length = newBackLength;
+
+        _historyManager.Commit(CommandNames.SlideElements);
+        return true;
+    }
+
+    private static TimeSpan ClampTrimDelta(TimeSpan delta, TimeSpan frontLength, TimeSpan backLength, TimeSpan minDuration)
+    {
+        TimeSpan minDelta = minDuration - frontLength;
+        TimeSpan maxDelta = backLength - minDuration;
+        return Clamp(delta, minDelta, maxDelta);
+    }
+
+    private static TimeSpan Clamp(TimeSpan value, TimeSpan min, TimeSpan max)
+    {
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
+    }
 }

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -241,85 +241,178 @@ public sealed class ElementResizeService : IElementResizeService
         return clampedLength > TimeSpan.Zero ? clampedLength : length;
     }
 
-    public (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, Element front, Element back)
+    public (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, IReadOnlyList<ElementTrimPair> pairs)
     {
         ArgumentNullException.ThrowIfNull(scene);
-        ArgumentNullException.ThrowIfNull(front);
-        ArgumentNullException.ThrowIfNull(back);
+        ArgumentNullException.ThrowIfNull(pairs);
+        ThrowIfAnyNullParticipant(pairs);
 
-        return ComputeTrimDeltaBounds(scene, front, back,
-            SlippableMedia.Collect(front), SlippableMedia.Collect(back));
+        (TimeSpan min, TimeSpan max) = (TimeSpan.Zero, TimeSpan.Zero);
+        for (int i = 0; i < pairs.Count; i++)
+        {
+            (Element front, Element back) = pairs[i];
+            (TimeSpan pairMin, TimeSpan pairMax) = ComputeTrimDeltaBounds(scene, front, back,
+                SlippableMedia.Collect(front), SlippableMedia.Collect(back));
+            if (i == 0)
+            {
+                (min, max) = (pairMin, pairMax);
+            }
+            else
+            {
+                if (pairMin > min) min = pairMin;
+                if (pairMax < max) max = pairMax;
+            }
+        }
+
+        return (min, max);
     }
 
-    public bool Roll(Scene scene, Element front, Element back, TimeSpan delta)
+    public bool Roll(Scene scene, IReadOnlyList<ElementTrimPair> pairs, TimeSpan delta)
     {
         ArgumentNullException.ThrowIfNull(scene);
-        ArgumentNullException.ThrowIfNull(front);
-        ArgumentNullException.ThrowIfNull(back);
-        if (front == back) return false;
-        // Coincidental time adjacency across layers is not an editable cut, and elements
-        // outside the supplied scene must not be mutated through this public seam — the
-        // UI guarantees both, direct service callers may not.
-        if (front.ZIndex != back.ZIndex) return false;
-        if (!scene.Children.Contains(front) || !scene.Children.Contains(back)) return false;
-        if (front.Range.End != back.Start) return false;
-        // Roll writes both clips, so a locked side blocks the whole op rather than being filtered.
-        if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return false;
+        ArgumentNullException.ThrowIfNull(pairs);
+        ThrowIfAnyNullParticipant(pairs);
+        if (pairs.Count == 0) return false;
 
-        List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
-        List<SlippableMedia.Target> backTargets = SlippableMedia.Collect(back);
-        (TimeSpan min, TimeSpan max) = ComputeTrimDeltaBounds(scene, front, back, frontTargets, backTargets);
+        // One shared delta moves every cut, so a single invalid pair rejects the whole
+        // operation — a partial roll would desync the grouped cuts it was asked to keep together.
+        var used = new HashSet<Element>();
+        foreach ((Element front, Element back) in pairs)
+        {
+            if (front == back) return false;
+            // Coincidental time adjacency across layers is not an editable cut, and elements
+            // outside the supplied scene must not be mutated through this public seam — the
+            // UI guarantees both, direct service callers may not.
+            if (front.ZIndex != back.ZIndex) return false;
+            if (!scene.Children.Contains(front) || !scene.Children.Contains(back)) return false;
+            if (front.Range.End != back.Start) return false;
+            // Roll writes both clips, so a locked side blocks the whole op rather than being filtered.
+            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return false;
+            // An element in two pairs would take two geometry writes and break the invariant.
+            if (!used.Add(front) || !used.Add(back)) return false;
+        }
+
+        var backTargets = new List<SlippableMedia.Target>[pairs.Count];
+        (TimeSpan min, TimeSpan max) = (TimeSpan.MinValue, TimeSpan.MaxValue);
+        for (int i = 0; i < pairs.Count; i++)
+        {
+            (Element front, Element back) = pairs[i];
+            backTargets[i] = SlippableMedia.Collect(back);
+            (TimeSpan pairMin, TimeSpan pairMax) = ComputeTrimDeltaBounds(scene, front, back,
+                SlippableMedia.Collect(front), backTargets[i]);
+            if (pairMin > min) min = pairMin;
+            if (pairMax < max) max = pairMax;
+        }
+
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
-        // Bypass Scene.MoveChild's overlap handling: Roll intentionally keeps the
-        // two clips exactly adjacent (front.End == back.Start), which MoveCommand
-        // treats as overlap and refuses. Direct property setters still record.
-        front.Length += clamped;
-        back.Start += clamped;
-        back.Length -= clamped;
-        // Preserve the back clip's content across the moving cut: its in-point advances
-        // by the same delta so the same source frames stay under the same timeline times.
-        SlippableMedia.ApplyOffsetDelta(backTargets, clamped);
+        for (int i = 0; i < pairs.Count; i++)
+        {
+            (Element front, Element back) = pairs[i];
+            // Bypass Scene.MoveChild's overlap handling: Roll intentionally keeps the
+            // two clips exactly adjacent (front.End == back.Start), which MoveCommand
+            // treats as overlap and refuses. Direct property setters still record.
+            front.Length += clamped;
+            back.Start += clamped;
+            back.Length -= clamped;
+            // Preserve the back clip's content across the moving cut: its in-point advances
+            // by the same delta so the same source frames stay under the same timeline times.
+            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped);
+        }
 
         _historyManager.Commit(CommandNames.RollElements);
         return true;
     }
 
-    public bool Slide(Scene scene, Element front, Element middle, Element back, TimeSpan delta)
+    public bool Slide(Scene scene, IReadOnlyList<ElementSlideLane> lanes, TimeSpan delta)
     {
         ArgumentNullException.ThrowIfNull(scene);
-        ArgumentNullException.ThrowIfNull(front);
-        ArgumentNullException.ThrowIfNull(middle);
-        ArgumentNullException.ThrowIfNull(back);
-        if (front == middle || middle == back || front == back) return false;
-        if (front.ZIndex != middle.ZIndex || middle.ZIndex != back.ZIndex) return false;
-        if (!scene.Children.Contains(front) || !scene.Children.Contains(middle) || !scene.Children.Contains(back))
-            return false;
-        if (front.Range.End != middle.Start) return false;
-        if (middle.Range.End != back.Start) return false;
-        // Slide writes all three clips, so any locked participant blocks the whole op.
-        if (scene.IsElementLocked(front) || scene.IsElementLocked(middle) || scene.IsElementLocked(back))
-            return false;
+        ArgumentNullException.ThrowIfNull(lanes);
+        foreach ((Element front, IReadOnlyList<Element> middles, Element back) in lanes)
+        {
+            if (front is null || back is null || middles is null)
+                throw new ArgumentNullException(nameof(lanes), "lanes must not contain null participants.");
+            if (middles.Count == 0)
+                throw new ArgumentException("Every lane needs at least one middle element.", nameof(lanes));
+            foreach (Element middle in middles)
+            {
+                if (middle is null)
+                    throw new ArgumentNullException(nameof(lanes), "lanes must not contain null participants.");
+            }
+        }
 
-        // The middle clip's length is unaffected by Slide, so only front and back bound the delta.
-        List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
-        List<SlippableMedia.Target> backTargets = SlippableMedia.Collect(back);
-        (TimeSpan min, TimeSpan max) = ComputeTrimDeltaBounds(scene, front, back, frontTargets, backTargets);
+        if (lanes.Count == 0) return false;
+
+        // One shared delta moves every lane, so a single invalid lane rejects the whole
+        // operation — a partial slide would desync the grouped block it was asked to keep together.
+        var used = new HashSet<Element>();
+        foreach ((Element front, IReadOnlyList<Element> middles, Element back) in lanes)
+        {
+            if (!used.Add(front) || !used.Add(back)) return false;
+            if (front.ZIndex != back.ZIndex) return false;
+            if (!scene.Children.Contains(front) || !scene.Children.Contains(back)) return false;
+            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return false;
+
+            TimeSpan expectedStart = front.Range.End;
+            foreach (Element middle in middles)
+            {
+                if (!used.Add(middle)) return false;
+                if (middle.ZIndex != front.ZIndex) return false;
+                if (!scene.Children.Contains(middle)) return false;
+                if (scene.IsElementLocked(middle)) return false;
+                if (middle.Start != expectedStart) return false;
+                expectedStart = middle.Range.End;
+            }
+
+            if (back.Start != expectedStart) return false;
+        }
+
+        // The middle clips' lengths are unaffected by Slide, so only front and back bound the delta.
+        var backTargets = new List<SlippableMedia.Target>[lanes.Count];
+        (TimeSpan min, TimeSpan max) = (TimeSpan.MinValue, TimeSpan.MaxValue);
+        for (int i = 0; i < lanes.Count; i++)
+        {
+            (Element front, _, Element back) = lanes[i];
+            backTargets[i] = SlippableMedia.Collect(back);
+            (TimeSpan laneMin, TimeSpan laneMax) = ComputeTrimDeltaBounds(scene, front, back,
+                SlippableMedia.Collect(front), backTargets[i]);
+            if (laneMin > min) min = laneMin;
+            if (laneMax < max) max = laneMax;
+        }
+
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
 
-        // Invariant: front.Length + middle.Length + back.Length is unchanged.
-        front.Length += clamped;
-        middle.Start += clamped;
-        back.Start += clamped;
-        back.Length -= clamped;
-        // The middle clip only shifts in time (its in-point is unchanged), but the back clip is
-        // trimmed at its head, so advance its media offset by the same delta to keep its content.
-        SlippableMedia.ApplyOffsetDelta(backTargets, clamped);
+        for (int i = 0; i < lanes.Count; i++)
+        {
+            (Element front, IReadOnlyList<Element> middles, Element back) = lanes[i];
+            // Invariant per lane: front.Length + Σ middles.Length + back.Length is unchanged.
+            front.Length += clamped;
+            foreach (Element middle in middles)
+            {
+                middle.Start += clamped;
+            }
+
+            back.Start += clamped;
+            back.Length -= clamped;
+            // The middle clips only shift in time (their in-points are unchanged), but the back
+            // clip is trimmed at its head, so advance its media offset by the same delta to keep
+            // its content.
+            SlippableMedia.ApplyOffsetDelta(backTargets[i], clamped);
+        }
 
         _historyManager.Commit(CommandNames.SlideElements);
         return true;
+    }
+
+    private static void ThrowIfAnyNullParticipant(IReadOnlyList<ElementTrimPair> pairs)
+    {
+        foreach ((Element front, Element back) in pairs)
+        {
+            if (front is null || back is null)
+                throw new ArgumentNullException(nameof(pairs), "pairs must not contain null participants.");
+        }
     }
 
     // Shared Roll/Slide delta window. Min (≤ 0) is bounded by the shrinking front keeping one

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -263,6 +263,8 @@ public sealed class ElementResizeService : IElementResizeService
         if (front.ZIndex != back.ZIndex) return false;
         if (!scene.Children.Contains(front) || !scene.Children.Contains(back)) return false;
         if (front.Range.End != back.Start) return false;
+        // Roll writes both clips, so a locked side blocks the whole op rather than being filtered.
+        if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return false;
 
         List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
         List<SlippableMedia.Target> backTargets = SlippableMedia.Collect(back);
@@ -296,6 +298,9 @@ public sealed class ElementResizeService : IElementResizeService
             return false;
         if (front.Range.End != middle.Start) return false;
         if (middle.Range.End != back.Start) return false;
+        // Slide writes all three clips, so any locked participant blocks the whole op.
+        if (scene.IsElementLocked(front) || scene.IsElementLocked(middle) || scene.IsElementLocked(back))
+            return false;
 
         // The middle clip's length is unaffected by Slide, so only front and back bound the delta.
         List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -253,18 +253,18 @@ public sealed class ElementResizeService : IElementResizeService
         TimeSpan minDuration = TimeSpan.FromSeconds(1d / rate);
 
         TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
+        clamped = ClampToSourceBounds(clamped, front, back);
         if (clamped == TimeSpan.Zero) return false;
-
-        TimeSpan newFrontLength = front.Length + clamped;
-        TimeSpan newBackStart = back.Start + clamped;
-        TimeSpan newBackLength = back.Length - clamped;
 
         // Bypass Scene.MoveChild's overlap handling: Roll intentionally keeps the
         // two clips exactly adjacent (front.End == back.Start), which MoveCommand
         // treats as overlap and refuses. Direct property setters still record.
-        front.Length = newFrontLength;
-        back.Start = newBackStart;
-        back.Length = newBackLength;
+        front.Length += clamped;
+        back.Start += clamped;
+        back.Length -= clamped;
+        // Preserve the back clip's content across the moving cut: its in-point advances
+        // by the same delta so the same source frames stay under the same timeline times.
+        SlippableMedia.ApplyOffsetDelta(SlippableMedia.Collect(back), clamped);
 
         _historyManager.Commit(CommandNames.RollElements);
         return true;
@@ -285,21 +285,40 @@ public sealed class ElementResizeService : IElementResizeService
 
         // The middle clip's length is unaffected by Slide, so only front and back bound the delta.
         TimeSpan clamped = ClampTrimDelta(delta, front.Length, back.Length, minDuration);
+        clamped = ClampToSourceBounds(clamped, front, back);
         if (clamped == TimeSpan.Zero) return false;
 
         // Invariant: front.Length + middle.Length + back.Length is unchanged.
-        TimeSpan newFrontLength = front.Length + clamped;
-        TimeSpan newMiddleStart = middle.Start + clamped;
-        TimeSpan newBackStart = back.Start + clamped;
-        TimeSpan newBackLength = back.Length - clamped;
-
-        front.Length = newFrontLength;
-        middle.Start = newMiddleStart;
-        back.Start = newBackStart;
-        back.Length = newBackLength;
+        front.Length += clamped;
+        middle.Start += clamped;
+        back.Start += clamped;
+        back.Length -= clamped;
+        // The middle clip only shifts in time (its in-point is unchanged), but the back clip is
+        // trimmed at its head, so advance its media offset by the same delta to keep its content.
+        SlippableMedia.ApplyOffsetDelta(SlippableMedia.Collect(back), clamped);
 
         _historyManager.Commit(CommandNames.SlideElements);
         return true;
+    }
+
+    // A positive delta extends the front clip's out-point and pulls the back clip's in-point
+    // forward; a negative delta pulls the back clip's in-point earlier. Each direction can run
+    // past a finite source, so clamp by the front's remaining tail (positive) or the back's
+    // remaining head (negative). Clips without a bounded source impose no limit.
+    private static TimeSpan ClampToSourceBounds(TimeSpan clamped, Element front, Element back)
+    {
+        if (clamped > TimeSpan.Zero)
+        {
+            TimeSpan room = SlippableMedia.OutPointRoom(front);
+            if (room < clamped) clamped = room;
+        }
+        else if (clamped < TimeSpan.Zero)
+        {
+            TimeSpan room = SlippableMedia.InPointRoom(back);
+            if (room < -clamped) clamped = -room;
+        }
+
+        return clamped;
     }
 
     private static TimeSpan ClampTrimDelta(TimeSpan delta, TimeSpan frontLength, TimeSpan backLength, TimeSpan minDuration)

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -304,8 +304,14 @@ public sealed class ElementResizeService : IElementResizeService
 
     private static TimeSpan ClampTrimDelta(TimeSpan delta, TimeSpan frontLength, TimeSpan backLength, TimeSpan minDuration)
     {
+        if (frontLength < minDuration || backLength < minDuration)
+            return TimeSpan.Zero;
+
         TimeSpan minDelta = minDuration - frontLength;
         TimeSpan maxDelta = backLength - minDuration;
+        if (minDelta > maxDelta)
+            return TimeSpan.Zero;
+
         return Clamp(delta, minDelta, maxDelta);
     }
 

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -294,16 +294,28 @@ public sealed class ElementResizeService : IElementResizeService
         }
 
         var backTargets = new List<SlippableMedia.Target>[pairs.Count];
+        var fixedOffsets = new HashSet<IProperty<TimeSpan>>();
         (TimeSpan min, TimeSpan max) = (TimeSpan.MinValue, TimeSpan.MaxValue);
         for (int i = 0; i < pairs.Count; i++)
         {
             (Element front, Element back) = pairs[i];
             backTargets[i] = SlippableMedia.Collect(back);
+            List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
+            foreach (SlippableMedia.Target target in frontTargets)
+            {
+                fixedOffsets.Add(target.Offset);
+            }
+
             (TimeSpan pairMin, TimeSpan pairMax) = ComputeTrimDeltaBounds(scene, front, back,
-                SlippableMedia.Collect(front), backTargets[i]);
+                frontTargets, backTargets[i]);
             if (pairMin > min) min = pairMin;
             if (pairMax < max) max = pairMax;
         }
+
+        // A media object shared between a front and a back participant cannot take the
+        // back-side offset advance without also shifting the front clip's fixed in-point,
+        // so the whole operation is rejected rather than applied desynced.
+        if (backTargets.Any(targets => targets.Any(t => fixedOffsets.Contains(t.Offset)))) return false;
 
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;
@@ -372,16 +384,37 @@ public sealed class ElementResizeService : IElementResizeService
 
         // The middle clips' lengths are unaffected by Slide, so only front and back bound the delta.
         var backTargets = new List<SlippableMedia.Target>[lanes.Count];
+        var fixedOffsets = new HashSet<IProperty<TimeSpan>>();
         (TimeSpan min, TimeSpan max) = (TimeSpan.MinValue, TimeSpan.MaxValue);
         for (int i = 0; i < lanes.Count; i++)
         {
-            (Element front, _, Element back) = lanes[i];
+            (Element front, IReadOnlyList<Element> middles, Element back) = lanes[i];
             backTargets[i] = SlippableMedia.Collect(back);
+            List<SlippableMedia.Target> frontTargets = SlippableMedia.Collect(front);
+            foreach (SlippableMedia.Target target in frontTargets)
+            {
+                fixedOffsets.Add(target.Offset);
+            }
+
+            // Middle in-points are fixed too: they move in time without re-trimming.
+            foreach (Element middle in middles)
+            {
+                foreach (SlippableMedia.Target target in SlippableMedia.Collect(middle))
+                {
+                    fixedOffsets.Add(target.Offset);
+                }
+            }
+
             (TimeSpan laneMin, TimeSpan laneMax) = ComputeTrimDeltaBounds(scene, front, back,
-                SlippableMedia.Collect(front), backTargets[i]);
+                frontTargets, backTargets[i]);
             if (laneMin > min) min = laneMin;
             if (laneMax < max) max = laneMax;
         }
+
+        // A media object shared between a back participant and a front/middle participant
+        // cannot take the back-side offset advance without also shifting content that must
+        // stay fixed, so the whole operation is rejected rather than applied desynced.
+        if (backTargets.Any(targets => targets.Any(t => fixedOffsets.Contains(t.Offset)))) return false;
 
         TimeSpan clamped = Clamp(delta, min, max);
         if (clamped == TimeSpan.Zero) return false;

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -17,8 +17,10 @@ public sealed class ElementSlipService : IElementSlipService
         ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(element);
         if (delta == TimeSpan.Zero) return false;
-        // The element or its layer may have been locked after the drag began, so re-check here
-        // rather than trusting the press-time IsEditable gate.
+        // Re-check membership and lock at the mutation boundary (matching Roll/Slide): a direct
+        // caller may pass an off-scene element, and the clip or its layer may have been locked
+        // after the drag began, so the press-time IsEditable gate is not enough.
+        if (!scene.Children.Contains(element)) return false;
         if (scene.IsElementLocked(element)) return false;
 
         List<SlippableMedia.Target> targets = SlippableMedia.Collect(element);

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -12,10 +12,14 @@ public sealed class ElementSlipService : IElementSlipService
         _historyManager = historyManager ?? throw new ArgumentNullException(nameof(historyManager));
     }
 
-    public bool Slip(Element element, TimeSpan delta)
+    public bool Slip(Scene scene, Element element, TimeSpan delta)
     {
+        ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(element);
         if (delta == TimeSpan.Zero) return false;
+        // The element or its layer may have been locked after the drag began, so re-check here
+        // rather than trusting the press-time IsEditable gate.
+        if (scene.IsElementLocked(element)) return false;
 
         List<SlippableMedia.Target> targets = SlippableMedia.Collect(element);
         if (targets.Count == 0) return false;

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Language;
+﻿using Beutl.Engine;
+using Beutl.Language;
 using Beutl.ProjectSystem;
 
 namespace Beutl.Editor.Services;
@@ -53,9 +54,10 @@ public sealed class ElementSlipService : IElementSlipService
             if (effective == TimeSpan.Zero) return false;
         }
 
+        var applied = new HashSet<IProperty<TimeSpan>>();
         foreach ((List<SlippableMedia.Target> targets, _) in applicable)
         {
-            SlippableMedia.ApplyOffsetDelta(targets, effective);
+            SlippableMedia.ApplyOffsetDelta(targets, effective, applied);
         }
 
         _historyManager.Commit(CommandNames.SlipElement);

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -25,13 +25,11 @@ public sealed class ElementSlipService : IElementSlipService
         {
             if (obj is SourceVideo sv)
             {
-                sv.OffsetPosition.CurrentValue += delta;
-                applied = true;
+                applied |= ShiftOffset(sv, delta);
             }
             else if (obj is Sound sound)
             {
-                sound.OffsetPosition.CurrentValue += delta;
-                applied = true;
+                applied |= ShiftOffset(sound, delta);
             }
         }
 
@@ -40,5 +38,30 @@ public sealed class ElementSlipService : IElementSlipService
             _historyManager.Commit(CommandNames.SlipElement);
         }
         return applied;
+    }
+
+    private static bool ShiftOffset(SourceVideo source, TimeSpan delta)
+    {
+        TimeSpan current = source.OffsetPosition.CurrentValue;
+        TimeSpan next = ClampOffset(current + delta);
+        if (next == current) return false;
+
+        source.OffsetPosition.CurrentValue = next;
+        return true;
+    }
+
+    private static bool ShiftOffset(Sound sound, TimeSpan delta)
+    {
+        TimeSpan current = sound.OffsetPosition.CurrentValue;
+        TimeSpan next = ClampOffset(current + delta);
+        if (next == current) return false;
+
+        sound.OffsetPosition.CurrentValue = next;
+        return true;
+    }
+
+    private static TimeSpan ClampOffset(TimeSpan value)
+    {
+        return value < TimeSpan.Zero ? TimeSpan.Zero : value;
     }
 }

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -12,24 +12,52 @@ public sealed class ElementSlipService : IElementSlipService
         _historyManager = historyManager ?? throw new ArgumentNullException(nameof(historyManager));
     }
 
-    public bool Slip(Scene scene, Element element, TimeSpan delta)
+    public bool Slip(Scene scene, IReadOnlyList<Element> elements, TimeSpan delta)
     {
         ArgumentNullException.ThrowIfNull(scene);
-        ArgumentNullException.ThrowIfNull(element);
+        ArgumentNullException.ThrowIfNull(elements);
+        foreach (Element element in elements)
+        {
+            if (element is null)
+                throw new ArgumentNullException(nameof(elements), "elements must not contain null.");
+        }
+
         if (delta == TimeSpan.Zero) return false;
-        // Re-check membership and lock at the mutation boundary (matching Roll/Slide): a direct
-        // caller may pass an off-scene element, and the clip or its layer may have been locked
-        // after the drag began, so the press-time IsEditable gate is not enough.
-        if (!scene.Children.Contains(element)) return false;
-        if (scene.IsElementLocked(element)) return false;
 
-        List<SlippableMedia.Target> targets = SlippableMedia.Collect(element);
-        if (targets.Count == 0) return false;
+        // Re-check membership and lock at the mutation boundary (matching Resize): a direct
+        // caller may pass an off-scene element, and a clip or its layer may have been locked
+        // after the drag began, so the press-time IsEditable gate is not enough. Disqualified
+        // members are dropped rather than blocking the rest of the group.
+        var seen = new HashSet<Element>();
+        var applicable = new List<(List<SlippableMedia.Target> Targets, TimeSpan Length)>();
+        foreach (Element element in elements)
+        {
+            if (!seen.Add(element)) continue;
+            if (!scene.Children.Contains(element)) continue;
+            if (scene.IsElementLocked(element)) continue;
 
-        TimeSpan effective = SlippableMedia.ClampSharedDelta(targets, delta, element.Length);
-        if (effective == TimeSpan.Zero) return false;
+            List<SlippableMedia.Target> targets = SlippableMedia.Collect(element);
+            if (targets.Count == 0) continue;
 
-        SlippableMedia.ApplyOffsetDelta(targets, effective);
+            applicable.Add((targets, element.Length));
+        }
+
+        if (applicable.Count == 0) return false;
+
+        // Chained clamping: each element can only shrink the magnitude, so the final value is
+        // the delta every stream of every element can absorb — grouped linked media stay in sync.
+        TimeSpan effective = delta;
+        foreach ((List<SlippableMedia.Target> targets, TimeSpan length) in applicable)
+        {
+            effective = SlippableMedia.ClampSharedDelta(targets, effective, length);
+            if (effective == TimeSpan.Zero) return false;
+        }
+
+        foreach ((List<SlippableMedia.Target> targets, _) in applicable)
+        {
+            SlippableMedia.ApplyOffsetDelta(targets, effective);
+        }
+
         _historyManager.Commit(CommandNames.SlipElement);
         return true;
     }

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -1,7 +1,4 @@
-﻿using Beutl.Audio;
-using Beutl.Engine;
-using Beutl.Graphics;
-using Beutl.Language;
+﻿using Beutl.Language;
 using Beutl.ProjectSystem;
 
 namespace Beutl.Editor.Services;
@@ -20,93 +17,14 @@ public sealed class ElementSlipService : IElementSlipService
         ArgumentNullException.ThrowIfNull(element);
         if (delta == TimeSpan.Zero) return false;
 
-        bool applied = false;
-        foreach (EngineObject obj in element.Objects)
-        {
-            if (obj is SourceVideo sv)
-            {
-                applied |= ShiftOffset(sv, delta, element.Length);
-            }
-            else if (obj is Sound sound)
-            {
-                applied |= ShiftSound(sound, delta, element.Length);
-            }
-        }
+        List<SlippableMedia.Target> targets = SlippableMedia.Collect(element);
+        if (targets.Count == 0) return false;
 
-        if (applied)
-        {
-            _historyManager.Commit(CommandNames.SlipElement);
-        }
-        return applied;
-    }
+        TimeSpan effective = SlippableMedia.ClampSharedDelta(targets, delta, element.Length);
+        if (effective == TimeSpan.Zero) return false;
 
-    private static bool ShiftOffset(SourceVideo source, TimeSpan delta, TimeSpan elementLength)
-    {
-        TimeSpan current = source.OffsetPosition.CurrentValue;
-        TimeSpan? maxOffset = null;
-        if (source.TryGetOriginalDuration(out TimeSpan remainingDuration))
-        {
-            maxOffset = GetMaxOffset(current, remainingDuration, elementLength);
-        }
-
-        TimeSpan next = ClampOffset(current + delta, maxOffset);
-        if (next == current) return false;
-
-        source.OffsetPosition.CurrentValue = next;
+        SlippableMedia.ApplyOffsetDelta(targets, effective);
+        _historyManager.Commit(CommandNames.SlipElement);
         return true;
-    }
-
-    private static bool ShiftSound(Sound sound, TimeSpan delta, TimeSpan elementLength)
-    {
-        return sound switch
-        {
-            SourceSound sourceSound => ShiftOffset(sourceSound, delta, elementLength),
-            SoundGroup group => ShiftSoundGroup(group, delta, elementLength),
-            _ => false
-        };
-    }
-
-    private static bool ShiftSoundGroup(SoundGroup group, TimeSpan delta, TimeSpan elementLength)
-    {
-        bool applied = false;
-        foreach (Sound child in group.Children)
-        {
-            applied |= ShiftSound(child, delta, elementLength);
-        }
-
-        return applied;
-    }
-
-    private static bool ShiftOffset(SourceSound sound, TimeSpan delta, TimeSpan elementLength)
-    {
-        TimeSpan current = sound.OffsetPosition.CurrentValue;
-        TimeSpan? maxOffset = null;
-        if (sound.TryGetOriginalDuration(out TimeSpan originalDuration))
-        {
-            maxOffset = GetMaxOffset(TimeSpan.Zero, originalDuration, elementLength);
-        }
-
-        TimeSpan next = ClampOffset(current + delta, maxOffset);
-        if (next == current) return false;
-
-        sound.OffsetPosition.CurrentValue = next;
-        return true;
-    }
-
-    private static TimeSpan GetMaxOffset(TimeSpan currentOffset, TimeSpan remainingDuration, TimeSpan elementLength)
-    {
-        TimeSpan maxOffset = currentOffset + remainingDuration - elementLength;
-        return maxOffset < TimeSpan.Zero ? TimeSpan.Zero : maxOffset;
-    }
-
-    private static TimeSpan ClampOffset(TimeSpan value, TimeSpan? maxOffset)
-    {
-        if (value < TimeSpan.Zero)
-            return TimeSpan.Zero;
-
-        if (maxOffset.HasValue && value > maxOffset.Value)
-            return maxOffset.Value;
-
-        return value;
     }
 }

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -1,0 +1,44 @@
+﻿using Beutl.Audio;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Language;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+public sealed class ElementSlipService : IElementSlipService
+{
+    private readonly HistoryManager _historyManager;
+
+    public ElementSlipService(HistoryManager historyManager)
+    {
+        _historyManager = historyManager ?? throw new ArgumentNullException(nameof(historyManager));
+    }
+
+    public bool Slip(Element element, TimeSpan delta)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+        if (delta == TimeSpan.Zero) return false;
+
+        bool applied = false;
+        foreach (EngineObject obj in element.Objects)
+        {
+            if (obj is SourceVideo sv)
+            {
+                sv.OffsetPosition.CurrentValue += delta;
+                applied = true;
+            }
+            else if (obj is Sound sound)
+            {
+                sound.OffsetPosition.CurrentValue += delta;
+                applied = true;
+            }
+        }
+
+        if (applied)
+        {
+            _historyManager.Commit(CommandNames.SlipElement);
+        }
+        return applied;
+    }
+}

--- a/src/Beutl.Editor/Services/ElementSlipService.cs
+++ b/src/Beutl.Editor/Services/ElementSlipService.cs
@@ -25,11 +25,11 @@ public sealed class ElementSlipService : IElementSlipService
         {
             if (obj is SourceVideo sv)
             {
-                applied |= ShiftOffset(sv, delta);
+                applied |= ShiftOffset(sv, delta, element.Length);
             }
             else if (obj is Sound sound)
             {
-                applied |= ShiftOffset(sound, delta);
+                applied |= ShiftSound(sound, delta, element.Length);
             }
         }
 
@@ -40,28 +40,73 @@ public sealed class ElementSlipService : IElementSlipService
         return applied;
     }
 
-    private static bool ShiftOffset(SourceVideo source, TimeSpan delta)
+    private static bool ShiftOffset(SourceVideo source, TimeSpan delta, TimeSpan elementLength)
     {
         TimeSpan current = source.OffsetPosition.CurrentValue;
-        TimeSpan next = ClampOffset(current + delta);
+        TimeSpan? maxOffset = null;
+        if (source.TryGetOriginalDuration(out TimeSpan remainingDuration))
+        {
+            maxOffset = GetMaxOffset(current, remainingDuration, elementLength);
+        }
+
+        TimeSpan next = ClampOffset(current + delta, maxOffset);
         if (next == current) return false;
 
         source.OffsetPosition.CurrentValue = next;
         return true;
     }
 
-    private static bool ShiftOffset(Sound sound, TimeSpan delta)
+    private static bool ShiftSound(Sound sound, TimeSpan delta, TimeSpan elementLength)
+    {
+        return sound switch
+        {
+            SourceSound sourceSound => ShiftOffset(sourceSound, delta, elementLength),
+            SoundGroup group => ShiftSoundGroup(group, delta, elementLength),
+            _ => false
+        };
+    }
+
+    private static bool ShiftSoundGroup(SoundGroup group, TimeSpan delta, TimeSpan elementLength)
+    {
+        bool applied = false;
+        foreach (Sound child in group.Children)
+        {
+            applied |= ShiftSound(child, delta, elementLength);
+        }
+
+        return applied;
+    }
+
+    private static bool ShiftOffset(SourceSound sound, TimeSpan delta, TimeSpan elementLength)
     {
         TimeSpan current = sound.OffsetPosition.CurrentValue;
-        TimeSpan next = ClampOffset(current + delta);
+        TimeSpan? maxOffset = null;
+        if (sound.TryGetOriginalDuration(out TimeSpan originalDuration))
+        {
+            maxOffset = GetMaxOffset(TimeSpan.Zero, originalDuration, elementLength);
+        }
+
+        TimeSpan next = ClampOffset(current + delta, maxOffset);
         if (next == current) return false;
 
         sound.OffsetPosition.CurrentValue = next;
         return true;
     }
 
-    private static TimeSpan ClampOffset(TimeSpan value)
+    private static TimeSpan GetMaxOffset(TimeSpan currentOffset, TimeSpan remainingDuration, TimeSpan elementLength)
     {
-        return value < TimeSpan.Zero ? TimeSpan.Zero : value;
+        TimeSpan maxOffset = currentOffset + remainingDuration - elementLength;
+        return maxOffset < TimeSpan.Zero ? TimeSpan.Zero : maxOffset;
+    }
+
+    private static TimeSpan ClampOffset(TimeSpan value, TimeSpan? maxOffset)
+    {
+        if (value < TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        if (maxOffset.HasValue && value > maxOffset.Value)
+            return maxOffset.Value;
+
+        return value;
     }
 }

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -24,7 +24,10 @@ public interface IElementResizeService
     /// <summary>
     /// Roll: shift the boundary between two adjacent clips. <c>front.Length += d</c>,
     /// <c>back.Start += d</c>, <c>back.Length -= d</c>; total length is preserved. The
-    /// delta is clamped so both clips keep at least one frame at the scene's frame rate.
+    /// delta is clamped so both clips keep at least one frame at the scene's frame rate,
+    /// and — for source-backed clips — so the front's out-point stays within its source
+    /// and the back's in-point stays within its source. The back clip's media offset is
+    /// advanced by the same delta so its content stays anchored across the moving cut.
     /// Returns <see langword="false"/> (no commit) when <c>front.End != back.Start</c>
     /// (not adjacent) or the clamped delta is zero.
     /// </summary>
@@ -34,7 +37,10 @@ public interface IElementResizeService
     /// Slide: shift a middle clip's Start by <paramref name="delta"/>; the front clip
     /// grows by <paramref name="delta"/> and the back clip shrinks by
     /// <paramref name="delta"/>, preserving the total length. The delta is clamped so
-    /// the front and back clips keep at least one frame at the scene's frame rate.
+    /// the front and back clips keep at least one frame at the scene's frame rate, and —
+    /// for source-backed clips — so neither the front's out-point nor the back's in-point
+    /// runs past its source. The back clip's media offset is advanced by the same delta so
+    /// its content stays anchored; the middle clip only moves in time.
     /// Returns <see langword="false"/> (no commit) when the three clips are not
     /// mutually adjacent (<c>front.End != middle.Start</c> or
     /// <c>middle.End != back.Start</c>) or the clamped delta is zero.

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -3,18 +3,23 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Element-geometry trim operations on <see cref="Element"/>s: writes to
-/// <see cref="Element.Start"/> / <see cref="Element.Length"/> / <see cref="Element.ZIndex"/>
-/// only. Each method owns a single history commit boundary for one user-visible
-/// operation. The View handles per-pointer-frame preview via VM reactive properties;
-/// the service runs once on drag release with the final values.
+/// Element-geometry trim operations on <see cref="Element"/>s: primarily writes
+/// <see cref="Element.Start"/> / <see cref="Element.Length"/> / <see cref="Element.ZIndex"/>.
+/// Each method owns a single history commit boundary for one user-visible operation. The
+/// View handles per-pointer-frame preview via VM reactive properties; the service runs once
+/// on drag release with the final values.
 /// <para>
 /// <see cref="Resize"/> writes the final (start, length, zIndex) per element in one
 /// transaction. <see cref="Roll"/> and <see cref="Slide"/> are the roll / slide trim
-/// modes, which adjust clip boundaries while preserving the total timeline length.
-/// Media-offset shifts (the Slip mode) are owned by <see cref="IElementSlipService"/>
-/// — they write the source-media window, not element geometry, and are kept separate
-/// so a plugin replacing one family does not inherit the other.
+/// modes, which adjust clip boundaries while preserving the total timeline length; they
+/// additionally advance the trimmed neighbour's media offset so its content stays anchored
+/// across the moving cut (see the shared primitives in <c>SlippableMedia</c>).
+/// </para>
+/// <para>
+/// The pure media-offset shift (the Slip mode) is owned by <see cref="IElementSlipService"/>
+/// — kept as a separate service by responsibility (media-window vs. clip-geometry editing),
+/// each owning its own history commit boundary. These are in-tree editing seams consumed by
+/// the Timeline View; the concrete implementations are wired in <c>EditViewModel.GetService</c>.
 /// </para>
 /// </summary>
 public interface IElementResizeService

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -29,44 +29,50 @@ public interface IElementResizeService
     void Resize(Scene scene, IReadOnlyList<ElementResizeRequest> requests, bool ripple = false);
 
     /// <summary>
-    /// Roll: shift the boundary between two adjacent clips. <c>front.Length += d</c>,
-    /// <c>back.Start += d</c>, <c>back.Length -= d</c>; total length is preserved. The
-    /// delta is clamped so both clips keep at least one frame at the scene's frame rate,
-    /// and — for source-backed clips — so the back's in-point never goes below zero and,
-    /// when the editor's ClampResizeToOriginalLength preference is on, so the front's
-    /// out-point stays within its source. The back clip's media offset is
-    /// advanced by the same delta so its content stays anchored across the moving cut.
-    /// Returns <see langword="false"/> (no commit) when <c>front.End != back.Start</c>
-    /// (not adjacent) or the clamped delta is zero.
+    /// Roll: shift the boundary between two adjacent clips, for every supplied pair at
+    /// once. Per pair: <c>front.Length += d</c>, <c>back.Start += d</c>,
+    /// <c>back.Length -= d</c>; total length is preserved. One shared delta — clamped to
+    /// the intersection of every pair's window (see <see cref="GetTrimDeltaBounds"/>) — is
+    /// applied to all pairs so grouped cuts (e.g. a video + audio pair on separate layers)
+    /// move together. Each back clip's media offset is advanced by the same delta so its
+    /// content stays anchored across the moving cut. Returns <see langword="false"/> (no
+    /// commit) when <paramref name="pairs"/> is empty, any pair is invalid — front and back
+    /// not distinct, on different layers, not both in <paramref name="scene"/>,
+    /// <c>front.End != back.Start</c>, either side locked, or an element appearing in more
+    /// than one pair — or the shared clamped delta is zero. A single invalid pair rejects
+    /// the whole operation (never a partial, desynced roll).
     /// </summary>
-    bool Roll(Scene scene, Element front, Element back, TimeSpan delta);
+    bool Roll(Scene scene, IReadOnlyList<ElementTrimPair> pairs, TimeSpan delta);
 
     /// <summary>
-    /// Slide: shift a middle clip's Start by <paramref name="delta"/>; the front clip
-    /// grows by <paramref name="delta"/> and the back clip shrinks by
-    /// <paramref name="delta"/>, preserving the total length. The delta is clamped so
-    /// the front and back clips keep at least one frame at the scene's frame rate, and —
-    /// for source-backed clips — so the back's in-point never goes below zero and, when
-    /// the editor's ClampResizeToOriginalLength preference is on, so the front's out-point
-    /// stays within its source. The back clip's media offset is advanced by the same delta so
-    /// its content stays anchored; the middle clip only moves in time.
-    /// Returns <see langword="false"/> (no commit) when the three clips are not
-    /// mutually adjacent (<c>front.End != middle.Start</c> or
-    /// <c>middle.End != back.Start</c>) or the clamped delta is zero.
+    /// Slide: shift a run of middle clips in time, for every supplied lane at once. Per
+    /// lane: the front clip grows by the delta, every middle clip's Start shifts by it,
+    /// and the back clip shrinks by it, preserving the total length. One shared delta —
+    /// clamped to the intersection of every lane's front/back window (the middles' lengths
+    /// are unaffected) — is applied to all lanes so a grouped block spanning layers moves
+    /// together. Each back clip's media offset is advanced by the same delta so its content
+    /// stays anchored; the middle clips only move in time. Returns <see langword="false"/>
+    /// (no commit) when <paramref name="lanes"/> is empty, any lane is invalid — members on
+    /// different layers, not all in <paramref name="scene"/>, the
+    /// front → middles → back chain not contiguously adjacent, any participant locked, or
+    /// an element appearing twice across lanes — or the shared clamped delta is zero. A
+    /// single invalid lane rejects the whole operation (never a partial, desynced slide).
     /// </summary>
-    bool Slide(Scene scene, Element front, Element middle, Element back, TimeSpan delta);
+    bool Slide(Scene scene, IReadOnlyList<ElementSlideLane> lanes, TimeSpan delta);
 
     /// <summary>
-    /// The delta window shared by <see cref="Roll"/> and <see cref="Slide"/> for a given
-    /// front/back pair: <c>Min ≤ 0 ≤ Max</c>, bounded by both clips keeping at least one
-    /// frame at the scene's frame rate, the back in-point staying at or above zero, and —
-    /// when the editor's ClampResizeToOriginalLength preference is on — the front out-point
-    /// staying within its source. Both operations clamp with the same window on commit;
-    /// the Timeline View queries it once at drag start so the per-pointer-frame preview
-    /// cannot overshoot what the release will apply. <c>(Zero, Zero)</c> when no trim is
-    /// possible. Adjacency is not validated here; callers check it before starting a drag.
+    /// The delta window shared by <see cref="Roll"/> and <see cref="Slide"/>: the
+    /// intersection over <paramref name="pairs"/> of each front/back window,
+    /// <c>Min ≤ 0 ≤ Max</c>, bounded per pair by both clips keeping at least one frame at
+    /// the scene's frame rate, the back in-point staying at or above zero, and — when the
+    /// editor's ClampResizeToOriginalLength preference is on — the front out-point staying
+    /// within its source. Both operations clamp with the same window on commit; the
+    /// Timeline View queries it once at drag start so the per-pointer-frame preview cannot
+    /// overshoot what the release will apply. <c>(Zero, Zero)</c> when
+    /// <paramref name="pairs"/> is empty or no trim is possible. Adjacency is not validated
+    /// here; callers check it before starting a drag.
     /// </summary>
-    (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, Element front, Element back);
+    (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, IReadOnlyList<ElementTrimPair> pairs);
 }
 
 public readonly record struct ElementResizeRequest(
@@ -74,3 +80,15 @@ public readonly record struct ElementResizeRequest(
     TimeSpan NewStart,
     TimeSpan NewLength,
     int ZIndex);
+
+/// <summary>
+/// One rolled cut: <see cref="Front"/> ends exactly where <see cref="Back"/> starts, on
+/// the same layer.
+/// </summary>
+public readonly record struct ElementTrimPair(Element Front, Element Back);
+
+/// <summary>
+/// One slid lane: a contiguous run of <see cref="Middles"/> (ordered by Start) with the
+/// adjacent <see cref="Front"/> before and <see cref="Back"/> after, all on the same layer.
+/// </summary>
+public readonly record struct ElementSlideLane(Element Front, IReadOnlyList<Element> Middles, Element Back);

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -16,10 +16,12 @@ namespace Beutl.Editor.Services;
 /// across the moving cut (see the shared primitives in <c>SlippableMedia</c>).
 /// </para>
 /// <para>
-/// The pure media-offset shift (the Slip mode) is owned by <see cref="IElementSlipService"/>
-/// — kept as a separate service by responsibility (media-window vs. clip-geometry editing),
-/// each owning its own history commit boundary. These are in-tree editing seams consumed by
-/// the Timeline View; the concrete implementations are wired in <c>EditViewModel.GetService</c>.
+/// The pure media-offset shift (the Slip mode) is owned by <see cref="IElementSlipService"/>.
+/// Slip is media-window-only; Roll / Slide are geometry-primary and additionally shift the
+/// trimmed neighbour's media window, so media-offset writes are not exclusive to the slip
+/// service — the shared primitives live in <c>SlippableMedia</c>. Each service owns its own
+/// history commit boundary. These are in-tree editing seams consumed by the Timeline View;
+/// the concrete implementations are wired in <c>EditViewModel.GetService</c>.
 /// </para>
 /// </summary>
 public interface IElementResizeService
@@ -30,8 +32,9 @@ public interface IElementResizeService
     /// Roll: shift the boundary between two adjacent clips. <c>front.Length += d</c>,
     /// <c>back.Start += d</c>, <c>back.Length -= d</c>; total length is preserved. The
     /// delta is clamped so both clips keep at least one frame at the scene's frame rate,
-    /// and — for source-backed clips — so the front's out-point stays within its source
-    /// and the back's in-point stays within its source. The back clip's media offset is
+    /// and — for source-backed clips — so the back's in-point never goes below zero and,
+    /// when the editor's ClampResizeToOriginalLength preference is on, so the front's
+    /// out-point stays within its source. The back clip's media offset is
     /// advanced by the same delta so its content stays anchored across the moving cut.
     /// Returns <see langword="false"/> (no commit) when <c>front.End != back.Start</c>
     /// (not adjacent) or the clamped delta is zero.
@@ -43,8 +46,9 @@ public interface IElementResizeService
     /// grows by <paramref name="delta"/> and the back clip shrinks by
     /// <paramref name="delta"/>, preserving the total length. The delta is clamped so
     /// the front and back clips keep at least one frame at the scene's frame rate, and —
-    /// for source-backed clips — so neither the front's out-point nor the back's in-point
-    /// runs past its source. The back clip's media offset is advanced by the same delta so
+    /// for source-backed clips — so the back's in-point never goes below zero and, when
+    /// the editor's ClampResizeToOriginalLength preference is on, so the front's out-point
+    /// stays within its source. The back clip's media offset is advanced by the same delta so
     /// its content stays anchored; the middle clip only moves in time.
     /// Returns <see langword="false"/> (no commit) when the three clips are not
     /// mutually adjacent (<c>front.End != middle.Start</c> or

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -3,14 +3,43 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Applies resize requests to one or more <see cref="Element"/>s and commits one
-/// MoveElement entry. The View handles per-pointer-frame preview via VM reactive
-/// properties; the service runs once on drag release with the final
-/// (start, length, zIndex) per element.
+/// Element-geometry trim operations on <see cref="Element"/>s: writes to
+/// <see cref="Element.Start"/> / <see cref="Element.Length"/> / <see cref="Element.ZIndex"/>
+/// only. Each method owns a single history commit boundary for one user-visible
+/// operation. The View handles per-pointer-frame preview via VM reactive properties;
+/// the service runs once on drag release with the final values.
+/// <para>
+/// <see cref="Resize"/> writes the final (start, length, zIndex) per element in one
+/// transaction. <see cref="Roll"/> and <see cref="Slide"/> are the roll / slide trim
+/// modes, which adjust clip boundaries while preserving the total timeline length.
+/// Media-offset shifts (the Slip mode) are owned by <see cref="IElementSlipService"/>
+/// — they write the source-media window, not element geometry, and are kept separate
+/// so a plugin replacing one family does not inherit the other.
+/// </para>
 /// </summary>
 public interface IElementResizeService
 {
     void Resize(Scene scene, IReadOnlyList<ElementResizeRequest> requests, bool ripple = false);
+
+    /// <summary>
+    /// Roll: shift the boundary between two adjacent clips. <c>front.Length += d</c>,
+    /// <c>back.Start += d</c>, <c>back.Length -= d</c>; total length is preserved. The
+    /// delta is clamped so both clips keep at least one frame at the scene's frame rate.
+    /// Returns <see langword="false"/> (no commit) when <c>front.End != back.Start</c>
+    /// (not adjacent) or the clamped delta is zero.
+    /// </summary>
+    bool Roll(Scene scene, Element front, Element back, TimeSpan delta);
+
+    /// <summary>
+    /// Slide: shift a middle clip's Start by <paramref name="delta"/>; the front clip
+    /// grows by <paramref name="delta"/> and the back clip shrinks by
+    /// <paramref name="delta"/>, preserving the total length. The delta is clamped so
+    /// the front and back clips keep at least one frame at the scene's frame rate.
+    /// Returns <see langword="false"/> (no commit) when the three clips are not
+    /// mutually adjacent (<c>front.End != middle.Start</c> or
+    /// <c>middle.End != back.Start</c>) or the clamped delta is zero.
+    /// </summary>
+    bool Slide(Scene scene, Element front, Element middle, Element back, TimeSpan delta);
 }
 
 public readonly record struct ElementResizeRequest(

--- a/src/Beutl.Editor/Services/IElementResizeService.cs
+++ b/src/Beutl.Editor/Services/IElementResizeService.cs
@@ -51,6 +51,18 @@ public interface IElementResizeService
     /// <c>middle.End != back.Start</c>) or the clamped delta is zero.
     /// </summary>
     bool Slide(Scene scene, Element front, Element middle, Element back, TimeSpan delta);
+
+    /// <summary>
+    /// The delta window shared by <see cref="Roll"/> and <see cref="Slide"/> for a given
+    /// front/back pair: <c>Min ≤ 0 ≤ Max</c>, bounded by both clips keeping at least one
+    /// frame at the scene's frame rate, the back in-point staying at or above zero, and —
+    /// when the editor's ClampResizeToOriginalLength preference is on — the front out-point
+    /// staying within its source. Both operations clamp with the same window on commit;
+    /// the Timeline View queries it once at drag start so the per-pointer-frame preview
+    /// cannot overshoot what the release will apply. <c>(Zero, Zero)</c> when no trim is
+    /// possible. Adjacency is not validated here; callers check it before starting a drag.
+    /// </summary>
+    (TimeSpan Min, TimeSpan Max) GetTrimDeltaBounds(Scene scene, Element front, Element back);
 }
 
 public readonly record struct ElementResizeRequest(

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -23,8 +23,9 @@ public interface IElementSlipService
     /// Drawable and Sound containers. A single effective delta — the largest the tightest
     /// stream can accept without leaving its source — is applied to all streams so linked
     /// media (e.g. a video + audio pair) stay in sync. Returns <see langword="false"/>
-    /// (no commit) when <paramref name="delta"/> is zero, the element carries no slip-able
-    /// media, or the shared clamped delta is zero.
+    /// (no commit) when <paramref name="delta"/> is zero, <paramref name="element"/> or its
+    /// layer is locked in <paramref name="scene"/>, the element carries no slip-able media,
+    /// or the shared clamped delta is zero.
     /// </summary>
-    bool Slip(Element element, TimeSpan delta);
+    bool Slip(Scene scene, Element element, TimeSpan delta);
 }

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -3,8 +3,8 @@
 namespace Beutl.Editor.Services;
 
 /// <summary>
-/// Slip: shift the source-media window inside an <see cref="Element"/> without
-/// changing the element's <see cref="Element.Start"/> / <see cref="Element.Length"/>.
+/// Slip: shift the source-media window inside one or more <see cref="Element"/>s without
+/// changing any element's <see cref="Element.Start"/> / <see cref="Element.Length"/>.
 /// Writes the media's in-source offset (<see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
 /// / <see cref="Beutl.Audio.Sound.OffsetPosition"/>), not element geometry, and owns
 /// the single history commit boundary for one user-visible slip. Kept separate from
@@ -16,16 +16,19 @@ namespace Beutl.Editor.Services;
 public interface IElementSlipService
 {
     /// <summary>
-    /// Shift the source-media window inside <paramref name="element"/> by
+    /// Shift the source-media window inside every element of <paramref name="elements"/> by
     /// <paramref name="delta"/>. Adjusts <see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
     /// and <see cref="Beutl.Audio.Sound.OffsetPosition"/> on every slip-able media object
     /// reachable from <see cref="Element.Objects"/>, including sources nested inside
     /// Drawable and Sound containers. A single effective delta — the largest the tightest
-    /// stream can accept without leaving its source — is applied to all streams so linked
-    /// media (e.g. a video + audio pair) stay in sync. Returns <see langword="false"/>
-    /// (no commit) when <paramref name="delta"/> is zero, <paramref name="element"/> or its
-    /// layer is locked in <paramref name="scene"/>, the element carries no slip-able media,
-    /// or the shared clamped delta is zero.
+    /// stream across all supplied elements can accept without leaving its source — is applied
+    /// to every stream so linked media (e.g. a video + audio pair, whether inside one element
+    /// or grouped across elements) stay in sync. Elements that are duplicated in the list,
+    /// no longer in <paramref name="scene"/>, locked (directly or via their layer), or carry
+    /// no slip-able media are dropped at this mutation boundary (matching
+    /// <see cref="IElementResizeService.Resize"/>) rather than blocking the group. Returns
+    /// <see langword="false"/> (no commit) when <paramref name="delta"/> is zero, no element
+    /// survives that filter, or the shared clamped delta is zero.
     /// </summary>
-    bool Slip(Scene scene, Element element, TimeSpan delta);
+    bool Slip(Scene scene, IReadOnlyList<Element> elements, TimeSpan delta);
 }

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -7,9 +7,10 @@ namespace Beutl.Editor.Services;
 /// changing the element's <see cref="Element.Start"/> / <see cref="Element.Length"/>.
 /// Writes the media's in-source offset (<see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
 /// / <see cref="Beutl.Audio.Sound.OffsetPosition"/>), not element geometry, and owns
-/// the single history commit boundary for one user-visible slip. Distinct from
-/// <see cref="IElementResizeService"/> so a plugin replacing the geometry-trim family
-/// does not inherit the media-offset family.
+/// the single history commit boundary for one user-visible slip. Kept separate from
+/// <see cref="IElementResizeService"/> by responsibility — this edits the media window,
+/// that edits clip geometry — even though Roll / Slide reuse the same media-offset
+/// primitives to keep a trimmed neighbour's content anchored across a moving cut.
 /// </summary>
 public interface IElementSlipService
 {

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -16,9 +16,13 @@ public interface IElementSlipService
     /// <summary>
     /// Shift the source-media window inside <paramref name="element"/> by
     /// <paramref name="delta"/>. Adjusts <see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
-    /// and <see cref="Beutl.Audio.Sound.OffsetPosition"/> on the media objects inside
-    /// <see cref="Element.Objects"/>. Returns <see langword="false"/> (no commit) when
-    /// <paramref name="delta"/> is zero or the element carries no slip-able media.
+    /// and <see cref="Beutl.Audio.Sound.OffsetPosition"/> on every slip-able media object
+    /// reachable from <see cref="Element.Objects"/>, including sources nested inside
+    /// Drawable and Sound containers. A single effective delta — the largest the tightest
+    /// stream can accept without leaving its source — is applied to all streams so linked
+    /// media (e.g. a video + audio pair) stay in sync. Returns <see langword="false"/>
+    /// (no commit) when <paramref name="delta"/> is zero, the element carries no slip-able
+    /// media, or the shared clamped delta is zero.
     /// </summary>
     bool Slip(Element element, TimeSpan delta);
 }

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -1,0 +1,24 @@
+﻿using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+/// <summary>
+/// Slip: shift the source-media window inside an <see cref="Element"/> without
+/// changing the element's <see cref="Element.Start"/> / <see cref="Element.Length"/>.
+/// Writes the media's in-source offset (<see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
+/// / <see cref="Beutl.Audio.Sound.OffsetPosition"/>), not element geometry, and owns
+/// the single history commit boundary for one user-visible slip. Distinct from
+/// <see cref="IElementResizeService"/> so a plugin replacing the geometry-trim family
+/// does not inherit the media-offset family.
+/// </summary>
+public interface IElementSlipService
+{
+    /// <summary>
+    /// Shift the source-media window inside <paramref name="element"/> by
+    /// <paramref name="delta"/>. Adjusts <see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
+    /// and <see cref="Beutl.Audio.Sound.OffsetPosition"/> on the media objects inside
+    /// <see cref="Element.Objects"/>. Returns <see langword="false"/> (no commit) when
+    /// <paramref name="delta"/> is zero or the element carries no slip-able media.
+    /// </summary>
+    bool Slip(Element element, TimeSpan delta);
+}

--- a/src/Beutl.Editor/Services/IElementSlipService.cs
+++ b/src/Beutl.Editor/Services/IElementSlipService.cs
@@ -8,9 +8,10 @@ namespace Beutl.Editor.Services;
 /// Writes the media's in-source offset (<see cref="Beutl.Graphics.SourceVideo.OffsetPosition"/>
 /// / <see cref="Beutl.Audio.Sound.OffsetPosition"/>), not element geometry, and owns
 /// the single history commit boundary for one user-visible slip. Kept separate from
-/// <see cref="IElementResizeService"/> by responsibility — this edits the media window,
-/// that edits clip geometry — even though Roll / Slide reuse the same media-offset
-/// primitives to keep a trimmed neighbour's content anchored across a moving cut.
+/// <see cref="IElementResizeService"/> because Slip is media-window-only; Roll / Slide
+/// over there are geometry-primary but also shift the trimmed neighbour's media window
+/// through the same <c>SlippableMedia</c> primitives, so media-offset writes are not
+/// exclusive to this service.
 /// </summary>
 public interface IElementSlipService
 {

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -66,6 +66,9 @@ internal static class SlippableMedia
             case SourceSound sound:
                 targets.Add(CreateSoundTarget(sound));
                 break;
+            case SceneSound sceneSound:
+                targets.Add(CreateSceneSoundTarget(sceneSound));
+                break;
             case SoundGroup soundGroup:
                 foreach (Sound child in soundGroup.Children)
                     CollectFrom(child, targets, visited);
@@ -101,6 +104,15 @@ internal static class SlippableMedia
     {
         // SourceSound.TryGetOriginalDuration returns the full source duration.
         TimeSpan? total = sound.TryGetOriginalDuration(out TimeSpan duration) ? duration : null;
+        return new Target(sound.OffsetPosition, total);
+    }
+
+    private static Target CreateSceneSoundTarget(SceneSound sound)
+    {
+        // The referenced scene is the "source": its duration bounds how far the media
+        // window can advance. Unresolved references stay unbounded, like a SourceVideo
+        // without a loaded source.
+        TimeSpan? total = sound.ReferencedScene.CurrentValue?.Duration;
         return new Target(sound.OffsetPosition, total);
     }
 

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -16,20 +16,20 @@ internal static class SlippableMedia
     // Total is the absolute source duration (null when the stream has no bounded source).
     internal sealed class Target
     {
-        private readonly IProperty<TimeSpan> _offset;
-
         public Target(IProperty<TimeSpan> offset, TimeSpan? total)
         {
-            _offset = offset;
+            Offset = offset;
             Total = total;
         }
+
+        public IProperty<TimeSpan> Offset { get; }
 
         public TimeSpan? Total { get; }
 
         public TimeSpan Current
         {
-            get => _offset.CurrentValue;
-            set => _offset.CurrentValue = value;
+            get => Offset.CurrentValue;
+            set => Offset.CurrentValue = value;
         }
     }
 
@@ -132,13 +132,21 @@ internal static class SlippableMedia
         return Math.Max(0L, (maxOffset - target.Current).Ticks);
     }
 
-    public static void ApplyOffsetDelta(IReadOnlyList<Target> targets, TimeSpan delta)
+    // `applied` spans one whole trim operation: the per-element visited set in Collect only
+    // dedups within an element, so a media instance referenced from several participating
+    // elements (e.g. via another element's DrawablePresenter.Target) would otherwise receive
+    // the delta once per element. Callers touching multiple elements pass one shared set.
+    public static void ApplyOffsetDelta(
+        IReadOnlyList<Target> targets, TimeSpan delta, HashSet<IProperty<TimeSpan>>? applied = null)
     {
         if (delta == TimeSpan.Zero) return;
 
         foreach (Target target in targets)
         {
-            target.Current += delta;
+            if (applied is null || applied.Add(target.Offset))
+            {
+                target.Current += delta;
+            }
         }
     }
 

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -126,14 +126,14 @@ internal static class SlippableMedia
 
     // Room to extend the element's out-point (grow its length while the in-point stays put),
     // bounded by the tightest source tail among its streams. TimeSpan.MaxValue when unbounded.
-    public static TimeSpan OutPointRoom(Element element)
+    public static TimeSpan OutPointRoom(IReadOnlyList<Target> targets, TimeSpan elementLength)
     {
         TimeSpan room = TimeSpan.MaxValue;
-        foreach (Target target in Collect(element))
+        foreach (Target target in targets)
         {
             if (target.Total is not { } total) continue;
 
-            TimeSpan available = total - target.Current - element.Length;
+            TimeSpan available = total - target.Current - elementLength;
             if (available < TimeSpan.Zero) available = TimeSpan.Zero;
             if (available < room) room = available;
         }
@@ -145,10 +145,10 @@ internal static class SlippableMedia
     // its streams (the offset cannot go below zero). Unlike OutPointRoom this bound holds even
     // when the source duration is unknown (Total == null), so those streams are not skipped.
     // TimeSpan.MaxValue when the element has no slip-able media.
-    public static TimeSpan InPointRoom(Element element)
+    public static TimeSpan InPointRoom(IReadOnlyList<Target> targets)
     {
         TimeSpan room = TimeSpan.MaxValue;
-        foreach (Target target in Collect(element))
+        foreach (Target target in targets)
         {
             if (target.Current < room) room = target.Current;
         }

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -1,0 +1,157 @@
+﻿using Beutl.Audio;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+// Shared media-offset primitives for the trim services. Slip shifts the media window
+// of a single element; Roll/Slide additionally shift the trimmed neighbour's in-point so
+// its content stays anchored across the moving cut. Both need the same source-backed
+// media enumeration (including nested Drawable/Sound containers) and the same "one delta
+// across every stream" clamping, so it lives here rather than being duplicated per service.
+internal static class SlippableMedia
+{
+    // A single source-backed media stream whose OffsetPosition can be slipped.
+    // Total is the absolute source duration (null when the stream has no bounded source).
+    internal sealed class Target
+    {
+        private readonly IProperty<TimeSpan> _offset;
+
+        public Target(IProperty<TimeSpan> offset, TimeSpan? total)
+        {
+            _offset = offset;
+            Total = total;
+        }
+
+        public TimeSpan? Total { get; }
+
+        public TimeSpan Current
+        {
+            get => _offset.CurrentValue;
+            set => _offset.CurrentValue = value;
+        }
+    }
+
+    public static List<Target> Collect(Element element)
+    {
+        var targets = new List<Target>();
+        foreach (EngineObject obj in element.Objects)
+        {
+            CollectFrom(obj, targets);
+        }
+
+        return targets;
+    }
+
+    private static void CollectFrom(object obj, List<Target> targets)
+    {
+        switch (obj)
+        {
+            case SourceVideo video:
+                targets.Add(CreateVideoTarget(video));
+                break;
+            case SourceSound sound:
+                targets.Add(CreateSoundTarget(sound));
+                break;
+            case SoundGroup soundGroup:
+                foreach (Sound child in soundGroup.Children)
+                    CollectFrom(child, targets);
+                break;
+            case DrawableGroup drawableGroup:
+                foreach (Drawable child in drawableGroup.Children)
+                    CollectFrom(child, targets);
+                break;
+            case DrawableDecorator decorator:
+                foreach (Drawable child in decorator.Children)
+                    CollectFrom(child, targets);
+                break;
+        }
+    }
+
+    private static Target CreateVideoTarget(SourceVideo video)
+    {
+        // SourceVideo.TryGetOriginalDuration returns the duration remaining from the current
+        // offset, so the absolute source length is current + remaining.
+        TimeSpan? total = video.TryGetOriginalDuration(out TimeSpan remaining)
+            ? video.OffsetPosition.CurrentValue + remaining
+            : null;
+        return new Target(video.OffsetPosition, total);
+    }
+
+    private static Target CreateSoundTarget(SourceSound sound)
+    {
+        // SourceSound.TryGetOriginalDuration returns the full source duration.
+        TimeSpan? total = sound.TryGetOriginalDuration(out TimeSpan duration) ? duration : null;
+        return new Target(sound.OffsetPosition, total);
+    }
+
+    // The largest-magnitude delta (in the requested direction) that every stream can apply
+    // without leaving [0, Total - elementLength]. Applying one shared delta keeps linked
+    // streams (e.g. a video + audio pair) in sync even when one hits its source boundary first.
+    public static TimeSpan ClampSharedDelta(IReadOnlyList<Target> targets, TimeSpan delta, TimeSpan elementLength)
+    {
+        if (delta == TimeSpan.Zero || targets.Count == 0) return TimeSpan.Zero;
+
+        long magnitude = Math.Abs(delta.Ticks);
+        foreach (Target target in targets)
+        {
+            long allowed = delta > TimeSpan.Zero
+                ? ForwardHeadroom(target, elementLength)
+                : Math.Max(0L, target.Current.Ticks);
+            magnitude = Math.Min(magnitude, allowed);
+        }
+
+        return TimeSpan.FromTicks(delta > TimeSpan.Zero ? magnitude : -magnitude);
+    }
+
+    private static long ForwardHeadroom(Target target, TimeSpan elementLength)
+    {
+        if (target.Total is not { } total) return long.MaxValue;
+
+        TimeSpan maxOffset = total - elementLength;
+        if (maxOffset < TimeSpan.Zero) maxOffset = TimeSpan.Zero;
+        return Math.Max(0L, (maxOffset - target.Current).Ticks);
+    }
+
+    public static void ApplyOffsetDelta(IReadOnlyList<Target> targets, TimeSpan delta)
+    {
+        if (delta == TimeSpan.Zero) return;
+
+        foreach (Target target in targets)
+        {
+            target.Current += delta;
+        }
+    }
+
+    // Room to extend the element's out-point (grow its length while the in-point stays put),
+    // bounded by the tightest source tail among its streams. TimeSpan.MaxValue when unbounded.
+    public static TimeSpan OutPointRoom(Element element)
+    {
+        TimeSpan room = TimeSpan.MaxValue;
+        foreach (Target target in Collect(element))
+        {
+            if (target.Total is not { } total) continue;
+
+            TimeSpan available = total - target.Current - element.Length;
+            if (available < TimeSpan.Zero) available = TimeSpan.Zero;
+            if (available < room) room = available;
+        }
+
+        return room;
+    }
+
+    // Room to pull the element's in-point earlier, bounded by the smallest current offset among
+    // its streams (the offset cannot go below zero). TimeSpan.MaxValue when unbounded.
+    public static TimeSpan InPointRoom(Element element)
+    {
+        TimeSpan room = TimeSpan.MaxValue;
+        foreach (Target target in Collect(element))
+        {
+            if (target.Total is null) continue;
+            if (target.Current < room) room = target.Current;
+        }
+
+        return room;
+    }
+}

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -72,6 +72,12 @@ internal static class SlippableMedia
                 foreach (Drawable child in decorator.Children)
                     CollectFrom(child, targets);
                 break;
+            // DrawablePresenter / DrawableTimeController render the drawable in Target
+            // rather than a Children list, so a wrapped SourceVideo is only reachable here.
+            case IPresenter<Drawable> presenter:
+                if (presenter.Target.CurrentValue is { } presented)
+                    CollectFrom(presented, targets);
+                break;
         }
     }
 

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -42,16 +42,22 @@ internal static class SlippableMedia
     public static List<Target> Collect(Element element)
     {
         var targets = new List<Target>();
+        var visited = new HashSet<object>();
         foreach (EngineObject obj in element.Objects)
         {
-            CollectFrom(obj, targets);
+            CollectFrom(obj, targets, visited);
         }
 
         return targets;
     }
 
-    private static void CollectFrom(object obj, List<Target> targets)
+    // The visited set makes each node contribute once: a media object reachable through
+    // several paths (e.g. one SourceVideo shared by two DrawablePresenter.Targets) must not
+    // receive the shared delta once per path, and a presenter cycle must not recurse forever.
+    private static void CollectFrom(object obj, List<Target> targets, HashSet<object> visited)
     {
+        if (!visited.Add(obj)) return;
+
         switch (obj)
         {
             case SourceVideo video:
@@ -62,21 +68,21 @@ internal static class SlippableMedia
                 break;
             case SoundGroup soundGroup:
                 foreach (Sound child in soundGroup.Children)
-                    CollectFrom(child, targets);
+                    CollectFrom(child, targets, visited);
                 break;
             case DrawableGroup drawableGroup:
                 foreach (Drawable child in drawableGroup.Children)
-                    CollectFrom(child, targets);
+                    CollectFrom(child, targets, visited);
                 break;
             case DrawableDecorator decorator:
                 foreach (Drawable child in decorator.Children)
-                    CollectFrom(child, targets);
+                    CollectFrom(child, targets, visited);
                 break;
             // DrawablePresenter / DrawableTimeController render the drawable in Target
             // rather than a Children list, so a wrapped SourceVideo is only reachable here.
             case IPresenter<Drawable> presenter:
                 if (presenter.Target.CurrentValue is { } presented)
-                    CollectFrom(presented, targets);
+                    CollectFrom(presented, targets, visited);
                 break;
         }
     }

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -33,6 +33,12 @@ internal static class SlippableMedia
         }
     }
 
+    // Disabled (IsEnabled == false) media is deliberately included, unlike playback's
+    // Element.CollectObjects: trim edits apply one shared delta to every stream so linked
+    // media (e.g. a temporarily muted audio track) stays in sync with the visible content
+    // and re-enabling it does not reveal a desynced or out-of-range offset. The same
+    // reasoning keeps disabled streams in the clamp bounds — a delta that would push a
+    // disabled stream outside its source is refused, not applied desynced.
     public static List<Target> Collect(Element element)
     {
         var targets = new List<Target>();

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -142,13 +142,14 @@ internal static class SlippableMedia
     }
 
     // Room to pull the element's in-point earlier, bounded by the smallest current offset among
-    // its streams (the offset cannot go below zero). TimeSpan.MaxValue when unbounded.
+    // its streams (the offset cannot go below zero). Unlike OutPointRoom this bound holds even
+    // when the source duration is unknown (Total == null), so those streams are not skipped.
+    // TimeSpan.MaxValue when the element has no slip-able media.
     public static TimeSpan InPointRoom(Element element)
     {
         TimeSpan room = TimeSpan.MaxValue;
         foreach (Target target in Collect(element))
         {
-            if (target.Total is null) continue;
             if (target.Current < room) room = target.Current;
         }
 

--- a/src/Beutl.Editor/Services/TrimGroupCollector.cs
+++ b/src/Beutl.Editor/Services/TrimGroupCollector.cs
@@ -17,12 +17,13 @@ public static class TrimGroupCollector
     /// on its layer becomes the back; for each member starting there, the clip ending
     /// there becomes the front. The partner may itself be outside
     /// <paramref name="members"/> (rolling against an ungrouped neighbour is a valid cut).
-    /// Pairs with a locked side are skipped — they would make
-    /// <see cref="IElementResizeService.Roll"/> reject the whole operation — as are
-    /// members with no adjacent partner (their edge simply is not a cut). A pair whose
-    /// both sides are members is collected once.
+    /// Members with no adjacent partner are skipped (their edge simply is not a cut, so
+    /// nothing desynchronizes); a pair whose both sides are members is collected once.
+    /// Returns <see langword="null"/> when any collected pair has a locked side — that cut
+    /// is aligned but immovable, so rolling the rest would desynchronize the grouped cuts;
+    /// <see cref="IElementResizeService.Slide"/>'s lanes apply the same all-or-nothing rule.
     /// </summary>
-    public static IReadOnlyList<ElementTrimPair> CollectRollPairs(
+    public static IReadOnlyList<ElementTrimPair>? CollectRollPairs(
         Scene scene, IReadOnlyList<Element> members, TimeSpan boundary)
     {
         ArgumentNullException.ThrowIfNull(scene);
@@ -48,7 +49,7 @@ public static class TrimGroupCollector
             }
 
             if (front is null || back is null) continue;
-            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) continue;
+            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return null;
             if (!seenFronts.Add(front)) continue;
 
             pairs.Add(new ElementTrimPair(front, back));

--- a/src/Beutl.Editor/Services/TrimGroupCollector.cs
+++ b/src/Beutl.Editor/Services/TrimGroupCollector.cs
@@ -1,0 +1,122 @@
+﻿using Beutl.ProjectSystem;
+
+namespace Beutl.Editor.Services;
+
+/// <summary>
+/// Builds the multi-element inputs for <see cref="IElementResizeService.Roll"/> /
+/// <see cref="IElementResizeService.Slide"/> from a set of group / selection members, so a
+/// trim gesture on one clip moves every grouped cut or block with it. Model-level so the
+/// collection rules are unit-testable; the Timeline View resolves the returned elements to
+/// its ViewModels for the drag preview.
+/// </summary>
+public static class TrimGroupCollector
+{
+    /// <summary>
+    /// The rollable pairs among <paramref name="members"/> whose cut sits exactly at
+    /// <paramref name="boundary"/>: for each member ending there, the clip starting there
+    /// on its layer becomes the back; for each member starting there, the clip ending
+    /// there becomes the front. The partner may itself be outside
+    /// <paramref name="members"/> (rolling against an ungrouped neighbour is a valid cut).
+    /// Pairs with a locked side are skipped — they would make
+    /// <see cref="IElementResizeService.Roll"/> reject the whole operation — as are
+    /// members with no adjacent partner (their edge simply is not a cut). A pair whose
+    /// both sides are members is collected once.
+    /// </summary>
+    public static IReadOnlyList<ElementTrimPair> CollectRollPairs(
+        Scene scene, IReadOnlyList<Element> members, TimeSpan boundary)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(members);
+
+        var pairs = new List<ElementTrimPair>();
+        var seenFronts = new HashSet<Element>();
+        var seenMembers = new HashSet<Element>();
+        foreach (Element member in members)
+        {
+            if (!seenMembers.Add(member)) continue;
+            if (!scene.Children.Contains(member)) continue;
+
+            Element? front = null;
+            Element? back = null;
+            if (member.Range.End == boundary)
+            {
+                (front, back) = (member, FindStartingAt(scene, member.ZIndex, boundary, member));
+            }
+            else if (member.Start == boundary)
+            {
+                (front, back) = (FindEndingAt(scene, member.ZIndex, boundary, member), member);
+            }
+
+            if (front is null || back is null) continue;
+            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) continue;
+            if (!seenFronts.Add(front)) continue;
+
+            pairs.Add(new ElementTrimPair(front, back));
+        }
+
+        return pairs;
+    }
+
+    /// <summary>
+    /// The slide lanes formed by <paramref name="members"/>: per layer, the members must
+    /// form one contiguous run with an adjacent, unlocked clip on each side (front and
+    /// back), which may be outside <paramref name="members"/>. Returns
+    /// <see langword="null"/> when any layer cannot slide — members not contiguous, no
+    /// adjacent front or back, or a locked participant — because a partial slide would
+    /// desync the grouped block; <see cref="IElementResizeService.Slide"/> applies the
+    /// same all-or-nothing rule.
+    /// </summary>
+    public static IReadOnlyList<ElementSlideLane>? CollectSlideLanes(
+        Scene scene, IReadOnlyList<Element> members)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(members);
+
+        var lanes = new List<ElementSlideLane>();
+        foreach (IGrouping<int, Element> lane in members.Distinct()
+                     .GroupBy(m => m.ZIndex)
+                     .OrderBy(g => g.Key))
+        {
+            Element[] middles = lane.OrderBy(m => m.Start).ToArray();
+            foreach (Element middle in middles)
+            {
+                if (!scene.Children.Contains(middle)) return null;
+                if (scene.IsElementLocked(middle)) return null;
+            }
+
+            for (int i = 1; i < middles.Length; i++)
+            {
+                if (middles[i - 1].Range.End != middles[i].Start) return null;
+            }
+
+            Element? front = FindEndingAt(scene, lane.Key, middles[0].Start, middles[0]);
+            Element? back = FindStartingAt(scene, lane.Key, middles[^1].Range.End, middles[^1]);
+            if (front is null || back is null) return null;
+            if (scene.IsElementLocked(front) || scene.IsElementLocked(back)) return null;
+
+            lanes.Add(new ElementSlideLane(front, middles, back));
+        }
+
+        return lanes.Count == 0 ? null : lanes;
+    }
+
+    private static Element? FindStartingAt(Scene scene, int zIndex, TimeSpan start, Element exclude)
+    {
+        foreach (Element item in scene.Children)
+        {
+            if (item != exclude && item.ZIndex == zIndex && item.Start == start) return item;
+        }
+
+        return null;
+    }
+
+    private static Element? FindEndingAt(Scene scene, int zIndex, TimeSpan end, Element exclude)
+    {
+        foreach (Element item in scene.Children)
+        {
+            if (item != exclude && item.ZIndex == zIndex && item.Range.End == end) return item;
+        }
+
+        return null;
+    }
+}

--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -55,27 +55,36 @@ public class ContextCommandDefinition(
     {
         if (keyGestures == null) return keyGestures;
 
-        ContextCommandKeyGesture? fallbackGesture = null;
-        ContextCommandKeyGesture? windows = null;
-        ContextCommandKeyGesture? linux = null;
-        ContextCommandKeyGesture? osx = null;
+        var fallbacks = new List<ContextCommandKeyGesture>();
+        var windows = new List<ContextCommandKeyGesture>();
+        var linux = new List<ContextCommandKeyGesture>();
+        var osx = new List<ContextCommandKeyGesture>();
 
         foreach (ContextCommandKeyGesture gesture in keyGestures)
         {
-            if (gesture.Platform == null) fallbackGesture = gesture;
-            else if (gesture.Platform == OSPlatform.Windows) windows = gesture;
-            else if (gesture.Platform == OSPlatform.Linux) linux = gesture;
-            else if (gesture.Platform == OSPlatform.OSX) osx = gesture;
+            if (gesture.Platform == null) fallbacks.Add(gesture);
+            else if (gesture.Platform == OSPlatform.Windows) windows.Add(gesture);
+            else if (gesture.Platform == OSPlatform.Linux) linux.Add(gesture);
+            else if (gesture.Platform == OSPlatform.OSX) osx.Add(gesture);
         }
 
-        if (windows == null && fallbackGesture != null)
-            windows = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.Windows);
-        if (linux == null && fallbackGesture != null)
-            linux = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.Linux);
-        if (osx == null && fallbackGesture != null)
-            osx = new ContextCommandKeyGesture(fallbackGesture.KeyGesture, OSPlatform.OSX);
+        // A platform with no explicit gesture inherits every platform-less fallback, so a command
+        // declaring several fallbacks (e.g. V and Escape) keeps all of them per platform rather
+        // than only the last one. A platform with its own gesture(s) overrides the fallbacks.
+        FillFromFallbacks(windows, fallbacks, OSPlatform.Windows);
+        FillFromFallbacks(linux, fallbacks, OSPlatform.Linux);
+        FillFromFallbacks(osx, fallbacks, OSPlatform.OSX);
 
-        return new[] { windows, linux, osx }.Where(i => i != null).ToArray()!;
+        return windows.Concat(linux).Concat(osx).ToArray();
+    }
+
+    private static void FillFromFallbacks(
+        List<ContextCommandKeyGesture> target, List<ContextCommandKeyGesture> fallbacks, OSPlatform platform)
+    {
+        if (target.Count != 0) return;
+
+        foreach (ContextCommandKeyGesture fallback in fallbacks)
+            target.Add(new ContextCommandKeyGesture(fallback.KeyGesture, platform));
     }
 }
 

--- a/src/Beutl.Language/CommandNames.ja.resx
+++ b/src/Beutl.Language/CommandNames.ja.resx
@@ -30,6 +30,15 @@
   <data name="MoveElement" xml:space="preserve">
     <value>要素を移動</value>
   </data>
+  <data name="SlipElement" xml:space="preserve">
+    <value>要素をスリップ</value>
+  </data>
+  <data name="RollElements" xml:space="preserve">
+    <value>要素をロール</value>
+  </data>
+  <data name="SlideElements" xml:space="preserve">
+    <value>要素をスライド</value>
+  </data>
   <data name="SplitElement" xml:space="preserve">
     <value>要素を分割</value>
   </data>

--- a/src/Beutl.Language/CommandNames.resx
+++ b/src/Beutl.Language/CommandNames.resx
@@ -35,6 +35,15 @@
   <data name="MoveElement" xml:space="preserve">
     <value>Move Element</value>
   </data>
+  <data name="SlipElement" xml:space="preserve">
+    <value>Slip Element</value>
+  </data>
+  <data name="RollElements" xml:space="preserve">
+    <value>Roll Elements</value>
+  </data>
+  <data name="SlideElements" xml:space="preserve">
+    <value>Slide Elements</value>
+  </data>
   <data name="SplitElement" xml:space="preserve">
     <value>Split Element</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -246,6 +246,9 @@
   <data name="Duplicate" xml:space="preserve">
     <value>複製</value>
   </data>
+  <data name="EditingMode" xml:space="preserve">
+    <value>編集モード</value>
+  </data>
   <data name="RazorTool" xml:space="preserve">
     <value>レーザーモード</value>
   </data>

--- a/src/Beutl.Language/Strings.ja.resx
+++ b/src/Beutl.Language/Strings.ja.resx
@@ -258,6 +258,42 @@
   <data name="ExitRazorTool_Description" xml:space="preserve">
     <value>レーザーモードを終了し、選択ツールに戻ります。</value>
   </data>
+  <data name="SlipTool" xml:space="preserve">
+    <value>スリップツール</value>
+  </data>
+  <data name="SlipTool_Description" xml:space="preserve">
+    <value>スリップツールを切り替えます。クリップをドラッグして、クリップを移動せずにソースメディアの表示位置をずらします。</value>
+  </data>
+  <data name="ExitSlipTool" xml:space="preserve">
+    <value>スリップツールを終了</value>
+  </data>
+  <data name="ExitSlipTool_Description" xml:space="preserve">
+    <value>スリップモードを終了し、選択ツールに戻ります。</value>
+  </data>
+  <data name="RollTool" xml:space="preserve">
+    <value>ロールツール</value>
+  </data>
+  <data name="RollTool_Description" xml:space="preserve">
+    <value>ロールツールを切り替えます。クリップの端をドラッグして隣接クリップとの境界を移動し、全体の長さを保ちます。</value>
+  </data>
+  <data name="ExitRollTool" xml:space="preserve">
+    <value>ロールツールを終了</value>
+  </data>
+  <data name="ExitRollTool_Description" xml:space="preserve">
+    <value>ロールモードを終了し、選択ツールに戻ります。</value>
+  </data>
+  <data name="SlideTool" xml:space="preserve">
+    <value>スライドツール</value>
+  </data>
+  <data name="SlideTool_Description" xml:space="preserve">
+    <value>スライドツールを切り替えます。クリップをドラッグして移動し、両隣のクリップが補正して全体の長さを保ちます。</value>
+  </data>
+  <data name="ExitSlideTool" xml:space="preserve">
+    <value>スライドツールを終了</value>
+  </data>
+  <data name="ExitSlideTool_Description" xml:space="preserve">
+    <value>スライドモードを終了し、選択ツールに戻ります。</value>
+  </data>
   <data name="SampleRate" xml:space="preserve">
     <value>サンプルレート</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -182,6 +182,42 @@
   <data name="ExitRazorTool_Description" xml:space="preserve">
     <value>Exit razor mode and return to selection tool.</value>
   </data>
+  <data name="SlipTool" xml:space="preserve">
+    <value>Slip Tool</value>
+  </data>
+  <data name="SlipTool_Description" xml:space="preserve">
+    <value>Toggle slip tool. Drag a clip to shift its source-media window without moving the clip.</value>
+  </data>
+  <data name="ExitSlipTool" xml:space="preserve">
+    <value>Exit Slip Tool</value>
+  </data>
+  <data name="ExitSlipTool_Description" xml:space="preserve">
+    <value>Exit slip mode and return to selection tool.</value>
+  </data>
+  <data name="RollTool" xml:space="preserve">
+    <value>Roll Tool</value>
+  </data>
+  <data name="RollTool_Description" xml:space="preserve">
+    <value>Toggle roll tool. Drag a clip edge to shift the boundary with its neighbor, preserving total length.</value>
+  </data>
+  <data name="ExitRollTool" xml:space="preserve">
+    <value>Exit Roll Tool</value>
+  </data>
+  <data name="ExitRollTool_Description" xml:space="preserve">
+    <value>Exit roll mode and return to selection tool.</value>
+  </data>
+  <data name="SlideTool" xml:space="preserve">
+    <value>Slide Tool</value>
+  </data>
+  <data name="SlideTool_Description" xml:space="preserve">
+    <value>Toggle slide tool. Drag a clip to shift it while neighbors compensate, preserving total length.</value>
+  </data>
+  <data name="ExitSlideTool" xml:space="preserve">
+    <value>Exit Slide Tool</value>
+  </data>
+  <data name="ExitSlideTool_Description" xml:space="preserve">
+    <value>Exit slide mode and return to selection tool.</value>
+  </data>
   <data name="Delete" xml:space="preserve">
     <value>Delete</value>
   </data>

--- a/src/Beutl.Language/Strings.resx
+++ b/src/Beutl.Language/Strings.resx
@@ -170,6 +170,9 @@
   <data name="Duplicate" xml:space="preserve">
     <value>Duplicate</value>
   </data>
+  <data name="EditingMode" xml:space="preserve">
+    <value>Editing Mode</value>
+  </data>
   <data name="RazorTool" xml:space="preserve">
     <value>Razor Tool</value>
   </data>

--- a/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml
@@ -41,7 +41,7 @@
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="viewModels:KeyMapSettingsItem">
-                                            <OptionsDisplayItem Description="{Binding Command.Definition.Description}" Header="{Binding Command.Definition.DisplayName}">
+                                            <OptionsDisplayItem Description="{Binding Command.Definition.Description}" Header="{Binding DisplayName}">
                                                 <OptionsDisplayItem.ActionButton>
                                                     <Button Click="OnItemClicked"
                                                             KeyDown="OnButtonKeyDown"

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -40,6 +40,7 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
     private readonly ElementAdderImpl _elementAdder;
     private SceneTimeRangeService? _sceneTimeRangeService;
     private ElementResizeService? _elementResizeService;
+    private ElementSlipService? _elementSlipService;
     private ElementDuplicateService? _elementDuplicateService;
     private ElementMoveService? _elementMoveService;
     private ElementGapService? _elementGapService;
@@ -916,6 +917,9 @@ public sealed partial class EditViewModel : IEditorContext, ISupportAutoSaveEdit
 
         if (serviceType.IsAssignableTo(typeof(IElementResizeService)))
             return _elementResizeService ??= new ElementResizeService(HistoryManager);
+
+        if (serviceType.IsAssignableTo(typeof(IElementSlipService)))
+            return _elementSlipService ??= new ElementSlipService(HistoryManager);
 
         if (serviceType.IsAssignableTo(typeof(IElementDuplicateService)))
             return _elementDuplicateService ??= new ElementDuplicateService(HistoryManager);

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -57,8 +57,9 @@ public class KeyMapSettingsItem
 
     public void SetKeyGesture(KeyGesture? gesture)
     {
-        KeyGesture.Value = gesture;
+        // Persist before updating the UI so a throwing ChangeKeyGesture leaves the displayed binding untouched.
         _commandManager.ChangeKeyGesture(Command, gesture, CurrentPlatform, GestureIndex);
+        KeyGesture.Value = gesture;
     }
 }
 

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -23,31 +23,41 @@ public class KeyMapSettingsItem
 {
     private readonly ContextCommandManager _commandManager;
 
-    public KeyMapSettingsItem(ContextCommandEntry command, ContextCommandManager commandManager)
+    public KeyMapSettingsItem(ContextCommandEntry command, ContextCommandManager commandManager, int gestureIndex)
     {
         _commandManager = commandManager;
         Command = command;
-        OSPlatform os = OperatingSystem.IsWindows() ? OSPlatform.Windows :
-            OperatingSystem.IsLinux() ? OSPlatform.Linux :
-            OSPlatform.OSX;
+        GestureIndex = gestureIndex;
         var gesture = command.KeyGestures
-            .FirstOrDefault(i => i.Platform == os)
+            .Where(i => i.Platform == CurrentPlatform)
+            .ElementAtOrDefault(gestureIndex)
             ?.KeyGesture;
         KeyGesture = new ReactiveProperty<KeyGesture?>(gesture);
     }
 
+    internal static OSPlatform CurrentPlatform => OperatingSystem.IsWindows() ? OSPlatform.Windows :
+        OperatingSystem.IsLinux() ? OSPlatform.Linux :
+        OSPlatform.OSX;
+
     public ContextCommandEntry Command { get; set; }
+
+    /// <summary>
+    /// Which of the command's same-platform gesture slots this row edits. A command binding
+    /// several gestures (e.g. V and Escape) gets one row per slot, so remapping one binding
+    /// leaves the others intact.
+    /// </summary>
+    public int GestureIndex { get; }
+
+    public string? DisplayName => GestureIndex == 0
+        ? Command.Definition.DisplayName
+        : $"{Command.Definition.DisplayName} ({GestureIndex + 1})";
 
     public ReactiveProperty<KeyGesture?> KeyGesture { get; set; }
 
     public void SetKeyGesture(KeyGesture? gesture)
     {
         KeyGesture.Value = gesture;
-        OSPlatform os = OperatingSystem.IsWindows() ? OSPlatform.Windows :
-            OperatingSystem.IsLinux() ? OSPlatform.Linux :
-            OperatingSystem.IsMacOS() ? OSPlatform.OSX :
-            throw new NotSupportedException();
-        _commandManager.ChangeKeyGesture(Command, gesture, os);
+        _commandManager.ChangeKeyGesture(Command, gesture, CurrentPlatform, GestureIndex);
     }
 }
 
@@ -72,7 +82,12 @@ public class KeyMapSettingsPageViewModel : PageContext
 
                 return new KeyMapSettingsGroup(
                     extension,
-                    i.Select(j => new KeyMapSettingsItem(j, _commandManager)).ToArray());
+                    i.SelectMany(j =>
+                    {
+                        int slots = Math.Max(1, j.KeyGestures.Count(g => g.Platform == KeyMapSettingsItem.CurrentPlatform));
+                        return Enumerable.Range(0, slots)
+                            .Select(index => new KeyMapSettingsItem(j, _commandManager, index));
+                    }).ToArray());
             })
             .OfType<KeyMapSettingsGroup>()
             .ToArray();

--- a/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/KeyMapSettingsPageViewModel.cs
@@ -36,8 +36,9 @@ public class KeyMapSettingsItem
     }
 
     internal static OSPlatform CurrentPlatform => OperatingSystem.IsWindows() ? OSPlatform.Windows :
+        OperatingSystem.IsMacOS() ? OSPlatform.OSX :
         OperatingSystem.IsLinux() ? OSPlatform.Linux :
-        OSPlatform.OSX;
+        throw new PlatformNotSupportedException();
 
     public ContextCommandEntry Command { get; set; }
 

--- a/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
+++ b/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
@@ -99,6 +99,33 @@ public class ContextCommandManagerTests
     }
 
     [Test]
+    public void ChangeKeyGesture_NextFreeSlot_AppendsGesture()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        manager.ChangeKeyGesture(entry, KeyGesture.Parse("F2"), OSPlatform.Windows, gestureIndex: 2);
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("Escape"), KeyGesture.Parse("F2") }));
+    }
+
+    [Test]
+    public void ChangeKeyGesture_IndexBeyondNextFreeSlot_Throws()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => manager.ChangeKeyGesture(entry, KeyGesture.Parse("B"), OSPlatform.Windows, gestureIndex: 5));
+        // The failed call must not have persisted or mutated anything.
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("Escape") }));
+    }
+
+    [Test]
     public void ChangeKeyGesture_RemapRoundTrip_RestoresBothSlots()
     {
         var json = new JsonObject();

--- a/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
+++ b/tests/Beutl.UnitTests/Api/ContextCommandManagerTests.cs
@@ -1,0 +1,169 @@
+﻿using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using Avalonia.Input;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public class ContextCommandManagerTests
+{
+    // A command binding two platform-less gestures (like the timeline's Exit* commands binding
+    // V and Escape) — the regression shape for multi-gesture remapping.
+    private sealed class TestViewExtension : ViewExtension
+    {
+        public override IEnumerable<ContextCommandDefinition> ContextCommands =>
+        [
+            new ContextCommandDefinition("ExitTool", "Exit Tool", null,
+            [
+                new ContextCommandKeyGesture("V"),
+                new ContextCommandKeyGesture("Escape"),
+            ]),
+        ];
+    }
+
+    private static string CommandFullName =>
+        $"{typeof(TestViewExtension).Namespace}.{typeof(TestViewExtension).Name}.ExitTool";
+
+    private static ContextCommandManager CreateManager(JsonObject json)
+    {
+        return new ContextCommandManager(
+            new ContextCommandSettingsStore(json, persist: false),
+            new ContextCommandHandlerRegistry());
+    }
+
+    private static KeyGesture?[] GesturesFor(ContextCommandEntry entry, OSPlatform platform)
+    {
+        return entry.KeyGestures
+            .Where(g => g.Platform == platform)
+            .Select(g => g.KeyGesture)
+            .ToArray();
+    }
+
+    [Test]
+    public void ChangeKeyGesture_DefaultIndex_ChangesOnlyFirstSlot()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        manager.ChangeKeyGesture(entry, KeyGesture.Parse("B"), OSPlatform.Windows);
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new[] { KeyGesture.Parse("B"), KeyGesture.Parse("Escape") }));
+    }
+
+    [Test]
+    public void ChangeKeyGesture_SecondSlot_KeepsFirstSlotAndOtherPlatforms()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        manager.ChangeKeyGesture(entry, KeyGesture.Parse("B"), OSPlatform.Windows, gestureIndex: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GesturesFor(entry, OSPlatform.Windows),
+                Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("B") }));
+            Assert.That(GesturesFor(entry, OSPlatform.OSX),
+                Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("Escape") }));
+        });
+    }
+
+    [Test]
+    public void ChangeKeyGesture_ClearSlot_KeepsOtherSlot()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        manager.ChangeKeyGesture(entry, null, OSPlatform.Windows);
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new KeyGesture?[] { null, KeyGesture.Parse("Escape") }));
+    }
+
+    [Test]
+    public void ChangeKeyGesture_MissingPlatform_AppendsGesture()
+    {
+        var manager = CreateManager([]);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        manager.ChangeKeyGesture(entry, KeyGesture.Parse("B"), OSPlatform.FreeBSD);
+
+        Assert.That(GesturesFor(entry, OSPlatform.FreeBSD),
+            Is.EqualTo(new[] { KeyGesture.Parse("B") }));
+    }
+
+    [Test]
+    public void ChangeKeyGesture_RemapRoundTrip_RestoresBothSlots()
+    {
+        var json = new JsonObject();
+        var manager = CreateManager(json);
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+        manager.ChangeKeyGesture(entry, KeyGesture.Parse("B"), OSPlatform.Windows, gestureIndex: 1);
+
+        // A fresh manager on the same persisted JSON = the next application launch.
+        var restored = CreateManager(json);
+        restored.Register(new TestViewExtension());
+        ContextCommandEntry restoredEntry = restored.GetDefinitions<TestViewExtension>().Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GesturesFor(restoredEntry, OSPlatform.Windows),
+                Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("B") }));
+            Assert.That(GesturesFor(restoredEntry, OSPlatform.OSX),
+                Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("Escape") }));
+        });
+    }
+
+    [Test]
+    public void Restore_LegacyStringEntry_AppliesToFirstSlotOnly()
+    {
+        // Entries written before multi-gesture support persist a plain string per platform.
+        var json = new JsonObject { ["Windows"] = new JsonObject { [CommandFullName] = "F1" } };
+        var manager = CreateManager(json);
+
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new[] { KeyGesture.Parse("F1"), KeyGesture.Parse("Escape") }));
+    }
+
+    [Test]
+    public void Restore_ClearedSlotInArray_RestoresAsCleared()
+    {
+        var json = new JsonObject
+        {
+            ["Windows"] = new JsonObject { [CommandFullName] = new JsonArray("F1", null) }
+        };
+        var manager = CreateManager(json);
+
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new KeyGesture?[] { KeyGesture.Parse("F1"), null }));
+    }
+
+    [Test]
+    public void Restore_ListLongerThanDefaults_AppendsExtraSlots()
+    {
+        var json = new JsonObject
+        {
+            ["Windows"] = new JsonObject { [CommandFullName] = new JsonArray("V", "Escape", "F2") }
+        };
+        var manager = CreateManager(json);
+
+        manager.Register(new TestViewExtension());
+        ContextCommandEntry entry = manager.GetDefinitions<TestViewExtension>().Single();
+
+        Assert.That(GesturesFor(entry, OSPlatform.Windows),
+            Is.EqualTo(new[] { KeyGesture.Parse("V"), KeyGesture.Parse("Escape"), KeyGesture.Parse("F2") }));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -715,4 +715,81 @@ public class ElementResizeServiceTests
             Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
         });
     }
+
+    // --- GetTrimDeltaBounds ---
+
+    [Test]
+    public void GetTrimDeltaBounds_NullArguments_Throw()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(null!, front, back));
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, null!, back));
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, front, null!));
+        });
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_NoSourceMedia_BoundsByMinFrameLengths()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+
+        TimeSpan minDuration = TimeSpan.FromSeconds(1d / 30);
+        Assert.Multiple(() =>
+        {
+            Assert.That(min, Is.EqualTo(minDuration - TimeSpan.FromSeconds(2)));
+            Assert.That(max, Is.EqualTo(TimeSpan.FromSeconds(3) - minDuration));
+        });
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_SourceBackedFront_MaxClampedToSourceTail()
+    {
+        // Same shape as Roll_PositiveDelta_ClampedByFrontSourceTail: 3s source, 2s clip →
+        // 1s of tail; the bounds must report the same +1s ceiling the Roll commit applies.
+        var frontSource = new VideoSource();
+        frontSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
+
+        (TimeSpan _, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+
+        Assert.That(max, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_BackInPoint_MinClampedToSourceHead()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
+        back.Objects.Add(video);
+
+        (TimeSpan min, TimeSpan _) = _service.GetTrimDeltaBounds(_scene, front, back);
+
+        Assert.That(min, Is.EqualTo(TimeSpan.FromSeconds(-0.5)));
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_SubFrameClip_ReturnsZeroWindow()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
+        Element back = AddElement(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(2));
+
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(min, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(max, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -221,9 +221,9 @@ public class ElementResizeServiceTests
 
         Assert.Multiple(() =>
         {
-            Assert.Throws<ArgumentNullException>(() => _service.Roll(null!, front, back, TimeSpan.Zero));
-            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, null!, back, TimeSpan.Zero));
-            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, front, null!, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(null!, [new ElementTrimPair(front, back)], TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, [new ElementTrimPair(null!, back)], TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, [new ElementTrimPair(front, null!)], TimeSpan.Zero));
         });
     }
 
@@ -233,7 +233,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, front, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, front)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -250,7 +250,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -269,7 +269,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -291,7 +291,7 @@ public class ElementResizeServiceTests
         back.IsLocked = true;
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -311,7 +311,7 @@ public class ElementResizeServiceTests
         _scene.Layers.Add(new TimelineLayer { ZIndex = 4, IsLocked = true });
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -327,7 +327,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
         Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
 
-        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+        _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -345,7 +345,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(1d / 30));
         Element back = AddElement(TimeSpan.FromSeconds(1d / 30), TimeSpan.FromSeconds(2));
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(-1));
 
         // Clamped to -(front.Length - 1 frame) = 0, so no effective delta.
         Assert.Multiple(() =>
@@ -362,7 +362,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1d / 30));
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         // Clamped to back.Length - 1 frame = 0, so no effective delta.
         Assert.Multiple(() =>
@@ -380,7 +380,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -397,7 +397,7 @@ public class ElementResizeServiceTests
     {
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
-        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
         Assert.Multiple(() =>
         {
             Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
@@ -422,7 +422,7 @@ public class ElementResizeServiceTests
         var video = new SourceVideo();
         back.Objects.Add(video);
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -441,7 +441,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
         var video = new SourceVideo();
         back.Objects.Add(video);
-        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         _history.Undo();
 
@@ -459,7 +459,7 @@ public class ElementResizeServiceTests
         front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(5));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -485,7 +485,7 @@ public class ElementResizeServiceTests
             front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
             Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
 
-            bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(5));
+            bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(5));
 
             Assert.Multiple(() =>
             {
@@ -513,7 +513,7 @@ public class ElementResizeServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
         back.Objects.Add(video);
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-5));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(-5));
 
         Assert.Multiple(() =>
         {
@@ -536,7 +536,7 @@ public class ElementResizeServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
         back.Objects.Add(video);
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-5));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(-5));
 
         Assert.Multiple(() =>
         {
@@ -559,10 +559,10 @@ public class ElementResizeServiceTests
 
         Assert.Multiple(() =>
         {
-            Assert.Throws<ArgumentNullException>(() => _service.Slide(null!, front, middle, back, TimeSpan.Zero));
-            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, null!, middle, back, TimeSpan.Zero));
-            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, front, null!, back, TimeSpan.Zero));
-            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, front, middle, null!, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(null!, [new ElementSlideLane(front, [middle], back)], TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, [new ElementSlideLane(null!, [middle], back)], TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, [new ElementSlideLane(front, [null!], back)], TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, [new ElementSlideLane(front, [middle], null!)], TimeSpan.Zero));
         });
     }
 
@@ -573,7 +573,7 @@ public class ElementResizeServiceTests
         Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, middle, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], middle)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -590,7 +590,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -607,7 +607,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)); // gap before
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -624,7 +624,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -649,7 +649,7 @@ public class ElementResizeServiceTests
         middle.IsLocked = true;
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -668,7 +668,7 @@ public class ElementResizeServiceTests
         Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
 
-        _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+        _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -688,7 +688,7 @@ public class ElementResizeServiceTests
         Element middle = AddElement(TimeSpan.FromSeconds(1d / 30), TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(1d / 30) + TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -704,7 +704,7 @@ public class ElementResizeServiceTests
         Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1d / 30));
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -721,7 +721,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromMilliseconds(2001), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -739,7 +739,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
-        _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         _history.Undo();
 
@@ -762,7 +762,7 @@ public class ElementResizeServiceTests
         var video = new SourceVideo();
         back.Objects.Add(video);
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -783,7 +783,7 @@ public class ElementResizeServiceTests
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
         int before = _history.UndoCount;
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -800,7 +800,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         var back = new Element { Start = TimeSpan.FromSeconds(2), Length = TimeSpan.FromSeconds(3) };
 
-        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Roll(_scene, [new ElementTrimPair(front, back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -816,7 +816,7 @@ public class ElementResizeServiceTests
         Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
         Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), zIndex: 0);
 
-        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slide(_scene, [new ElementSlideLane(front, [middle], back)], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -835,9 +835,9 @@ public class ElementResizeServiceTests
 
         Assert.Multiple(() =>
         {
-            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(null!, front, back));
-            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, null!, back));
-            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, front, null!));
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(null!, [new ElementTrimPair(front, back)]));
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(null!, back)]));
+            Assert.Throws<ArgumentNullException>(() => _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, null!)]));
         });
     }
 
@@ -847,7 +847,7 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
 
-        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, back)]);
 
         TimeSpan minDuration = TimeSpan.FromSeconds(1d / 30);
         Assert.Multiple(() =>
@@ -868,7 +868,7 @@ public class ElementResizeServiceTests
         front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
 
-        (TimeSpan _, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+        (TimeSpan _, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, back)]);
 
         Assert.That(max, Is.EqualTo(TimeSpan.FromSeconds(1)));
     }
@@ -882,7 +882,7 @@ public class ElementResizeServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
         back.Objects.Add(video);
 
-        (TimeSpan min, TimeSpan _) = _service.GetTrimDeltaBounds(_scene, front, back);
+        (TimeSpan min, TimeSpan _) = _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, back)]);
 
         Assert.That(min, Is.EqualTo(TimeSpan.FromSeconds(-0.5)));
     }
@@ -899,7 +899,7 @@ public class ElementResizeServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(-1);
         back.Objects.Add(video);
 
-        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, back)]);
 
         Assert.Multiple(() =>
         {
@@ -914,12 +914,311 @@ public class ElementResizeServiceTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
         Element back = AddElement(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(2));
 
-        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, [new ElementTrimPair(front, back)]);
 
         Assert.Multiple(() =>
         {
             Assert.That(min, Is.EqualTo(TimeSpan.Zero));
             Assert.That(max, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_EmptyPairs_ReturnsZeroWindow()
+    {
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, []);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(min, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(max, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void GetTrimDeltaBounds_MultiplePairs_ReturnsIntersection()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(5), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), zIndex: 1);
+
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(
+            _scene, [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)]);
+
+        TimeSpan minDuration = TimeSpan.FromSeconds(1d / 30);
+        Assert.Multiple(() =>
+        {
+            // Min is bounded by the shorter front (A, 2s); Max by the shorter back (B, 1s).
+            Assert.That(min, Is.EqualTo(minDuration - TimeSpan.FromSeconds(2)));
+            Assert.That(max, Is.EqualTo(TimeSpan.FromSeconds(1) - minDuration));
+        });
+    }
+
+    // --- Roll / Slide: grouped multi-lane operations ---
+
+    [Test]
+    public void Roll_EmptyPairs_NoCommit()
+    {
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, [], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_TwoPairs_AppliesBothAndCommitsOnce()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        var backVideo = new SourceVideo();
+        backA.Objects.Add(backVideo);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backA.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backA.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(frontB.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backB.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backB.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(backVideo.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Roll_TwoPairs_SharedDeltaClampedByTightestPair()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)],
+            TimeSpan.FromSeconds(5));
+
+        TimeSpan expected = TimeSpan.FromSeconds(1) - TimeSpan.FromSeconds(1d / 30);
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(2) + expected));
+            Assert.That(frontB.Length, Is.EqualTo(TimeSpan.FromSeconds(2) + expected));
+            Assert.That(backB.Length, Is.EqualTo(TimeSpan.FromSeconds(1) - expected));
+        });
+    }
+
+    [Test]
+    public void Roll_OneInvalidPair_RejectsWholeOperation()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2), zIndex: 1);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(backA.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_ElementInTwoPairs_NoCommit()
+    {
+        Element first = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element second = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        Element third = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(first, second), new ElementTrimPair(second, third)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_EmptyLanes_NoCommit()
+    {
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, [], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_EmptyMiddles_Throws()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+
+        Assert.Throws<ArgumentException>(
+            () => _service.Slide(_scene, [new ElementSlideLane(front, [], back)], TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void Slide_TwoLanes_AppliesBothAndCommitsOnce()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element middleA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element middleB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 1);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(
+            _scene,
+            [
+                new ElementSlideLane(frontA, [middleA], backA),
+                new ElementSlideLane(frontB, [middleB], backB)
+            ],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(middleA.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backA.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(backA.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(frontB.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(middleB.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(backB.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(backB.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slide_MultipleMiddlesInLane_ShiftsAllPreservingTotalLength()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element firstMiddle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element secondMiddle = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(3));
+
+        bool applied = _service.Slide(
+            _scene,
+            [new ElementSlideLane(front, [firstMiddle, secondMiddle], back)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(firstMiddle.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(secondMiddle.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
+    [Test]
+    public void Slide_NonContiguousMiddles_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element firstMiddle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element secondMiddle = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(3));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(
+            _scene,
+            [new ElementSlideLane(front, [firstMiddle, secondMiddle], back)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_ElementSharedAcrossLanes_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(
+            _scene,
+            [
+                new ElementSlideLane(front, [middle], back),
+                new ElementSlideLane(front, [middle], back)
+            ],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_OneInvalidLane_RejectsWholeOperation()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element middleA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element middleB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 1);
+        backB.IsLocked = true;
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(
+            _scene,
+            [
+                new ElementSlideLane(frontA, [middleA], backA),
+                new ElementSlideLane(frontB, [middleB], backB)
+            ],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(middleA.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -329,6 +329,25 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void Roll_AlreadyShorterThanMinFrame_DoesNotFlipDelta()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
+        Element back = AddElement(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromMilliseconds(1)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromMilliseconds(1)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
     public void Roll_UndoRestoresBothClips()
     {
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
@@ -491,6 +510,26 @@ public class ElementResizeServiceTests
         {
             Assert.That(applied, Is.False);
             Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        });
+    }
+
+    [Test]
+    public void Slide_AlreadyShorterThanMinFrame_DoesNotFlipDelta()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
+        Element middle = AddElement(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromMilliseconds(2001), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromMilliseconds(1)));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromMilliseconds(1)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromMilliseconds(2001)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -779,6 +779,27 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void GetTrimDeltaBounds_NegativeBackOffset_WindowStillSpansZero()
+    {
+        // A negative media offset is invalid state owned elsewhere, but the bounds contract
+        // (Min ≤ 0 ≤ Max) must hold structurally — the View's per-move ClampDelta throws on
+        // an inverted window.
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(-1);
+        back.Objects.Add(video);
+
+        (TimeSpan min, TimeSpan max) = _service.GetTrimDeltaBounds(_scene, front, back);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(min, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(max, Is.GreaterThanOrEqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
     public void GetTrimDeltaBounds_SubFrameClip_ReturnsZeroWindow()
     {
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -433,6 +433,37 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void Roll_PositiveDelta_ClampDisabled_ExtendsPastFrontSource()
+    {
+        // With ClampResizeToOriginalLength off, Roll must not clamp the front out-point to its
+        // source tail — the clip may run past its media, matching the normal edge-resize path.
+        bool original = GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength;
+        GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength = false;
+        try
+        {
+            var frontSource = new VideoSource();
+            frontSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+            Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+            front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
+            Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
+
+            bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(applied, Is.True);
+                Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+                Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(7)));
+                Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            });
+        }
+        finally
+        {
+            GlobalConfiguration.Instance.EditorConfig.ClampResizeToOriginalLength = original;
+        }
+    }
+
+    [Test]
     public void Roll_NegativeDelta_ClampedByBackSourceHead()
     {
         // Back source in-point sits at 0.5s, so a -5s roll can only pull it back to 0 (-0.5s).

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -716,6 +716,56 @@ public class ElementResizeServiceTests
         });
     }
 
+    [Test]
+    public void Roll_DifferentLayers_NoCommit()
+    {
+        // Time-adjacent clips on different layers do not share an editable cut.
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_ElementOutsideScene_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        var back = new Element { Start = TimeSpan.FromSeconds(2), Length = TimeSpan.FromSeconds(3) };
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
+    [Test]
+    public void Slide_DifferentLayers_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2), zIndex: 0);
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
     // --- GetTrimDeltaBounds ---
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -1,7 +1,11 @@
 ﻿using Beutl.Configuration;
 using Beutl.Editor;
 using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Source;
 using Beutl.ProjectSystem;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
 using Beutl.UnitTests.TestInfrastructure;
 
 namespace Beutl.UnitTests.Editor.Services;
@@ -13,6 +17,9 @@ public class ElementResizeServiceTests
     private Scene _scene = null!;
     private HistoryManager _history = null!;
     private ElementResizeService _service = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => TestMediaHelper.RegisterTestDecoder();
 
     [SetUp]
     public void Setup()
@@ -369,6 +376,86 @@ public class ElementResizeServiceTests
         });
     }
 
+    [Test]
+    public void Roll_SourceBackedBack_AdvancesInPointByDelta()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        var video = new SourceVideo();
+        back.Objects.Add(video);
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            // Back in-point advances so its content stays anchored to the timeline.
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Roll_UndoRestoresBackInPoint()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        var video = new SourceVideo();
+        back.Objects.Add(video);
+        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        _history.Undo();
+
+        Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void Roll_PositiveDelta_ClampedByFrontSourceTail()
+    {
+        // Front source is 3s; with a 2s element only 1s of tail remains, so a +5s roll that the
+        // adjacent lengths would allow must clamp to +1s rather than extend past the media.
+        var frontSource = new VideoSource();
+        frontSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        front.Objects.Add(new SourceVideo { Source = { CurrentValue = frontSource } });
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10));
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(9)));
+        });
+    }
+
+    [Test]
+    public void Roll_NegativeDelta_ClampedByBackSourceHead()
+    {
+        // Back source in-point sits at 0.5s, so a -5s roll can only pull it back to 0 (-0.5s).
+        var backSource = new VideoSource();
+        backSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo { Source = { CurrentValue = backSource } };
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
+        back.Objects.Add(video);
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+        });
+    }
+
     // --- Slide ---
 
     [Test]
@@ -550,6 +637,28 @@ public class ElementResizeServiceTests
             Assert.That(middle.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
             Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
             Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
+    [Test]
+    public void Slide_SourceBackedBack_AdvancesInPointByDelta()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        back.Objects.Add(video);
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(6)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            // Middle only shifts in time; the back clip is trimmed at its head, so its in-point advances.
+            Assert.That(middle.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
         });
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -203,4 +203,314 @@ public class ElementResizeServiceTests
             GlobalConfiguration.Instance.EditorConfig.AutoAdjustSceneDuration = original;
         }
     }
+
+    // --- Roll ---
+
+    [Test]
+    public void Roll_NullArguments_Throw()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(null!, front, back, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, null!, back, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Roll(_scene, front, null!, TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void Roll_SameElement_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, front, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_NotAdjacent_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        // Gap of 1s between front.End (2s) and back.Start (4s).
+        Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_Adjacent_AppliesAndCommitsOnce()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            // Total length preserved.
+            Assert.That(front.Length + back.Length, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Roll_NegativeDelta_ShrinksFrontGrowsBack()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+
+        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+        });
+    }
+
+    [Test]
+    public void Roll_DeltaClampedToMinFrame_DoesNotUndersizeFront()
+    {
+        // 30fps default: 1 frame ~ 33.3ms. front is 1 frame; asking to roll -1s
+        // would empty front — must clamp so front keeps >= 1 frame.
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(1d / 30));
+        Element back = AddElement(TimeSpan.FromSeconds(1d / 30), TimeSpan.FromSeconds(2));
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-1));
+
+        // Clamped to -(front.Length - 1 frame) = 0, so no effective delta.
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
+
+    [Test]
+    public void Roll_DeltaClampedToMinFrame_DoesNotUndersizeBack()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1d / 30));
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        // Clamped to back.Length - 1 frame = 0, so no effective delta.
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        });
+    }
+
+    [Test]
+    public void Roll_UndoRestoresBothClips()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+
+        _history.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+        });
+    }
+
+    // --- Slide ---
+
+    [Test]
+    public void Slide_NullArguments_Throw()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(null!, front, middle, back, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, null!, middle, back, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, front, null!, back, TimeSpan.Zero));
+            Assert.Throws<ArgumentNullException>(() => _service.Slide(_scene, front, middle, null!, TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void Slide_DuplicateElements_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, middle, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_NotAdjacentFrontMiddle_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)); // gap before
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_NotAdjacentMiddleBack_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)); // gap before
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_AdjacentTriplet_ShiftsMiddlePreservesTotalLength()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(middle.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(6)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            // Total length preserved: 2+3+2 = 7 before; 3+3+1 = 7 after.
+            Assert.That(front.Length + middle.Length + back.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slide_NegativeDelta_ShiftsMiddleLeft()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+
+        _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(middle.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(front.Length + middle.Length + back.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
+        });
+    }
+
+    [Test]
+    public void Slide_DeltaClamped_DoesNotUndersizeFront()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(1d / 30));
+        Element middle = AddElement(TimeSpan.FromSeconds(1d / 30), TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(1d / 30) + TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        });
+    }
+
+    [Test]
+    public void Slide_DeltaClamped_DoesNotUndersizeBack()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1d / 30));
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        });
+    }
+
+    [Test]
+    public void Slide_UndoRestoresAllThreeClips()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        _history.Undo();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(middle.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        });
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -1025,6 +1025,31 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void Roll_SharedSourceAcrossBacks_ShiftsOffsetOnce()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        var video = new SourceVideo();
+        backA.Objects.Add(video);
+        var presenter = new DrawablePresenter();
+        presenter.Target.CurrentValue = video;
+        backB.Objects.Add(presenter);
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
     public void Roll_OneInvalidPair_RejectsWholeOperation()
     {
         Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -456,6 +456,29 @@ public class ElementResizeServiceTests
         });
     }
 
+    [Test]
+    public void Roll_NegativeDelta_UnknownDurationBack_ClampsInPointAtZero()
+    {
+        // Back media has no loadable source, so its duration is unknown. The in-point still cannot
+        // go below zero, so a large negative roll must clamp the offset at 0, not drive it negative.
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
+        back.Objects.Add(video);
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(-5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+        });
+    }
+
     // --- Slide ---
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -1050,6 +1050,34 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void Roll_SharedSourceBetweenFrontAndBack_NoCommit()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        var video = new SourceVideo();
+        frontA.Objects.Add(video);
+        var presenter = new DrawablePresenter();
+        presenter.Target.CurrentValue = video;
+        backB.Objects.Add(presenter);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(
+            _scene,
+            [new ElementTrimPair(frontA, backA), new ElementTrimPair(frontB, backB)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(frontA.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
     public void Roll_OneInvalidPair_RejectsWholeOperation()
     {
         Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
@@ -1214,6 +1242,33 @@ public class ElementResizeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slide_SharedSourceBetweenMiddleAndBack_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+        var video = new SourceVideo();
+        middle.Objects.Add(video);
+        var presenter = new DrawablePresenter();
+        presenter.Target.CurrentValue = video;
+        back.Objects.Add(presenter);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(
+            _scene,
+            [new ElementSlideLane(front, [middle], back)],
+            TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
             Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -284,6 +284,44 @@ public class ElementResizeServiceTests
     }
 
     [Test]
+    public void Roll_LockedNeighbour_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        back.IsLocked = true;
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Roll_LockedLayer_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 4);
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 4);
+        _scene.Layers.Add(new TimelineLayer { ZIndex = 4, IsLocked = true });
+        int before = _history.UndoCount;
+
+        bool applied = _service.Roll(_scene, front, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
     public void Roll_NegativeDelta_ShrinksFrontGrowsBack()
     {
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3));
@@ -599,6 +637,27 @@ public class ElementResizeServiceTests
             // Total length preserved: 2+3+2 = 7 before; 3+3+1 = 7 after.
             Assert.That(front.Length + middle.Length + back.Length, Is.EqualTo(TimeSpan.FromSeconds(7)));
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slide_LockedParticipant_NoCommit()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        Element back = AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2));
+        middle.IsLocked = true;
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slide(_scene, front, middle, back, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(front.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(middle.Start, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(back.Start, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -93,6 +93,22 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_ElementNotInScene_NoCommit()
+    {
+        var element = new Element { Start = TimeSpan.FromSeconds(1), Length = TimeSpan.FromSeconds(2) };
+        element.Objects.Add(new SourceVideo());
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
     public void Slip_ZeroDelta_NoCommit()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -49,13 +49,20 @@ public class ElementSlipServiceTests
     public void Slip_NullScene_Throws()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
-        Assert.Throws<ArgumentNullException>(() => _service.Slip(null!, element, TimeSpan.FromSeconds(1)));
+        Assert.Throws<ArgumentNullException>(() => _service.Slip(null!, [element], TimeSpan.FromSeconds(1)));
     }
 
     [Test]
-    public void Slip_NullElement_Throws()
+    public void Slip_NullElements_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => _service.Slip(_scene, null!, TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void Slip_ElementsContainingNull_Throws()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Assert.Throws<ArgumentNullException>(() => _service.Slip(_scene, [element, null!], TimeSpan.FromSeconds(1)));
     }
 
     [Test]
@@ -66,7 +73,7 @@ public class ElementSlipServiceTests
         element.IsLocked = true;
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -83,7 +90,7 @@ public class ElementSlipServiceTests
         _scene.Layers.Add(new TimelineLayer { ZIndex = 3, IsLocked = true });
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -99,7 +106,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(new SourceVideo());
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -115,7 +122,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(new SourceVideo());
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.Zero);
+        bool applied = _service.Slip(_scene, [element], TimeSpan.Zero);
 
         Assert.Multiple(() =>
         {
@@ -130,7 +137,7 @@ public class ElementSlipServiceTests
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -147,7 +154,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -171,7 +178,7 @@ public class ElementSlipServiceTests
         };
         element.Objects.Add(video);
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -188,7 +195,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(sound);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromMilliseconds(500));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromMilliseconds(500));
 
         Assert.Multiple(() =>
         {
@@ -210,7 +217,7 @@ public class ElementSlipServiceTests
         };
         element.Objects.Add(sound);
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -226,7 +233,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(new FallbackSound());
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -245,7 +252,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(group);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromMilliseconds(500));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromMilliseconds(500));
 
         Assert.Multiple(() =>
         {
@@ -266,7 +273,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(sound);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(2));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(2));
 
         Assert.Multiple(() =>
         {
@@ -285,7 +292,7 @@ public class ElementSlipServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(3);
         element.Objects.Add(video);
 
-        _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
+        _service.Slip(_scene, [element], TimeSpan.FromSeconds(-1));
 
         Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2)));
     }
@@ -298,7 +305,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -317,7 +324,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -333,7 +340,7 @@ public class ElementSlipServiceTests
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         var video = new SourceVideo();
         element.Objects.Add(video);
-        _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
         Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
 
         _history.Undo();
@@ -356,7 +363,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         element.Objects.Add(sound);
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -376,7 +383,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(group);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -396,7 +403,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(presenter);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -415,12 +422,136 @@ public class ElementSlipServiceTests
         controller.Target.CurrentValue = video;
         element.Objects.Add(controller);
 
-        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
             Assert.That(applied, Is.True);
             Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Slip_MultipleElements_ShiftsAllAndCommitsOnce()
+    {
+        Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+        Element second = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        var video = new SourceVideo();
+        var sound = new SourceSound();
+        first.Objects.Add(video);
+        second.Objects.Add(sound);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, [first, second], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_MultipleElements_ClampsToTightestElement()
+    {
+        // First element's video source only allows a 1s slip (3s source - 2s element); the
+        // second element's media is unbounded. The shared delta must land both at 1s.
+        Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        var video = new SourceVideo { Source = { CurrentValue = videoSource } };
+        first.Objects.Add(video);
+
+        Element second = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        var sound = new SourceSound();
+        second.Objects.Add(sound);
+
+        bool applied = _service.Slip(_scene, [first, second], TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Slip_MultipleElements_NegativeDelta_ClampsToTightestOffset()
+    {
+        Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(3);
+        first.Objects.Add(video);
+
+        Element second = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        var sound = new SourceSound();
+        sound.OffsetPosition.CurrentValue = TimeSpan.FromMilliseconds(500);
+        second.Objects.Add(sound);
+
+        bool applied = _service.Slip(_scene, [first, second], TimeSpan.FromSeconds(-2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    public void Slip_LockedMember_IsDroppedNotBlocking()
+    {
+        Element unlocked = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+        var video = new SourceVideo();
+        unlocked.Objects.Add(video);
+
+        Element locked = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        var lockedVideo = new SourceVideo();
+        locked.Objects.Add(lockedVideo);
+        locked.IsLocked = true;
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, [unlocked, locked], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(lockedVideo.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_DuplicateElement_ShiftsOnce()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        element.Objects.Add(video);
+
+        bool applied = _service.Slip(_scene, [element, element], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Slip_EmptyElements_NoCommit()
+    {
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, [], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
         });
     }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -149,6 +149,43 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_NegativeDeltaAtZero_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        element.Objects.Add(video);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slip_NegativeDeltaPastZero_ClampsAndCommitsOnce()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromMilliseconds(500);
+        element.Objects.Add(video);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(-1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
     public void Slip_UndoRestoresOffsetPosition()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -46,9 +46,50 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_NullScene_Throws()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Assert.Throws<ArgumentNullException>(() => _service.Slip(null!, element, TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
     public void Slip_NullElement_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => _service.Slip(null!, TimeSpan.FromSeconds(1)));
+        Assert.Throws<ArgumentNullException>(() => _service.Slip(_scene, null!, TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void Slip_LockedElement_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        element.Objects.Add(new SourceVideo());
+        element.IsLocked = true;
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slip_LockedLayer_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 3);
+        element.Objects.Add(new SourceVideo());
+        _scene.Layers.Add(new TimelineLayer { ZIndex = 3, IsLocked = true });
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
     }
 
     [Test]
@@ -58,7 +99,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(new SourceVideo());
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.Zero);
+        bool applied = _service.Slip(_scene, element, TimeSpan.Zero);
 
         Assert.Multiple(() =>
         {
@@ -73,7 +114,7 @@ public class ElementSlipServiceTests
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -90,7 +131,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -114,7 +155,7 @@ public class ElementSlipServiceTests
         };
         element.Objects.Add(video);
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -131,7 +172,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(sound);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromMilliseconds(500));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromMilliseconds(500));
 
         Assert.Multiple(() =>
         {
@@ -153,7 +194,7 @@ public class ElementSlipServiceTests
         };
         element.Objects.Add(sound);
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -169,7 +210,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(new FallbackSound());
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -188,7 +229,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(group);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromMilliseconds(500));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromMilliseconds(500));
 
         Assert.Multiple(() =>
         {
@@ -209,7 +250,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(sound);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(2));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(2));
 
         Assert.Multiple(() =>
         {
@@ -228,7 +269,7 @@ public class ElementSlipServiceTests
         video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(3);
         element.Objects.Add(video);
 
-        _service.Slip(element, TimeSpan.FromSeconds(-1));
+        _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
 
         Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2)));
     }
@@ -241,7 +282,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -260,7 +301,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(-1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(-1));
 
         Assert.Multiple(() =>
         {
@@ -276,7 +317,7 @@ public class ElementSlipServiceTests
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         var video = new SourceVideo();
         element.Objects.Add(video);
-        _service.Slip(element, TimeSpan.FromSeconds(1));
+        _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
         Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
 
         _history.Undo();
@@ -299,7 +340,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(video);
         element.Objects.Add(sound);
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -319,7 +360,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(group);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -339,7 +380,7 @@ public class ElementSlipServiceTests
         element.Objects.Add(presenter);
         int before = _history.UndoCount;
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {
@@ -358,7 +399,7 @@ public class ElementSlipServiceTests
         controller.Target.CurrentValue = video;
         element.Objects.Add(controller);
 
-        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+        bool applied = _service.Slip(_scene, element, TimeSpan.FromSeconds(1));
 
         Assert.Multiple(() =>
         {

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -432,6 +432,27 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_SharedSourceReachableViaTwoPresenters_ShiftsOnce()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        var firstPresenter = new DrawablePresenter();
+        firstPresenter.Target.CurrentValue = video;
+        var secondPresenter = new DrawablePresenter();
+        secondPresenter.Target.CurrentValue = video;
+        element.Objects.Add(firstPresenter);
+        element.Objects.Add(secondPresenter);
+
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
     public void Slip_MultipleElements_ShiftsAllAndCommitsOnce()
     {
         Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -283,4 +283,49 @@ public class ElementSlipServiceTests
 
         Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
     }
+
+    [Test]
+    public void Slip_LinkedStreamsWithDifferentBounds_ShiftsAllByTheTighterDelta()
+    {
+        // Video source allows a 1s offset (3s source - 2s element); audio source allows 3s
+        // (5s - 2s). A +5s request must land both at the tighter 1s so the streams stay in sync.
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        var video = new SourceVideo { Source = { CurrentValue = videoSource } };
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(TestMediaHelper.CreateTestAudioFile(durationSeconds: 5)));
+        var sound = new SourceSound { Source = { CurrentValue = soundSource } };
+        element.Objects.Add(video);
+        element.Objects.Add(sound);
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Slip_VideoNestedInDrawableGroup_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        var group = new DrawableGroup();
+        group.Children.Add(video);
+        element.Objects.Add(group);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -453,6 +453,27 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_SharedSourceAcrossElements_ShiftsOnce()
+    {
+        Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
+        var video = new SourceVideo();
+        first.Objects.Add(video);
+
+        Element second = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        var presenter = new DrawablePresenter();
+        presenter.Target.CurrentValue = video;
+        second.Objects.Add(presenter);
+
+        bool applied = _service.Slip(_scene, [first, second], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
     public void Slip_MultipleElements_ShiftsAllAndCommitsOnce()
     {
         Element first = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -2,7 +2,10 @@
 using Beutl.Editor;
 using Beutl.Editor.Services;
 using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Source;
 using Beutl.ProjectSystem;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
 using Beutl.UnitTests.TestInfrastructure;
 
 namespace Beutl.UnitTests.Editor.Services;
@@ -14,6 +17,9 @@ public class ElementSlipServiceTests
     private Scene _scene = null!;
     private HistoryManager _history = null!;
     private ElementSlipService _service = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => TestMediaHelper.RegisterTestDecoder();
 
     [SetUp]
     public void Setup()
@@ -97,6 +103,27 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_SourceVideo_ClampsToUsableSourceDuration()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 90)));
+        var video = new SourceVideo
+        {
+            Source = { CurrentValue = videoSource }
+        };
+        element.Objects.Add(video);
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
     public void Slip_SourceSound_ShiftsOffsetPositionAndCommits()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
@@ -110,6 +137,64 @@ public class ElementSlipServiceTests
         {
             Assert.That(applied, Is.True);
             Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromMilliseconds(500)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_SourceSound_ClampsToUsableSourceDuration()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(TestMediaHelper.CreateTestAudioFile(durationSeconds: 3)));
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource }
+        };
+        element.Objects.Add(sound);
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Slip_FallbackSound_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        element.Objects.Add(new FallbackSound());
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slip_SoundGroup_ShiftsSourceChildrenAndCommitsOnce()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var source = new SourceSound();
+        var group = new SoundGroup();
+        group.Children.Add(source);
+        element.Objects.Add(group);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromMilliseconds(500));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(source.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromMilliseconds(500)));
+            Assert.That(group.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -1,0 +1,164 @@
+﻿using Beutl.Audio;
+using Beutl.Editor;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.ProjectSystem;
+using Beutl.UnitTests.TestInfrastructure;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class ElementSlipServiceTests
+{
+    private SceneHistoryHarness _harness = null!;
+    private Scene _scene = null!;
+    private HistoryManager _history = null!;
+    private ElementSlipService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _harness = new SceneHistoryHarness("beutl_slip", start: TimeSpan.Zero, duration: TimeSpan.FromSeconds(30));
+        _scene = _harness.Scene;
+        _history = _harness.History;
+        _service = new ElementSlipService(_history);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _harness.Dispose();
+    }
+
+    private Element AddElement(TimeSpan start, TimeSpan length, int zIndex = 0)
+        => _harness.AddElement(start, length, zIndex);
+
+    [Test]
+    public void Constructor_NullHistoryManager_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ElementSlipService(null!));
+    }
+
+    [Test]
+    public void Slip_NullElement_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _service.Slip(null!, TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void Slip_ZeroDelta_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        element.Objects.Add(new SourceVideo());
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.Zero);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slip_NoSplittableMedia_NoCommit()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.False);
+            Assert.That(_history.UndoCount, Is.EqualTo(before));
+        });
+    }
+
+    [Test]
+    public void Slip_SourceVideo_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        element.Objects.Add(video);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_SourceSound_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var sound = new SourceSound();
+        element.Objects.Add(sound);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromMilliseconds(500));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromMilliseconds(500)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_MultipleMedia_ShiftsAllAndCommitsOnce()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        var sound = new SourceSound();
+        element.Objects.Add(video);
+        element.Objects.Add(sound);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(2));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(sound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_NegativeDelta_ShiftsBackward()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(3);
+        element.Objects.Add(video);
+
+        _service.Slip(element, TimeSpan.FromSeconds(-1));
+
+        Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void Slip_UndoRestoresOffsetPosition()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        element.Objects.Add(video);
+        _service.Slip(element, TimeSpan.FromSeconds(1));
+        Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+
+        _history.Undo();
+
+        Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.Zero));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -227,6 +227,43 @@ public class ElementSlipServiceTests
     }
 
     [Test]
+    public void Slip_SceneSound_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var sceneSound = new SceneSound();
+        element.Objects.Add(sceneSound);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(sceneSound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_SceneSound_ClampsToReferencedSceneDuration()
+    {
+        // A 3s referenced scene with a 2s clip leaves 1s of headroom, like a 3s file source.
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var referenced = new Scene { Duration = TimeSpan.FromSeconds(3) };
+        var sceneSound = new SceneSound();
+        sceneSound.ReferencedScene.CurrentValue = referenced;
+        element.Objects.Add(sceneSound);
+
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(sceneSound.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
     public void Slip_FallbackSound_NoCommit()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -328,4 +328,42 @@ public class ElementSlipServiceTests
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }
+
+    [Test]
+    public void Slip_VideoNestedInDrawablePresenter_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        var presenter = new DrawablePresenter();
+        presenter.Target.CurrentValue = video;
+        element.Objects.Add(presenter);
+        int before = _history.UndoCount;
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Slip_VideoNestedInDrawableTimeController_ShiftsOffsetPositionAndCommits()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        var video = new SourceVideo();
+        var controller = new DrawableTimeController();
+        controller.Target.CurrentValue = video;
+        element.Objects.Add(controller);
+
+        bool applied = _service.Slip(element, TimeSpan.FromSeconds(1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(video.OffsetPosition.CurrentValue, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
 }

--- a/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
@@ -126,6 +126,21 @@ public class TrimGroupCollectorTests
     }
 
     [Test]
+    public void CollectRollPairs_LockedMemberAtBoundary_ReturnsNull()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element lockedFront = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        lockedFront.IsLocked = true;
+
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [frontA, lockedFront], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.Null);
+    }
+
+    [Test]
     public void CollectRollPairs_OffSceneMember_IsExcluded()
     {
         var offScene = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(2) };
@@ -225,6 +240,19 @@ public class TrimGroupCollectorTests
 
         IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
             _scene, [middleA, noNeighbours]);
+
+        Assert.That(lanes, Is.Null);
+    }
+
+    [Test]
+    public void CollectSlideLanes_LockedMember_ReturnsNull()
+    {
+        AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+        middle.IsLocked = true;
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(_scene, [middle]);
 
         Assert.That(lanes, Is.Null);
     }

--- a/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
@@ -35,7 +35,7 @@ public class TrimGroupCollectorTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [front], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
@@ -47,7 +47,7 @@ public class TrimGroupCollectorTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [back], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
@@ -59,7 +59,7 @@ public class TrimGroupCollectorTests
         Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
         Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [front, back], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
@@ -73,7 +73,7 @@ public class TrimGroupCollectorTests
         Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
         Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [frontA, frontB], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EquivalentTo(new[]
@@ -91,7 +91,7 @@ public class TrimGroupCollectorTests
         Element offBoundary = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3), zIndex: 1);
         AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2), zIndex: 1);
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [frontA, offBoundary], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
@@ -104,25 +104,25 @@ public class TrimGroupCollectorTests
         Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
         Element lonely = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [frontA, lonely], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
     }
 
     [Test]
-    public void CollectRollPairs_LockedPartner_SkipsPair()
+    public void CollectRollPairs_LockedPartner_ReturnsNull()
     {
         Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
-        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
         Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
         Element lockedBack = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
         lockedBack.IsLocked = true;
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [frontA, frontB], TimeSpan.FromSeconds(2));
 
-        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
+        Assert.That(pairs, Is.Null);
     }
 
     [Test]
@@ -130,7 +130,7 @@ public class TrimGroupCollectorTests
     {
         var offScene = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(2) };
 
-        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+        IReadOnlyList<ElementTrimPair>? pairs = TrimGroupCollector.CollectRollPairs(
             _scene, [offScene], TimeSpan.FromSeconds(2));
 
         Assert.That(pairs, Is.Empty);

--- a/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/TrimGroupCollectorTests.cs
@@ -1,0 +1,252 @@
+﻿using Beutl.Editor;
+using Beutl.Editor.Services;
+using Beutl.ProjectSystem;
+using Beutl.UnitTests.TestInfrastructure;
+
+namespace Beutl.UnitTests.Editor.Services;
+
+[TestFixture]
+public class TrimGroupCollectorTests
+{
+    private SceneHistoryHarness _harness = null!;
+    private Scene _scene = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _harness = new SceneHistoryHarness("beutl_trimcollect", start: TimeSpan.Zero, duration: TimeSpan.FromSeconds(30));
+        _scene = _harness.Scene;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _harness.Dispose();
+    }
+
+    private Element AddElement(TimeSpan start, TimeSpan length, int zIndex = 0)
+        => _harness.AddElement(start, length, zIndex);
+
+    // --- CollectRollPairs ---
+
+    [Test]
+    public void CollectRollPairs_MemberEndingAtBoundary_PairsWithAdjacentBack()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [front], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_MemberStartingAtBoundary_PairsWithAdjacentFront()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [back], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_BothSidesAreMembers_CollectsPairOnce()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element back = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [front, back], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(front, back) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_GroupedCutsAcrossLayers_CollectsEveryAlignedPair()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [frontA, frontB], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EquivalentTo(new[]
+        {
+            new ElementTrimPair(frontA, backA),
+            new ElementTrimPair(frontB, backB)
+        }));
+    }
+
+    [Test]
+    public void CollectRollPairs_MemberNotTouchingBoundary_IsExcluded()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element offBoundary = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(3), zIndex: 1);
+        AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2), zIndex: 1);
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [frontA, offBoundary], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_MemberWithoutAdjacentPartner_IsExcluded()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element lonely = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [frontA, lonely], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_LockedPartner_SkipsPair()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 1);
+        Element lockedBack = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), zIndex: 1);
+        lockedBack.IsLocked = true;
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [frontA, frontB], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.EqualTo(new[] { new ElementTrimPair(frontA, backA) }));
+    }
+
+    [Test]
+    public void CollectRollPairs_OffSceneMember_IsExcluded()
+    {
+        var offScene = new Element { Start = TimeSpan.Zero, Length = TimeSpan.FromSeconds(2) };
+
+        IReadOnlyList<ElementTrimPair> pairs = TrimGroupCollector.CollectRollPairs(
+            _scene, [offScene], TimeSpan.FromSeconds(2));
+
+        Assert.That(pairs, Is.Empty);
+    }
+
+    // --- CollectSlideLanes ---
+
+    [Test]
+    public void CollectSlideLanes_SingleMemberWithNeighbours_BuildsLane()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(_scene, [middle]);
+
+        Assert.That(lanes, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(lanes, Has.Count.EqualTo(1));
+            Assert.That(lanes![0].Front, Is.SameAs(front));
+            Assert.That(lanes[0].Middles, Is.EqualTo(new[] { middle }));
+            Assert.That(lanes[0].Back, Is.SameAs(back));
+        });
+    }
+
+    [Test]
+    public void CollectSlideLanes_ContiguousMembersOnOneLayer_FormOneLaneOrderedByStart()
+    {
+        Element front = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element firstMiddle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element secondMiddle = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
+            _scene, [secondMiddle, firstMiddle]);
+
+        Assert.That(lanes, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(lanes![0].Front, Is.SameAs(front));
+            Assert.That(lanes[0].Middles, Is.EqualTo(new[] { firstMiddle, secondMiddle }));
+            Assert.That(lanes[0].Back, Is.SameAs(back));
+        });
+    }
+
+    [Test]
+    public void CollectSlideLanes_MembersAcrossLayers_BuildOneLanePerLayer()
+    {
+        Element frontA = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element middleA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+        Element backA = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element frontB = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(1), zIndex: 1);
+        Element middleB = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 1);
+        Element backB = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2), zIndex: 1);
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
+            _scene, [middleA, middleB]);
+
+        Assert.That(lanes, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(lanes, Has.Count.EqualTo(2));
+            Assert.That(lanes![0].Front, Is.SameAs(frontA));
+            Assert.That(lanes[0].Back, Is.SameAs(backA));
+            Assert.That(lanes[1].Front, Is.SameAs(frontB));
+            Assert.That(lanes[1].Back, Is.SameAs(backB));
+        });
+    }
+
+    [Test]
+    public void CollectSlideLanes_NonContiguousMembers_ReturnsNull()
+    {
+        AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element firstMiddle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element secondMiddle = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1));
+        AddElement(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
+            _scene, [firstMiddle, secondMiddle]);
+
+        Assert.That(lanes, Is.Null);
+    }
+
+    [Test]
+    public void CollectSlideLanes_MissingNeighbourOnAnyLayer_ReturnsNull()
+    {
+        AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2), zIndex: 0);
+        Element middleA = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 0);
+        AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), zIndex: 0);
+        Element noNeighbours = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), zIndex: 1);
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(
+            _scene, [middleA, noNeighbours]);
+
+        Assert.That(lanes, Is.Null);
+    }
+
+    [Test]
+    public void CollectSlideLanes_LockedNeighbour_ReturnsNull()
+    {
+        AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        Element middle = AddElement(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1));
+        Element back = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+        back.IsLocked = true;
+
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(_scene, [middle]);
+
+        Assert.That(lanes, Is.Null);
+    }
+
+    [Test]
+    public void CollectSlideLanes_EmptyMembers_ReturnsNull()
+    {
+        IReadOnlyList<ElementSlideLane>? lanes = TrimGroupCollector.CollectSlideLanes(_scene, []);
+
+        Assert.That(lanes, Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -58,6 +58,37 @@ public class TimelineTabViewModelTests
         });
     }
 
+    // The V/Escape gestures are shared by every Exit* command; the dispatcher relies on
+    // CanExecute being true only for the active mode to fall through to the right one.
+    [Test]
+    public void CanExecute_ExitCommands_TrueOnlyForActiveMode()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+        viewModel.IsRollMode.Value = true;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitRollMode")), Is.True);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitRazorMode")), Is.False);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitSlipMode")), Is.False);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitSlideMode")), Is.False);
+        });
+    }
+
+    [Test]
+    public void CanExecute_ExitCommands_AllFalseWhenNoModeActive()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitRazorMode")), Is.False);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitSlipMode")), Is.False);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitRollMode")), Is.False);
+            Assert.That(viewModel.CanExecute(new ContextCommandExecution("ExitSlideMode")), Is.False);
+        });
+    }
+
     private static TimelineTabViewModel CreateViewModel()
     {
         var scene = new Scene();

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -1,0 +1,176 @@
+﻿using System.Numerics;
+using System.Reactive.Linq;
+
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class TimelineTabViewModelTests
+{
+    [Test]
+    public void DirectRazorModeSet_ClearsActiveTrimMode()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+        viewModel.IsSlipMode.Value = true;
+
+        viewModel.IsRazorMode.Value = true;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.IsRazorMode.Value, Is.True);
+            Assert.That(viewModel.IsSlipMode.Value, Is.False);
+            Assert.That(viewModel.IsRollMode.Value, Is.False);
+            Assert.That(viewModel.IsSlideMode.Value, Is.False);
+        });
+    }
+
+    [Test]
+    public void DirectTrimModeSet_ClearsRazorAndOtherTrimModes()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+        viewModel.IsRazorMode.Value = true;
+
+        viewModel.IsRollMode.Value = true;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.IsRazorMode.Value, Is.False);
+            Assert.That(viewModel.IsSlipMode.Value, Is.False);
+            Assert.That(viewModel.IsRollMode.Value, Is.True);
+            Assert.That(viewModel.IsSlideMode.Value, Is.False);
+        });
+
+        viewModel.IsSlideMode.Value = true;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.IsRazorMode.Value, Is.False);
+            Assert.That(viewModel.IsSlipMode.Value, Is.False);
+            Assert.That(viewModel.IsRollMode.Value, Is.False);
+            Assert.That(viewModel.IsSlideMode.Value, Is.True);
+        });
+    }
+
+    private static TimelineTabViewModel CreateViewModel()
+    {
+        var scene = new Scene();
+        var editorContext = new TestEditorContext(scene);
+        editorContext.AddService<ITimelineOptionsProvider>(new TestTimelineOptionsProvider(scene));
+        editorContext.AddService<IEditorClock>(new TestEditorClock());
+        editorContext.AddService<IBufferStatus>(new TestBufferStatus());
+        return new TimelineTabViewModel(editorContext);
+    }
+
+    private sealed class TestEditorContext(CoreObject obj) : IEditorContext
+    {
+        private readonly Dictionary<Type, object> _services = [];
+
+        public CoreObject Object { get; } = obj;
+
+        public EditorExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public void AddService<T>(T service)
+            where T : notnull
+        {
+            _services[typeof(T)] = service;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            return _services.GetValueOrDefault(serviceType);
+        }
+
+        public T? FindToolTab<T>(Func<T, bool> condition)
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public T? FindToolTab<T>()
+            where T : IToolContext
+        {
+            return default;
+        }
+
+        public bool OpenToolTab(IToolContext item)
+        {
+            return false;
+        }
+
+        public void CloseToolTab(IToolContext item)
+        {
+        }
+    }
+
+    private sealed class TestTimelineOptionsProvider(Scene scene) : ITimelineOptionsProvider
+    {
+        public Scene Scene { get; } = scene;
+
+        public IReactiveProperty<TimelineOptions> Options { get; } =
+            new ReactiveProperty<TimelineOptions>(new TimelineOptions(1, Vector2.Zero, 0));
+
+        public IObservable<float> Scale => Options.Select(x => x.Scale);
+
+        public IObservable<Vector2> Offset => Options.Select(x => x.Offset);
+    }
+
+    private sealed class TestEditorClock : IEditorClock
+    {
+        public IReactiveProperty<TimeSpan> CurrentTime { get; } = new ReactivePropertySlim<TimeSpan>(TimeSpan.Zero);
+
+        public IReadOnlyReactiveProperty<TimeSpan> MaximumTime { get; } =
+            new ReactivePropertySlim<TimeSpan>(TimeSpan.FromSeconds(30));
+    }
+
+    private sealed class TestBufferStatus : IBufferStatus
+    {
+        public IReadOnlyReactiveProperty<TimeSpan> StartTime { get; } =
+            new ReactivePropertySlim<TimeSpan>(TimeSpan.Zero);
+
+        public IReadOnlyReactiveProperty<TimeSpan> EndTime { get; } =
+            new ReactivePropertySlim<TimeSpan>(TimeSpan.Zero);
+
+        public IReadOnlyReactiveProperty<double> Start { get; } = new ReactivePropertySlim<double>(0);
+
+        public IReadOnlyReactiveProperty<double> End { get; } = new ReactivePropertySlim<double>(0);
+
+        public IReadOnlyReactiveProperty<CacheBlock[]> CacheBlocks { get; } =
+            new ReactivePropertySlim<CacheBlock[]>([]);
+
+        public void UpdateBlocks()
+        {
+        }
+
+        public void ClearCache()
+        {
+        }
+
+        public void LockCache(int startFrame, int endFrame)
+        {
+        }
+
+        public void UnlockCache(int startFrame, int endFrame)
+        {
+        }
+
+        public void DeleteCache(int startFrame, int endFrame)
+        {
+        }
+
+        public long CalculateCacheByteCount(int startFrame, int endFrame)
+        {
+            return 0;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/TrimDeltaCalculatorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TrimDeltaCalculatorTests.cs
@@ -1,0 +1,69 @@
+﻿using Beutl.Editor.Components.Helpers;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class TrimDeltaCalculatorTests
+{
+    // A snap function that pulls any time within one frame of a cut onto that cut.
+    private static Func<TimeSpan, TimeSpan> SnapToCut(TimeSpan cut, TimeSpan tolerance)
+    {
+        return t => (t - cut).Duration() <= tolerance ? cut : t;
+    }
+
+    [Test]
+    public void SnappedDelta_NullSnap_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => TrimDeltaCalculator.SnappedDelta(TimeSpan.Zero, TimeSpan.Zero, null!));
+    }
+
+    [Test]
+    public void SnappedDelta_NoMoveClick_IsZero()
+    {
+        TimeSpan press = TimeSpan.FromSeconds(5);
+        TimeSpan release = TimeSpan.FromSeconds(5);
+
+        TimeSpan delta = TrimDeltaCalculator.SnappedDelta(press, release, t => t);
+
+        Assert.That(delta, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void SnappedDelta_NoMoveClickNearCut_SnapsBothEndpointsToZero()
+    {
+        // Press and release are the same point, both just off a cut. Snapping only the release
+        // would yield a spurious one-frame delta; snapping both endpoints identically cancels out.
+        TimeSpan cut = TimeSpan.FromSeconds(5);
+        TimeSpan point = cut + TimeSpan.FromMilliseconds(10);
+        Func<TimeSpan, TimeSpan> snap = SnapToCut(cut, TimeSpan.FromMilliseconds(33));
+
+        TimeSpan delta = TrimDeltaCalculator.SnappedDelta(point, point, snap);
+
+        Assert.That(delta, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void SnappedDelta_ReleaseSnapsToCut_ReturnsSnappedDistance()
+    {
+        TimeSpan cut = TimeSpan.FromSeconds(5);
+        TimeSpan press = TimeSpan.FromSeconds(4);
+        TimeSpan release = cut + TimeSpan.FromMilliseconds(10);
+        Func<TimeSpan, TimeSpan> snap = SnapToCut(cut, TimeSpan.FromMilliseconds(33));
+
+        TimeSpan delta = TrimDeltaCalculator.SnappedDelta(press, release, snap);
+
+        Assert.That(delta, Is.EqualTo(cut - press));
+    }
+
+    [Test]
+    public void SnappedDelta_NegativeMovement_IsNegative()
+    {
+        TimeSpan press = TimeSpan.FromSeconds(5);
+        TimeSpan release = TimeSpan.FromSeconds(3);
+
+        TimeSpan delta = TrimDeltaCalculator.SnappedDelta(press, release, t => t);
+
+        Assert.That(delta, Is.EqualTo(TimeSpan.FromSeconds(-2)));
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/TrimDeltaCalculatorTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TrimDeltaCalculatorTests.cs
@@ -66,4 +66,30 @@ public class TrimDeltaCalculatorTests
 
         Assert.That(delta, Is.EqualTo(TimeSpan.FromSeconds(-2)));
     }
+
+    [Test]
+    public void ClampDelta_InsideWindow_IsUnchanged()
+    {
+        TimeSpan delta = TrimDeltaCalculator.ClampDelta(
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-2), TimeSpan.FromSeconds(3));
+
+        Assert.That(delta, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+
+    [TestCase(-5, -2)]
+    [TestCase(5, 3)]
+    public void ClampDelta_OutsideWindow_ClampsToBound(int deltaSeconds, int expectedSeconds)
+    {
+        TimeSpan delta = TrimDeltaCalculator.ClampDelta(
+            TimeSpan.FromSeconds(deltaSeconds), TimeSpan.FromSeconds(-2), TimeSpan.FromSeconds(3));
+
+        Assert.That(delta, Is.EqualTo(TimeSpan.FromSeconds(expectedSeconds)));
+    }
+
+    [Test]
+    public void ClampDelta_InvertedWindow_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => TrimDeltaCalculator.ClampDelta(
+            TimeSpan.Zero, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-1)));
+    }
 }

--- a/tests/Beutl.UnitTests/Extensibility/ContextCommandDefinitionTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ContextCommandDefinitionTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Runtime.InteropServices;
+
+using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Extensibility;
+
+[TestFixture]
+public class ContextCommandDefinitionTests
+{
+    private static readonly OSPlatform[] s_platforms = [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX];
+
+    [Test]
+    public void Normalize_MultiplePlatformlessGestures_KeepsAllPerPlatform()
+    {
+        var def = new ContextCommandDefinition(
+            "ExitTool",
+            keyGestures: [new ContextCommandKeyGesture("V"), new ContextCommandKeyGesture("Escape")]);
+
+        Assert.That(def.KeyGestures, Is.Not.Null);
+        foreach (OSPlatform platform in s_platforms)
+        {
+            string?[] keys = def.KeyGestures!.Where(g => g.Platform == platform).Select(g => g.KeyGesture).ToArray();
+            Assert.That(keys, Is.EquivalentTo(new[] { "V", "Escape" }), $"platform {platform}");
+        }
+    }
+
+    [Test]
+    public void Normalize_SinglePlatformlessGesture_ExpandsToEachPlatform()
+    {
+        var def = new ContextCommandDefinition("Toggle", keyGestures: [new ContextCommandKeyGesture("C")]);
+
+        foreach (OSPlatform platform in s_platforms)
+        {
+            string?[] keys = def.KeyGestures!.Where(g => g.Platform == platform).Select(g => g.KeyGesture).ToArray();
+            Assert.That(keys, Is.EquivalentTo(new[] { "C" }), $"platform {platform}");
+        }
+    }
+
+    [Test]
+    public void Normalize_ExplicitPlatformGesture_OverridesFallback()
+    {
+        var def = new ContextCommandDefinition(
+            "Cmd",
+            keyGestures:
+            [
+                new ContextCommandKeyGesture("A"),
+                new ContextCommandKeyGesture("B", OSPlatform.Windows),
+            ]);
+
+        string?[] windows = def.KeyGestures!.Where(g => g.Platform == OSPlatform.Windows).Select(g => g.KeyGesture).ToArray();
+        string?[] osx = def.KeyGestures!.Where(g => g.Platform == OSPlatform.OSX).Select(g => g.KeyGesture).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(windows, Is.EquivalentTo(new[] { "B" }));
+            Assert.That(osx, Is.EquivalentTo(new[] { "A" }));
+        });
+    }
+}


### PR DESCRIPTION
Slip shifts the source-media window inside a clip (writes SourceVideo/Sound OffsetPosition, element geometry fixed) via a new IElementSlipService — kept separate from IElementResizeService so a plugin replacing the geometry-trim family does not inherit the media-offset family.

Roll shifts the boundary between two adjacent clips (front.Length += d, back.Start += d, back.Length -= d; total preserved). Slide shifts a middle clip's Start while front grows and back shrinks to compensate. Both live on IElementResizeService and use direct Element.Start/Length setters to bypass Scene.MoveChild's exact-adjacency overlap refusal. The byte-identical clamp helpers collapse into ClampTrimDelta.

UI invocation: IsSlipMode / IsRollMode / IsSlideMode flags on TimelineTabViewModel (mutually exclusive with each other and IsRazorMode), S / R / D ContextCommandDefinition shortcuts, and ElementView drag routing — Slip via middle-drag, Roll / Slide via edge-drag with neighbor checks — calling the services once on drag release with per-frame VM preview for Roll / Slide.

Player split / thumbnail overlay during drag is manual-verification (the visual aid; the service-commit path is fully tested).

Element.IsLocked guard deferred until PR #2065 merges (the guard property is not on main yet).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three timeline trim tools: **Slip**, **Roll**, and **Slide**, with new mode shortcuts/commands and dedicated exit bindings.
  * Enabled drag interactions for these tools, including live clamped previews and snap-based time delta behavior.
  * Added localized UI strings/labels for the new tools (including Japanese).
* **Bug Fixes**
  * Improved timeline tool-mode switching to ensure modes remain mutually exclusive and transitions preview-to-commit reliably.
* **Tests**
  * Added/expanded unit tests for Slip, Roll, and Slide, including edge cases, undo, and clamping/no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->