### PR TITLE
feat!: add Gate audio effect and unify the dynamics node scaffolding

### DIFF
--- a/src/Beutl.Engine/Audio/Effects/GateEffect.cs
+++ b/src/Beutl.Engine/Audio/Effects/GateEffect.cs
@@ -1,0 +1,63 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Language;
+
+using static Beutl.Audio.Effects.GateParameters;
+
+namespace Beutl.Audio.Effects;
+
+[Display(Name = nameof(AudioStrings.GateEffect), ResourceType = typeof(AudioStrings))]
+public sealed partial class GateEffect : AudioEffect
+{
+    public GateEffect()
+    {
+        ScanProperties<GateEffect>();
+    }
+
+    [Range(MinThresholdDb, MaxThresholdDb)]
+    [Display(Name = nameof(AudioStrings.GateEffect_Threshold), Description = nameof(AudioStrings.GateEffect_Threshold_Description), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
+    public IProperty<float> Threshold { get; } = Property.CreateAnimatable(DefaultThresholdDb);
+
+    [Range(MinAttackMs, MaxAttackMs)]
+    [Display(Name = nameof(AudioStrings.GateEffect_Attack), Description = nameof(AudioStrings.GateEffect_Attack_Description), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
+    public IProperty<float> Attack { get; } = Property.CreateAnimatable(DefaultAttackMs);
+
+    [Range(MinHoldMs, MaxHoldMs)]
+    [Display(Name = nameof(AudioStrings.GateEffect_Hold), Description = nameof(AudioStrings.GateEffect_Hold_Description), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    [NumberStep(100, 10)]
+    public IProperty<float> Hold { get; } = Property.CreateAnimatable(DefaultHoldMs);
+
+    [Range(MinReleaseMs, MaxReleaseMs)]
+    [Display(Name = nameof(AudioStrings.GateEffect_Release), Description = nameof(AudioStrings.GateEffect_Release_Description), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    [NumberStep(100, 10)]
+    public IProperty<float> Release { get; } = Property.CreateAnimatable(DefaultReleaseMs);
+
+    [Range(MinRangeDb, MaxRangeDb)]
+    [Display(Name = nameof(AudioStrings.GateEffect_Range), Description = nameof(AudioStrings.GateEffect_Range_Description), ResourceType = typeof(AudioStrings))]
+    [SuppressResourceClassGeneration]
+    [NumberStep(10, 1)]
+    public IProperty<float> Range { get; } = Property.CreateAnimatable(DefaultRangeDb);
+
+    public override AudioNode CreateNode(AudioContext context, AudioNode inputNode)
+    {
+        var gateNode = context.AddNode(new GateNode
+        {
+            Threshold = Threshold,
+            Attack = Attack,
+            Hold = Hold,
+            Release = Release,
+            Range = Range
+        });
+
+        context.Connect(inputNode, gateNode);
+        return gateNode;
+    }
+}

--- a/src/Beutl.Engine/Audio/Effects/GateParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/GateParameters.cs
@@ -1,0 +1,30 @@
+﻿namespace Beutl.Audio.Effects;
+
+// Single source of truth for the noise gate's ranges and defaults, shared by GateEffect's
+// [Range] declarations and GateNode's per-sample clamps so the two cannot drift.
+// GateEffectTests.GateParameters_RangeIsConsistent asserts each entry's consistency.
+internal static class GateParameters
+{
+    public const float MinThresholdDb = -100f;
+    public const float MaxThresholdDb = 0f;
+    public const float DefaultThresholdDb = -40f;
+
+    public const float MinAttackMs = 0.1f;
+    public const float MaxAttackMs = 500f;
+    public const float DefaultAttackMs = 1f;
+
+    public const float MinHoldMs = 0f;
+    public const float MaxHoldMs = 5000f;
+    public const float DefaultHoldMs = 10f;
+
+    public const float MinReleaseMs = 1f;
+    public const float MaxReleaseMs = 5000f;
+    public const float DefaultReleaseMs = 100f;
+
+    // Attenuation applied while the gate is closed. 0 dB disables gating (the closed floor equals the
+    // open level), and more negative values attenuate harder. Kept above -∞ so a closed gate ramps to
+    // a finite floor rather than clicking to hard mute.
+    public const float MinRangeDb = -100f;
+    public const float MaxRangeDb = 0f;
+    public const float DefaultRangeDb = -60f;
+}

--- a/src/Beutl.Engine/Audio/Effects/GateParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/GateParameters.cs
@@ -1,6 +1,5 @@
 ﻿namespace Beutl.Audio.Effects;
 
-// Shared ranges and defaults keep validation and per-sample clamps aligned.
 internal static class GateParameters
 {
     public const float MinThresholdDb = -100f;

--- a/src/Beutl.Engine/Audio/Effects/GateParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/GateParameters.cs
@@ -1,8 +1,6 @@
 ﻿namespace Beutl.Audio.Effects;
 
-// Single source of truth for the noise gate's ranges and defaults, shared by GateEffect's
-// [Range] declarations and GateNode's per-sample clamps so the two cannot drift.
-// GateEffectTests.GateParameters_RangeIsConsistent asserts each entry's consistency.
+// Shared ranges and defaults keep validation and per-sample clamps aligned.
 internal static class GateParameters
 {
     public const float MinThresholdDb = -100f;
@@ -21,9 +19,7 @@ internal static class GateParameters
     public const float MaxReleaseMs = 5000f;
     public const float DefaultReleaseMs = 100f;
 
-    // Attenuation applied while the gate is closed. 0 dB disables gating (the closed floor equals the
-    // open level), and more negative values attenuate harder. Kept above -∞ so a closed gate ramps to
-    // a finite floor rather than clicking to hard mute.
+    // A finite floor lets the closed gate ramp without clicking; 0 dB disables gating.
     public const float MinRangeDb = -100f;
     public const float MaxRangeDb = 0f;
     public const float DefaultRangeDb = -60f;

--- a/src/Beutl.Engine/Audio/Effects/GateParameters.cs
+++ b/src/Beutl.Engine/Audio/Effects/GateParameters.cs
@@ -11,6 +11,8 @@ internal static class GateParameters
     public const float MaxAttackMs = 500f;
     public const float DefaultAttackMs = 1f;
 
+    // Peak detection is unsmoothed, so Hold is what bridges a waveform's zero crossings: at 0 ms a
+    // low-frequency signal modulates the gain at twice its frequency unless Release is slow enough.
     public const float MinHoldMs = 0f;
     public const float MaxHoldMs = 5000f;
     public const float DefaultHoldMs = 10f;

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -60,10 +60,9 @@ public sealed class AudioProcessContext
     /// Returns whether this chunk continues directly from a previous chunk that ended at <paramref name="previousEnd"/>.
     /// </summary>
     /// <remarks>
-    /// Independently rounded <see cref="TimeSpan"/> values can place adjacent sample boundaries one tick
-    /// apart, so a one-tick gap or overlap still counts as contiguous; two ticks or more is a real
-    /// seek/edit boundary. Every stateful node must route through this helper, or the same scrub would
-    /// reset some nodes in a chain and not others.
+    /// Independently rounded sample boundaries may differ by one tick. A one-tick gap or overlap is
+    /// contiguous; two ticks or more is a seek/edit boundary. Stateful nodes must use this helper so
+    /// a chain resets consistently.
     /// </remarks>
     public bool ContinuesFrom(TimeSpan previousEnd)
     {

--- a/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
+++ b/src/Beutl.Engine/Audio/Graph/AudioProcessContext.cs
@@ -6,6 +6,8 @@ namespace Beutl.Audio.Graph;
 
 public sealed class AudioProcessContext
 {
+    private const long TimestampQuantizationToleranceTicks = 1;
+
     public AudioProcessContext(TimeRange timeRange, int sampleRate, AnimationSampler animationSampler, TimeRange? originalTimeRange)
     {
         ArgumentNullException.ThrowIfNull(animationSampler);
@@ -52,6 +54,21 @@ public sealed class AudioProcessContext
             throw new ArgumentOutOfRangeException(nameof(range), $"Sample count {samples} exceeds Int32.MaxValue at sampleRate={sampleRate}.");
 
         return (int)samples;
+    }
+
+    /// <summary>
+    /// Returns whether this chunk continues directly from a previous chunk that ended at <paramref name="previousEnd"/>.
+    /// </summary>
+    /// <remarks>
+    /// Independently rounded <see cref="TimeSpan"/> values can place adjacent sample boundaries one tick
+    /// apart, so a one-tick gap or overlap still counts as contiguous; two ticks or more is a real
+    /// seek/edit boundary. Every stateful node must route through this helper, or the same scrub would
+    /// reset some nodes in a chain and not others.
+    /// </remarks>
+    public bool ContinuesFrom(TimeSpan previousEnd)
+    {
+        long difference = TimeRange.Start.Ticks - previousEnd.Ticks;
+        return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
     }
 
     public TimeSpan GetTimeForSample(int sampleIndex)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -72,13 +72,12 @@ public sealed class CompressorNode : DynamicsNode
                 for (int i = 0; i < sampleCount; i++)
                 {
                     float s0 = in0[i];
-                    float peak = MathF.Abs(s0);
+                    float peak = AccumulatePeak(0f, s0);
                     float s1 = 0f;
                     if (channels == 2)
                     {
                         s1 = in1[i];
-                        float a1 = MathF.Abs(s1);
-                        if (a1 > peak) peak = a1;
+                        peak = AccumulatePeak(peak, s1);
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
@@ -97,8 +96,7 @@ public sealed class CompressorNode : DynamicsNode
                     float peak = 0f;
                     for (int ch = 0; ch < channels; ch++)
                     {
-                        float a = MathF.Abs(inputChannels[ch].Span[i]);
-                        if (a > peak) peak = a;
+                        peak = AccumulatePeak(peak, inputChannels[ch].Span[i]);
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
@@ -196,13 +194,12 @@ public sealed class CompressorNode : DynamicsNode
                     if (channels <= 2)
                     {
                         float s0 = in0[idx];
-                        float peak = MathF.Abs(s0);
+                        float peak = AccumulatePeak(0f, s0);
                         float s1 = 0f;
                         if (channels == 2)
                         {
                             s1 = in1[idx];
-                            float a1 = MathF.Abs(s1);
-                            if (a1 > peak) peak = a1;
+                            peak = AccumulatePeak(peak, s1);
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
@@ -218,8 +215,7 @@ public sealed class CompressorNode : DynamicsNode
                         float peak = 0f;
                         for (int ch = 0; ch < channels; ch++)
                         {
-                            float a = MathF.Abs(inputChannels[ch].Span[idx]);
-                            if (a > peak) peak = a;
+                            peak = AccumulatePeak(peak, inputChannels[ch].Span[idx]);
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, slope);
@@ -273,8 +269,8 @@ public sealed class CompressorNode : DynamicsNode
         };
     }
 
-    // Without this, one non-finite envelope sample would poison the state until the next Reset().
-    // First occurrence is logged, the rest suppressed.
+    // Unreachable while AccumulatePeak keeps the detector peak finite. Kept so that a change breaking
+    // that invariant surfaces as one warning instead of an envelope poisoned until the next Reset().
     private void RecoverEnvelopeIfNonFinite()
     {
         if (float.IsFinite(_envelopeDb)) return;
@@ -290,8 +286,8 @@ public sealed class CompressorNode : DynamicsNode
     // ProcessStatic and ProcessAnimated so the envelope/gain math cannot drift between the paths.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, float slope)
     {
-        // peak == 0 (silence) collapses inputDb to MinDb. The caller's abs/max keeps peak finite
-        // (a stray NaN never raises it); other non-finite envelope state is recovered below.
+        // peak == 0 (silence) collapses inputDb to MinDb; AccumulatePeak keeps peak finite, so the
+        // envelope stays finite as well.
         float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
         float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
         _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -8,35 +8,13 @@ using static Beutl.Audio.Effects.CompressorParameters;
 
 namespace Beutl.Audio.Graph.Nodes;
 
-public sealed class CompressorNode : AudioNode
+public sealed class CompressorNode : DynamicsNode
 {
     private static readonly ILogger s_logger = Log.CreateLogger<CompressorNode>();
 
-    private const float MinDb = -100f;
-
     private float _envelopeDb = MinDb;
-    private int _lastSampleRate;
-    private TimeSpan? _lastTimeRangeEnd;
 
-    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing.
-    // Memory<float> (not Span, a ref struct); arrays reused across Process(), reallocated only on
-    // channel-count change.
-    private Memory<float>[]? _inputChannelCache;
-    private Memory<float>[]? _outputChannelCache;
-
-    // Latched per node instance so each non-finite warning fires only once, not per sample.
     private bool _loggedNonFiniteEnvelope;
-    private bool _loggedNonFiniteSample;
-    // Per-parameter so a non-finite value on one parameter does not suppress diagnostics for another.
-    private readonly HashSet<string> _loggedNonFiniteParameters = new();
-    // Separate once-per-parameter latch for the "finite but out-of-[Range]" case, so clamp and
-    // non-finite warnings for the same parameter are not conflated.
-    private readonly HashSet<string> _loggedClampedParameters = new();
-
-    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted, letting the latch
-    // re-arm semantics be asserted without a logger sink.
-    internal int NonFiniteSampleWarnings;
-    internal int ClampWarnings;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -50,60 +28,23 @@ public sealed class CompressorNode : AudioNode
 
     public required IProperty<float> MakeupGain { get; init; }
 
-    public override AudioBuffer Process(AudioProcessContext context)
-    {
-        if (Inputs.Count != 1)
-            throw new InvalidOperationException(
-                $"Compressor node requires exactly one input but got {Inputs.Count}.");
+    protected override ILogger Logger => s_logger;
 
-        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
-        using var input = Inputs[0].Process(context);
+    protected override string DiagnosticName => "Compressor";
 
-        // A sample-rate change needs new coefficients, so treat it as a full session boundary:
-        // reset both the envelope and the one-shot diagnostic latches.
-        if (_lastSampleRate != context.SampleRate)
-        {
-            Reset();
-            _lastSampleRate = context.SampleRate;
-        }
+    // Expression-backed properties are deliberately not treated as animated: AnimationSampler does not
+    // yet evaluate expressions per-sample, so routing them to ProcessAnimated would just re-read the
+    // same CurrentValue every iteration. FIXME: once it does (see EqualizerEffect.IsNeutral), treat
+    // HasExpression as live here too, or such parameters stay frozen at build-time value.
+    protected override bool HasAnimatedParameters =>
+        Threshold.Animation != null ||
+        Ratio.Animation != null ||
+        Attack.Animation != null ||
+        Release.Animation != null ||
+        Knee.Animation != null ||
+        MakeupGain.Animation != null;
 
-        // Reset the envelope on the first call or whenever this chunk does not continue from the
-        // previous one. The node is cached across Compose() calls, so without this guard stale
-        // envelope state would bleed in after a seek/restart. Only DSP state resets here, NOT the
-        // diagnostic latches — re-arming them on every scrub discontinuity would let a persistent
-        // non-finite condition re-log per Process call. Diagnostics re-arm only on a sample-rate
-        // change or an explicit Reset().
-        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
-        {
-            ResetEnvelope();
-        }
-        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
-
-        if (input.SampleCount == 0)
-        {
-            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
-        }
-
-        // Expression-backed properties are deliberately not checked: AnimationSampler does not yet
-        // evaluate expressions per-sample, so routing them to ProcessAnimated would just re-read the
-        // same CurrentValue every iteration. FIXME: once it does (see EqualizerEffect.IsNeutral),
-        // treat HasExpression as live here too, or such parameters stay frozen at build-time value.
-        bool hasAnimation = Threshold.Animation != null ||
-                            Ratio.Animation != null ||
-                            Attack.Animation != null ||
-                            Release.Animation != null ||
-                            Knee.Animation != null ||
-                            MakeupGain.Animation != null;
-
-        if (!hasAnimation)
-        {
-            return ProcessStatic(input, context);
-        }
-
-        return ProcessAnimated(input, context);
-    }
-
-    private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+    protected override AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
         try
@@ -180,7 +121,7 @@ public sealed class CompressorNode : AudioNode
         }
     }
 
-    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    protected override AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
         try
@@ -304,36 +245,16 @@ public sealed class CompressorNode : AudioNode
         }
     }
 
-    // Caches per-channel Memory handles, reusing the backing arrays across calls (reallocated only
-    // on a channel-count change) so the hot loops avoid per-sample GetChannelData. See field comment.
-    private (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
-    {
-        int channels = input.ChannelCount;
-        if (_inputChannelCache is null || _inputChannelCache.Length != channels)
-        {
-            _inputChannelCache = new Memory<float>[channels];
-            _outputChannelCache = new Memory<float>[channels];
-        }
-
-        for (int ch = 0; ch < channels; ch++)
-        {
-            _inputChannelCache[ch] = input.GetChannelMemory(ch);
-            _outputChannelCache![ch] = output.GetChannelMemory(ch);
-        }
-
-        return (_inputChannelCache, _outputChannelCache!);
-    }
-
     private EffectiveParameters ReadStaticParameters()
     {
         return new EffectiveParameters
         {
-            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
-            Ratio = Sanitize(Ratio.CurrentValue, Ratio.DefaultValue, MinRatio, MaxRatio, nameof(Ratio)),
-            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, MinAttackMs, MaxAttackMs, nameof(Attack)),
-            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, MinReleaseMs, MaxReleaseMs, nameof(Release)),
-            Knee = Sanitize(Knee.CurrentValue, Knee.DefaultValue, MinKneeDb, MaxKneeDb, nameof(Knee)),
-            MakeupGain = Sanitize(MakeupGain.CurrentValue, MakeupGain.DefaultValue, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
+            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, DefaultThresholdDb, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Ratio = Sanitize(Ratio.CurrentValue, Ratio.DefaultValue, DefaultRatio, MinRatio, MaxRatio, nameof(Ratio)),
+            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, DefaultAttackMs, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, DefaultReleaseMs, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Knee = Sanitize(Knee.CurrentValue, Knee.DefaultValue, DefaultKneeDb, MinKneeDb, MaxKneeDb, nameof(Knee)),
+            MakeupGain = Sanitize(MakeupGain.CurrentValue, MakeupGain.DefaultValue, DefaultMakeupGainDb, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
         };
     }
 
@@ -343,33 +264,13 @@ public sealed class CompressorNode : AudioNode
     {
         return new EffectiveParameters
         {
-            Threshold = Sanitize(threshold, fallback.Threshold, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
-            Ratio = Sanitize(ratio, fallback.Ratio, MinRatio, MaxRatio, nameof(Ratio)),
-            Attack = Sanitize(attack, fallback.Attack, MinAttackMs, MaxAttackMs, nameof(Attack)),
-            Release = Sanitize(release, fallback.Release, MinReleaseMs, MaxReleaseMs, nameof(Release)),
-            Knee = Sanitize(knee, fallback.Knee, MinKneeDb, MaxKneeDb, nameof(Knee)),
-            MakeupGain = Sanitize(makeup, fallback.MakeupGain, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
+            Threshold = Sanitize(threshold, fallback.Threshold, DefaultThresholdDb, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Ratio = Sanitize(ratio, fallback.Ratio, DefaultRatio, MinRatio, MaxRatio, nameof(Ratio)),
+            Attack = Sanitize(attack, fallback.Attack, DefaultAttackMs, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Release = Sanitize(release, fallback.Release, DefaultReleaseMs, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Knee = Sanitize(knee, fallback.Knee, DefaultKneeDb, MinKneeDb, MaxKneeDb, nameof(Knee)),
+            MakeupGain = Sanitize(makeup, fallback.MakeupGain, DefaultMakeupGainDb, MinMakeupGainDb, MaxMakeupGainDb, nameof(MakeupGain)),
         };
-    }
-
-    // Substitute fallback for NaN/Infinity, then clamp to the parameter's [Range]. The clamp stops
-    // an animated value (e.g. Attack of 1e9 ms) from bypassing the declared range and freezing the
-    // envelope. A finite-but-out-of-range value is a real authoring error distinct from the
-    // non-finite case, so it gets its own once-per-parameter warning as a breadcrumb.
-    private float Sanitize(float value, float fallback, float min, float max, string paramName)
-    {
-        float safe = SafeParameter(value, fallback, paramName);
-        float clamped = Math.Clamp(safe, min, max);
-        // Only finite values reach here as `safe != clamped` (non-finite was already replaced by the
-        // in-range fallback). Latch once per parameter; re-armed only by ResetDiagnostics.
-        if (clamped != safe && _loggedClampedParameters.Add(paramName))
-        {
-            ClampWarnings++;
-            s_logger.LogWarning(
-                "Compressor parameter '{Param}' value {Value} is outside its valid range [{Min}, {Max}]; clamping to {Clamped}. Further out-of-range occurrences for this parameter will be suppressed.",
-                paramName, safe, min, max, clamped);
-        }
-        return clamped;
     }
 
     // Without this, one non-finite envelope sample would poison the state until the next Reset().
@@ -379,38 +280,10 @@ public sealed class CompressorNode : AudioNode
         if (float.IsFinite(_envelopeDb)) return;
         _envelopeDb = MinDb;
         if (_loggedNonFiniteEnvelope) return;
-        s_logger.LogWarning(
+        Logger.LogWarning(
             "Compressor envelope became non-finite (input sample produced inf/NaN); resetting to {MinDb} dB. Further occurrences will be suppressed.",
             MinDb);
         _loggedNonFiniteEnvelope = true;
-    }
-
-    private float SafeParameter(float value, float fallback, string paramName)
-    {
-        if (float.IsFinite(value)) return value;
-        if (_loggedNonFiniteParameters.Add(paramName))
-        {
-            s_logger.LogWarning(
-                "Compressor parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
-                paramName, fallback);
-        }
-        return fallback;
-    }
-
-    private float SanitizeOutput(float sample)
-    {
-        if (float.IsFinite(sample)) return sample;
-        if (!_loggedNonFiniteSample)
-        {
-            NonFiniteSampleWarnings++;
-            // Parameters are clamped and the envelope recovered, so the gain cannot overflow — a
-            // non-finite sample here almost always came from upstream. Zero it to protect downstream
-            // nodes and point the breadcrumb at the likely culprit.
-            s_logger.LogWarning(
-                "Compressor encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.");
-            _loggedNonFiniteSample = true;
-        }
-        return 0f;
     }
 
     // Advances the envelope follower by one sample's peak and returns the linear gain. Shared by
@@ -433,13 +306,6 @@ public sealed class CompressorNode : AudioNode
     private static float ComputeGainLinear(float gainReductionDb, float makeupDb)
     {
         return AudioMath.ConvertDbToLinear(makeupDb - gainReductionDb);
-    }
-
-    // One-pole IIR smoothing coefficient for a 1/e settling time of `timeMs`: the envelope reaches
-    // ~63% of a step change after `timeMs`. dB-domain because that better matches perceived loudness.
-    private static float ComputeCoeff(float timeMs, int sampleRate)
-    {
-        return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
     }
 
     // Soft-knee gain computer (Reece/Giannoulis): when kneeDb > 0, a C¹-continuous quadratic blends
@@ -468,46 +334,15 @@ public sealed class CompressorNode : AudioNode
         return envelopeDb > thresholdDb ? slope * (envelopeDb - thresholdDb) : 0f;
     }
 
-    /// <summary>
-    /// Resets the compressor to a clean "new render session" state: zeroes the envelope follower
-    /// and re-arms the one-shot non-finite diagnostic warnings.
-    /// </summary>
-    /// <remarks>
-    /// Do not call mid-buffer during playback — zeroing the envelope there clicks. This is for
-    /// genuine session boundaries (a deliberate re-render or an orchestrator-driven stop/seek);
-    /// <see cref="Process"/> already resets the envelope on a sample-rate change or time-range
-    /// discontinuity. Public to match the sibling stateful nodes <c>EqualizerNode</c> / <c>DelayNode</c>.
-    /// </remarks>
-    public void Reset()
-    {
-        ResetEnvelope();
-        ResetDiagnostics();
-    }
-
-    private void ResetEnvelope()
+    protected override void ResetDspState()
     {
         _envelopeDb = MinDb;
     }
 
-    private void ResetDiagnostics()
+    protected override void ResetDiagnostics()
     {
+        base.ResetDiagnostics();
         _loggedNonFiniteEnvelope = false;
-        _loggedNonFiniteSample = false;
-        _loggedNonFiniteParameters.Clear();
-        _loggedClampedParameters.Clear();
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            // Drop the cached handles so we do not pin the last buffers' pooled memory after
-            // disposal; they are re-filled on the next Process() call.
-            _inputChannelCache = null;
-            _outputChannelCache = null;
-        }
-
-        base.Dispose(disposing);
     }
 
     // readonly + init-only: built once via object initializer, then only read (passed `in`), so

--- a/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/CompressorNode.cs
@@ -32,10 +32,8 @@ public sealed class CompressorNode : DynamicsNode
 
     protected override string DiagnosticName => "Compressor";
 
-    // Expression-backed properties are deliberately not treated as animated: AnimationSampler does not
-    // yet evaluate expressions per-sample, so routing them to ProcessAnimated would just re-read the
-    // same CurrentValue every iteration. FIXME: once it does (see EqualizerEffect.IsNeutral), treat
-    // HasExpression as live here too, or such parameters stay frozen at build-time value.
+    // AnimationSampler does not evaluate expressions per sample, so expression-backed properties
+    // remain at CurrentValue.
     protected override bool HasAnimatedParameters =>
         Threshold.Animation != null ||
         Ratio.Animation != null ||
@@ -269,8 +267,7 @@ public sealed class CompressorNode : DynamicsNode
         };
     }
 
-    // Unreachable while AccumulatePeak keeps the detector peak finite. Kept so that a change breaking
-    // that invariant surfaces as one warning instead of an envelope poisoned until the next Reset().
+    // Defensive fallback if the finite detector-peak invariant is broken.
     private void RecoverEnvelopeIfNonFinite()
     {
         if (float.IsFinite(_envelopeDb)) return;
@@ -286,8 +283,7 @@ public sealed class CompressorNode : DynamicsNode
     // ProcessStatic and ProcessAnimated so the envelope/gain math cannot drift between the paths.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, float slope)
     {
-        // peak == 0 (silence) collapses inputDb to MinDb; AccumulatePeak keeps peak finite, so the
-        // envelope stays finite as well.
+        // Silence maps to MinDb; AccumulatePeak guarantees a finite envelope input.
         float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
         float coeff = inputDb > _envelopeDb ? attackCoeff : releaseCoeff;
         _envelopeDb = inputDb + coeff * (_envelopeDb - inputDb);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DelayNode.cs
@@ -41,7 +41,7 @@ public sealed class DelayNode : AudioNode
         // Reset on the first call or any seek (a chunk not starting where the previous one ended).
         // The node is cached across Compose() calls, so stale delay-line content would otherwise
         // bleed in. Matches CompressorNode/EqualizerNode.
-        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
+        if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
         {
             Reset();
         }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -210,6 +210,21 @@ public abstract class DynamicsNode : AudioNode
     }
 
     /// <summary>
+    /// Folds one channel's sample into the running linked peak, ignoring non-finite values.
+    /// </summary>
+    /// <remarks>
+    /// A NaN already compares false, but an Infinity would become the peak for every channel, so one
+    /// corrupt channel would drive the gain shared by all of them — opening a gate, or collapsing a
+    /// compressor envelope to its floor — while <see cref="SanitizeOutput"/> only zeroes the corrupt
+    /// channel itself.
+    /// </remarks>
+    protected static float AccumulatePeak(float peak, float sample)
+    {
+        float abs = MathF.Abs(sample);
+        return float.IsFinite(abs) && abs > peak ? abs : peak;
+    }
+
+    /// <summary>
     /// Replaces a non-finite output sample with 0 so it cannot propagate downstream.
     /// </summary>
     protected float SanitizeOutput(float sample)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -88,11 +88,13 @@ public abstract class DynamicsNode : AudioNode
             {
                 ResetDspState();
             }
-            _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
             AudioBuffer output = HasAnimatedParameters
                 ? ProcessAnimated(input, context)
                 : ProcessStatic(input, context);
+
+            // A chunk that threw must not look contiguous, or the next one inherits half-mutated state.
+            _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
             // A hook may hand the input straight back, as the neutral paths of GainNode / EqualizerNode
             // do; ownership then belongs to the caller and disposing it here would hand the next

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -57,39 +57,56 @@ public abstract class DynamicsNode : AudioNode
             throw new InvalidOperationException(
                 $"{DiagnosticName} node requires exactly one input but got {Inputs.Count}.");
 
-        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
-        using var input = Inputs[0].Process(context);
-
-        // Coefficients come from context.SampleRate while the output carries input.SampleRate, so a
-        // mismatch would mislabel samples; this node does not resample.
-        if (input.SampleRate != context.SampleRate)
-            throw new InvalidOperationException(
-                $"{DiagnosticName} node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
-
-        // A sample-rate change needs new coefficients, so treat it as a full session boundary and
-        // re-arm the diagnostics too.
-        if (_lastSampleRate != context.SampleRate)
+        AudioBuffer input = Inputs[0].Process(context);
+        bool ownsInput = true;
+        try
         {
-            Reset();
-            _lastSampleRate = context.SampleRate;
-        }
+            // Coefficients come from context.SampleRate while the output carries input.SampleRate, so a
+            // mismatch would mislabel samples; this node does not resample.
+            if (input.SampleRate != context.SampleRate)
+                throw new InvalidOperationException(
+                    $"{DiagnosticName} node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
 
-        // Returns before _lastTimeRangeEnd advances: an empty chunk would otherwise mask a discontinuity.
-        if (input.SampleCount == 0)
+            // A sample-rate change needs new coefficients, so treat it as a full session boundary and
+            // re-arm the diagnostics too.
+            if (_lastSampleRate != context.SampleRate)
+            {
+                Reset();
+                _lastSampleRate = context.SampleRate;
+            }
+
+            // Returns before _lastTimeRangeEnd advances: an empty chunk would otherwise mask a discontinuity.
+            if (input.SampleCount == 0)
+            {
+                return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+            }
+
+            // Nodes are cached across Compose() calls, so stale DSP state must not survive a seek or
+            // restart. Diagnostics latches are deliberately kept — re-arming them on every scrub would let
+            // a persistent fault re-log once per Process call.
+            if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
+            {
+                ResetDspState();
+            }
+            _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
+
+            AudioBuffer output = HasAnimatedParameters
+                ? ProcessAnimated(input, context)
+                : ProcessStatic(input, context);
+
+            // A hook may hand the input straight back, as the neutral paths of GainNode / EqualizerNode
+            // do; ownership then belongs to the caller and disposing it here would hand the next
+            // consumer a returned pooled buffer.
+            ownsInput = !ReferenceEquals(output, input);
+            return output;
+        }
+        finally
         {
-            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+            if (ownsInput)
+            {
+                input.Dispose();
+            }
         }
-
-        // Nodes are cached across Compose() calls, so stale DSP state must not survive a seek or
-        // restart. Diagnostics latches are deliberately kept — re-arming them on every scrub would let
-        // a persistent fault re-log once per Process call.
-        if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
-        {
-            ResetDspState();
-        }
-        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
-
-        return HasAnimatedParameters ? ProcessAnimated(input, context) : ProcessStatic(input, context);
     }
 
     protected abstract AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -1,0 +1,233 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Beutl.Audio.Graph.Nodes;
+
+/// <summary>
+/// Shared scaffolding for dynamics processors that derive one linked gain per sample from the peak
+/// across all channels and apply it to every channel.
+/// </summary>
+/// <remarks>
+/// Covers chunk validation, session/seek state resets, the per-channel buffer view cache, parameter
+/// sanitization and the warn-once diagnostics. Derived nodes supply the parameter set and the gain
+/// math. <c>LimiterNode</c> deliberately does not derive from this: its lookahead delay lines and
+/// per-parameter error-severity diagnostics are a different contract, not a variation of this one.
+/// </remarks>
+public abstract class DynamicsNode : AudioNode
+{
+    protected const float MinDb = -100f;
+
+    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing;
+    // arrays reused across Process(), reallocated only on a channel-count change.
+    private Memory<float>[]? _inputChannelCache;
+    private Memory<float>[]? _outputChannelCache;
+
+    private int _lastSampleRate;
+    private TimeSpan? _lastTimeRangeEnd;
+
+    private bool _loggedNonFiniteSample;
+    // Per-parameter so a fault on one parameter does not suppress diagnostics for another.
+    private readonly HashSet<string> _loggedNonFiniteParameters = new();
+    // Separate from the non-finite latch so clamp and non-finite faults are not conflated.
+    private readonly HashSet<string> _loggedClampedParameters = new();
+
+    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted, letting the latch
+    // re-arm semantics be asserted without a logger sink.
+    internal int NonFiniteSampleWarnings;
+    internal int ClampWarnings;
+
+    /// <summary>
+    /// Logger for this node type. Implement with a <c>static readonly</c> field so one logger is
+    /// shared per node type rather than allocated per instance.
+    /// </summary>
+    protected abstract ILogger Logger { get; }
+
+    /// <summary>
+    /// Human-readable node name used in exception and diagnostic messages (e.g. "Gate").
+    /// </summary>
+    protected abstract string DiagnosticName { get; }
+
+    /// <summary>
+    /// Whether any parameter carries a keyframe animation and processing must therefore run per-sample.
+    /// </summary>
+    protected abstract bool HasAnimatedParameters { get; }
+
+    public override AudioBuffer Process(AudioProcessContext context)
+    {
+        if (Inputs.Count != 1)
+            throw new InvalidOperationException(
+                $"{DiagnosticName} node requires exactly one input but got {Inputs.Count}.");
+
+        // Every path emits a fresh buffer (no pass-through), so dispose the consumed input.
+        using var input = Inputs[0].Process(context);
+
+        // Coefficients come from context.SampleRate while the output carries input.SampleRate, so a
+        // mismatch would mislabel samples; this node does not resample.
+        if (input.SampleRate != context.SampleRate)
+            throw new InvalidOperationException(
+                $"{DiagnosticName} node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
+
+        // A sample-rate change needs new coefficients, so treat it as a full session boundary and
+        // re-arm the diagnostics too.
+        if (_lastSampleRate != context.SampleRate)
+        {
+            Reset();
+            _lastSampleRate = context.SampleRate;
+        }
+
+        // Returns before _lastTimeRangeEnd advances: an empty chunk would otherwise mask a discontinuity.
+        if (input.SampleCount == 0)
+        {
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+        }
+
+        // Nodes are cached across Compose() calls, so stale DSP state must not survive a seek or
+        // restart. Diagnostics latches are deliberately kept — re-arming them on every scrub would let
+        // a persistent fault re-log once per Process call.
+        if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
+        {
+            ResetDspState();
+        }
+        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
+
+        return HasAnimatedParameters ? ProcessAnimated(input, context) : ProcessStatic(input, context);
+    }
+
+    protected abstract AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context);
+
+    protected abstract AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context);
+
+    /// <summary>
+    /// Clears the DSP state (envelope / gain followers, hold counters) without touching diagnostics.
+    /// </summary>
+    protected abstract void ResetDspState();
+
+    /// <summary>
+    /// Resets this node to a clean "new render session" state: clears the DSP state and re-arms the
+    /// one-shot diagnostic warnings.
+    /// </summary>
+    /// <remarks>
+    /// Do not call mid-buffer during playback — dropping the follower there clicks. This is for genuine
+    /// session boundaries (a deliberate re-render or an orchestrator-driven stop/seek);
+    /// <see cref="Process"/> already handles sample-rate changes and time-range discontinuities.
+    /// </remarks>
+    public void Reset()
+    {
+        ResetDspState();
+        ResetDiagnostics();
+    }
+
+    /// <summary>
+    /// Re-arms the one-shot diagnostic warnings. Override to also re-arm latches a derived node adds,
+    /// calling <c>base.ResetDiagnostics()</c>.
+    /// </summary>
+    protected virtual void ResetDiagnostics()
+    {
+        _loggedNonFiniteSample = false;
+        _loggedNonFiniteParameters.Clear();
+        _loggedClampedParameters.Clear();
+    }
+
+    /// <summary>
+    /// Caches per-channel <see cref="Memory{T}"/> handles for the input and output buffers.
+    /// </summary>
+    /// <remarks>
+    /// The backing arrays are reused across calls (reallocated only on a channel-count change) so the
+    /// hot loops avoid per-sample GetChannelData. <see cref="Memory{T}"/> rather than <see cref="Span{T}"/>
+    /// because a ref struct cannot live in an array.
+    /// </remarks>
+    protected (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
+    {
+        int channels = input.ChannelCount;
+        if (_inputChannelCache is null || _inputChannelCache.Length != channels)
+        {
+            _inputChannelCache = new Memory<float>[channels];
+            _outputChannelCache = new Memory<float>[channels];
+        }
+
+        for (int ch = 0; ch < channels; ch++)
+        {
+            _inputChannelCache[ch] = input.GetChannelMemory(ch);
+            _outputChannelCache![ch] = output.GetChannelMemory(ch);
+        }
+
+        return (_inputChannelCache, _outputChannelCache!);
+    }
+
+    /// <summary>
+    /// Substitutes <paramref name="fallback"/> for a non-finite value, then clamps to
+    /// [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <remarks>
+    /// The clamp stops an animated value (e.g. an Attack of 1e9 ms) from bypassing the declared
+    /// <c>[Range]</c> and freezing the follower. A finite-but-out-of-range value is a different
+    /// authoring error from a non-finite one, so each gets its own once-per-parameter warning.
+    /// </remarks>
+    protected float Sanitize(float value, float fallback, float declaredDefault, float min, float max, string paramName)
+    {
+        float safe = SafeParameter(value, fallback, declaredDefault, paramName);
+        float clamped = Math.Clamp(safe, min, max);
+        if (clamped != safe && _loggedClampedParameters.Add(paramName))
+        {
+            ClampWarnings++;
+            Logger.LogWarning(
+                "{Node} parameter '{Param}' value {Value} is outside its valid range [{Min}, {Max}]; clamping to {Clamped}. Further out-of-range occurrences for this parameter will be suppressed.",
+                DiagnosticName, paramName, safe, min, max, clamped);
+        }
+        return clamped;
+    }
+
+    private float SafeParameter(float value, float fallback, float declaredDefault, string paramName)
+    {
+        if (float.IsFinite(value)) return value;
+        // IProperty implementations may expose non-finite defaults, which Math.Clamp cannot recover.
+        float safeFallback = float.IsFinite(fallback) ? fallback : declaredDefault;
+        if (_loggedNonFiniteParameters.Add(paramName))
+        {
+            Logger.LogWarning(
+                "{Node} parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
+                DiagnosticName, paramName, safeFallback);
+        }
+        return safeFallback;
+    }
+
+    /// <summary>
+    /// Replaces a non-finite output sample with 0 so it cannot propagate downstream.
+    /// </summary>
+    protected float SanitizeOutput(float sample)
+    {
+        if (float.IsFinite(sample)) return sample;
+        if (!_loggedNonFiniteSample)
+        {
+            NonFiniteSampleWarnings++;
+            Logger.LogWarning(
+                "{Node} encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.",
+                DiagnosticName);
+            _loggedNonFiniteSample = true;
+        }
+        return 0f;
+    }
+
+    /// <summary>
+    /// One-pole IIR smoothing coefficient whose 1/e settling time is <paramref name="timeMs"/>.
+    /// </summary>
+    /// <remarks>
+    /// Applied in the dB domain, which tracks perceived loudness better than the linear one.
+    /// </remarks>
+    protected static float ComputeCoeff(float timeMs, int sampleRate)
+    {
+        return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Drop the cached handles so we do not pin the last buffers' pooled memory after disposal;
+            // they are re-filled on the next Process() call.
+            _inputChannelCache = null;
+            _outputChannelCache = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -7,17 +7,14 @@ namespace Beutl.Audio.Graph.Nodes;
 /// across all channels and apply it to every channel.
 /// </summary>
 /// <remarks>
-/// Covers chunk validation, session/seek state resets, the per-channel buffer view cache, parameter
-/// sanitization and the warn-once diagnostics. Derived nodes supply the parameter set and the gain
-/// math. <c>LimiterNode</c> deliberately does not derive from this: its lookahead delay lines and
-/// per-parameter error-severity diagnostics are a different contract, not a variation of this one.
+/// Derived nodes supply parameter sampling and gain math. <c>LimiterNode</c> remains separate because
+/// its lookahead delay lines and error-severity diagnostics require a different lifecycle.
 /// </remarks>
 public abstract class DynamicsNode : AudioNode
 {
     protected const float MinDb = -100f;
 
-    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing;
-    // arrays reused across Process(), reallocated only on a channel-count change.
+    // Cache channel views across Process calls to avoid repeated slicing in hot loops.
     private Memory<float>[]? _inputChannelCache;
     private Memory<float>[]? _outputChannelCache;
 
@@ -25,13 +22,9 @@ public abstract class DynamicsNode : AudioNode
     private TimeSpan? _lastTimeRangeEnd;
 
     private bool _loggedNonFiniteSample;
-    // Per-parameter so a fault on one parameter does not suppress diagnostics for another.
     private readonly HashSet<string> _loggedNonFiniteParameters = new();
-    // Separate from the non-finite latch so clamp and non-finite faults are not conflated.
     private readonly HashSet<string> _loggedClampedParameters = new();
 
-    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted, letting the latch
-    // re-arm semantics be asserted without a logger sink.
     internal int NonFiniteSampleWarnings;
     internal int ClampWarnings;
 
@@ -61,8 +54,7 @@ public abstract class DynamicsNode : AudioNode
         bool ownsInput = true;
         try
         {
-            // Coefficients come from context.SampleRate while the output carries input.SampleRate, so a
-            // mismatch would mislabel samples; this node does not resample.
+            // This node does not resample; mismatched rates would produce mislabeled output.
             if (input.SampleRate != context.SampleRate)
                 throw new InvalidOperationException(
                     $"{DiagnosticName} node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
@@ -81,9 +73,7 @@ public abstract class DynamicsNode : AudioNode
                 return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
             }
 
-            // Nodes are cached across Compose() calls, so stale DSP state must not survive a seek or
-            // restart. Diagnostics latches are deliberately kept — re-arming them on every scrub would let
-            // a persistent fault re-log once per Process call.
+            // Reset DSP state across seeks without re-arming warnings for persistent faults.
             if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
             {
                 ResetDspState();
@@ -96,9 +86,7 @@ public abstract class DynamicsNode : AudioNode
             // A chunk that threw must not look contiguous, or the next one inherits half-mutated state.
             _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
-            // A hook may hand the input straight back, as the neutral paths of GainNode / EqualizerNode
-            // do; ownership then belongs to the caller and disposing it here would hand the next
-            // consumer a returned pooled buffer.
+            // If a hook returns the input, ownership transfers to the caller.
             ownsInput = !ReferenceEquals(output, input);
             return output;
         }
@@ -150,9 +138,8 @@ public abstract class DynamicsNode : AudioNode
     /// Caches per-channel <see cref="Memory{T}"/> handles for the input and output buffers.
     /// </summary>
     /// <remarks>
-    /// The backing arrays are reused across calls (reallocated only on a channel-count change) so the
-    /// hot loops avoid per-sample GetChannelData. <see cref="Memory{T}"/> rather than <see cref="Span{T}"/>
-    /// because a ref struct cannot live in an array.
+    /// Backing arrays are reused across calls. <see cref="Memory{T}"/> is required because ref structs
+    /// cannot live in arrays.
     /// </remarks>
     protected (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
     {
@@ -213,10 +200,8 @@ public abstract class DynamicsNode : AudioNode
     /// Folds one channel's sample into the running linked peak, ignoring non-finite values.
     /// </summary>
     /// <remarks>
-    /// A NaN already compares false, but an Infinity would become the peak for every channel, so one
-    /// corrupt channel would drive the gain shared by all of them — opening a gate, or collapsing a
-    /// compressor envelope to its floor — while <see cref="SanitizeOutput"/> only zeroes the corrupt
-    /// channel itself.
+    /// Infinity would become the shared peak and alter every channel's gain, while
+    /// <see cref="SanitizeOutput"/> only zeroes the corrupt channel.
     /// </remarks>
     protected static float AccumulatePeak(float peak, float sample)
     {
@@ -256,8 +241,7 @@ public abstract class DynamicsNode : AudioNode
     {
         if (disposing)
         {
-            // Drop the cached handles so we do not pin the last buffers' pooled memory after disposal;
-            // they are re-filled on the next Process() call.
+            // Do not pin the last buffers' pooled memory after disposal.
             _inputChannelCache = null;
             _outputChannelCache = null;
         }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/DynamicsNode.cs
@@ -90,6 +90,11 @@ public abstract class DynamicsNode : AudioNode
             ownsInput = !ReferenceEquals(output, input);
             return output;
         }
+        catch
+        {
+            _lastTimeRangeEnd = null;
+            throw;
+        }
         finally
         {
             if (ownsInput)

--- a/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/EqualizerNode.cs
@@ -46,7 +46,7 @@ public sealed class EqualizerNode : AudioNode
         // Reset whenever the chunk does not continue directly from the previous one, because the
         // node instance is cached across Compose() calls and stale IIR state would otherwise bleed
         // into the first samples after a seek or stop/restart.
-        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
+        if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
         {
             Reset();
         }

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -117,7 +117,11 @@ public sealed class GateNode : AudioNode
                 for (int i = 0; i < sampleCount; i++)
                 {
                     float s0 = in0[i];
-                    float peak = MathF.Abs(s0);
+                    // Seed from 0 and compare (NaN > 0 is false) so a NaN in one channel is skipped
+                    // rather than poisoning the linked-stereo peak; a finite channel still drives it.
+                    float peak = 0f;
+                    float a0 = MathF.Abs(s0);
+                    if (a0 > peak) peak = a0;
                     float s1 = 0f;
                     if (channels == 2)
                     {
@@ -234,7 +238,11 @@ public sealed class GateNode : AudioNode
                     if (channels <= 2)
                     {
                         float s0 = in0[idx];
-                        float peak = MathF.Abs(s0);
+                        // Seed from 0 and compare (NaN > 0 is false) so a NaN in one channel is
+                        // skipped rather than poisoning the linked-stereo peak.
+                        float peak = 0f;
+                        float a0 = MathF.Abs(s0);
+                        if (a0 > peak) peak = a0;
                         float s1 = 0f;
                         if (channels == 2)
                         {
@@ -384,8 +392,11 @@ public sealed class GateNode : AudioNode
     // ProcessAnimated so the gate/hold math cannot drift between the paths.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, int holdSamples)
     {
+        // Digital silence (peak == 0) is -inf dB — below any threshold — so it must never open the
+        // gate, not even when Threshold sits at its -100 dB minimum where inputDb would otherwise
+        // collapse to MinDb and compare equal (-100 >= -100). Require real signal energy to open.
         float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
-        bool aboveThreshold = inputDb >= p.Threshold;
+        bool aboveThreshold = peak > 0f && inputDb >= p.Threshold;
         if (aboveThreshold)
         {
             _holdCounter = holdSamples;
@@ -393,6 +404,15 @@ public sealed class GateNode : AudioNode
         else if (_holdCounter > 0)
         {
             _holdCounter--;
+        }
+
+        // Range 0 dB disables gating: the closed floor equals the open level, so the gate is an exact
+        // identity. Snap the follower fully open and bypass smoothing so the disabled case adds no
+        // attack ramp or asymptotic sub-unity gain — output equals input sample-for-sample.
+        if (p.Range >= 0f)
+        {
+            _gateGainDb = 0f;
+            return 1f;
         }
 
         // Open (0 dB) while the signal is above threshold or the hold timer keeps it latched; else

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -1,0 +1,468 @@
+﻿using Beutl.Audio.Effects;
+using Beutl.Engine;
+using Beutl.Logging;
+using Beutl.Media;
+using Microsoft.Extensions.Logging;
+
+using static Beutl.Audio.Effects.GateParameters;
+
+namespace Beutl.Audio.Graph.Nodes;
+
+public sealed class GateNode : AudioNode
+{
+    private static readonly ILogger s_logger = Log.CreateLogger<GateNode>();
+
+    private const float MinDb = -100f;
+
+    // Gate gain in dB, smoothed toward 0 (open) or the Range floor (closed). Starts fully closed so a
+    // silent lead-in stays quiet until the signal crosses the threshold.
+    private float _gateGainDb = MinDb;
+    // Samples remaining before a gate that has dropped below threshold begins to release.
+    private int _holdCounter;
+    private int _lastSampleRate;
+    private TimeSpan? _lastTimeRangeEnd;
+
+    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing;
+    // arrays reused across Process(), reallocated only on a channel-count change.
+    private Memory<float>[]? _inputChannelCache;
+    private Memory<float>[]? _outputChannelCache;
+
+    // Latched per node instance so each non-finite warning fires only once, not per sample.
+    private bool _loggedNonFiniteGain;
+    private bool _loggedNonFiniteSample;
+    private readonly HashSet<string> _loggedNonFiniteParameters = new();
+    private readonly HashSet<string> _loggedClampedParameters = new();
+
+    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted.
+    internal int NonFiniteSampleWarnings;
+    internal int ClampWarnings;
+
+    public required IProperty<float> Threshold { get; init; }
+
+    public required IProperty<float> Attack { get; init; }
+
+    public required IProperty<float> Hold { get; init; }
+
+    public required IProperty<float> Release { get; init; }
+
+    public required IProperty<float> Range { get; init; }
+
+    public override AudioBuffer Process(AudioProcessContext context)
+    {
+        if (Inputs.Count != 1)
+            throw new InvalidOperationException(
+                $"Gate node requires exactly one input but got {Inputs.Count}.");
+
+        using var input = Inputs[0].Process(context);
+
+        if (_lastSampleRate != context.SampleRate)
+        {
+            Reset();
+            _lastSampleRate = context.SampleRate;
+        }
+
+        // Reset the gate on the first call or whenever this chunk does not continue from the previous
+        // one; the node is cached across Compose() calls, so stale gate state would otherwise bleed in
+        // after a seek/restart. Only DSP state resets here, not the diagnostic latches.
+        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
+        {
+            ResetGate();
+        }
+        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
+
+        if (input.SampleCount == 0)
+        {
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+        }
+
+        // Expression-backed properties are deliberately not treated as animated: AnimationSampler does
+        // not yet evaluate expressions per-sample, so routing them through ProcessAnimated would just
+        // re-read the same CurrentValue every iteration.
+        bool hasAnimation = Threshold.Animation != null ||
+                            Attack.Animation != null ||
+                            Hold.Animation != null ||
+                            Release.Animation != null ||
+                            Range.Animation != null;
+
+        if (!hasAnimation)
+        {
+            return ProcessStatic(input, context);
+        }
+
+        return ProcessAnimated(input, context);
+    }
+
+    private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        try
+        {
+            EffectiveParameters p = ReadStaticParameters();
+
+            float attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+            float releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+            int holdSamples = HoldSamples(p.Hold, context.SampleRate);
+
+            int channels = input.ChannelCount;
+            int sampleCount = input.SampleCount;
+            var (inputChannels, outputChannels) = MapChannels(input, output);
+
+            if (channels <= 2)
+            {
+                Span<float> in0 = inputChannels[0].Span;
+                Span<float> out0 = outputChannels[0].Span;
+                Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+                Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    float s0 = in0[i];
+                    float peak = MathF.Abs(s0);
+                    float s1 = 0f;
+                    if (channels == 2)
+                    {
+                        s1 = in1[i];
+                        float a1 = MathF.Abs(s1);
+                        if (a1 > peak) peak = a1;
+                    }
+
+                    float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
+
+                    out0[i] = SanitizeOutput(s0 * gainLinear);
+                    if (channels == 2)
+                    {
+                        out1[i] = SanitizeOutput(s1 * gainLinear);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    float peak = 0f;
+                    for (int ch = 0; ch < channels; ch++)
+                    {
+                        float a = MathF.Abs(inputChannels[ch].Span[i]);
+                        if (a > peak) peak = a;
+                    }
+
+                    float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
+
+                    for (int ch = 0; ch < channels; ch++)
+                    {
+                        float sample = inputChannels[ch].Span[i] * gainLinear;
+                        outputChannels[ch].Span[i] = SanitizeOutput(sample);
+                    }
+                }
+            }
+
+            return output;
+        }
+        catch
+        {
+            output.Dispose();
+            throw;
+        }
+    }
+
+    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    {
+        var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        try
+        {
+            const int maxChunkSize = 1024;
+            int bufferSize = Math.Min(maxChunkSize, input.SampleCount);
+            Span<float> thresholds = stackalloc float[bufferSize];
+            Span<float> attacks = stackalloc float[bufferSize];
+            Span<float> holds = stackalloc float[bufferSize];
+            Span<float> releases = stackalloc float[bufferSize];
+            Span<float> ranges = stackalloc float[bufferSize];
+
+            EffectiveParameters fallback = ReadStaticParameters();
+
+            int channels = input.ChannelCount;
+            int sampleCount = input.SampleCount;
+            var (inputChannels, outputChannels) = MapChannels(input, output);
+
+            Span<float> in0 = channels <= 2 ? inputChannels[0].Span : default;
+            Span<float> out0 = channels <= 2 ? outputChannels[0].Span : default;
+            Span<float> in1 = channels == 2 ? inputChannels[1].Span : default;
+            Span<float> out1 = channels == 2 ? outputChannels[1].Span : default;
+
+            int processed = 0;
+
+            // Seed with NaN so the first comparison is always unequal and coefficients compute on
+            // sample 0; afterwards Exp runs only when the animated ms value changes.
+            float lastAttackMs = float.NaN;
+            float lastReleaseMs = float.NaN;
+            float attackCoeff = 0f;
+            float releaseCoeff = 0f;
+
+            while (processed < sampleCount)
+            {
+                int chunkSize = Math.Min(bufferSize, sampleCount - processed);
+
+                var chunkStart = context.GetTimeForSample(processed);
+                var chunkEnd = context.GetTimeForSample(processed + chunkSize);
+                var chunkRange = new TimeRange(chunkStart, chunkEnd - chunkStart);
+
+                context.AnimationSampler.SampleBuffer(Threshold, chunkRange, context.SampleRate, thresholds[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Attack, chunkRange, context.SampleRate, attacks[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Hold, chunkRange, context.SampleRate, holds[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Release, chunkRange, context.SampleRate, releases[..chunkSize]);
+                context.AnimationSampler.SampleBuffer(Range, chunkRange, context.SampleRate, ranges[..chunkSize]);
+
+                for (int i = 0; i < chunkSize; i++)
+                {
+                    int idx = processed + i;
+
+                    EffectiveParameters p = SanitizeAnimated(
+                        thresholds[i], attacks[i], holds[i], releases[i], ranges[i], fallback);
+
+                    if (p.Attack != lastAttackMs)
+                    {
+                        attackCoeff = ComputeCoeff(p.Attack, context.SampleRate);
+                        lastAttackMs = p.Attack;
+                    }
+                    if (p.Release != lastReleaseMs)
+                    {
+                        releaseCoeff = ComputeCoeff(p.Release, context.SampleRate);
+                        lastReleaseMs = p.Release;
+                    }
+                    int holdSamples = HoldSamples(p.Hold, context.SampleRate);
+
+                    if (channels <= 2)
+                    {
+                        float s0 = in0[idx];
+                        float peak = MathF.Abs(s0);
+                        float s1 = 0f;
+                        if (channels == 2)
+                        {
+                            s1 = in1[idx];
+                            float a1 = MathF.Abs(s1);
+                            if (a1 > peak) peak = a1;
+                        }
+
+                        float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
+
+                        out0[idx] = SanitizeOutput(s0 * gainLinear);
+                        if (channels == 2)
+                        {
+                            out1[idx] = SanitizeOutput(s1 * gainLinear);
+                        }
+                    }
+                    else
+                    {
+                        float peak = 0f;
+                        for (int ch = 0; ch < channels; ch++)
+                        {
+                            float a = MathF.Abs(inputChannels[ch].Span[idx]);
+                            if (a > peak) peak = a;
+                        }
+
+                        float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
+
+                        for (int ch = 0; ch < channels; ch++)
+                        {
+                            float sample = inputChannels[ch].Span[idx] * gainLinear;
+                            outputChannels[ch].Span[idx] = SanitizeOutput(sample);
+                        }
+                    }
+                }
+
+                processed += chunkSize;
+            }
+
+            return output;
+        }
+        catch
+        {
+            output.Dispose();
+            throw;
+        }
+    }
+
+    private (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
+    {
+        int channels = input.ChannelCount;
+        if (_inputChannelCache is null || _inputChannelCache.Length != channels)
+        {
+            _inputChannelCache = new Memory<float>[channels];
+            _outputChannelCache = new Memory<float>[channels];
+        }
+
+        for (int ch = 0; ch < channels; ch++)
+        {
+            _inputChannelCache[ch] = input.GetChannelMemory(ch);
+            _outputChannelCache![ch] = output.GetChannelMemory(ch);
+        }
+
+        return (_inputChannelCache, _outputChannelCache!);
+    }
+
+    private EffectiveParameters ReadStaticParameters()
+    {
+        return new EffectiveParameters
+        {
+            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Hold = Sanitize(Hold.CurrentValue, Hold.DefaultValue, MinHoldMs, MaxHoldMs, nameof(Hold)),
+            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Range = Sanitize(Range.CurrentValue, Range.DefaultValue, MinRangeDb, MaxRangeDb, nameof(Range)),
+        };
+    }
+
+    private EffectiveParameters SanitizeAnimated(
+        float threshold, float attack, float hold, float release, float range,
+        in EffectiveParameters fallback)
+    {
+        return new EffectiveParameters
+        {
+            Threshold = Sanitize(threshold, fallback.Threshold, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Attack = Sanitize(attack, fallback.Attack, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Hold = Sanitize(hold, fallback.Hold, MinHoldMs, MaxHoldMs, nameof(Hold)),
+            Release = Sanitize(release, fallback.Release, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Range = Sanitize(range, fallback.Range, MinRangeDb, MaxRangeDb, nameof(Range)),
+        };
+    }
+
+    // Substitute fallback for NaN/Infinity, then clamp to the parameter's [Range]. A finite-but-out-of-
+    // range value is a real authoring error distinct from the non-finite case, so it gets its own
+    // once-per-parameter warning.
+    private float Sanitize(float value, float fallback, float min, float max, string paramName)
+    {
+        float safe = SafeParameter(value, fallback, paramName);
+        float clamped = Math.Clamp(safe, min, max);
+        if (clamped != safe && _loggedClampedParameters.Add(paramName))
+        {
+            ClampWarnings++;
+            s_logger.LogWarning(
+                "Gate parameter '{Param}' value {Value} is outside its valid range [{Min}, {Max}]; clamping to {Clamped}. Further out-of-range occurrences for this parameter will be suppressed.",
+                paramName, safe, min, max, clamped);
+        }
+        return clamped;
+    }
+
+    // Without this, one non-finite gain sample would poison the state until the next Reset().
+    private void RecoverGainIfNonFinite()
+    {
+        if (float.IsFinite(_gateGainDb)) return;
+        _gateGainDb = MinDb;
+        if (_loggedNonFiniteGain) return;
+        s_logger.LogWarning(
+            "Gate gain became non-finite (input sample produced inf/NaN); resetting to {MinDb} dB. Further occurrences will be suppressed.",
+            MinDb);
+        _loggedNonFiniteGain = true;
+    }
+
+    private float SafeParameter(float value, float fallback, string paramName)
+    {
+        if (float.IsFinite(value)) return value;
+        if (_loggedNonFiniteParameters.Add(paramName))
+        {
+            s_logger.LogWarning(
+                "Gate parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
+                paramName, fallback);
+        }
+        return fallback;
+    }
+
+    private float SanitizeOutput(float sample)
+    {
+        if (float.IsFinite(sample)) return sample;
+        if (!_loggedNonFiniteSample)
+        {
+            NonFiniteSampleWarnings++;
+            s_logger.LogWarning(
+                "Gate encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.");
+            _loggedNonFiniteSample = true;
+        }
+        return 0f;
+    }
+
+    // Advances the gate one sample and returns the linear gain. Shared by ProcessStatic and
+    // ProcessAnimated so the gate/hold math cannot drift between the paths.
+    private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, int holdSamples)
+    {
+        float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
+        bool aboveThreshold = inputDb >= p.Threshold;
+        if (aboveThreshold)
+        {
+            _holdCounter = holdSamples;
+        }
+        else if (_holdCounter > 0)
+        {
+            _holdCounter--;
+        }
+
+        // Open (0 dB) while the signal is above threshold or the hold timer keeps it latched; else
+        // fall to the Range floor. Attack smooths the rise (opening), release smooths the fall.
+        float targetDb = aboveThreshold || _holdCounter > 0 ? 0f : p.Range;
+        float coeff = targetDb > _gateGainDb ? attackCoeff : releaseCoeff;
+        _gateGainDb = targetDb + coeff * (_gateGainDb - targetDb);
+        RecoverGainIfNonFinite();
+
+        return AudioMath.ConvertDbToLinear(_gateGainDb);
+    }
+
+    // One-pole IIR smoothing coefficient for a 1/e settling time of `timeMs`.
+    private static float ComputeCoeff(float timeMs, int sampleRate)
+    {
+        return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
+    }
+
+    private static int HoldSamples(float holdMs, int sampleRate)
+    {
+        int samples = (int)(holdMs * 0.001f * sampleRate);
+        return samples < 0 ? 0 : samples;
+    }
+
+    /// <summary>
+    /// Resets the gate to a clean "new render session" state: closes the gate, clears the hold timer,
+    /// and re-arms the one-shot non-finite diagnostic warnings.
+    /// </summary>
+    /// <remarks>
+    /// Do not call mid-buffer during playback — closing the gate there clicks. This is for genuine
+    /// session boundaries; <see cref="Process"/> already resets the gate on a sample-rate change or
+    /// time-range discontinuity. Public to match the sibling stateful nodes.
+    /// </remarks>
+    public void Reset()
+    {
+        ResetGate();
+        ResetDiagnostics();
+    }
+
+    private void ResetGate()
+    {
+        _gateGainDb = MinDb;
+        _holdCounter = 0;
+    }
+
+    private void ResetDiagnostics()
+    {
+        _loggedNonFiniteGain = false;
+        _loggedNonFiniteSample = false;
+        _loggedNonFiniteParameters.Clear();
+        _loggedClampedParameters.Clear();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inputChannelCache = null;
+            _outputChannelCache = null;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private readonly struct EffectiveParameters
+    {
+        public float Threshold { get; init; }
+        public float Attack { get; init; }
+        public float Hold { get; init; }
+        public float Release { get; init; }
+        public float Range { get; init; }
+    }
+}

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -14,9 +14,17 @@ public sealed class GateNode : AudioNode
 
     private const float MinDb = -100f;
 
-    // Gate gain in dB, smoothed toward 0 (open) or the Range floor (closed). Starts fully closed so a
-    // silent lead-in stays quiet until the signal crosses the threshold.
+    // Adjacent sample-boundary chunks can differ by one tick from independent TimeSpan rounding; only a
+    // larger gap is a real seek/edit boundary that must reset the gate. Matches LimiterNode.
+    private const long TimestampQuantizationToleranceTicks = 1;
+
+    // Gate gain in dB, smoothed toward 0 (open) or the Range floor (closed). Seeded at the effective
+    // Range floor on the first sample after a reset (see NextGain) so a below-threshold lead-in rests at
+    // the user's floor rather than fading in from the -100 dB sentinel; true silence stays silent
+    // regardless of the seed, since a zero input sample multiplies any gain to zero.
     private float _gateGainDb = MinDb;
+    // False until the first sample after a reset has seeded the follower at the effective Range floor.
+    private bool _gatePrimed;
     // Samples remaining before a gate that has dropped below threshold begins to release.
     private int _holdCounter;
     private int _lastSampleRate;
@@ -64,7 +72,7 @@ public sealed class GateNode : AudioNode
         // Reset the gate on the first call or whenever this chunk does not continue from the previous
         // one; the node is cached across Compose() calls, so stale gate state would otherwise bleed in
         // after a seek/restart. Only DSP state resets here, not the diagnostic latches.
-        if (!_lastTimeRangeEnd.HasValue || _lastTimeRangeEnd.Value != context.TimeRange.Start)
+        if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
         {
             ResetGate();
         }
@@ -406,6 +414,16 @@ public sealed class GateNode : AudioNode
             _holdCounter--;
         }
 
+        // First sample after a reset: seed the follower at the effective closed floor (Range) instead
+        // of the -100 dB reset sentinel, so a below-threshold lead-in rests at the user's Range floor
+        // rather than fading in from near-silence. An above-threshold onset still ramps open from this
+        // floor via Attack. The Range >= 0 disabled path below overrides the seed to fully open.
+        if (!_gatePrimed)
+        {
+            _gatePrimed = true;
+            _gateGainDb = p.Range;
+        }
+
         // Range 0 dB disables gating: the closed floor equals the open level, so the gate is an exact
         // identity. Snap the follower fully open and bypass smoothing so the disabled case adds no
         // attack ramp or asymptotic sub-unity gain — output equals input sample-for-sample.
@@ -456,6 +474,13 @@ public sealed class GateNode : AudioNode
     {
         _gateGainDb = MinDb;
         _holdCounter = 0;
+        _gatePrimed = false;
+    }
+
+    private static bool IsTimestampContiguous(TimeSpan previousEnd, TimeSpan nextStart)
+    {
+        long difference = nextStart.Ticks - previousEnd.Ticks;
+        return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
     }
 
     private void ResetDiagnostics()

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -14,34 +14,25 @@ public sealed class GateNode : AudioNode
 
     private const float MinDb = -100f;
 
-    // Adjacent sample-boundary chunks can differ by one tick from independent TimeSpan rounding; only a
-    // larger gap is a real seek/edit boundary that must reset the gate. Matches LimiterNode.
+    // Independent TimeSpan rounding can shift adjacent sample boundaries by one tick.
     private const long TimestampQuantizationToleranceTicks = 1;
 
-    // Gate gain in dB, smoothed toward 0 (open) or the Range floor (closed). Seeded at the effective
-    // Range floor on the first sample after a reset (see NextGain) so a below-threshold lead-in rests at
-    // the user's floor rather than fading in from the -100 dB sentinel; true silence stays silent
-    // regardless of the seed, since a zero input sample multiplies any gain to zero.
     private float _gateGainDb = MinDb;
-    // False until the first sample after a reset has seeded the follower at the effective Range floor.
     private bool _gatePrimed;
-    // Samples remaining before a gate that has dropped below threshold begins to release.
     private int _holdCounter;
     private int _lastSampleRate;
     private TimeSpan? _lastTimeRangeEnd;
 
-    // Cached per-channel buffer handles so the hot loops skip GetChannelData's checks/re-slicing;
-    // arrays reused across Process(), reallocated only on a channel-count change.
+    // Reuse channel views to avoid checks and slicing in the sample loops.
     private Memory<float>[]? _inputChannelCache;
     private Memory<float>[]? _outputChannelCache;
 
-    // Latched per node instance so each non-finite warning fires only once, not per sample.
+    // Diagnostic warnings are emitted once per node, not once per sample.
     private bool _loggedNonFiniteGain;
     private bool _loggedNonFiniteSample;
     private readonly HashSet<string> _loggedNonFiniteParameters = new();
     private readonly HashSet<string> _loggedClampedParameters = new();
 
-    // Test-only counters (via InternalsVisibleTo) of warnings actually emitted.
     internal int NonFiniteSampleWarnings;
     internal int ClampWarnings;
 
@@ -63,8 +54,7 @@ public sealed class GateNode : AudioNode
 
         using var input = Inputs[0].Process(context);
 
-        // Coefficients and the hold count come from context.SampleRate while the output buffer carries
-        // input.SampleRate, so a mismatch would mislabel the samples rather than resample them.
+        // A mismatch would mislabel samples because this node does not resample.
         if (input.SampleRate != context.SampleRate)
             throw new InvalidOperationException(
                 $"Gate node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
@@ -75,9 +65,7 @@ public sealed class GateNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
-        // Reset the gate on the first call or whenever this chunk does not continue from the previous
-        // one; the node is cached across Compose() calls, so stale gate state would otherwise bleed in
-        // after a seek/restart. Only DSP state resets here, not the diagnostic latches.
+        // Cached nodes must not carry DSP state across seeks or restarts.
         if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
         {
             ResetGate();
@@ -89,9 +77,7 @@ public sealed class GateNode : AudioNode
             return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
         }
 
-        // Expression-backed properties are deliberately not treated as animated: AnimationSampler does
-        // not yet evaluate expressions per-sample, so routing them through ProcessAnimated would just
-        // re-read the same CurrentValue every iteration.
+        // AnimationSampler does not yet evaluate expressions per sample.
         bool hasAnimation = Threshold.Animation != null ||
                             Attack.Animation != null ||
                             Hold.Animation != null ||
@@ -131,8 +117,7 @@ public sealed class GateNode : AudioNode
                 for (int i = 0; i < sampleCount; i++)
                 {
                     float s0 = in0[i];
-                    // Seed from 0 and compare (NaN > 0 is false) so a NaN in one channel is skipped
-                    // rather than poisoning the linked-stereo peak; a finite channel still drives it.
+                    // Comparisons against NaN stay false, preserving a finite channel's peak.
                     float peak = 0f;
                     float a0 = MathF.Abs(s0);
                     if (a0 > peak) peak = a0;
@@ -209,8 +194,7 @@ public sealed class GateNode : AudioNode
 
             int processed = 0;
 
-            // Seed with NaN so the first comparison is always unequal and coefficients compute on
-            // sample 0; afterwards Exp runs only when the animated ms value changes.
+            // NaN forces coefficient calculation for sample zero.
             float lastAttackMs = float.NaN;
             float lastReleaseMs = float.NaN;
             float attackCoeff = 0f;
@@ -252,8 +236,7 @@ public sealed class GateNode : AudioNode
                     if (channels <= 2)
                     {
                         float s0 = in0[idx];
-                        // Seed from 0 and compare (NaN > 0 is false) so a NaN in one channel is
-                        // skipped rather than poisoning the linked-stereo peak.
+                        // Comparisons against NaN stay false, preserving a finite channel's peak.
                         float peak = 0f;
                         float a0 = MathF.Abs(s0);
                         if (a0 > peak) peak = a0;
@@ -348,9 +331,7 @@ public sealed class GateNode : AudioNode
         };
     }
 
-    // Substitute fallback for NaN/Infinity, then clamp to the parameter's [Range]. A finite-but-out-of-
-    // range value is a real authoring error distinct from the non-finite case, so it gets its own
-    // once-per-parameter warning.
+    // Non-finite and out-of-range values have distinct once-per-parameter warnings.
     private float Sanitize(float value, float fallback, float declaredDefault, float min, float max, string paramName)
     {
         float safe = SafeParameter(value, fallback, declaredDefault, paramName);
@@ -365,7 +346,7 @@ public sealed class GateNode : AudioNode
         return clamped;
     }
 
-    // Without this, one non-finite gain sample would poison the state until the next Reset().
+    // A non-finite gain would otherwise poison the state until Reset().
     private void RecoverGainIfNonFinite()
     {
         if (float.IsFinite(_gateGainDb)) return;
@@ -380,8 +361,7 @@ public sealed class GateNode : AudioNode
     private float SafeParameter(float value, float fallback, float declaredDefault, string paramName)
     {
         if (float.IsFinite(value)) return value;
-        // A library user can declare an IProperty whose DefaultValue is itself non-finite; returning it
-        // would defeat the caller's Math.Clamp (NaN clamps to NaN), so drop to the declared constant.
+        // IProperty implementations may expose non-finite defaults, which Math.Clamp cannot recover.
         float safeFallback = float.IsFinite(fallback) ? fallback : declaredDefault;
         if (_loggedNonFiniteParameters.Add(paramName))
         {
@@ -405,13 +385,10 @@ public sealed class GateNode : AudioNode
         return 0f;
     }
 
-    // Advances the gate one sample and returns the linear gain. Shared by ProcessStatic and
-    // ProcessAnimated so the gate/hold math cannot drift between the paths.
+    // Shared by static and animated processing to keep gate state transitions identical.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, int holdSamples)
     {
-        // Digital silence (peak == 0) is -inf dB — below any threshold — so it must never open the
-        // gate, not even when Threshold sits at its -100 dB minimum where inputDb would otherwise
-        // collapse to MinDb and compare equal (-100 >= -100). Require real signal energy to open.
+        // Digital silence must remain closed even at the -100 dB minimum threshold.
         float inputDb = peak > 0f ? 20f * MathF.Log10(peak) : MinDb;
         bool aboveThreshold = peak > 0f && inputDb >= p.Threshold;
         if (aboveThreshold)
@@ -419,35 +396,27 @@ public sealed class GateNode : AudioNode
             _holdCounter = holdSamples;
         }
 
-        // The latch must be read for the current sample before it is spent, or a hold of N samples
-        // would only keep the gate open for N-1 (and a one-sample hold for none at all).
+        // Read the latch before decrementing so a hold of N lasts exactly N samples.
         bool heldOpen = _holdCounter > 0;
         if (!aboveThreshold && heldOpen)
         {
             _holdCounter--;
         }
 
-        // First sample after a reset: seed the follower at the effective closed floor (Range) instead
-        // of the -100 dB reset sentinel, so a below-threshold lead-in rests at the user's Range floor
-        // rather than fading in from near-silence. An above-threshold onset still ramps open from this
-        // floor via Attack. The Range >= 0 disabled path below overrides the seed to fully open.
+        // Seed at Range so a below-threshold lead-in starts at the configured floor.
         if (!_gatePrimed)
         {
             _gatePrimed = true;
             _gateGainDb = p.Range;
         }
 
-        // Range 0 dB disables gating: the closed floor equals the open level, so the gate is an exact
-        // identity. Snap the follower fully open and bypass smoothing so the disabled case adds no
-        // attack ramp or asymptotic sub-unity gain — output equals input sample-for-sample.
+        // Disabled gating must be an exact identity without smoothing artifacts.
         if (p.Range >= 0f)
         {
             _gateGainDb = 0f;
             return 1f;
         }
 
-        // Open (0 dB) while the signal is above threshold or the hold timer keeps it latched; else
-        // fall to the Range floor. Attack smooths the rise (opening), release smooths the fall.
         float targetDb = aboveThreshold || heldOpen ? 0f : p.Range;
         float coeff = targetDb > _gateGainDb ? attackCoeff : releaseCoeff;
         _gateGainDb = targetDb + coeff * (_gateGainDb - targetDb);
@@ -456,7 +425,7 @@ public sealed class GateNode : AudioNode
         return AudioMath.ConvertDbToLinear(_gateGainDb);
     }
 
-    // One-pole IIR smoothing coefficient for a 1/e settling time of `timeMs`.
+    // One-pole IIR coefficient with a 1/e settling time of timeMs.
     private static float ComputeCoeff(float timeMs, int sampleRate)
     {
         return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
@@ -469,13 +438,11 @@ public sealed class GateNode : AudioNode
     }
 
     /// <summary>
-    /// Resets the gate to a clean "new render session" state: closes the gate, clears the hold timer,
-    /// and re-arms the one-shot non-finite diagnostic warnings.
+    /// Resets all gate state for a new render session.
     /// </summary>
     /// <remarks>
-    /// Do not call mid-buffer during playback — closing the gate there clicks. This is for genuine
-    /// session boundaries; <see cref="Process"/> already resets the gate on a sample-rate change or
-    /// time-range discontinuity. Public to match the sibling stateful nodes.
+    /// Do not call during playback because closing the gate mid-buffer clicks.
+    /// <see cref="Process"/> handles sample-rate changes and time-range discontinuities.
     /// </remarks>
     public void Reset()
     {

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -63,16 +63,17 @@ public sealed class GateNode : DynamicsNode
                 for (int i = 0; i < sampleCount; i++)
                 {
                     float s0 = in0[i];
-                    // Comparisons against NaN stay false, preserving a finite channel's peak.
+                    // A corrupt channel must not drive the linked peak: NaN already compares false,
+                    // and an Infinity would hold the gate open for every other channel.
                     float peak = 0f;
                     float a0 = MathF.Abs(s0);
-                    if (a0 > peak) peak = a0;
+                    if (float.IsFinite(a0) && a0 > peak) peak = a0;
                     float s1 = 0f;
                     if (channels == 2)
                     {
                         s1 = in1[i];
                         float a1 = MathF.Abs(s1);
-                        if (a1 > peak) peak = a1;
+                        if (float.IsFinite(a1) && a1 > peak) peak = a1;
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -28,7 +28,6 @@ public sealed class GateNode : AudioNode
     private Memory<float>[]? _outputChannelCache;
 
     // Diagnostic warnings are emitted once per node, not once per sample.
-    private bool _loggedNonFiniteGain;
     private bool _loggedNonFiniteSample;
     private readonly HashSet<string> _loggedNonFiniteParameters = new();
     private readonly HashSet<string> _loggedClampedParameters = new();
@@ -65,17 +64,18 @@ public sealed class GateNode : AudioNode
             _lastSampleRate = context.SampleRate;
         }
 
+        // Returns before _lastTimeRangeEnd advances: an empty chunk would otherwise mask a discontinuity.
+        if (input.SampleCount == 0)
+        {
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
+        }
+
         // Cached nodes must not carry DSP state across seeks or restarts.
         if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
         {
             ResetGate();
         }
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
-
-        if (input.SampleCount == 0)
-        {
-            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
-        }
 
         // AnimationSampler does not yet evaluate expressions per sample.
         bool hasAnimation = Threshold.Animation != null ||
@@ -346,18 +346,6 @@ public sealed class GateNode : AudioNode
         return clamped;
     }
 
-    // A non-finite gain would otherwise poison the state until Reset().
-    private void RecoverGainIfNonFinite()
-    {
-        if (float.IsFinite(_gateGainDb)) return;
-        _gateGainDb = MinDb;
-        if (_loggedNonFiniteGain) return;
-        s_logger.LogWarning(
-            "Gate gain became non-finite (input sample produced inf/NaN); resetting to {MinDb} dB. Further occurrences will be suppressed.",
-            MinDb);
-        _loggedNonFiniteGain = true;
-    }
-
     private float SafeParameter(float value, float fallback, float declaredDefault, string paramName)
     {
         if (float.IsFinite(value)) return value;
@@ -419,8 +407,8 @@ public sealed class GateNode : AudioNode
 
         float targetDb = aboveThreshold || heldOpen ? 0f : p.Range;
         float coeff = targetDb > _gateGainDb ? attackCoeff : releaseCoeff;
+        // Clamped targetDb and coeff in [0, 1) keep the follower finite without a recovery clamp.
         _gateGainDb = targetDb + coeff * (_gateGainDb - targetDb);
-        RecoverGainIfNonFinite();
 
         return AudioMath.ConvertDbToLinear(_gateGainDb);
     }
@@ -465,7 +453,6 @@ public sealed class GateNode : AudioNode
 
     private void ResetDiagnostics()
     {
-        _loggedNonFiniteGain = false;
         _loggedNonFiniteSample = false;
         _loggedNonFiniteParameters.Clear();
         _loggedClampedParameters.Clear();

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -92,7 +92,7 @@ public sealed class GateNode : DynamicsNode
                     for (int ch = 0; ch < channels; ch++)
                     {
                         float a = MathF.Abs(inputChannels[ch].Span[i]);
-                        if (a > peak) peak = a;
+                        if (float.IsFinite(a) && a > peak) peak = a;
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
@@ -182,16 +182,17 @@ public sealed class GateNode : DynamicsNode
                     if (channels <= 2)
                     {
                         float s0 = in0[idx];
-                        // Comparisons against NaN stay false, preserving a finite channel's peak.
+                        // A corrupt channel must not drive the linked peak: NaN already compares false,
+                        // and an Infinity would hold the gate open for every other channel.
                         float peak = 0f;
                         float a0 = MathF.Abs(s0);
-                        if (a0 > peak) peak = a0;
+                        if (float.IsFinite(a0) && a0 > peak) peak = a0;
                         float s1 = 0f;
                         if (channels == 2)
                         {
                             s1 = in1[idx];
                             float a1 = MathF.Abs(s1);
-                            if (a1 > peak) peak = a1;
+                            if (float.IsFinite(a1) && a1 > peak) peak = a1;
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
@@ -208,7 +209,7 @@ public sealed class GateNode : DynamicsNode
                         for (int ch = 0; ch < channels; ch++)
                         {
                             float a = MathF.Abs(inputChannels[ch].Span[idx]);
-                            if (a > peak) peak = a;
+                            if (float.IsFinite(a) && a > peak) peak = a;
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -8,32 +8,13 @@ using static Beutl.Audio.Effects.GateParameters;
 
 namespace Beutl.Audio.Graph.Nodes;
 
-public sealed class GateNode : AudioNode
+public sealed class GateNode : DynamicsNode
 {
     private static readonly ILogger s_logger = Log.CreateLogger<GateNode>();
-
-    private const float MinDb = -100f;
-
-    // Independent TimeSpan rounding can shift adjacent sample boundaries by one tick.
-    private const long TimestampQuantizationToleranceTicks = 1;
 
     private float _gateGainDb = MinDb;
     private bool _gatePrimed;
     private int _holdCounter;
-    private int _lastSampleRate;
-    private TimeSpan? _lastTimeRangeEnd;
-
-    // Reuse channel views to avoid checks and slicing in the sample loops.
-    private Memory<float>[]? _inputChannelCache;
-    private Memory<float>[]? _outputChannelCache;
-
-    // Diagnostic warnings are emitted once per node, not once per sample.
-    private bool _loggedNonFiniteSample;
-    private readonly HashSet<string> _loggedNonFiniteParameters = new();
-    private readonly HashSet<string> _loggedClampedParameters = new();
-
-    internal int NonFiniteSampleWarnings;
-    internal int ClampWarnings;
 
     public required IProperty<float> Threshold { get; init; }
 
@@ -45,54 +26,19 @@ public sealed class GateNode : AudioNode
 
     public required IProperty<float> Range { get; init; }
 
-    public override AudioBuffer Process(AudioProcessContext context)
-    {
-        if (Inputs.Count != 1)
-            throw new InvalidOperationException(
-                $"Gate node requires exactly one input but got {Inputs.Count}.");
+    protected override ILogger Logger => s_logger;
 
-        using var input = Inputs[0].Process(context);
+    protected override string DiagnosticName => "Gate";
 
-        // A mismatch would mislabel samples because this node does not resample.
-        if (input.SampleRate != context.SampleRate)
-            throw new InvalidOperationException(
-                $"Gate node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
+    // AnimationSampler does not yet evaluate expressions per sample.
+    protected override bool HasAnimatedParameters =>
+        Threshold.Animation != null ||
+        Attack.Animation != null ||
+        Hold.Animation != null ||
+        Release.Animation != null ||
+        Range.Animation != null;
 
-        if (_lastSampleRate != context.SampleRate)
-        {
-            Reset();
-            _lastSampleRate = context.SampleRate;
-        }
-
-        // Returns before _lastTimeRangeEnd advances: an empty chunk would otherwise mask a discontinuity.
-        if (input.SampleCount == 0)
-        {
-            return new AudioBuffer(input.SampleRate, input.ChannelCount, 0);
-        }
-
-        // Cached nodes must not carry DSP state across seeks or restarts.
-        if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
-        {
-            ResetGate();
-        }
-        _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
-
-        // AnimationSampler does not yet evaluate expressions per sample.
-        bool hasAnimation = Threshold.Animation != null ||
-                            Attack.Animation != null ||
-                            Hold.Animation != null ||
-                            Release.Animation != null ||
-                            Range.Animation != null;
-
-        if (!hasAnimation)
-        {
-            return ProcessStatic(input, context);
-        }
-
-        return ProcessAnimated(input, context);
-    }
-
-    private AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+    protected override AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
         try
@@ -168,7 +114,7 @@ public sealed class GateNode : AudioNode
         }
     }
 
-    private AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+    protected override AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
     {
         var output = new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
         try
@@ -287,24 +233,6 @@ public sealed class GateNode : AudioNode
         }
     }
 
-    private (Memory<float>[] Inputs, Memory<float>[] Outputs) MapChannels(AudioBuffer input, AudioBuffer output)
-    {
-        int channels = input.ChannelCount;
-        if (_inputChannelCache is null || _inputChannelCache.Length != channels)
-        {
-            _inputChannelCache = new Memory<float>[channels];
-            _outputChannelCache = new Memory<float>[channels];
-        }
-
-        for (int ch = 0; ch < channels; ch++)
-        {
-            _inputChannelCache[ch] = input.GetChannelMemory(ch);
-            _outputChannelCache![ch] = output.GetChannelMemory(ch);
-        }
-
-        return (_inputChannelCache, _outputChannelCache!);
-    }
-
     private EffectiveParameters ReadStaticParameters()
     {
         return new EffectiveParameters
@@ -329,48 +257,6 @@ public sealed class GateNode : AudioNode
             Release = Sanitize(release, fallback.Release, DefaultReleaseMs, MinReleaseMs, MaxReleaseMs, nameof(Release)),
             Range = Sanitize(range, fallback.Range, DefaultRangeDb, MinRangeDb, MaxRangeDb, nameof(Range)),
         };
-    }
-
-    // Non-finite and out-of-range values have distinct once-per-parameter warnings.
-    private float Sanitize(float value, float fallback, float declaredDefault, float min, float max, string paramName)
-    {
-        float safe = SafeParameter(value, fallback, declaredDefault, paramName);
-        float clamped = Math.Clamp(safe, min, max);
-        if (clamped != safe && _loggedClampedParameters.Add(paramName))
-        {
-            ClampWarnings++;
-            s_logger.LogWarning(
-                "Gate parameter '{Param}' value {Value} is outside its valid range [{Min}, {Max}]; clamping to {Clamped}. Further out-of-range occurrences for this parameter will be suppressed.",
-                paramName, safe, min, max, clamped);
-        }
-        return clamped;
-    }
-
-    private float SafeParameter(float value, float fallback, float declaredDefault, string paramName)
-    {
-        if (float.IsFinite(value)) return value;
-        // IProperty implementations may expose non-finite defaults, which Math.Clamp cannot recover.
-        float safeFallback = float.IsFinite(fallback) ? fallback : declaredDefault;
-        if (_loggedNonFiniteParameters.Add(paramName))
-        {
-            s_logger.LogWarning(
-                "Gate parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
-                paramName, safeFallback);
-        }
-        return safeFallback;
-    }
-
-    private float SanitizeOutput(float sample)
-    {
-        if (float.IsFinite(sample)) return sample;
-        if (!_loggedNonFiniteSample)
-        {
-            NonFiniteSampleWarnings++;
-            s_logger.LogWarning(
-                "Gate encountered a non-finite (NaN/Infinity) sample — with all parameters clamped this almost certainly originates upstream — and replaced it with 0 to protect downstream nodes. Further occurrences will be suppressed.");
-            _loggedNonFiniteSample = true;
-        }
-        return 0f;
     }
 
     // Shared by static and animated processing to keep gate state transitions identical.
@@ -413,60 +299,17 @@ public sealed class GateNode : AudioNode
         return AudioMath.ConvertDbToLinear(_gateGainDb);
     }
 
-    // One-pole IIR coefficient with a 1/e settling time of timeMs.
-    private static float ComputeCoeff(float timeMs, int sampleRate)
-    {
-        return MathF.Exp(-1f / (timeMs * 0.001f * sampleRate));
-    }
-
     private static int HoldSamples(float holdMs, int sampleRate)
     {
         int samples = (int)(holdMs * 0.001f * sampleRate);
         return samples < 0 ? 0 : samples;
     }
 
-    /// <summary>
-    /// Resets all gate state for a new render session.
-    /// </summary>
-    /// <remarks>
-    /// Do not call during playback because closing the gate mid-buffer clicks.
-    /// <see cref="Process"/> handles sample-rate changes and time-range discontinuities.
-    /// </remarks>
-    public void Reset()
-    {
-        ResetGate();
-        ResetDiagnostics();
-    }
-
-    private void ResetGate()
+    protected override void ResetDspState()
     {
         _gateGainDb = MinDb;
         _holdCounter = 0;
         _gatePrimed = false;
-    }
-
-    private static bool IsTimestampContiguous(TimeSpan previousEnd, TimeSpan nextStart)
-    {
-        long difference = nextStart.Ticks - previousEnd.Ticks;
-        return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
-    }
-
-    private void ResetDiagnostics()
-    {
-        _loggedNonFiniteSample = false;
-        _loggedNonFiniteParameters.Clear();
-        _loggedClampedParameters.Clear();
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _inputChannelCache = null;
-            _outputChannelCache = null;
-        }
-
-        base.Dispose(disposing);
     }
 
     private readonly struct EffectiveParameters

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -63,17 +63,12 @@ public sealed class GateNode : DynamicsNode
                 for (int i = 0; i < sampleCount; i++)
                 {
                     float s0 = in0[i];
-                    // A corrupt channel must not drive the linked peak: NaN already compares false,
-                    // and an Infinity would hold the gate open for every other channel.
-                    float peak = 0f;
-                    float a0 = MathF.Abs(s0);
-                    if (float.IsFinite(a0) && a0 > peak) peak = a0;
+                    float peak = AccumulatePeak(0f, s0);
                     float s1 = 0f;
                     if (channels == 2)
                     {
                         s1 = in1[i];
-                        float a1 = MathF.Abs(s1);
-                        if (float.IsFinite(a1) && a1 > peak) peak = a1;
+                        peak = AccumulatePeak(peak, s1);
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
@@ -92,8 +87,7 @@ public sealed class GateNode : DynamicsNode
                     float peak = 0f;
                     for (int ch = 0; ch < channels; ch++)
                     {
-                        float a = MathF.Abs(inputChannels[ch].Span[i]);
-                        if (float.IsFinite(a) && a > peak) peak = a;
+                        peak = AccumulatePeak(peak, inputChannels[ch].Span[i]);
                     }
 
                     float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
@@ -183,17 +177,12 @@ public sealed class GateNode : DynamicsNode
                     if (channels <= 2)
                     {
                         float s0 = in0[idx];
-                        // A corrupt channel must not drive the linked peak: NaN already compares false,
-                        // and an Infinity would hold the gate open for every other channel.
-                        float peak = 0f;
-                        float a0 = MathF.Abs(s0);
-                        if (float.IsFinite(a0) && a0 > peak) peak = a0;
+                        float peak = AccumulatePeak(0f, s0);
                         float s1 = 0f;
                         if (channels == 2)
                         {
                             s1 = in1[idx];
-                            float a1 = MathF.Abs(s1);
-                            if (float.IsFinite(a1) && a1 > peak) peak = a1;
+                            peak = AccumulatePeak(peak, s1);
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);
@@ -209,8 +198,7 @@ public sealed class GateNode : DynamicsNode
                         float peak = 0f;
                         for (int ch = 0; ch < channels; ch++)
                         {
-                            float a = MathF.Abs(inputChannels[ch].Span[idx]);
-                            if (float.IsFinite(a) && a > peak) peak = a;
+                            peak = AccumulatePeak(peak, inputChannels[ch].Span[idx]);
                         }
 
                         float gainLinear = NextGain(peak, attackCoeff, releaseCoeff, p, holdSamples);

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -249,7 +249,6 @@ public sealed class GateNode : DynamicsNode
         };
     }
 
-    // Shared by static and animated processing to keep gate state transitions identical.
     private float NextGain(float peak, float attackCoeff, float releaseCoeff, in EffectiveParameters p, int holdSamples)
     {
         // Digital silence must remain closed even at the -100 dB minimum threshold.

--- a/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/GateNode.cs
@@ -63,6 +63,12 @@ public sealed class GateNode : AudioNode
 
         using var input = Inputs[0].Process(context);
 
+        // Coefficients and the hold count come from context.SampleRate while the output buffer carries
+        // input.SampleRate, so a mismatch would mislabel the samples rather than resample them.
+        if (input.SampleRate != context.SampleRate)
+            throw new InvalidOperationException(
+                $"Gate node: sample rate mismatch. context={context.SampleRate}, input={input.SampleRate}.");
+
         if (_lastSampleRate != context.SampleRate)
         {
             Reset();
@@ -320,11 +326,11 @@ public sealed class GateNode : AudioNode
     {
         return new EffectiveParameters
         {
-            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
-            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, MinAttackMs, MaxAttackMs, nameof(Attack)),
-            Hold = Sanitize(Hold.CurrentValue, Hold.DefaultValue, MinHoldMs, MaxHoldMs, nameof(Hold)),
-            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, MinReleaseMs, MaxReleaseMs, nameof(Release)),
-            Range = Sanitize(Range.CurrentValue, Range.DefaultValue, MinRangeDb, MaxRangeDb, nameof(Range)),
+            Threshold = Sanitize(Threshold.CurrentValue, Threshold.DefaultValue, DefaultThresholdDb, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Attack = Sanitize(Attack.CurrentValue, Attack.DefaultValue, DefaultAttackMs, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Hold = Sanitize(Hold.CurrentValue, Hold.DefaultValue, DefaultHoldMs, MinHoldMs, MaxHoldMs, nameof(Hold)),
+            Release = Sanitize(Release.CurrentValue, Release.DefaultValue, DefaultReleaseMs, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Range = Sanitize(Range.CurrentValue, Range.DefaultValue, DefaultRangeDb, MinRangeDb, MaxRangeDb, nameof(Range)),
         };
     }
 
@@ -334,20 +340,20 @@ public sealed class GateNode : AudioNode
     {
         return new EffectiveParameters
         {
-            Threshold = Sanitize(threshold, fallback.Threshold, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
-            Attack = Sanitize(attack, fallback.Attack, MinAttackMs, MaxAttackMs, nameof(Attack)),
-            Hold = Sanitize(hold, fallback.Hold, MinHoldMs, MaxHoldMs, nameof(Hold)),
-            Release = Sanitize(release, fallback.Release, MinReleaseMs, MaxReleaseMs, nameof(Release)),
-            Range = Sanitize(range, fallback.Range, MinRangeDb, MaxRangeDb, nameof(Range)),
+            Threshold = Sanitize(threshold, fallback.Threshold, DefaultThresholdDb, MinThresholdDb, MaxThresholdDb, nameof(Threshold)),
+            Attack = Sanitize(attack, fallback.Attack, DefaultAttackMs, MinAttackMs, MaxAttackMs, nameof(Attack)),
+            Hold = Sanitize(hold, fallback.Hold, DefaultHoldMs, MinHoldMs, MaxHoldMs, nameof(Hold)),
+            Release = Sanitize(release, fallback.Release, DefaultReleaseMs, MinReleaseMs, MaxReleaseMs, nameof(Release)),
+            Range = Sanitize(range, fallback.Range, DefaultRangeDb, MinRangeDb, MaxRangeDb, nameof(Range)),
         };
     }
 
     // Substitute fallback for NaN/Infinity, then clamp to the parameter's [Range]. A finite-but-out-of-
     // range value is a real authoring error distinct from the non-finite case, so it gets its own
     // once-per-parameter warning.
-    private float Sanitize(float value, float fallback, float min, float max, string paramName)
+    private float Sanitize(float value, float fallback, float declaredDefault, float min, float max, string paramName)
     {
-        float safe = SafeParameter(value, fallback, paramName);
+        float safe = SafeParameter(value, fallback, declaredDefault, paramName);
         float clamped = Math.Clamp(safe, min, max);
         if (clamped != safe && _loggedClampedParameters.Add(paramName))
         {
@@ -371,16 +377,19 @@ public sealed class GateNode : AudioNode
         _loggedNonFiniteGain = true;
     }
 
-    private float SafeParameter(float value, float fallback, string paramName)
+    private float SafeParameter(float value, float fallback, float declaredDefault, string paramName)
     {
         if (float.IsFinite(value)) return value;
+        // A library user can declare an IProperty whose DefaultValue is itself non-finite; returning it
+        // would defeat the caller's Math.Clamp (NaN clamps to NaN), so drop to the declared constant.
+        float safeFallback = float.IsFinite(fallback) ? fallback : declaredDefault;
         if (_loggedNonFiniteParameters.Add(paramName))
         {
             s_logger.LogWarning(
                 "Gate parameter '{Param}' produced a non-finite value; falling back to {Fallback}. Further occurrences for this parameter will be suppressed.",
-                paramName, fallback);
+                paramName, safeFallback);
         }
-        return fallback;
+        return safeFallback;
     }
 
     private float SanitizeOutput(float sample)
@@ -409,7 +418,11 @@ public sealed class GateNode : AudioNode
         {
             _holdCounter = holdSamples;
         }
-        else if (_holdCounter > 0)
+
+        // The latch must be read for the current sample before it is spent, or a hold of N samples
+        // would only keep the gate open for N-1 (and a one-sample hold for none at all).
+        bool heldOpen = _holdCounter > 0;
+        if (!aboveThreshold && heldOpen)
         {
             _holdCounter--;
         }
@@ -435,7 +448,7 @@ public sealed class GateNode : AudioNode
 
         // Open (0 dB) while the signal is above threshold or the hold timer keeps it latched; else
         // fall to the Range floor. Attack smooths the rise (opening), release smooths the fall.
-        float targetDb = aboveThreshold || _holdCounter > 0 ? 0f : p.Range;
+        float targetDb = aboveThreshold || heldOpen ? 0f : p.Range;
         float coeff = targetDb > _gateGainDb ? attackCoeff : releaseCoeff;
         _gateGainDb = targetDb + coeff * (_gateGainDb - targetDb);
         RecoverGainIfNonFinite();

--- a/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
+++ b/src/Beutl.Engine/Audio/Graph/Nodes/LimiterNode.cs
@@ -14,7 +14,6 @@ public sealed class LimiterNode : AudioNode
     // Caps the per-chunk animation-sampling scratch at 4 parameters × 1024 floats = 16 KiB of
     // stackalloc per ProcessAnimated call, while still amortizing the per-chunk sampling overhead.
     private const int AnimationChunkSize = 1024;
-    private const long TimestampQuantizationToleranceTicks = 1;
 
     private static readonly ILogger s_logger = Log.CreateLogger<LimiterNode>();
 
@@ -100,7 +99,7 @@ public sealed class LimiterNode : AudioNode
         // The node is reused across chunks. When the next chunk doesn't continue from the previous
         // one (seek, loop, edit, restart), drop the delay line and gain state — otherwise the
         // previous segment leaks into the first lookahead window of output.
-        if (!_lastTimeRangeEnd.HasValue || !IsTimestampContiguous(_lastTimeRangeEnd.Value, context.TimeRange.Start))
+        if (!_lastTimeRangeEnd.HasValue || !context.ContinuesFrom(_lastTimeRangeEnd.Value))
         {
             if (_lastTimeRangeEnd.HasValue)
             {
@@ -130,14 +129,6 @@ public sealed class LimiterNode : AudioNode
         _lastTimeRangeEnd = context.TimeRange.Start + context.TimeRange.Duration;
 
         return output;
-    }
-
-    private static bool IsTimestampContiguous(TimeSpan previousEnd, TimeSpan nextStart)
-    {
-        // Adjacent sample boundaries can differ by one tick from independent TimeSpan rounding; a
-        // two-tick difference is a real seek/edit boundary and must reset the delay line.
-        long difference = nextStart.Ticks - previousEnd.Ticks;
-        return difference is >= -TimestampQuantizationToleranceTicks and <= TimestampQuantizationToleranceTicks;
     }
 
     private void InitializeBuffers(int sampleRate, int channelCount)

--- a/src/Beutl.Language/AudioStrings.ja.resx
+++ b/src/Beutl.Language/AudioStrings.ja.resx
@@ -148,4 +148,37 @@
   <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
     <value>制限後に適用するゲイン。最終ピークは スレッショルド + メイクアップゲイン まで達することがあります。</value>
   </data>
+  <data name="GateEffect" xml:space="preserve">
+    <value>ゲート</value>
+  </data>
+  <data name="GateEffect_Threshold" xml:space="preserve">
+    <value>スレッショルド (dB)</value>
+  </data>
+  <data name="GateEffect_Attack" xml:space="preserve">
+    <value>アタック (ms)</value>
+  </data>
+  <data name="GateEffect_Hold" xml:space="preserve">
+    <value>ホールド (ms)</value>
+  </data>
+  <data name="GateEffect_Release" xml:space="preserve">
+    <value>リリース (ms)</value>
+  </data>
+  <data name="GateEffect_Range" xml:space="preserve">
+    <value>レンジ (dB)</value>
+  </data>
+  <data name="GateEffect_Threshold_Description" xml:space="preserve">
+    <value>これを下回るとゲートが閉じ、信号を減衰させるレベル。</value>
+  </data>
+  <data name="GateEffect_Attack_Description" xml:space="preserve">
+    <value>信号がスレッショルドを超えてからゲートが開くまでの速さ。</value>
+  </data>
+  <data name="GateEffect_Hold_Description" xml:space="preserve">
+    <value>信号がスレッショルドを下回ってからリリースを開始するまで、ゲートを開いたまま保持する時間。</value>
+  </data>
+  <data name="GateEffect_Release_Description" xml:space="preserve">
+    <value>ホールド時間の経過後にゲートが閉じるまでの速さ。</value>
+  </data>
+  <data name="GateEffect_Range_Description" xml:space="preserve">
+    <value>ゲートが閉じている間に適用する減衰量。0 でゲートを無効化し、値が小さいほど強く減衰します。</value>
+  </data>
 </root>

--- a/src/Beutl.Language/AudioStrings.resx
+++ b/src/Beutl.Language/AudioStrings.resx
@@ -153,4 +153,37 @@
   <data name="LimiterEffect_MakeupGain_Description" xml:space="preserve">
     <value>Gain applied after limiting. The final peak can reach Threshold + Makeup Gain.</value>
   </data>
+  <data name="GateEffect" xml:space="preserve">
+    <value>Gate</value>
+  </data>
+  <data name="GateEffect_Threshold" xml:space="preserve">
+    <value>Threshold (dB)</value>
+  </data>
+  <data name="GateEffect_Attack" xml:space="preserve">
+    <value>Attack (ms)</value>
+  </data>
+  <data name="GateEffect_Hold" xml:space="preserve">
+    <value>Hold (ms)</value>
+  </data>
+  <data name="GateEffect_Release" xml:space="preserve">
+    <value>Release (ms)</value>
+  </data>
+  <data name="GateEffect_Range" xml:space="preserve">
+    <value>Range (dB)</value>
+  </data>
+  <data name="GateEffect_Threshold_Description" xml:space="preserve">
+    <value>The level below which the gate closes and attenuates the signal.</value>
+  </data>
+  <data name="GateEffect_Attack_Description" xml:space="preserve">
+    <value>How quickly the gate opens once the signal rises above the threshold.</value>
+  </data>
+  <data name="GateEffect_Hold_Description" xml:space="preserve">
+    <value>How long the gate stays open after the signal falls below the threshold, before releasing.</value>
+  </data>
+  <data name="GateEffect_Release_Description" xml:space="preserve">
+    <value>How quickly the gate closes after the hold time elapses.</value>
+  </data>
+  <data name="GateEffect_Range_Description" xml:space="preserve">
+    <value>Attenuation applied while the gate is closed. 0 disables gating; more negative values attenuate harder.</value>
+  </data>
 </root>

--- a/src/Beutl/Services/LibraryRegistrar.cs
+++ b/src/Beutl/Services/LibraryRegistrar.cs
@@ -212,6 +212,7 @@ public static class LibraryRegistrar
                 .AddAudioEffect<EqualizerEffect>(AudioStrings.Equalizer)
                 .AddAudioEffect<CompressorEffect>(AudioStrings.CompressorEffect)
                 .AddAudioEffect<LimiterEffect>(AudioStrings.LimiterEffect)
+                .AddAudioEffect<GateEffect>(AudioStrings.GateEffect)
             );
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
@@ -80,8 +80,7 @@ public class AudioNodeBufferDisposalTests
         return property;
     }
 
-    // DynamicsNode consumes the input in the base class, so the pass-through half of the contract above
-    // has to be honoured there: a derived hook that hands the input straight back transfers ownership.
+    // A derived hook that returns the input transfers ownership to the caller.
     private sealed class PassThroughDynamicsNode : DynamicsNode
     {
         private static readonly ILogger s_logger = Log.CreateLogger<PassThroughDynamicsNode>();

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioNodeBufferDisposalTests.cs
@@ -5,7 +5,9 @@ using Beutl.Audio.Effects.Equalizer;
 using Beutl.Audio.Graph;
 using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
+using Beutl.Logging;
 using Beutl.Media;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.UnitTests.Engine.Audio;
 
@@ -76,6 +78,63 @@ public class AudioNodeBufferDisposalTests
         animation.KeyFrames.Add(new KeyFrame<float> { KeyTime = TimeSpan.FromSeconds(durationSeconds), Value = toPercent, Easing = new LinearEasing() });
         property.Animation = animation;
         return property;
+    }
+
+    // DynamicsNode consumes the input in the base class, so the pass-through half of the contract above
+    // has to be honoured there: a derived hook that hands the input straight back transfers ownership.
+    private sealed class PassThroughDynamicsNode : DynamicsNode
+    {
+        private static readonly ILogger s_logger = Log.CreateLogger<PassThroughDynamicsNode>();
+
+        protected override ILogger Logger => s_logger;
+
+        protected override string DiagnosticName => "PassThrough";
+
+        protected override bool HasAnimatedParameters => false;
+
+        protected override AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context) => input;
+
+        protected override AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context) => input;
+
+        protected override void ResetDspState()
+        {
+        }
+    }
+
+    [Test]
+    public void DynamicsNode_PassThroughHook_DoesNotDisposeReturnedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new PassThroughDynamicsNode();
+        node.AddInput(inputNode);
+
+        AudioBuffer result = node.Process(CreateContext());
+
+        Assert.That(ReferenceEquals(result, inputNode.Last), Is.True, "the hook returned the input, so it must reach the caller");
+        Assert.That(IsDisposed(result), Is.False, "pass-through must not dispose the buffer the caller now owns");
+        result.Dispose();
+    }
+
+    [Test]
+    public void GateNode_DisposesConsumedInput()
+    {
+        var inputNode = new CapturingInputNode(SampleRate, 2, SampleCount, 0.5f);
+        using var node = new GateNode
+        {
+            Threshold = Static(-40f),
+            Attack = Static(1f),
+            Hold = Static(10f),
+            Release = Static(100f),
+            Range = Static(-60f),
+        };
+        node.AddInput(inputNode);
+
+        using (AudioBuffer result = node.Process(CreateContext()))
+        {
+            Assert.That(ReferenceEquals(result, inputNode.Last), Is.False, "gate must emit a new buffer, not the input");
+        }
+
+        Assert.That(IsDisposed(inputNode.Last), Is.True, "consumed input buffer must be disposed");
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -127,8 +127,7 @@ public class AudioProcessContextTests
     [TestCase(-2L, false)]
     public void ContinuesFrom_ToleratesOneTickOfBoundaryRounding(long tickOffset, bool expected)
     {
-        // Stateful nodes reset their DSP state when this returns false, so the tolerance decides whether
-        // a rounding artifact is heard as a click.
+        // The tolerance prevents stateful nodes from treating rounding artifacts as seeks.
         var previousEnd = TimeSpan.FromSeconds(1);
         var context = new AudioProcessContext(
             new TimeRange(previousEnd + TimeSpan.FromTicks(tickOffset), TimeSpan.FromSeconds(0.1)),

--- a/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/AudioProcessContextTests.cs
@@ -119,4 +119,31 @@ public class AudioProcessContextTests
             () => AudioProcessContext.GetSampleCount(range, 44100));
         Assert.That(ex!.ParamName, Is.EqualTo("range"));
     }
+
+    [TestCase(0L, true)]
+    [TestCase(1L, true)]
+    [TestCase(-1L, true)]
+    [TestCase(2L, false)]
+    [TestCase(-2L, false)]
+    public void ContinuesFrom_ToleratesOneTickOfBoundaryRounding(long tickOffset, bool expected)
+    {
+        // Stateful nodes reset their DSP state when this returns false, so the tolerance decides whether
+        // a rounding artifact is heard as a click.
+        var previousEnd = TimeSpan.FromSeconds(1);
+        var context = new AudioProcessContext(
+            new TimeRange(previousEnd + TimeSpan.FromTicks(tickOffset), TimeSpan.FromSeconds(0.1)),
+            48000, new AnimationSampler(), null);
+
+        Assert.That(context.ContinuesFrom(previousEnd), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ContinuesFrom_Seek_IsNotContiguous()
+    {
+        var context = new AudioProcessContext(
+            new TimeRange(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.1)),
+            48000, new AnimationSampler(), null);
+
+        Assert.That(context.ContinuesFrom(TimeSpan.FromSeconds(1)), Is.False);
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -7,6 +7,7 @@ using Beutl.Engine;
 using Beutl.Engine.Expressions;
 using Beutl.Media;
 
+using static Beutl.Audio.Effects.CompressorParameters;
 using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
 
 namespace Beutl.UnitTests.Engine.Audio;
@@ -1296,5 +1297,127 @@ public class CompressorNodeTests
 
         Assert.That(node.ClampWarnings, Is.EqualTo(1),
             "An out-of-range animated Attack must warn exactly once for the whole chunk, not zero and not per-sample.");
+    }
+
+    [TestCase(-1L)]
+    [TestCase(1L)]
+    public void Process_OneTickBoundaryRounding_DoesNotResetEnvelope(long tickOffset)
+    {
+        // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the
+        // warmed-up envelope must survive so the first sample stays quieter than a fresh node's.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        var ctx2 = CreateContext(chunkDuration + TimeSpan.FromTicks(tickOffset), chunkDuration);
+
+        var node = CreateNode(release: 1000f);
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        using var warmup = node.Process(ctx1);
+        node.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(followInput));
+        using var followOutput = node.Process(ctx2);
+
+        var nodeFresh = CreateNode(release: 1000f);
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        float continuingFirst = MathF.Abs(followOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(continuingFirst, Is.LessThan(freshFirst),
+            $"A one-tick boundary rounding must not reset the envelope (continuing≈{continuingFirst:F4}, fresh≈{freshFirst:F4}).");
+    }
+
+    [Test]
+    public void Process_EmptyChunkWithDuration_DoesNotMaskLaterDiscontinuity()
+    {
+        // A chunk that spans time but carries no samples leaves a hole; the chunk after it is not
+        // contiguous with the chunk before it.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+
+        var node = CreateNode(release: 1000f);
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        using var warmup = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+
+        node.ClearInputs();
+        using var emptyInput = new AudioBuffer(SampleRate, 2, 0);
+        node.AddInput(new BufferReplayNode(emptyInput));
+        using var emptyOutput = node.Process(CreateContext(chunkDuration, chunkDuration));
+        Assert.That(emptyOutput.SampleCount, Is.EqualTo(0));
+
+        node.ClearInputs();
+        using var afterHoleInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(afterHoleInput));
+        using var afterHoleOutput = node.Process(CreateContext(chunkDuration + chunkDuration, chunkDuration));
+
+        var nodeFresh = CreateNode(release: 1000f);
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+
+        Assert.That(
+            MathF.Abs(afterHoleOutput.GetChannelData(0)[0]),
+            Is.EqualTo(MathF.Abs(freshOutput.GetChannelData(0)[0])).Within(1e-4f),
+            "The chunk after an empty-but-timed chunk must start from a reset envelope.");
+    }
+
+    [Test]
+    public void Process_InputSampleRateMismatch_Throws()
+    {
+        // Coefficients come from the context rate while the buffer carries the input's, so a mismatched
+        // upstream buffer must be rejected rather than silently relabelled.
+        const int altSampleRate = 44100;
+        using var input = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        Assert.Throws<InvalidOperationException>(
+            () => node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1))));
+    }
+
+    [Test]
+    public void Process_NonFinitePropertyDefault_FallsBackToDeclaredConstant()
+    {
+        // A library user can declare a property whose CurrentValue and DefaultValue are both non-finite.
+        // Returning the non-finite default would defeat the clamp (NaN clamps to NaN) and mute the node,
+        // so the declared CompressorParameters constants must take over.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        var node = new CompressorNode
+        {
+            Threshold = Property.CreateAnimatable(float.NaN),
+            Ratio = Property.CreateAnimatable(float.NaN),
+            Attack = Property.CreateAnimatable(float.NaN),
+            Release = Property.CreateAnimatable(float.NaN),
+            Knee = Property.CreateAnimatable(float.NaN),
+            MakeupGain = Property.CreateAnimatable(float.NaN)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        // Defaults compress 0.9 (≈-0.9 dB) against a -20 dB threshold at ratio 4, so the tail lands
+        // around -15 dB; a muted node would sit at the -100 dB floor instead.
+        float inputPeakDb = PeakDb(input, 0);
+        float slope = 1f - 1f / DefaultRatio;
+        float expectedDb = inputPeakDb - slope * (inputPeakDb - DefaultThresholdDb);
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.EqualTo(expectedDb).Within(3f),
+            $"With non-finite property defaults the declared constants must apply, but the tail measured {steadyPeakDb:F2} dB.");
     }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -510,11 +510,10 @@ public class CompressorNodeTests
     }
 
     [Test]
-    public void Process_InfinityInputSamples_RecoversAndDoesNotLeakNonFiniteOutput()
+    public void Process_InfinityInputSamples_DoesNotLeakNonFiniteOutput()
     {
-        // The first samples on every channel are +Infinity, polluting the envelope; the rest is a
-        // normal sine. The self-recovery clamp must reset the envelope and the sanitizer must keep
-        // any NaN/Infinity from escaping downstream.
+        // The first samples on every channel are +Infinity, the rest is a normal sine. The detector
+        // must skip them and the sanitizer must keep any NaN/Infinity from escaping downstream.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         for (int ch = 0; ch < input.ChannelCount; ch++)
@@ -546,6 +545,60 @@ public class CompressorNodeTests
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
         Assert.That(steadyPeakDb, Is.GreaterThan(-30f));
         Assert.That(steadyPeakDb, Is.LessThan(0f));
+    }
+
+    // Every peak-detection site is covered: the stereo fast path and the >2-channel fallback, in both
+    // the static and the animated loop. The four sites are written out separately, so one of them
+    // missing the guard is exactly the kind of gap this matrix has to catch.
+    [TestCase(2, false)]
+    [TestCase(2, true)]
+    [TestCase(4, false)]
+    [TestCase(4, true)]
+    public void Process_OneChannelInfinity_DoesNotReleaseCompressionOnValidChannels(int channels, bool animated)
+    {
+        // An Infinity promoted to the linked peak drives the envelope to NaN, and the recovery then
+        // drops it to the -100 dB floor: every other channel escapes compression and bursts ~14 dB
+        // louder while the envelope re-attacks. The probe covers that re-attack window.
+        const int sampleCount = SampleRate / 2;
+        const float amplitude = 0.9f;
+        const float thresholdDb = -20f;
+        const float ratio = 4f;
+        int corruptIndex = sampleCount / 2;
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+
+        using var input = CreateBuffer(channels, sampleCount, (_, _) => amplitude);
+        input.GetChannelData(0)[corruptIndex] = float.PositiveInfinity;
+
+        var node = CreateNode(threshold: thresholdDb, ratio: ratio);
+        if (animated)
+        {
+            var thresholdAnim = new KeyFrameAnimation<float>();
+            thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = thresholdDb, KeyTime = TimeSpan.Zero });
+            thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = thresholdDb, KeyTime = duration });
+            node.Threshold.Animation = thresholdAnim;
+        }
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, duration));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        float inputDb = 20f * MathF.Log10(amplitude);
+        float slope = 1f - 1f / ratio;
+        float compressedDb = inputDb - slope * (inputDb - thresholdDb);
+        float afterCorruptDb = ChannelPeakDb(output, 1, corruptIndex + 1);
+
+        Assert.That(afterCorruptDb, Is.LessThan(compressedDb + 3f),
+            $"A corrupt channel must not reset the shared envelope; channel 1 peaked at {afterCorruptDb:F2} dB " +
+            $"after the Infinity against a steady state of {compressedDb:F2} dB.");
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/CompressorNodeTests.cs
@@ -512,8 +512,6 @@ public class CompressorNodeTests
     [Test]
     public void Process_InfinityInputSamples_DoesNotLeakNonFiniteOutput()
     {
-        // The first samples on every channel are +Infinity, the rest is a normal sine. The detector
-        // must skip them and the sanitizer must keep any NaN/Infinity from escaping downstream.
         const int sampleCount = SampleRate / 4;
         using var input = CreateSineBuffer(0.9f, 1000f, sampleCount);
         for (int ch = 0; ch < input.ChannelCount; ch++)
@@ -547,18 +545,14 @@ public class CompressorNodeTests
         Assert.That(steadyPeakDb, Is.LessThan(0f));
     }
 
-    // Every peak-detection site is covered: the stereo fast path and the >2-channel fallback, in both
-    // the static and the animated loop. The four sites are written out separately, so one of them
-    // missing the guard is exactly the kind of gap this matrix has to catch.
+    // Covers linked-peak guards in the stereo/surround and static/animated paths.
     [TestCase(2, false)]
     [TestCase(2, true)]
     [TestCase(4, false)]
     [TestCase(4, true)]
     public void Process_OneChannelInfinity_DoesNotReleaseCompressionOnValidChannels(int channels, bool animated)
     {
-        // An Infinity promoted to the linked peak drives the envelope to NaN, and the recovery then
-        // drops it to the -100 dB floor: every other channel escapes compression and bursts ~14 dB
-        // louder while the envelope re-attacks. The probe covers that re-attack window.
+        // Without the guard, Infinity resets the envelope and valid channels briefly burst ~14 dB louder.
         const int sampleCount = SampleRate / 2;
         const float amplitude = 0.9f;
         const float thresholdDb = -20f;
@@ -1356,8 +1350,7 @@ public class CompressorNodeTests
     [TestCase(1L)]
     public void Process_OneTickBoundaryRounding_DoesNotResetEnvelope(long tickOffset)
     {
-        // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the
-        // warmed-up envelope must survive so the first sample stays quieter than a fresh node's.
+        // One-tick rounding must preserve the warmed-up envelope.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
@@ -1386,8 +1379,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_EmptyChunkWithDuration_DoesNotMaskLaterDiscontinuity()
     {
-        // A chunk that spans time but carries no samples leaves a hole; the chunk after it is not
-        // contiguous with the chunk before it.
+        // An empty timed chunk leaves a discontinuity.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
 
@@ -1421,8 +1413,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_InputSampleRateMismatch_Throws()
     {
-        // Coefficients come from the context rate while the buffer carries the input's, so a mismatched
-        // upstream buffer must be rejected rather than silently relabelled.
+        // This node cannot resample a buffer whose rate differs from the processing context.
         const int altSampleRate = 44100;
         using var input = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
         var node = CreateNode();
@@ -1435,9 +1426,7 @@ public class CompressorNodeTests
     [Test]
     public void Process_NonFinitePropertyDefault_FallsBackToDeclaredConstant()
     {
-        // A library user can declare a property whose CurrentValue and DefaultValue are both non-finite.
-        // Returning the non-finite default would defeat the clamp (NaN clamps to NaN) and mute the node,
-        // so the declared CompressorParameters constants must take over.
+        // A non-finite property default cannot serve as the sanitization fallback.
         const int sampleCount = SampleRate / 4;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
 
@@ -1464,8 +1453,6 @@ public class CompressorNodeTests
             }
         }
 
-        // Defaults compress 0.9 (≈-0.9 dB) against a -20 dB threshold at ratio 4, so the tail lands
-        // around -15 dB; a muted node would sit at the -100 dB floor instead.
         float inputPeakDb = PeakDb(input, 0);
         float slope = 1f - 1f / DefaultRatio;
         float expectedDb = inputPeakDb - slope * (inputPeakDb - DefaultThresholdDb);

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
@@ -73,6 +73,44 @@ public class DelayNodeTests
         return node;
     }
 
+    // A constant input keeps the signal independent of the chunk's start time, so only a reset can
+    // change the output. RampInputNode derives its values from the start time, and at 100 Hz one tick
+    // of offset would shift the ramp by a whole sample and mask what this asserts.
+    private static DelayNode CreateNodeWithConstantInput(AudioBuffer input)
+    {
+        var node = new DelayNode
+        {
+            DelayTime = Property.Create(200f),
+            Feedback = Property.Create(50f),
+            DryMix = Property.Create(60f),
+            WetMix = Property.Create(40f),
+        };
+        node.AddInput(new BufferReplayNode(input));
+        return node;
+    }
+
+    // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the delay
+    // lines must survive so the second chunk still replays the first one's tail.
+    [TestCase(-1L)]
+    [TestCase(1L)]
+    public void Process_OneTickBoundaryRounding_PreservesDelayLines(long tickOffset)
+    {
+        using var input = AudioTestBuffers.CreateConstantBuffer(0.5f, SampleRate, 2, SampleRate);
+
+        using var continuing = CreateNodeWithConstantInput(input);
+        continuing.Process(ContextAt(0)).Dispose();
+        using AudioBuffer afterRounding = continuing.Process(new AudioProcessContext(
+            new TimeRange(TimeSpan.FromSeconds(1) + TimeSpan.FromTicks(tickOffset), TimeSpan.FromSeconds(1)),
+            SampleRate, new AnimationSampler(), null));
+
+        using var fresh = CreateNodeWithConstantInput(input);
+        using AudioBuffer freshRun = fresh.Process(ContextAt(1));
+
+        Assert.That(afterRounding.GetChannelData(0).ToArray(),
+            Is.Not.EqualTo(freshRun.GetChannelData(0).ToArray()).AsCollection,
+            "A one-tick boundary rounding must not reset the delay lines.");
+    }
+
     // A seek in either direction is a discontinuity: the delay lines must not carry audio from the
     // previous range. Regression for the tracker that only reset on backward seeks before its pinned
     // start, so forward seeks replayed stale delay-line content.

--- a/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DelayNodeTests.cs
@@ -73,9 +73,7 @@ public class DelayNodeTests
         return node;
     }
 
-    // A constant input keeps the signal independent of the chunk's start time, so only a reset can
-    // change the output. RampInputNode derives its values from the start time, and at 100 Hz one tick
-    // of offset would shift the ramp by a whole sample and mask what this asserts.
+    // A constant input prevents RampInputNode's time-dependent values from masking a reset.
     private static DelayNode CreateNodeWithConstantInput(AudioBuffer input)
     {
         var node = new DelayNode
@@ -89,8 +87,7 @@ public class DelayNodeTests
         return node;
     }
 
-    // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the delay
-    // lines must survive so the second chunk still replays the first one's tail.
+    // One-tick rounding must preserve the previous chunk's delay tail.
     [TestCase(-1L)]
     [TestCase(1L)]
     public void Process_OneTickBoundaryRounding_PreservesDelayLines(long tickOffset)

--- a/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
@@ -1,0 +1,91 @@
+﻿using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Logging;
+using Beutl.Media;
+using Microsoft.Extensions.Logging;
+
+using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+// Pins the DynamicsNode base-class contract that no single derived node can cover on its own.
+[TestFixture]
+public class DynamicsNodeTests
+{
+    private const int SampleRate = 48000;
+    private const int ChunkSamples = SampleRate / 10;
+
+    private static readonly TimeSpan s_chunk = TimeSpan.FromSeconds(ChunkSamples / (double)SampleRate);
+
+    private sealed class RecordingDynamicsNode : DynamicsNode
+    {
+        private static readonly ILogger s_logger = Log.CreateLogger<RecordingDynamicsNode>();
+
+        public bool ThrowFromHook { get; set; }
+
+        public int ResetCount { get; private set; }
+
+        protected override ILogger Logger => s_logger;
+
+        protected override string DiagnosticName => "Recording";
+
+        protected override bool HasAnimatedParameters => false;
+
+        protected override AudioBuffer ProcessStatic(AudioBuffer input, AudioProcessContext context)
+        {
+            if (ThrowFromHook)
+                throw new InvalidOperationException("hook failed");
+
+            return new AudioBuffer(input.SampleRate, input.ChannelCount, input.SampleCount);
+        }
+
+        protected override AudioBuffer ProcessAnimated(AudioBuffer input, AudioProcessContext context)
+            => ProcessStatic(input, context);
+
+        protected override void ResetDspState() => ResetCount++;
+    }
+
+    private static AudioProcessContext CreateContext(TimeSpan start) =>
+        new(new TimeRange(start, s_chunk), SampleRate, new AnimationSampler(), null);
+
+    [Test]
+    public void Process_HookThrows_LeavesTheNextChunkNonContiguous()
+    {
+        using var input = CreateConstantBuffer(0.5f, ChunkSamples);
+        using var node = new RecordingDynamicsNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        // Counted as a delta: the opening chunk resets for both the sample-rate and the no-predecessor
+        // reason, which is an implementation detail this test must not depend on.
+        node.Process(CreateContext(TimeSpan.Zero)).Dispose();
+        int afterFirstChunk = node.ResetCount;
+
+        node.ThrowFromHook = true;
+        Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(s_chunk)));
+
+        node.ThrowFromHook = false;
+        node.Process(CreateContext(s_chunk + s_chunk)).Dispose();
+
+        Assert.That(node.ResetCount, Is.EqualTo(afterFirstChunk + 1),
+            "the chunk after a throwing hook must reset rather than inherit half-mutated state");
+    }
+
+    [Test]
+    public void Process_HookSucceeds_KeepsTheNextChunkContiguous()
+    {
+        using var input = CreateConstantBuffer(0.5f, ChunkSamples);
+        using var node = new RecordingDynamicsNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        node.Process(CreateContext(TimeSpan.Zero)).Dispose();
+        int afterFirstChunk = node.ResetCount;
+
+        node.Process(CreateContext(s_chunk)).Dispose();
+        node.Process(CreateContext(s_chunk + s_chunk)).Dispose();
+
+        Assert.That(node.ResetCount, Is.EqualTo(afterFirstChunk),
+            "contiguous chunks must not reset, or the follower restarts mid-signal");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
@@ -71,6 +71,26 @@ public class DynamicsNodeTests
     }
 
     [Test]
+    public void Process_HookThrows_RetryingSameChunkResetsDspState()
+    {
+        using var input = CreateConstantBuffer(0.5f, ChunkSamples);
+        using var node = new RecordingDynamicsNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        node.Process(CreateContext(TimeSpan.Zero)).Dispose();
+        int afterFirstChunk = node.ResetCount;
+
+        node.ThrowFromHook = true;
+        Assert.Throws<InvalidOperationException>(() => node.Process(CreateContext(s_chunk)));
+
+        node.ThrowFromHook = false;
+        node.Process(CreateContext(s_chunk)).Dispose();
+
+        Assert.That(node.ResetCount, Is.EqualTo(afterFirstChunk + 1),
+            "retrying a failed chunk must reset rather than inherit state mutated before the exception");
+    }
+
+    [Test]
     public void Process_HookSucceeds_KeepsTheNextChunkContiguous()
     {
         using var input = CreateConstantBuffer(0.5f, ChunkSamples);

--- a/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/DynamicsNodeTests.cs
@@ -10,7 +10,6 @@ using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
 
 namespace Beutl.UnitTests.Engine.Audio;
 
-// Pins the DynamicsNode base-class contract that no single derived node can cover on its own.
 [TestFixture]
 public class DynamicsNodeTests
 {
@@ -57,8 +56,7 @@ public class DynamicsNodeTests
         using var node = new RecordingDynamicsNode();
         node.AddInput(new BufferReplayNode(input));
 
-        // Counted as a delta: the opening chunk resets for both the sample-rate and the no-predecessor
-        // reason, which is an implementation detail this test must not depend on.
+        // Compare the delta because the opening chunk resets for two independent reasons.
         node.Process(CreateContext(TimeSpan.Zero)).Dispose();
         int afterFirstChunk = node.ResetCount;
 

--- a/tests/Beutl.UnitTests/Engine/Audio/EqualizerNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/EqualizerNodeTests.cs
@@ -52,8 +52,7 @@ public class EqualizerNodeTests
         return output.GetChannelData(0)[0];
     }
 
-    // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the IIR
-    // state must survive, or the biquad restarts from zero and clicks.
+    // One-tick rounding must preserve IIR state to avoid restarting the biquad.
     [TestCase(-1L)]
     [TestCase(1L)]
     public void Process_OneTickBoundaryRounding_PreservesFilterState(long tickOffset)

--- a/tests/Beutl.UnitTests/Engine/Audio/EqualizerNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/EqualizerNodeTests.cs
@@ -1,0 +1,77 @@
+﻿using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Effects.Equalizer;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Media;
+
+using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class EqualizerNodeTests
+{
+    private const int SampleRate = 48000;
+    private const int ChunkSamples = SampleRate / 10;
+
+    private static readonly TimeSpan s_chunkDuration =
+        TimeSpan.FromSeconds(ChunkSamples / (double)SampleRate);
+
+    private static EqualizerNode CreateNode()
+    {
+        var band = new EqualizerBand();
+        band.Frequency.CurrentValue = 1000f;
+        band.Gain.CurrentValue = 12f;
+        band.Q.CurrentValue = 1f;
+        return new EqualizerNode { Bands = [band] };
+    }
+
+    private static AudioProcessContext CreateContext(TimeSpan start) =>
+        new(new TimeRange(start, s_chunkDuration), SampleRate, new AnimationSampler(), null);
+
+    private static float FirstSampleAfterWarmup(EqualizerNode node, TimeSpan followStart)
+    {
+        using var warmupInput = CreateConstantBuffer(0.9f, ChunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        node.Process(CreateContext(TimeSpan.Zero)).Dispose();
+
+        node.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, ChunkSamples);
+        node.AddInput(new BufferReplayNode(followInput));
+        using var followOutput = node.Process(CreateContext(followStart));
+        return followOutput.GetChannelData(0)[0];
+    }
+
+    private static float FirstSampleFromFreshNode()
+    {
+        using var node = CreateNode();
+        using var input = CreateConstantBuffer(0.9f, ChunkSamples);
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero));
+        return output.GetChannelData(0)[0];
+    }
+
+    // Independently rounded chunk boundaries can land one tick apart, which is not a seek: the IIR
+    // state must survive, or the biquad restarts from zero and clicks.
+    [TestCase(-1L)]
+    [TestCase(1L)]
+    public void Process_OneTickBoundaryRounding_PreservesFilterState(long tickOffset)
+    {
+        using var node = CreateNode();
+        float continuing = FirstSampleAfterWarmup(node, s_chunkDuration + TimeSpan.FromTicks(tickOffset));
+
+        Assert.That(continuing, Is.Not.EqualTo(FirstSampleFromFreshNode()).Within(1e-6f),
+            "A one-tick boundary rounding must not reset the filter state.");
+    }
+
+    [Test]
+    public void Process_Seek_ResetsFilterState()
+    {
+        using var node = CreateNode();
+        float afterSeek = FirstSampleAfterWarmup(node, TimeSpan.FromSeconds(5));
+
+        Assert.That(afterSeek, Is.EqualTo(FirstSampleFromFreshNode()).Within(1e-6f),
+            "A seek must reset the filter state, so the first sample matches a fresh node's.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/GateEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateEffectTests.cs
@@ -1,0 +1,113 @@
+﻿using Beutl.Audio;
+using Beutl.Audio.Effects;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+
+using static Beutl.Audio.Effects.GateParameters;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class GateEffectTests
+{
+    private sealed class StubInputNode : AudioNode
+    {
+        public override AudioBuffer Process(AudioProcessContext context)
+        {
+            return new AudioBuffer(context.SampleRate, 2, 0);
+        }
+    }
+
+    [Test]
+    public void CreateNode_WiresEveryPropertyToMatchingNodeSlot()
+    {
+        // Each property must be forwarded to its node slot by reference, not copied: the node reads
+        // CurrentValue/Animation through these references at process time. Also catches a swap of any
+        // two properties.
+        var effect = new GateEffect();
+        using var context = new AudioContext(48000, 2);
+        var inputNode = context.AddNode(new StubInputNode());
+
+        var node = effect.CreateNode(context, inputNode);
+
+        Assert.That(node, Is.InstanceOf<GateNode>());
+        var gate = (GateNode)node;
+
+        Assert.That(gate.Threshold, Is.SameAs(effect.Threshold));
+        Assert.That(gate.Attack, Is.SameAs(effect.Attack));
+        Assert.That(gate.Hold, Is.SameAs(effect.Hold));
+        Assert.That(gate.Release, Is.SameAs(effect.Release));
+        Assert.That(gate.Range, Is.SameAs(effect.Range));
+    }
+
+    [Test]
+    public void CreateNode_ConnectsInputAheadOfGate()
+    {
+        var effect = new GateEffect();
+        using var context = new AudioContext(48000, 2);
+        var inputNode = context.AddNode(new StubInputNode());
+
+        var node = effect.CreateNode(context, inputNode);
+
+        Assert.That(node.Inputs, Has.Count.EqualTo(1));
+        Assert.That(node.Inputs[0], Is.SameAs(inputNode));
+        Assert.That(node, Is.Not.SameAs(inputNode));
+    }
+
+    [Test]
+    public void CreateNode_DefaultPropertyValuesMatchGateParameters()
+    {
+        var effect = new GateEffect();
+
+        Assert.That(effect.Threshold.CurrentValue, Is.EqualTo(DefaultThresholdDb));
+        Assert.That(effect.Attack.CurrentValue, Is.EqualTo(DefaultAttackMs));
+        Assert.That(effect.Hold.CurrentValue, Is.EqualTo(DefaultHoldMs));
+        Assert.That(effect.Release.CurrentValue, Is.EqualTo(DefaultReleaseMs));
+        Assert.That(effect.Range.CurrentValue, Is.EqualTo(DefaultRangeDb));
+    }
+
+    [Test]
+    public void ScanProperties_RegistersNamesAndRangeValidatorsForEveryProperty()
+    {
+        // ScanProperties (run in the constructor) must name each property after its CLR member and
+        // attach the [Range] validator so out-of-range values are clamped at the engine layer.
+        var effect = new GateEffect();
+
+        AssertNameAndRange(effect.Threshold, nameof(effect.Threshold), MinThresholdDb, MaxThresholdDb);
+        AssertNameAndRange(effect.Attack, nameof(effect.Attack), MinAttackMs, MaxAttackMs);
+        AssertNameAndRange(effect.Hold, nameof(effect.Hold), MinHoldMs, MaxHoldMs);
+        AssertNameAndRange(effect.Release, nameof(effect.Release), MinReleaseMs, MaxReleaseMs);
+        AssertNameAndRange(effect.Range, nameof(effect.Range), MinRangeDb, MaxRangeDb);
+    }
+
+    private static void AssertNameAndRange(IProperty<float> property, string expectedName, float min, float max)
+    {
+        Assert.That(property.Name, Is.EqualTo(expectedName),
+            $"ScanProperties must name the property '{expectedName}'.");
+
+        property.CurrentValue = max + 1000f;
+        Assert.That(property.CurrentValue, Is.EqualTo(max),
+            $"{expectedName}: a value above the max must be coerced to {max}; validator appears unwired.");
+
+        property.CurrentValue = min - 1000f;
+        Assert.That(property.CurrentValue, Is.EqualTo(min),
+            $"{expectedName}: a value below the min must be coerced to {min}; validator appears unwired.");
+    }
+
+    private static IEnumerable<TestCaseData> ParameterRanges()
+    {
+        yield return new TestCaseData(MinThresholdDb, DefaultThresholdDb, MaxThresholdDb).SetName("Threshold");
+        yield return new TestCaseData(MinAttackMs, DefaultAttackMs, MaxAttackMs).SetName("Attack");
+        yield return new TestCaseData(MinHoldMs, DefaultHoldMs, MaxHoldMs).SetName("Hold");
+        yield return new TestCaseData(MinReleaseMs, DefaultReleaseMs, MaxReleaseMs).SetName("Release");
+        yield return new TestCaseData(MinRangeDb, DefaultRangeDb, MaxRangeDb).SetName("Range");
+    }
+
+    [TestCaseSource(nameof(ParameterRanges))]
+    public void GateParameters_RangeIsConsistent(float min, float def, float max)
+    {
+        Assert.That(min, Is.LessThan(max), "Min must be strictly less than Max.");
+        Assert.That(def, Is.InRange(min, max), "Default must lie within [Min, Max].");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/GateEffectTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateEffectTests.cs
@@ -22,9 +22,6 @@ public class GateEffectTests
     [Test]
     public void CreateNode_WiresEveryPropertyToMatchingNodeSlot()
     {
-        // Each property must be forwarded to its node slot by reference, not copied: the node reads
-        // CurrentValue/Animation through these references at process time. Also catches a swap of any
-        // two properties.
         var effect = new GateEffect();
         using var context = new AudioContext(48000, 2);
         var inputNode = context.AddNode(new StubInputNode());
@@ -70,8 +67,6 @@ public class GateEffectTests
     [Test]
     public void ScanProperties_RegistersNamesAndRangeValidatorsForEveryProperty()
     {
-        // ScanProperties (run in the constructor) must name each property after its CLR member and
-        // attach the [Range] validator so out-of-range values are clamped at the engine layer.
         var effect = new GateEffect();
 
         AssertNameAndRange(effect.Threshold, nameof(effect.Threshold), MinThresholdDb, MaxThresholdDb);

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -1,0 +1,647 @@
+﻿using Beutl.Animation;
+using Beutl.Animation.Easings;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Audio.Graph.Nodes;
+using Beutl.Engine;
+using Beutl.Media;
+
+using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
+
+namespace Beutl.UnitTests.Engine.Audio;
+
+[TestFixture]
+public class GateNodeTests
+{
+    private const int SampleRate = 48000;
+
+    private static float PeakDb(AudioBuffer buffer, int startSample)
+    {
+        float peak = 0f;
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = startSample; i < buffer.SampleCount; i++)
+            {
+                float a = MathF.Abs(data[i]);
+                if (a > peak) peak = a;
+            }
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static float PeakDbInWindow(AudioBuffer buffer, int startSample, int width)
+    {
+        int end = Math.Min(buffer.SampleCount, startSample + width);
+        float peak = 0f;
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            var data = buffer.GetChannelData(ch);
+            for (int i = startSample; i < end; i++)
+            {
+                float a = MathF.Abs(data[i]);
+                if (a > peak) peak = a;
+            }
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static GateNode CreateNode(
+        float threshold = -40f,
+        float attack = 1f,
+        float hold = 10f,
+        float release = 50f,
+        float range = -60f)
+    {
+        return new GateNode
+        {
+            Threshold = Property.CreateAnimatable(threshold),
+            Attack = Property.CreateAnimatable(attack),
+            Hold = Property.CreateAnimatable(hold),
+            Release = Property.CreateAnimatable(release),
+            Range = Property.CreateAnimatable(range)
+        };
+    }
+
+    private static AudioProcessContext CreateContext(TimeSpan start, TimeSpan duration, int sampleRate = SampleRate)
+    {
+        return new AudioProcessContext(
+            new TimeRange(start, duration),
+            sampleRate,
+            new AnimationSampler(),
+            null);
+    }
+
+    // Two-phase buffer: a loud constant for the first half then a quiet constant for the second, used
+    // to drive the gate open and then observe how it releases against the quiet tail.
+    private static AudioBuffer MakeTwoPhaseBuffer(float loud, float quiet, int loudSamples, int totalSamples)
+    {
+        return CreateBuffer(2, totalSamples, (_, i) => i < loudSamples ? loud : quiet);
+    }
+
+    [Test]
+    public void Process_SilenceInput_ProducesExactSilenceOutput()
+    {
+        // A gate multiplies each sample by its gain, so a zero input must yield exact-zero output
+        // regardless of the internal gate state.
+        const int sampleCount = SampleRate / 4;
+        using var input = new AudioBuffer(SampleRate, 2, sampleCount);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(data[i], Is.EqualTo(0f),
+                    $"Silent input must produce exact-zero output, but [{ch}][{i}] = {data[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_AboveThreshold_OpensAndPassesSignalThrough()
+    {
+        // A steady tone well above the threshold opens the gate; the settled tail should reach unity
+        // gain (output peak ≈ input peak).
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        float inputPeakDb = PeakDb(input, 0);
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(1f),
+            $"Above-threshold signal should pass at unity (input≈{inputPeakDb:F2} dB, output≈{outputPeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_BelowThreshold_AttenuatesTowardRange()
+    {
+        // A steady tone below the threshold keeps the gate closed, so the tail is attenuated by close
+        // to the Range depth (here ≈60 dB below input).
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateConstantBuffer(0.003f, sampleCount); // ≈-50 dB, below -40 threshold
+        var node = CreateNode(range: -60f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        float inputPeakDb = PeakDb(input, 0);
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(outputPeakDb, Is.LessThan(inputPeakDb - 40f),
+            $"Below-threshold signal should be heavily attenuated (input≈{inputPeakDb:F2} dB, output≈{outputPeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_RangeZero_DisablesGating()
+    {
+        // Range = 0 means the closed floor equals the open level, so even a below-threshold signal
+        // passes through at unity — gating is effectively disabled.
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateConstantBuffer(0.01f, sampleCount); // below -40 threshold
+        var node = CreateNode(range: 0f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        float inputPeakDb = PeakDb(input, 0);
+        float outputPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(outputPeakDb, Is.EqualTo(inputPeakDb).Within(1f),
+            $"Range=0 should disable gating (input≈{inputPeakDb:F2} dB, output≈{outputPeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_AttackTimeConstant_GainReachesAbout63PercentAfterAttackMs()
+    {
+        // Opening from the fully-closed floor, a one-pole attack should close ~(1 - 1/e) ≈ 63% of the
+        // distance to 0 dB after attackMs, leaving the gain ≈-36.8 dB. Range=-100 makes the closed
+        // floor equal the -100 dB start so the silent lead-in does not pre-open the gate. Catches a
+        // dropped ms→s conversion in ComputeCoeff, which would leave the gate stuck near -100 dB.
+        const float attackMs = 50f;
+        const int sampleCount = SampleRate;
+        const int stepAt = SampleRate / 10; // step to loud at 100 ms
+        using var input = CreateBuffer(1, sampleCount, (_, i) => i < stepAt ? 0f : 0.9f);
+        var node = CreateNode(threshold: -40f, attack: attackMs, hold: 0f, release: 100f, range: -100f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(1.0)));
+
+        int probeIdx = stepAt + (int)(attackMs * 0.001f * SampleRate);
+        float gainLinear = MathF.Abs(output.GetChannelData(0)[probeIdx] / 0.9f);
+        float gainDb = 20f * MathF.Log10(gainLinear);
+
+        Assert.That(gainDb, Is.EqualTo(-36.8f).Within(8f),
+            $"At t = attackMs ({attackMs} ms), gate gain should reach ≈-36.8 dB but got {gainDb:F2} dB. " +
+            $"Near -100 dB indicates ComputeCoeff lost its ms→s conversion.");
+    }
+
+    [Test]
+    public void Process_Hold_KeepsGateOpenAfterSignalDrops()
+    {
+        // After a loud burst opens the gate, a long Hold latches it open across a following
+        // below-threshold tail, so that quiet tail passes far louder than with Hold=0 (which releases
+        // immediately).
+        const int loudSamples = SampleRate / 10;  // 100 ms loud
+        const int quietSamples = SampleRate / 10;  // 100 ms quiet tail
+        const int total = loudSamples + quietSamples;
+        using var input = MakeTwoPhaseBuffer(0.9f, 0.005f, loudSamples, total); // quiet ≈-46 dB < -40
+
+        var holdNode = CreateNode(hold: 500f, release: 50f);
+        holdNode.AddInput(new BufferReplayNode(input));
+        using var holdOut = holdNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(total / (double)SampleRate)));
+
+        var noHoldNode = CreateNode(hold: 0f, release: 50f);
+        noHoldNode.AddInput(new BufferReplayNode(input));
+        using var noHoldOut = noHoldNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(total / (double)SampleRate)));
+
+        // Probe the last 40 ms of the quiet tail.
+        int probeWidth = SampleRate / 25;
+        float holdTailDb = PeakDbInWindow(holdOut, total - probeWidth, probeWidth);
+        float noHoldTailDb = PeakDbInWindow(noHoldOut, total - probeWidth, probeWidth);
+
+        Assert.That(holdTailDb, Is.GreaterThan(noHoldTailDb + 20f),
+            $"Hold should keep the gate open over the quiet tail (hold≈{holdTailDb:F2} dB, no-hold≈{noHoldTailDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_GateStateContinuesAcrossChunks()
+    {
+        // A gate opened by a previous loud chunk must NOT re-close on a time-contiguous next chunk. The
+        // warmed-open gate's first sample is louder than a fresh gate still ramping open from closed.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        var ctx2 = CreateContext(chunkDuration, chunkDuration);
+
+        var nodeContinuing = CreateNode();
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeContinuing.AddInput(new BufferReplayNode(warmupInput));
+        using var warmup = nodeContinuing.Process(ctx1);
+        nodeContinuing.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeContinuing.AddInput(new BufferReplayNode(followInput));
+        using var followOutput = nodeContinuing.Process(ctx2);
+
+        var nodeFresh = CreateNode();
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        float continuingFirst = MathF.Abs(followOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(continuingFirst, Is.GreaterThan(freshFirst));
+    }
+
+    [Test]
+    public void Process_NonContiguousTimeRange_ResetsGate()
+    {
+        // A non-contiguous start time (a seek) must reset the gate to closed, so the first sample
+        // matches a fresh gate's first sample.
+        const int chunkSamples = SampleRate / 10;
+        using var loud = CreateConstantBuffer(0.9f, chunkSamples);
+
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(loud));
+        var ctx1 = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var firstOutput = node.Process(ctx1);
+
+        node.ClearInputs();
+        using var loud2 = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(loud2));
+        var ctxSeek = CreateContext(TimeSpan.FromSeconds(5.0), TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var seekedOutput = node.Process(ctxSeek);
+
+        var nodeFresh = CreateNode();
+        using var loud3 = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(loud3));
+        using var freshOutput = nodeFresh.Process(
+            CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate)));
+
+        float seekedFirst = MathF.Abs(seekedOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(seekedFirst, Is.EqualTo(freshFirst).Within(1e-4f));
+    }
+
+    [Test]
+    public void Process_SampleRateChange_ResetsGate()
+    {
+        const int chunkSamples = SampleRate / 10;
+        using var loud = CreateConstantBuffer(0.9f, chunkSamples);
+
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(loud));
+        var ctx48 = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(chunkSamples / (double)SampleRate));
+        using var firstOutput = node.Process(ctx48);
+
+        node.ClearInputs();
+        const int altSampleRate = 44100;
+        using var loud44 = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
+        node.AddInput(new BufferReplayNode(loud44));
+        var ctx44 = new AudioProcessContext(
+            new TimeRange(TimeSpan.FromSeconds(chunkSamples / (double)SampleRate), TimeSpan.FromSeconds(0.1)),
+            altSampleRate,
+            new AnimationSampler(),
+            null);
+        using var secondOutput = node.Process(ctx44);
+
+        var nodeFresh = CreateNode();
+        using var freshInput = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        var ctxFresh = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(0.1)),
+            altSampleRate,
+            new AnimationSampler(),
+            null);
+        using var freshOutput = nodeFresh.Process(ctxFresh);
+
+        float secondFirst = MathF.Abs(secondOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(secondFirst, Is.EqualTo(freshFirst).Within(1e-4f));
+    }
+
+    [Test]
+    public void Reset_ClearsGateState()
+    {
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        var ctx2 = CreateContext(chunkDuration, chunkDuration);
+
+        var node = CreateNode();
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        using var firstOutput = node.Process(ctx1);
+
+        node.Reset();
+        node.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(followInput));
+        using var afterResetOutput = node.Process(ctx2);
+
+        var nodeFresh = CreateNode();
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        Assert.That(
+            MathF.Abs(afterResetOutput.GetChannelData(0)[0]),
+            Is.EqualTo(MathF.Abs(freshOutput.GetChannelData(0)[0])).Within(1e-4f));
+    }
+
+    [Test]
+    public void Process_AnimatedThreshold_EngagesAnimatedPath()
+    {
+        // Threshold animates from -60 dB (below the -40 dB input → gate open) to -20 dB (above it →
+        // gate closed), so a steady quiet tone goes from passing to attenuated: the late portion is
+        // quieter, proving the animated path runs.
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateConstantBuffer(0.01f, sampleCount); // ≈-40 dB
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -60f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.FromSeconds(0.5) });
+        var thresholdProperty = Property.CreateAnimatable(-60f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new GateNode
+        {
+            Threshold = thresholdProperty,
+            Attack = Property.CreateAnimatable(1f),
+            Hold = Property.CreateAnimatable(0f),
+            Release = Property.CreateAnimatable(20f),
+            Range = Property.CreateAnimatable(-60f)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        int lastQuarterStart = sampleCount * 3 / 4;
+        float earlyPeakDb = PeakDbInWindow(output, sampleCount / 8, sampleCount / 8);
+        float latePeakDb = PeakDb(output, lastQuarterStart);
+        Assert.That(latePeakDb, Is.LessThan(earlyPeakDb - 2f),
+            $"Animated threshold should attenuate the late portion (early≈{earlyPeakDb:F2} dB, late≈{latePeakDb:F2} dB)");
+    }
+
+    [Test]
+    public void Process_StaticAndAnimatedPaths_ProduceIdenticalOutputForConstantParameters()
+    {
+        // ProcessStatic and ProcessAnimated share the same gate helpers, so with a constant Threshold
+        // animation the animated path must match the static path sample-for-sample. A two-phase buffer
+        // exercises both an opening and a releasing transition.
+        const int loudSamples = SampleRate / 4;
+        const int sampleCount = SampleRate / 2;
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = MakeTwoPhaseBuffer(0.9f, 0.003f, loudSamples, sampleCount);
+
+        var staticNode = CreateNode(threshold: -40f, attack: 2f, hold: 5f, release: 30f, range: -50f);
+        staticNode.AddInput(new BufferReplayNode(input));
+        using var staticOut = staticNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = duration });
+        var thresholdProperty = Property.CreateAnimatable(-40f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var animatedNode = new GateNode
+        {
+            Threshold = thresholdProperty,
+            Attack = Property.CreateAnimatable(2f),
+            Hold = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(30f),
+            Range = Property.CreateAnimatable(-50f)
+        };
+        animatedNode.AddInput(new BufferReplayNode(input));
+        using var animatedOut = animatedNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        for (int ch = 0; ch < staticOut.ChannelCount; ch++)
+        {
+            var s = staticOut.GetChannelData(ch);
+            var a = animatedOut.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(a[i], Is.EqualTo(s[i]).Within(1e-4f),
+                    $"Static and animated paths diverged at [{ch}][{i}]: static={s[i]}, animated={a[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_InfinityInputSamples_RecoversAndDoesNotLeakNonFiniteOutput()
+    {
+        // A +Infinity head sample pollutes the gain follower; the self-recovery clamp and the output
+        // sanitizer must keep any NaN/Infinity from escaping downstream.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+        for (int ch = 0; ch < input.ChannelCount; ch++)
+        {
+            input.GetChannelData(ch)[0] = float.PositiveInfinity;
+            input.GetChannelData(ch)[1] = float.PositiveInfinity;
+        }
+
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NaNInputSamples_ProducesFiniteOutput()
+    {
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+        input.GetChannelData(0)[0] = float.NaN;
+        input.GetChannelData(1)[0] = float.NaN;
+
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        Assert.That(output.GetChannelData(0)[0], Is.EqualTo(0f));
+        Assert.That(output.GetChannelData(1)[0], Is.EqualTo(0f));
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 1; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True);
+            }
+        }
+    }
+
+    public enum AnimatedParam { Threshold, Attack, Hold, Release, Range }
+
+    [TestCase(AnimatedParam.Threshold)]
+    [TestCase(AnimatedParam.Attack)]
+    [TestCase(AnimatedParam.Hold)]
+    [TestCase(AnimatedParam.Release)]
+    [TestCase(AnimatedParam.Range)]
+    public void Process_AnimatedNonFiniteValue_FallsBackWithoutMuting(AnimatedParam param)
+    {
+        // A NaN keyframe on any animated parameter must fall back to its static CurrentValue rather
+        // than reach the gate math and mute the output. A loud above-threshold signal should keep
+        // passing.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        var threshold = Property.CreateAnimatable(-40f);
+        var attack = Property.CreateAnimatable(1f);
+        var hold = Property.CreateAnimatable(10f);
+        var release = Property.CreateAnimatable(50f);
+        var range = Property.CreateAnimatable(-60f);
+
+        IProperty<float> target = param switch
+        {
+            AnimatedParam.Threshold => threshold,
+            AnimatedParam.Attack => attack,
+            AnimatedParam.Hold => hold,
+            AnimatedParam.Release => release,
+            AnimatedParam.Range => range,
+            _ => throw new ArgumentOutOfRangeException(nameof(param))
+        };
+        var anim = new KeyFrameAnimation<float>();
+        anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.Zero });
+        anim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = float.NaN, KeyTime = TimeSpan.FromSeconds(0.25) });
+        target.Animation = anim;
+
+        var node = new GateNode
+        {
+            Threshold = threshold,
+            Attack = attack,
+            Hold = hold,
+            Release = release,
+            Range = range
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.GreaterThan(-6f),
+            $"Fallback failed for {param}: above-threshold output appears to have been muted");
+    }
+
+    [Test]
+    public void Process_MonoBuffer_GatesCorrectly()
+    {
+        // A single-channel buffer must gate with no off-by-one: above-threshold passes, below-threshold
+        // is attenuated.
+        const int sampleCount = SampleRate / 2;
+        using var loud = CreateConstantBuffer(0.9f, sampleCount, channels: 1);
+        var loudNode = CreateNode();
+        loudNode.AddInput(new BufferReplayNode(loud));
+        using var loudOut = loudNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        using var quiet = CreateConstantBuffer(0.003f, sampleCount, channels: 1);
+        var quietNode = CreateNode();
+        quietNode.AddInput(new BufferReplayNode(quiet));
+        using var quietOut = quietNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        Assert.That(loudOut.ChannelCount, Is.EqualTo(1));
+        Assert.That(PeakDb(loudOut, sampleCount / 2), Is.EqualTo(PeakDb(loud, 0)).Within(1f));
+        Assert.That(PeakDb(quietOut, sampleCount / 2), Is.LessThan(PeakDb(quiet, 0) - 40f));
+    }
+
+    [Test]
+    public void Process_NoInputs_Throws()
+    {
+        var node = CreateNode();
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1));
+        Assert.Throws<InvalidOperationException>(() => node.Process(ctx));
+    }
+
+    [Test]
+    public void Process_TooManyInputs_Throws()
+    {
+        const int sampleCount = SampleRate / 10;
+        using var bufA = CreateConstantBuffer(0.1f, sampleCount);
+        using var bufB = CreateConstantBuffer(0.1f, sampleCount);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(bufA));
+        node.AddInput(new BufferReplayNode(bufB));
+        var ctx = CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1));
+        Assert.Throws<InvalidOperationException>(() => node.Process(ctx));
+    }
+
+    [Test]
+    public void Process_ZeroLengthInput_Static_ReturnsEmptyBuffer()
+    {
+        using var input = new AudioBuffer(SampleRate, 2, 0);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.Zero));
+
+        Assert.That(output.SampleCount, Is.EqualTo(0));
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
+        Assert.That(output.SampleRate, Is.EqualTo(SampleRate));
+    }
+
+    [Test]
+    public void Process_ZeroLengthInput_Animated_ReturnsEmptyBuffer()
+    {
+        using var input = new AudioBuffer(SampleRate, 2, 0);
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -20f, KeyTime = TimeSpan.FromSeconds(1.0) });
+        var thresholdProperty = Property.CreateAnimatable(-40f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new GateNode
+        {
+            Threshold = thresholdProperty,
+            Attack = Property.CreateAnimatable(1f),
+            Hold = Property.CreateAnimatable(10f),
+            Release = Property.CreateAnimatable(50f),
+            Range = Property.CreateAnimatable(-60f)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.Zero));
+
+        Assert.That(output.SampleCount, Is.EqualTo(0));
+        Assert.That(output.ChannelCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Process_AnimatedPath_SmoothAcrossChunkBoundary()
+    {
+        // ProcessAnimated walks the input in fixed-size chunks. A steady loud input must show no
+        // discontinuity at chunk boundaries — a jump there would mean the gate was reset at a boundary.
+        const int chunkSize = 1024;
+        const int sampleCount = chunkSize * 3 + 137;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.FromSeconds(sampleCount / (double)SampleRate) });
+        var thresholdProperty = Property.CreateAnimatable(-40f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var node = new GateNode
+        {
+            Threshold = thresholdProperty,
+            Attack = Property.CreateAnimatable(5f),
+            Hold = Property.CreateAnimatable(10f),
+            Release = Property.CreateAnimatable(50f),
+            Range = Property.CreateAnimatable(-60f)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        var data = output.GetChannelData(0);
+        for (int boundary = chunkSize; boundary < sampleCount; boundary += chunkSize)
+        {
+            float prevDelta = MathF.Abs(data[boundary - 1] - data[boundary - 2]);
+            float boundaryDelta = MathF.Abs(data[boundary] - data[boundary - 1]);
+            Assert.That(boundaryDelta, Is.LessThanOrEqualTo(prevDelta + 0.01f),
+                $"Discontinuity at chunk boundary {boundary}: prevDelta={prevDelta:F6}, boundaryDelta={boundaryDelta:F6}");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -729,4 +729,59 @@ public class GateNodeTests
         Assert.That(onsetPeakDb, Is.LessThan(-20f),
             $"Digital silence at min threshold must keep the gate closed; loud onset should ramp from closed but measured {onsetPeakDb:F2} dB");
     }
+
+    [Test]
+    public void Process_BelowThresholdLeadIn_StartsAtRangeFloorNotFullMute()
+    {
+        // A below-threshold lead-in must rest at the user's Range floor from the very first sample, not
+        // fade in from the -100 dB reset sentinel. With a shallow Range (-20 dB) and a slow attack the
+        // buggy code seeded the follower near -100 dB and only ramped up toward -20, over-attenuating
+        // the opening; the first sample's gain should already sit at the -20 dB floor.
+        const int sampleCount = SampleRate / 10;
+        const float rangeDb = -20f;
+        const float amplitude = 0.01f; // ≈-40 dB, below the -30 dB threshold
+        using var input = CreateConstantBuffer(amplitude, sampleCount);
+        var node = CreateNode(threshold: -30f, attack: 100f, hold: 0f, release: 100f, range: rangeDb);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        float firstGainDb = 20f * MathF.Log10(MathF.Abs(output.GetChannelData(0)[0]) / amplitude);
+        Assert.That(firstGainDb, Is.EqualTo(rangeDb).Within(2f),
+            $"Below-threshold lead-in should start at the Range floor ({rangeDb} dB), but first-sample gain was " +
+            $"{firstGainDb:F2} dB (a value near -100 dB indicates a fade-in from the reset sentinel).");
+    }
+
+    [Test]
+    public void Process_OneTickBoundaryRounding_DoesNotResetGate()
+    {
+        // Adjacent sample-boundary chunks can differ by one tick from independent TimeSpan rounding. A
+        // one-tick gap must NOT be treated as a seek: the warmed-open gate must continue (its first
+        // sample stays loud) rather than reset to closed like a fresh gate. Buggy exact-equality would
+        // reset here, dropping the continuing gate's first sample to the fresh gate's value.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
+        // Second chunk starts one tick before the exact previous end — within the rounding tolerance.
+        var ctx2 = CreateContext(chunkDuration - TimeSpan.FromTicks(1), chunkDuration);
+
+        var node = CreateNode();
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        using var warmup = node.Process(ctx1);
+        node.ClearInputs();
+        using var followInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(followInput));
+        using var followOutput = node.Process(ctx2);
+
+        var nodeFresh = CreateNode();
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(ctx1);
+
+        float continuingFirst = MathF.Abs(followOutput.GetChannelData(0)[0]);
+        float freshFirst = MathF.Abs(freshOutput.GetChannelData(0)[0]);
+        Assert.That(continuingFirst, Is.GreaterThan(freshFirst),
+            $"A one-tick boundary rounding must not reset the gate (continuing≈{continuingFirst:F4}, fresh≈{freshFirst:F4}).");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -644,4 +644,89 @@ public class GateNodeTests
                 $"Discontinuity at chunk boundary {boundary}: prevDelta={prevDelta:F6}, boundaryDelta={boundaryDelta:F6}");
         }
     }
+
+    [Test]
+    public void Process_RangeZero_IsExactIdentity()
+    {
+        // Range=0 disables gating, so output must equal input sample-for-sample — no startup attack
+        // ramp and no asymptotic sub-unity gain from the envelope follower. The buffer includes the
+        // initial samples (which would otherwise ramp up from the closed floor) and a below-threshold
+        // region (which a real gate would attenuate), so any residual smoothing would show up.
+        const int loudSamples = SampleRate / 4;
+        const int sampleCount = SampleRate / 2;
+        using var input = MakeTwoPhaseBuffer(0.9f, 0.003f, loudSamples, sampleCount);
+        var node = CreateNode(range: 0f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        for (int ch = 0; ch < input.ChannelCount; ch++)
+        {
+            var inData = input.GetChannelData(ch);
+            var outData = output.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(outData[i], Is.EqualTo(inData[i]),
+                    $"Range=0 must be exact identity, but [{ch}][{i}] output={outData[i]} != input={inData[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_OneChannelNaN_GatesFromValidChannel()
+    {
+        // A NaN in one channel must not poison linked-stereo peak detection: a loud, above-threshold
+        // valid channel must still open the gate and pass through, rather than the gate closing
+        // because Abs(NaN) contaminated the peak. All output stays finite (the NaN channel is zeroed).
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateBuffer(2, sampleCount, (ch, _) => ch == 0 ? float.NaN : 0.9f);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        float validPeak = 0f;
+        var validData = output.GetChannelData(1);
+        for (int i = sampleCount / 2; i < sampleCount; i++)
+        {
+            float a = MathF.Abs(validData[i]);
+            if (a > validPeak) validPeak = a;
+        }
+        float validPeakDb = validPeak > 0f ? 20f * MathF.Log10(validPeak) : -100f;
+        Assert.That(validPeakDb, Is.EqualTo(20f * MathF.Log10(0.9f)).Within(1f),
+            $"Valid channel should open the gate and pass at unity despite NaN in the other channel; got {validPeakDb:F2} dB");
+    }
+
+    [Test]
+    public void Process_MinThreshold_DigitalSilenceDoesNotOpenGate()
+    {
+        // At the -100 dB minimum Threshold, digital silence (sample 0 = -inf dB) must still leave the
+        // gate closed. If silence wrongly opened it, the following loud region would already be open
+        // and pass at unity immediately; with the gate correctly closed it ramps open (attack), so the
+        // loud onset starts heavily attenuated.
+        const int silenceSamples = SampleRate / 5; // 200 ms
+        const int sampleCount = SampleRate / 2;
+        using var input = CreateBuffer(1, sampleCount, (_, i) => i < silenceSamples ? 0f : 0.9f);
+        var node = CreateNode(threshold: -100f, attack: 50f, hold: 0f, release: 100f, range: -60f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        // First 1 ms of the loud region: a correctly-closed gate is only starting to open, so the peak
+        // there is far below unity. A gate wrongly opened during silence would already sit near 0.9.
+        int probeWidth = SampleRate / 1000;
+        float onsetPeakDb = PeakDbInWindow(output, silenceSamples, probeWidth);
+        Assert.That(onsetPeakDb, Is.LessThan(-20f),
+            $"Digital silence at min threshold must keep the gate closed; loud onset should ramp from closed but measured {onsetPeakDb:F2} dB");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -191,7 +191,7 @@ public class GateNodeTests
         // After one attack time constant, gain covers 1 - 1/e of the distance to 0 dB.
         const float attackMs = 50f;
         const int sampleCount = SampleRate;
-        const int stepAt = SampleRate / 10; // step to loud at 100 ms
+        const int stepAt = SampleRate / 10;
         using var input = CreateBuffer(1, sampleCount, (_, i) => i < stepAt ? 0f : 0.9f);
         var node = CreateNode(threshold: -40f, attack: attackMs, hold: 0f, release: 100f, range: -100f);
         node.AddInput(new BufferReplayNode(input));
@@ -210,8 +210,8 @@ public class GateNodeTests
     [Test]
     public void Process_Hold_KeepsGateOpenAfterSignalDrops()
     {
-        const int loudSamples = SampleRate / 10;  // 100 ms loud
-        const int quietSamples = SampleRate / 10;  // 100 ms quiet tail
+        const int loudSamples = SampleRate / 10;
+        const int quietSamples = SampleRate / 10;
         const int total = loudSamples + quietSamples;
         using var input = MakeTwoPhaseBuffer(0.9f, 0.005f, loudSamples, total); // quiet ≈-46 dB < -40
 
@@ -703,9 +703,7 @@ public class GateNodeTests
             $"Valid channel should open the gate and pass at unity despite NaN in the other channel; got {validPeakDb:F2} dB");
     }
 
-    // Every peak-detection site is covered: the stereo fast path and the >2-channel fallback, in both
-    // the static and the animated loop. The four sites are written out separately, so one of them
-    // missing the guard is exactly the kind of gap this matrix has to catch.
+    // Covers linked-peak guards in the stereo/surround and static/animated paths.
     [TestCase(2, 1, false)]
     [TestCase(2, 4, false)]
     [TestCase(2, 4, true)]
@@ -713,12 +711,10 @@ public class GateNodeTests
     [TestCase(4, 4, true)]
     public void Process_OneChannelInfinity_DoesNotOpenGateForValidChannels(int channels, int corruptSamples, bool animated)
     {
-        // An Infinity in one channel was promoted to the linked peak, opening the gate and arming its
-        // hold latch, so every other channel passed audibly for the hold+release window even though
-        // all of them sit below the threshold. The probe covers exactly that window.
+        // Without the guard, Infinity opens the linked gate for the hold and release window.
         const int sampleCount = SampleRate / 2;
         const float quiet = 0.003f; // ≈-50 dB, below the -40 dB threshold
-        const int holdSamples = (int)(10f * 0.001f * SampleRate); // CreateNode's default 10 ms hold
+        const int holdSamples = (int)(10f * 0.001f * SampleRate);
         var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
         using var input = CreateBuffer(channels, sampleCount, (_, _) => quiet);
         for (int i = 0; i < corruptSamples; i++)
@@ -757,7 +753,7 @@ public class GateNodeTests
     [Test]
     public void Process_MinThreshold_DigitalSilenceDoesNotOpenGate()
     {
-        const int silenceSamples = SampleRate / 5; // 200 ms
+        const int silenceSamples = SampleRate / 5;
         const int sampleCount = SampleRate / 2;
         using var input = CreateBuffer(1, sampleCount, (_, i) => i < silenceSamples ? 0f : 0.9f);
         var node = CreateNode(threshold: -100f, attack: 50f, hold: 0f, release: 100f, range: -60f);
@@ -889,7 +885,6 @@ public class GateNodeTests
     [Test]
     public void Process_LinkedSurround_OpensEveryChannelFromLoudestChannel()
     {
-        // Only channel 2 is above the threshold, so a detector that stops at channel 1 closes the gate.
         const int sampleCount = SampleRate / 2;
         const int channels = 4;
         const float loud = 0.9f;
@@ -918,9 +913,7 @@ public class GateNodeTests
     [Test]
     public void Process_StaticAndAnimatedPaths_MatchForSurroundBuffer()
     {
-        // The >2-channel fallback is written out separately in each path. Only channel 2 crosses the
-        // threshold and every channel carries a distinct level, so a detector or channel mix-up in
-        // either loop diverges here.
+        // Distinct channel levels expose detector or channel mix-ups in either surround path.
         const int loudSamples = SampleRate / 4;
         const int sampleCount = SampleRate / 2;
         const int channels = 4;
@@ -1033,7 +1026,6 @@ public class GateNodeTests
     [Test]
     public void Process_AnimatedOutOfRangeParameter_LogsClampWarningOncePerParameter()
     {
-        // Not zero times (a hidden misconfiguration) and not per sample (audio-thread spam).
         const int sampleCount = SampleRate / 4;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
 
@@ -1062,8 +1054,7 @@ public class GateNodeTests
     [Test]
     public void Process_EmptyChunkWithDuration_DoesNotMaskLaterDiscontinuity()
     {
-        // A chunk that spans time but carries no samples leaves a hole; the chunk after it is not
-        // contiguous with the chunk before it.
+        // An empty timed chunk leaves a discontinuity.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
 
@@ -1097,8 +1088,7 @@ public class GateNodeTests
     [Test]
     public void Process_ZeroHold_ModulatesLowFrequencyGainAcrossZeroCrossings()
     {
-        // Characterizes the unsmoothed peak detector: Hold bridges a waveform's zero crossings, so at
-        // Hold = 0 with the fastest Release a tone that never leaves the open region still pumps.
+        // With an unsmoothed detector, zero Hold and fast Release pump near zero crossings.
         const int sampleCount = SampleRate / 4;
         const float amplitude = 0.1f; // ≈-20 dB, well above the -40 dB threshold
         const float thresholdLinear = 0.01f; // the -40 dB threshold in linear terms

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -752,18 +752,21 @@ public class GateNodeTests
             $"{firstGainDb:F2} dB (a value near -100 dB indicates a fade-in from the reset sentinel).");
     }
 
-    [Test]
-    public void Process_OneTickBoundaryRounding_DoesNotResetGate()
+    [TestCase(-1L)]
+    [TestCase(1L)]
+    public void Process_OneTickBoundaryRounding_DoesNotResetGate(long tickOffset)
     {
         // Adjacent sample-boundary chunks can differ by one tick from independent TimeSpan rounding. A
-        // one-tick gap must NOT be treated as a seek: the warmed-open gate must continue (its first
-        // sample stays loud) rather than reset to closed like a fresh gate. Buggy exact-equality would
-        // reset here, dropping the continuing gate's first sample to the fresh gate's value.
+        // one-tick gap or overlap must NOT be treated as a seek: the warmed-open gate must continue (its
+        // first sample stays loud) rather than reset to closed like a fresh gate. The tolerance is
+        // symmetric, so both directions are covered; buggy exact-equality would reset either way,
+        // dropping the continuing gate's first sample to the fresh gate's value.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
-        // Second chunk starts one tick before the exact previous end — within the rounding tolerance.
-        var ctx2 = CreateContext(chunkDuration - TimeSpan.FromTicks(1), chunkDuration);
+        // Second chunk starts one tick before (-1) or after (+1) the exact previous end — either side is
+        // within the rounding tolerance and must not reset.
+        var ctx2 = CreateContext(chunkDuration + TimeSpan.FromTicks(tickOffset), chunkDuration);
 
         var node = CreateNode();
         using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -703,16 +703,20 @@ public class GateNodeTests
             $"Valid channel should open the gate and pass at unity despite NaN in the other channel; got {validPeakDb:F2} dB");
     }
 
-    [TestCase(1, false)]
-    [TestCase(4, false)]
-    [TestCase(4, true)]
-    public void Process_OneChannelInfinity_DoesNotOpenGateForValidChannels(int corruptSamples, bool animated)
+    // Every peak-detection site is covered: the stereo fast path and the >2-channel fallback, in both
+    // the static and the animated loop. The four sites are written out separately, so one of them
+    // missing the guard is exactly the kind of gap this matrix has to catch.
+    [TestCase(2, 1, false)]
+    [TestCase(2, 4, false)]
+    [TestCase(2, 4, true)]
+    [TestCase(4, 4, false)]
+    [TestCase(4, 4, true)]
+    public void Process_OneChannelInfinity_DoesNotOpenGateForValidChannels(int channels, int corruptSamples, bool animated)
     {
         // An Infinity in one channel was promoted to the linked peak, opening the gate and arming its
         // hold latch, so every other channel passed audibly for the hold+release window even though
         // all of them sit below the threshold. The probe covers exactly that window.
         const int sampleCount = SampleRate / 2;
-        const int channels = 4;
         const float quiet = 0.003f; // ≈-50 dB, below the -40 dB threshold
         const int holdSamples = (int)(10f * 0.001f * SampleRate); // CreateNode's default 10 ms hold
         var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -787,4 +787,87 @@ public class GateNodeTests
         Assert.That(continuingFirst, Is.GreaterThan(freshFirst),
             $"A one-tick boundary rounding must not reset the gate (continuing≈{continuingFirst:F4}, fresh≈{freshFirst:F4}).");
     }
+
+    [Test]
+    public void Process_Hold_KeepsGateOpenForEveryConfiguredSample()
+    {
+        // Hold of N samples must latch the gate open for all N below-threshold samples. Spending the
+        // latch before reading it made the gate release one sample early — and with a hold that converts
+        // to a single sample, immediately. The release is deliberately the fastest allowed (1 ms) so one
+        // sample of release is a large, unambiguous drop rather than a rounding-sized one.
+        const int holdSamples = 1;
+        const float holdMs = holdSamples * 1000f / SampleRate;
+        const int loudSamples = SampleRate / 100;
+        const int sampleCount = loudSamples + 8;
+        using var input = CreateBuffer(1, sampleCount, (_, i) => i < loudSamples ? 0.9f : 0.003f);
+        var node = CreateNode(threshold: -40f, attack: 0.1f, hold: holdMs, release: 1f, range: -60f);
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
+
+        var data = output.GetChannelData(0);
+        // The first below-threshold sample is still inside the hold window, so it passes at (near) unity.
+        float heldGain = MathF.Abs(data[loudSamples]) / 0.003f;
+        // The next one is past the window and has begun releasing toward the Range floor.
+        float releasedGain = MathF.Abs(data[loudSamples + 1]) / 0.003f;
+
+        Assert.That(heldGain, Is.EqualTo(1f).Within(0.01f),
+            $"A {holdSamples}-sample hold must keep the first below-threshold sample fully open, but its gain was {heldGain:F4}.");
+        Assert.That(releasedGain, Is.LessThan(heldGain),
+            $"The sample after the hold window must have started releasing (held≈{heldGain:F4}, released≈{releasedGain:F4}).");
+    }
+
+    [Test]
+    public void Process_InputSampleRateMismatch_Throws()
+    {
+        // Coefficients and the hold count are derived from the context sample rate while the output
+        // buffer carries the input's, so a mismatched upstream buffer must be rejected rather than
+        // silently relabelled.
+        const int altSampleRate = 44100;
+        using var input = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+
+        Assert.Throws<InvalidOperationException>(
+            () => node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.1))));
+    }
+
+    [Test]
+    public void Process_NonFinitePropertyDefault_FallsBackToDeclaredConstant()
+    {
+        // A library user can declare a property whose CurrentValue *and* DefaultValue are both
+        // non-finite. Returning the non-finite default would defeat the range clamp (NaN clamps to NaN)
+        // and collapse the gate to its recovery sentinel, so the declared GateParameters constants must
+        // take over: an above-threshold signal still passes at unity.
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        var node = new GateNode
+        {
+            Threshold = Property.CreateAnimatable(float.NaN),
+            Attack = Property.CreateAnimatable(float.NaN),
+            Hold = Property.CreateAnimatable(float.NaN),
+            Release = Property.CreateAnimatable(float.NaN),
+            Range = Property.CreateAnimatable(float.NaN)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        // Defaults are Threshold -40 dB / Range -60 dB, so 0.9 (≈-0.9 dB) is above threshold and the
+        // settled tail must reach unity instead of sitting at the -100 dB recovery sentinel.
+        float steadyPeakDb = PeakDb(output, sampleCount / 2);
+        Assert.That(steadyPeakDb, Is.EqualTo(PeakDb(input, 0)).Within(1f),
+            $"With non-finite property defaults the declared constants must apply, but the tail measured {steadyPeakDb:F2} dB.");
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -703,6 +703,53 @@ public class GateNodeTests
             $"Valid channel should open the gate and pass at unity despite NaN in the other channel; got {validPeakDb:F2} dB");
     }
 
+    [TestCase(1, false)]
+    [TestCase(4, false)]
+    [TestCase(4, true)]
+    public void Process_OneChannelInfinity_DoesNotOpenGateForValidChannels(int corruptSamples, bool animated)
+    {
+        // An Infinity in one channel was promoted to the linked peak, opening the gate and arming its
+        // hold latch, so every other channel passed audibly for the hold+release window even though
+        // all of them sit below the threshold. The probe covers exactly that window.
+        const int sampleCount = SampleRate / 2;
+        const int channels = 4;
+        const float quiet = 0.003f; // ≈-50 dB, below the -40 dB threshold
+        const int holdSamples = (int)(10f * 0.001f * SampleRate); // CreateNode's default 10 ms hold
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = CreateBuffer(channels, sampleCount, (_, _) => quiet);
+        for (int i = 0; i < corruptSamples; i++)
+        {
+            input.GetChannelData(0)[i] = float.PositiveInfinity;
+        }
+
+        var node = CreateNode();
+        if (animated)
+        {
+            var thresholdAnim = new KeyFrameAnimation<float>();
+            thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.Zero });
+            thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = duration });
+            node.Threshold.Animation = thresholdAnim;
+        }
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero, duration));
+
+        for (int ch = 0; ch < output.ChannelCount; ch++)
+        {
+            var data = output.GetChannelData(ch);
+            for (int i = 0; i < output.SampleCount; i++)
+            {
+                Assert.That(float.IsFinite(data[i]), Is.True,
+                    $"Output sample [{ch}][{i}] = {data[i]} is not finite");
+            }
+        }
+
+        float quietDb = 20f * MathF.Log10(quiet);
+        float peakDb = PeakDbInWindow(output, corruptSamples, holdSamples);
+        Assert.That(peakDb, Is.LessThan(quietDb - 40f),
+            $"Every finite channel is below the threshold, so the gate must stay shut after the corrupt " +
+            $"sample; the hold window peaked at {peakDb:F2} dB against a {quietDb:F2} dB input.");
+    }
+
     [Test]
     public void Process_MinThreshold_DigitalSilenceDoesNotOpenGate()
     {

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -72,8 +72,6 @@ public class GateNodeTests
             null);
     }
 
-    // Two-phase buffer: a loud constant for the first half then a quiet constant for the second, used
-    // to drive the gate open and then observe how it releases against the quiet tail.
     private static AudioBuffer MakeTwoPhaseBuffer(float loud, float quiet, int loudSamples, int totalSamples)
     {
         return CreateBuffer(2, totalSamples, (_, i) => i < loudSamples ? loud : quiet);
@@ -82,8 +80,6 @@ public class GateNodeTests
     [Test]
     public void Process_SilenceInput_ProducesExactSilenceOutput()
     {
-        // A gate multiplies each sample by its gain, so a zero input must yield exact-zero output
-        // regardless of the internal gate state.
         const int sampleCount = SampleRate / 4;
         using var input = new AudioBuffer(SampleRate, 2, sampleCount);
         var node = CreateNode();
@@ -105,8 +101,6 @@ public class GateNodeTests
     [Test]
     public void Process_AboveThreshold_OpensAndPassesSignalThrough()
     {
-        // A steady tone well above the threshold opens the gate; the settled tail should reach unity
-        // gain (output peak ≈ input peak).
         const int sampleCount = SampleRate / 2;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
         var node = CreateNode();
@@ -123,8 +117,6 @@ public class GateNodeTests
     [Test]
     public void Process_BelowThreshold_AttenuatesTowardRange()
     {
-        // A steady tone below the threshold keeps the gate closed, so the tail is attenuated by close
-        // to the Range depth (here ≈60 dB below input).
         const int sampleCount = SampleRate / 2;
         using var input = CreateConstantBuffer(0.003f, sampleCount); // ≈-50 dB, below -40 threshold
         var node = CreateNode(range: -60f);
@@ -141,8 +133,6 @@ public class GateNodeTests
     [Test]
     public void Process_RangeZero_DisablesGating()
     {
-        // Range = 0 means the closed floor equals the open level, so even a below-threshold signal
-        // passes through at unity — gating is effectively disabled.
         const int sampleCount = SampleRate / 2;
         using var input = CreateConstantBuffer(0.01f, sampleCount); // below -40 threshold
         var node = CreateNode(range: 0f);
@@ -159,10 +149,7 @@ public class GateNodeTests
     [Test]
     public void Process_AttackTimeConstant_GainReachesAbout63PercentAfterAttackMs()
     {
-        // Opening from the fully-closed floor, a one-pole attack should close ~(1 - 1/e) ≈ 63% of the
-        // distance to 0 dB after attackMs, leaving the gain ≈-36.8 dB. Range=-100 makes the closed
-        // floor equal the -100 dB start so the silent lead-in does not pre-open the gate. Catches a
-        // dropped ms→s conversion in ComputeCoeff, which would leave the gate stuck near -100 dB.
+        // After one attack time constant, gain covers 1 - 1/e of the distance to 0 dB.
         const float attackMs = 50f;
         const int sampleCount = SampleRate;
         const int stepAt = SampleRate / 10; // step to loud at 100 ms
@@ -184,9 +171,6 @@ public class GateNodeTests
     [Test]
     public void Process_Hold_KeepsGateOpenAfterSignalDrops()
     {
-        // After a loud burst opens the gate, a long Hold latches it open across a following
-        // below-threshold tail, so that quiet tail passes far louder than with Hold=0 (which releases
-        // immediately).
         const int loudSamples = SampleRate / 10;  // 100 ms loud
         const int quietSamples = SampleRate / 10;  // 100 ms quiet tail
         const int total = loudSamples + quietSamples;
@@ -200,7 +184,6 @@ public class GateNodeTests
         noHoldNode.AddInput(new BufferReplayNode(input));
         using var noHoldOut = noHoldNode.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(total / (double)SampleRate)));
 
-        // Probe the last 40 ms of the quiet tail.
         int probeWidth = SampleRate / 25;
         float holdTailDb = PeakDbInWindow(holdOut, total - probeWidth, probeWidth);
         float noHoldTailDb = PeakDbInWindow(noHoldOut, total - probeWidth, probeWidth);
@@ -212,8 +195,6 @@ public class GateNodeTests
     [Test]
     public void Process_GateStateContinuesAcrossChunks()
     {
-        // A gate opened by a previous loud chunk must NOT re-close on a time-contiguous next chunk. The
-        // warmed-open gate's first sample is louder than a fresh gate still ramping open from closed.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
@@ -241,8 +222,6 @@ public class GateNodeTests
     [Test]
     public void Process_NonContiguousTimeRange_ResetsGate()
     {
-        // A non-contiguous start time (a seek) must reset the gate to closed, so the first sample
-        // matches a fresh gate's first sample.
         const int chunkSamples = SampleRate / 10;
         using var loud = CreateConstantBuffer(0.9f, chunkSamples);
 
@@ -337,9 +316,6 @@ public class GateNodeTests
     [Test]
     public void Process_AnimatedThreshold_EngagesAnimatedPath()
     {
-        // Threshold animates from -60 dB (below the -40 dB input → gate open) to -20 dB (above it →
-        // gate closed), so a steady quiet tone goes from passing to attenuated: the late portion is
-        // quieter, proving the animated path runs.
         const int sampleCount = SampleRate / 2;
         using var input = CreateConstantBuffer(0.01f, sampleCount); // ≈-40 dB
 
@@ -371,9 +347,6 @@ public class GateNodeTests
     [Test]
     public void Process_StaticAndAnimatedPaths_ProduceIdenticalOutputForConstantParameters()
     {
-        // ProcessStatic and ProcessAnimated share the same gate helpers, so with a constant Threshold
-        // animation the animated path must match the static path sample-for-sample. A two-phase buffer
-        // exercises both an opening and a releasing transition.
         const int loudSamples = SampleRate / 4;
         const int sampleCount = SampleRate / 2;
         var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
@@ -415,8 +388,6 @@ public class GateNodeTests
     [Test]
     public void Process_InfinityInputSamples_RecoversAndDoesNotLeakNonFiniteOutput()
     {
-        // A +Infinity head sample pollutes the gain follower; the self-recovery clamp and the output
-        // sanitizer must keep any NaN/Infinity from escaping downstream.
         const int sampleCount = SampleRate / 4;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
         for (int ch = 0; ch < input.ChannelCount; ch++)
@@ -473,9 +444,6 @@ public class GateNodeTests
     [TestCase(AnimatedParam.Range)]
     public void Process_AnimatedNonFiniteValue_FallsBackWithoutMuting(AnimatedParam param)
     {
-        // A NaN keyframe on any animated parameter must fall back to its static CurrentValue rather
-        // than reach the gate math and mute the output. A loud above-threshold signal should keep
-        // passing.
         const int sampleCount = SampleRate / 4;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
 
@@ -529,8 +497,6 @@ public class GateNodeTests
     [Test]
     public void Process_MonoBuffer_GatesCorrectly()
     {
-        // A single-channel buffer must gate with no off-by-one: above-threshold passes, below-threshold
-        // is attenuated.
         const int sampleCount = SampleRate / 2;
         using var loud = CreateConstantBuffer(0.9f, sampleCount, channels: 1);
         var loudNode = CreateNode();
@@ -611,8 +577,6 @@ public class GateNodeTests
     [Test]
     public void Process_AnimatedPath_SmoothAcrossChunkBoundary()
     {
-        // ProcessAnimated walks the input in fixed-size chunks. A steady loud input must show no
-        // discontinuity at chunk boundaries — a jump there would mean the gate was reset at a boundary.
         const int chunkSize = 1024;
         const int sampleCount = chunkSize * 3 + 137;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
@@ -648,10 +612,6 @@ public class GateNodeTests
     [Test]
     public void Process_RangeZero_IsExactIdentity()
     {
-        // Range=0 disables gating, so output must equal input sample-for-sample — no startup attack
-        // ramp and no asymptotic sub-unity gain from the envelope follower. The buffer includes the
-        // initial samples (which would otherwise ramp up from the closed floor) and a below-threshold
-        // region (which a real gate would attenuate), so any residual smoothing would show up.
         const int loudSamples = SampleRate / 4;
         const int sampleCount = SampleRate / 2;
         using var input = MakeTwoPhaseBuffer(0.9f, 0.003f, loudSamples, sampleCount);
@@ -675,9 +635,6 @@ public class GateNodeTests
     [Test]
     public void Process_OneChannelNaN_GatesFromValidChannel()
     {
-        // A NaN in one channel must not poison linked-stereo peak detection: a loud, above-threshold
-        // valid channel must still open the gate and pass through, rather than the gate closing
-        // because Abs(NaN) contaminated the peak. All output stays finite (the NaN channel is zeroed).
         const int sampleCount = SampleRate / 2;
         using var input = CreateBuffer(2, sampleCount, (ch, _) => ch == 0 ? float.NaN : 0.9f);
         var node = CreateNode();
@@ -710,10 +667,6 @@ public class GateNodeTests
     [Test]
     public void Process_MinThreshold_DigitalSilenceDoesNotOpenGate()
     {
-        // At the -100 dB minimum Threshold, digital silence (sample 0 = -inf dB) must still leave the
-        // gate closed. If silence wrongly opened it, the following loud region would already be open
-        // and pass at unity immediately; with the gate correctly closed it ramps open (attack), so the
-        // loud onset starts heavily attenuated.
         const int silenceSamples = SampleRate / 5; // 200 ms
         const int sampleCount = SampleRate / 2;
         using var input = CreateBuffer(1, sampleCount, (_, i) => i < silenceSamples ? 0f : 0.9f);
@@ -722,8 +675,6 @@ public class GateNodeTests
 
         using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
 
-        // First 1 ms of the loud region: a correctly-closed gate is only starting to open, so the peak
-        // there is far below unity. A gate wrongly opened during silence would already sit near 0.9.
         int probeWidth = SampleRate / 1000;
         float onsetPeakDb = PeakDbInWindow(output, silenceSamples, probeWidth);
         Assert.That(onsetPeakDb, Is.LessThan(-20f),
@@ -733,10 +684,6 @@ public class GateNodeTests
     [Test]
     public void Process_BelowThresholdLeadIn_StartsAtRangeFloorNotFullMute()
     {
-        // A below-threshold lead-in must rest at the user's Range floor from the very first sample, not
-        // fade in from the -100 dB reset sentinel. With a shallow Range (-20 dB) and a slow attack the
-        // buggy code seeded the follower near -100 dB and only ramped up toward -20, over-attenuating
-        // the opening; the first sample's gain should already sit at the -20 dB floor.
         const int sampleCount = SampleRate / 10;
         const float rangeDb = -20f;
         const float amplitude = 0.01f; // ≈-40 dB, below the -30 dB threshold
@@ -756,16 +703,9 @@ public class GateNodeTests
     [TestCase(1L)]
     public void Process_OneTickBoundaryRounding_DoesNotResetGate(long tickOffset)
     {
-        // Adjacent sample-boundary chunks can differ by one tick from independent TimeSpan rounding. A
-        // one-tick gap or overlap must NOT be treated as a seek: the warmed-open gate must continue (its
-        // first sample stays loud) rather than reset to closed like a fresh gate. The tolerance is
-        // symmetric, so both directions are covered; buggy exact-equality would reset either way,
-        // dropping the continuing gate's first sample to the fresh gate's value.
         const int chunkSamples = SampleRate / 10;
         var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
         var ctx1 = CreateContext(TimeSpan.Zero, chunkDuration);
-        // Second chunk starts one tick before (-1) or after (+1) the exact previous end — either side is
-        // within the rounding tolerance and must not reset.
         var ctx2 = CreateContext(chunkDuration + TimeSpan.FromTicks(tickOffset), chunkDuration);
 
         var node = CreateNode();
@@ -791,10 +731,6 @@ public class GateNodeTests
     [Test]
     public void Process_Hold_KeepsGateOpenForEveryConfiguredSample()
     {
-        // Hold of N samples must latch the gate open for all N below-threshold samples. Spending the
-        // latch before reading it made the gate release one sample early — and with a hold that converts
-        // to a single sample, immediately. The release is deliberately the fastest allowed (1 ms) so one
-        // sample of release is a large, unambiguous drop rather than a rounding-sized one.
         const int holdSamples = 1;
         const float holdMs = holdSamples * 1000f / SampleRate;
         const int loudSamples = SampleRate / 100;
@@ -806,9 +742,7 @@ public class GateNodeTests
         using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(sampleCount / (double)SampleRate)));
 
         var data = output.GetChannelData(0);
-        // The first below-threshold sample is still inside the hold window, so it passes at (near) unity.
         float heldGain = MathF.Abs(data[loudSamples]) / 0.003f;
-        // The next one is past the window and has begun releasing toward the Range floor.
         float releasedGain = MathF.Abs(data[loudSamples + 1]) / 0.003f;
 
         Assert.That(heldGain, Is.EqualTo(1f).Within(0.01f),
@@ -820,9 +754,6 @@ public class GateNodeTests
     [Test]
     public void Process_InputSampleRateMismatch_Throws()
     {
-        // Coefficients and the hold count are derived from the context sample rate while the output
-        // buffer carries the input's, so a mismatched upstream buffer must be rejected rather than
-        // silently relabelled.
         const int altSampleRate = 44100;
         using var input = CreateConstantBuffer(0.9f, altSampleRate / 10, 2, altSampleRate);
         var node = CreateNode();
@@ -835,10 +766,6 @@ public class GateNodeTests
     [Test]
     public void Process_NonFinitePropertyDefault_FallsBackToDeclaredConstant()
     {
-        // A library user can declare a property whose CurrentValue *and* DefaultValue are both
-        // non-finite. Returning the non-finite default would defeat the range clamp (NaN clamps to NaN)
-        // and collapse the gate to its recovery sentinel, so the declared GateParameters constants must
-        // take over: an above-threshold signal still passes at unity.
         const int sampleCount = SampleRate / 4;
         using var input = CreateConstantBuffer(0.9f, sampleCount);
 
@@ -864,8 +791,6 @@ public class GateNodeTests
             }
         }
 
-        // Defaults are Threshold -40 dB / Range -60 dB, so 0.9 (≈-0.9 dB) is above threshold and the
-        // settled tail must reach unity instead of sitting at the -100 dB recovery sentinel.
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
         Assert.That(steadyPeakDb, Is.EqualTo(PeakDb(input, 0)).Within(1f),
             $"With non-finite property defaults the declared constants must apply, but the tail measured {steadyPeakDb:F2} dB.");

--- a/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Audio/GateNodeTests.cs
@@ -6,6 +6,7 @@ using Beutl.Audio.Graph.Nodes;
 using Beutl.Engine;
 using Beutl.Media;
 
+using static Beutl.Audio.Effects.GateParameters;
 using static Beutl.UnitTests.Engine.Audio.AudioTestBuffers;
 
 namespace Beutl.UnitTests.Engine.Audio;
@@ -44,6 +45,44 @@ public class GateNodeTests
             }
         }
         return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static float ChannelPeakDb(AudioBuffer buffer, int channel, int startSample)
+    {
+        var data = buffer.GetChannelData(channel);
+        float peak = 0f;
+        for (int i = startSample; i < buffer.SampleCount; i++)
+        {
+            float a = MathF.Abs(data[i]);
+            if (a > peak) peak = a;
+        }
+        return peak > 0f ? 20f * MathF.Log10(peak) : -100f;
+    }
+
+    private static AudioBuffer MakeInfinityHeadBuffer(int sampleCount, int sampleRate = SampleRate)
+    {
+        var buffer = CreateConstantBuffer(0.9f, sampleCount, 2, sampleRate);
+        for (int ch = 0; ch < buffer.ChannelCount; ch++)
+        {
+            buffer.GetChannelData(ch)[0] = float.PositiveInfinity;
+        }
+        return buffer;
+    }
+
+    private static float MinGainWhereInputIsAudible(
+        AudioBuffer input, AudioBuffer output, int startSample, float minInputAbs)
+    {
+        var inData = input.GetChannelData(0);
+        var outData = output.GetChannelData(0);
+        float min = float.MaxValue;
+        for (int i = startSample; i < input.SampleCount; i++)
+        {
+            float a = MathF.Abs(inData[i]);
+            if (a < minInputAbs) continue;
+            float gain = MathF.Abs(outData[i]) / a;
+            if (gain < min) min = gain;
+        }
+        return min;
     }
 
     private static GateNode CreateNode(
@@ -794,5 +833,246 @@ public class GateNodeTests
         float steadyPeakDb = PeakDb(output, sampleCount / 2);
         Assert.That(steadyPeakDb, Is.EqualTo(PeakDb(input, 0)).Within(1f),
             $"With non-finite property defaults the declared constants must apply, but the tail measured {steadyPeakDb:F2} dB.");
+    }
+
+    [Test]
+    public void Process_LinkedSurround_OpensEveryChannelFromLoudestChannel()
+    {
+        // Only channel 2 is above the threshold, so a detector that stops at channel 1 closes the gate.
+        const int sampleCount = SampleRate / 2;
+        const int channels = 4;
+        const float loud = 0.9f;
+        const float quiet = 0.0005f; // ≈-66 dB, below the -40 dB threshold
+        float[] amps = [quiet, quiet, loud, quiet];
+        using var input = CreateBuffer(channels, sampleCount, (ch, _) => amps[ch]);
+
+        var node = CreateNode();
+        node.AddInput(new BufferReplayNode(input));
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.5)));
+
+        Assert.That(output.ChannelCount, Is.EqualTo(channels));
+
+        int steadyStart = sampleCount / 2;
+        Assert.That(ChannelPeakDb(output, 2, steadyStart), Is.EqualTo(20f * MathF.Log10(loud)).Within(1f),
+            "The loudest channel must open the gate and pass at unity.");
+
+        float expectedQuietDb = 20f * MathF.Log10(quiet);
+        foreach (int ch in new[] { 0, 1, 3 })
+        {
+            Assert.That(ChannelPeakDb(output, ch, steadyStart), Is.EqualTo(expectedQuietDb).Within(1f),
+                $"Channel {ch} must pass at unity because channel 2 holds the linked gate open.");
+        }
+    }
+
+    [Test]
+    public void Process_StaticAndAnimatedPaths_MatchForSurroundBuffer()
+    {
+        // The >2-channel fallback is written out separately in each path. Only channel 2 crosses the
+        // threshold and every channel carries a distinct level, so a detector or channel mix-up in
+        // either loop diverges here.
+        const int loudSamples = SampleRate / 4;
+        const int sampleCount = SampleRate / 2;
+        const int channels = 4;
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = CreateBuffer(
+            channels, sampleCount,
+            (ch, i) => ch == 2 ? (i < loudSamples ? 0.9f : 0.003f) : 0.0002f * (ch + 1));
+
+        var staticNode = CreateNode(threshold: -40f, attack: 2f, hold: 5f, release: 30f, range: -50f);
+        staticNode.AddInput(new BufferReplayNode(input));
+        using var staticOut = staticNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        var thresholdAnim = new KeyFrameAnimation<float>();
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = TimeSpan.Zero });
+        thresholdAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = -40f, KeyTime = duration });
+        var thresholdProperty = Property.CreateAnimatable(-40f);
+        thresholdProperty.Animation = thresholdAnim;
+
+        var animatedNode = new GateNode
+        {
+            Threshold = thresholdProperty,
+            Attack = Property.CreateAnimatable(2f),
+            Hold = Property.CreateAnimatable(5f),
+            Release = Property.CreateAnimatable(30f),
+            Range = Property.CreateAnimatable(-50f)
+        };
+        animatedNode.AddInput(new BufferReplayNode(input));
+        using var animatedOut = animatedNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        Assert.That(animatedOut.ChannelCount, Is.EqualTo(channels));
+        for (int ch = 0; ch < channels; ch++)
+        {
+            var s = staticOut.GetChannelData(ch);
+            var a = animatedOut.GetChannelData(ch);
+            for (int i = 0; i < sampleCount; i++)
+            {
+                Assert.That(a[i], Is.EqualTo(s[i]).Within(1e-4f),
+                    $"Static and animated surround paths diverged at [{ch}][{i}]: static={s[i]}, animated={a[i]}");
+            }
+        }
+    }
+
+    [Test]
+    public void Process_NonFiniteSampleLatch_SurvivesSeekDiscontinuity()
+    {
+        // A seek resets DSP state only; re-arming here would re-log a persistent fault on every scrub.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var node = CreateNode();
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new BufferReplayNode(first));
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1),
+            "The first non-finite sample must emit exactly one warning.");
+
+        node.ClearInputs();
+        using var second = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new BufferReplayNode(second));
+        using var seekedOut = node.Process(CreateContext(TimeSpan.FromSeconds(5.0), chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1),
+            "A seek discontinuity must not re-arm the latch, so no second warning should be emitted.");
+    }
+
+    [Test]
+    public void Process_NonFiniteSampleLatch_ReArmsOnSampleRateChange()
+    {
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var node = CreateNode();
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new BufferReplayNode(first));
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1));
+
+        node.ClearInputs();
+        const int altSampleRate = 44100;
+        using var second = MakeInfinityHeadBuffer(altSampleRate / 10, altSampleRate);
+        node.AddInput(new BufferReplayNode(second));
+        using var secondOut = node.Process(new AudioProcessContext(
+            new TimeRange(chunkDuration, TimeSpan.FromSeconds(0.1)),
+            altSampleRate, new AnimationSampler(), null));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(2),
+            "A sample-rate change is a session boundary, so the recurring fault must warn again.");
+    }
+
+    [Test]
+    public void Reset_ReArmsNonFiniteSampleLatch()
+    {
+        // The second chunk stays time-contiguous so only the explicit Reset() can re-arm the latch.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+        var node = CreateNode();
+
+        using var first = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new BufferReplayNode(first));
+        using var firstOut = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(1));
+
+        node.Reset();
+        node.ClearInputs();
+        using var second = MakeInfinityHeadBuffer(chunkSamples);
+        node.AddInput(new BufferReplayNode(second));
+        using var secondOut = node.Process(CreateContext(chunkDuration, chunkDuration));
+        Assert.That(node.NonFiniteSampleWarnings, Is.EqualTo(2),
+            "Explicit Reset() re-arms the latch, so the recurring fault must warn a second time.");
+    }
+
+    [Test]
+    public void Process_AnimatedOutOfRangeParameter_LogsClampWarningOncePerParameter()
+    {
+        // Not zero times (a hidden misconfiguration) and not per sample (audio-thread spam).
+        const int sampleCount = SampleRate / 4;
+        using var input = CreateConstantBuffer(0.9f, sampleCount);
+
+        var attackAnim = new KeyFrameAnimation<float>();
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.Zero });
+        attackAnim.KeyFrames.Add(new KeyFrame<float> { Easing = new LinearEasing(), Value = 1e9f, KeyTime = TimeSpan.FromSeconds(0.25) });
+        var attackProperty = Property.CreateAnimatable(1f);
+        attackProperty.Animation = attackAnim;
+
+        var node = new GateNode
+        {
+            Threshold = Property.CreateAnimatable(-40f),
+            Attack = attackProperty,
+            Hold = Property.CreateAnimatable(10f),
+            Release = Property.CreateAnimatable(50f),
+            Range = Property.CreateAnimatable(-60f)
+        };
+        node.AddInput(new BufferReplayNode(input));
+
+        using var output = node.Process(CreateContext(TimeSpan.Zero, TimeSpan.FromSeconds(0.25)));
+
+        Assert.That(node.ClampWarnings, Is.EqualTo(1),
+            "An out-of-range animated Attack must warn exactly once for the whole chunk.");
+    }
+
+    [Test]
+    public void Process_EmptyChunkWithDuration_DoesNotMaskLaterDiscontinuity()
+    {
+        // A chunk that spans time but carries no samples leaves a hole; the chunk after it is not
+        // contiguous with the chunk before it.
+        const int chunkSamples = SampleRate / 10;
+        var chunkDuration = TimeSpan.FromSeconds(chunkSamples / (double)SampleRate);
+
+        var node = CreateNode();
+        using var warmupInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(warmupInput));
+        using var warmup = node.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+
+        node.ClearInputs();
+        using var emptyInput = new AudioBuffer(SampleRate, 2, 0);
+        node.AddInput(new BufferReplayNode(emptyInput));
+        using var emptyOutput = node.Process(CreateContext(chunkDuration, chunkDuration));
+        Assert.That(emptyOutput.SampleCount, Is.EqualTo(0));
+
+        node.ClearInputs();
+        using var afterHoleInput = CreateConstantBuffer(0.9f, chunkSamples);
+        node.AddInput(new BufferReplayNode(afterHoleInput));
+        using var afterHoleOutput = node.Process(CreateContext(chunkDuration + chunkDuration, chunkDuration));
+
+        var nodeFresh = CreateNode();
+        using var freshInput = CreateConstantBuffer(0.9f, chunkSamples);
+        nodeFresh.AddInput(new BufferReplayNode(freshInput));
+        using var freshOutput = nodeFresh.Process(CreateContext(TimeSpan.Zero, chunkDuration));
+
+        Assert.That(
+            MathF.Abs(afterHoleOutput.GetChannelData(0)[0]),
+            Is.EqualTo(MathF.Abs(freshOutput.GetChannelData(0)[0])).Within(1e-4f),
+            "The chunk after an empty-but-timed chunk must start from a reset gate, not the warmed-open one.");
+    }
+
+    [Test]
+    public void Process_ZeroHold_ModulatesLowFrequencyGainAcrossZeroCrossings()
+    {
+        // Characterizes the unsmoothed peak detector: Hold bridges a waveform's zero crossings, so at
+        // Hold = 0 with the fastest Release a tone that never leaves the open region still pumps.
+        const int sampleCount = SampleRate / 4;
+        const float amplitude = 0.1f; // ≈-20 dB, well above the -40 dB threshold
+        const float thresholdLinear = 0.01f; // the -40 dB threshold in linear terms
+        var duration = TimeSpan.FromSeconds(sampleCount / (double)SampleRate);
+        using var input = CreateSineBuffer(amplitude, 50f, sampleCount, channels: 1);
+
+        var fastNode = CreateNode(threshold: -40f, attack: 0.1f, hold: MinHoldMs, release: MinReleaseMs, range: -60f);
+        fastNode.AddInput(new BufferReplayNode(input));
+        using var fastOut = fastNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        var defaultNode = CreateNode(
+            threshold: DefaultThresholdDb, attack: DefaultAttackMs, hold: DefaultHoldMs,
+            release: DefaultReleaseMs, range: DefaultRangeDb);
+        defaultNode.AddInput(new BufferReplayNode(input));
+        using var defaultOut = defaultNode.Process(CreateContext(TimeSpan.Zero, duration));
+
+        int steadyStart = sampleCount / 2;
+        float fastMinGain = MinGainWhereInputIsAudible(input, fastOut, steadyStart, thresholdLinear);
+        float defaultMinGain = MinGainWhereInputIsAudible(input, defaultOut, steadyStart, thresholdLinear);
+
+        Assert.That(fastMinGain, Is.LessThan(0.2f),
+            $"Hold=0 with the fastest Release is expected to pump the gain near zero crossings, but the " +
+            $"minimum gain was {fastMinGain:F4} — if this rose, detector smoothing changed.");
+        Assert.That(defaultMinGain, Is.GreaterThan(0.99f),
+            $"The default Hold/Release must hold the gate fully open across zero crossings, but the " +
+            $"minimum gain was {defaultMinGain:F4}.");
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Gate** (noise gate) audio effect, completing the dynamics-processing set alongside the already-merged Compressor (#1724) and Limiter (#1725), then unifies the scaffolding the dynamics nodes had been duplicating:

- **`GateEffect`** (new, `Beutl.Engine.Audio.Effects`) — animatable `Threshold` / `Attack` / `Hold` / `Release` / `Range` properties, following the `CompressorEffect` surface pattern (`ScanProperties`, `[Range]`/`[Display]` attributes, `CreateNode` via `AddNode` + `Connect`).
- **`GateNode`** (new, `Beutl.Engine.Audio.Graph.Nodes`) — per-sample DSP: static/animated paths sharing one gate-gain helper, linked peak detection across all channels, hold-timer latching, one-pole dB-domain attack/release, `Range = 0` as an exact identity, and a below-threshold lead-in seeded at the Range floor.
- **`GateParameters`** (internal) — shared ranges/defaults, same convention as `CompressorParameters`/`LimiterParameters`.
- **`DynamicsNode`** (new, public abstract) — the scaffolding `CompressorNode` and `GateNode` each carried a copy of: chunk validation, session/seek state resets, the per-channel buffer view cache, parameter sanitization and the warn-once diagnostics. Each node now supplies only its parameter set and gain math. Net −82 lines of production code.
- **`AudioProcessContext.ContinuesFrom`** (new) — single home for the chunk-contiguity check, replacing three copies of the same one-tick tolerance and fixing two nodes that did not have it (see below).
- `LibraryRegistrar` registration + EN/JA display strings, so Gate appears in the audio-effect add menu (parameter UI is auto-generated by `AudioEffectEditor`).

`LimiterNode` deliberately does **not** derive from `DynamicsNode`: its lookahead delay lines and per-parameter error-severity diagnostics (`ref bool` latches, per-parameter fallbacks) are a different contract, not a variation of this one. It does share `ContinuesFrom`.

### Fixes to existing nodes

Pulled in because the shared base and the shared contiguity check made the divergences visible:

- **`DelayNode` / `EqualizerNode`** compared chunk timestamps exactly while Gate, Compressor and Limiter tolerate the one-tick difference independent `TimeSpan` rounding can put between adjacent sample boundaries. In a chain mixing them, one scrub dropped the delay lines and the biquad state while the dynamics nodes kept theirs — an audible click from a rounding artifact rather than a seek.
- **`CompressorNode`** gains four behaviours from the shared base: it rejects a sample-rate mismatch, tolerates one-tick boundary rounding, falls back to the declared constant when a property's default is itself non-finite, and no longer lets an empty chunk mask a later discontinuity.
- **`GateNode`**: an empty chunk (spans time, carries no samples) advanced `_lastTimeRangeEnd`, so the chunk after a hole looked contiguous with the chunk before it and inherited stale gate state.

### Known behaviour, deliberately unchanged

Peak detection is unsmoothed, so `Hold` is what bridges a waveform's zero crossings. At `Hold = 0` with the fastest `Release`, a low-frequency tone that never leaves the open region still pumps (50 Hz: minimum gain 0.069; the defaults measure 1.000). Real gates behave the same way at those settings, and smoothing the detector would need a time constant that duplicates `Hold`'s role — so the behaviour stays and is pinned by a characterization test plus a comment on `MinHoldMs`.

### Board-item scope note

The board item's 現状把握 predates #1724/#1725: Compressor and Limiter are already on `main` with full tests, so only Gate remained in the dynamics family. **NoiseSuppression (SpectralGate)** is a distinct FFT/STFT architecture that the item body itself splits into a separate phase; it is intentionally not part of this PR (no TODO markers left in code — the phase boundary is documented here and in the commit body). Future naming is collision-free (`SpectralGate*` vs `Gate*`).

## Breaking changes

`Beutl.Engine`:

- `CompressorNode` and `GateNode` now derive from the new public abstract `DynamicsNode` rather than directly from `AudioNode`. Treating them as `AudioNode` is unaffected; `Reset`, the channel-view cache and the parameter sanitizers now live on the base.
- `CompressorNode` throws `InvalidOperationException` when the upstream buffer's sample rate does not match the context's. It previously processed the buffer and mislabelled its samples. `GateNode` and `LimiterNode` already rejected this.

Plugin authors gain `DynamicsNode` as an extension point: deriving from it provides chunk validation, seek/session resets, the per-channel view cache and the warn-once parameter diagnostics without reimplementing them.

## Tests

- `GateNodeTests` + `GateEffectTests` — 51 tests: silence input, threshold open/close, attack time constant, hold latching down to a single sample, Range floor and exact `Range = 0` identity, chunk-boundary continuity, seek/sample-rate resets, mono and 4-channel linked gating, static-vs-animated equivalence (stereo and surround), non-finite input and parameter sanitization, diagnostic latch re-arm semantics, and the zero-hold characterization above.
- `CompressorNodeTests` +5, `AudioProcessContextTests` +6, `DelayNodeTests` +2, and a new `EqualizerNodeTests` fixture (+3) covering the behaviours listed under "Fixes to existing nodes". `EqualizerNode` had no test fixture before this PR.
- Every one-tick test was verified to actually fail when the tolerance is set to 0 (11 tests across all five stateful nodes), and the surround and empty-chunk tests were verified against deliberately broken code. Two of them were rewritten after that check showed they passed regardless: the surround static/animated comparison needed per-channel levels where only one channel crosses the threshold, and the Delay test needed a time-independent input because `RampInputNode` derives its samples from the chunk start time (at the fixture's 100 Hz, one tick of offset shifts the ramp by a whole sample).
- `Engine.Audio`: 267 passed / 0 failed. Full `Beutl.UnitTests`: 3928 passed / 0 failed.
- Local gates: `dotnet build Beutl.slnx` 0 errors; `dotnet format --verify-no-changes` clean; UTF-8 BOM on all new `.cs` files.

## Review

- Pre-PR design review: **approve** (pass 1, zero rework findings) — pattern-consistent with Compressor/Limiter, orthogonal property vocabulary.
- That review noted, as out of scope, that the dynamics nodes shared duplicated scaffolding that could someday become a joint `DynamicsNode` refactor. A follow-up review of this branch raised the same duplication plus five smaller findings (untested >2-channel paths, test-only counters with no test, unreachable defensive code, the empty-chunk ordering, and the unsmoothed detector); all six are addressed here.

## Manual verification

1. Real-time playback: gate an intermittent-speech clip, confirm no clicks at open/close transitions across buffer boundaries.
2. Export parity with preview (same `GateNode` drives both).
3. Scrub a chain that mixes Gate/Compressor with Delay/Equalizer and confirm no click at chunk boundaries (the contiguity fix above).
4. Undo/redo of parameter edits (CoreProperty-based).
5. "Gate" appears in the audio-effect add menu with correct EN/JA labels.

Refs: Project #9 board item「オーディオエフェクト拡充 (Compressor / Limiter / NoiseSuppression)」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new audio **Gate** effect with animatable **Threshold, Attack, Hold, Release,** and **Range** controls.
  * Added localized UI labels and descriptions for gate parameters (including Japanese) and included the effect in the audio effect library.
* **Bug Fixes**
  * Improved gate stability and continuity across renders, chunk boundaries, and sample-rate changes.
  * Enhanced handling for digital silence, non-finite values, and exact **Range = 0** passthrough.
* **Tests**
  * Added unit tests covering effect/node wiring, default values, and both static and animated processing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
