### PR TITLE
Fix FFmpegReader ignoring AVFrame linesize, causing diagonal display for non-16-multiple widths

### DIFF
--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -291,8 +291,8 @@ public sealed class FFmpegReader : MediaReader
             for (int y = 0; y < height; y++)
             {
                 Buffer.MemoryCopy(
-                    (void*)(filterFrame.Data[0] + y * srcRowBytes),
-                    (void*)((byte*)bmp.Data + y * dstRowBytes),
+                    (void*)(filterFrame.Data[0] + (long)y * srcRowBytes),
+                    (void*)((byte*)bmp.Data + (long)y * dstRowBytes),
                     dstRowBytes,
                     dstRowBytes);
             }
@@ -346,7 +346,7 @@ public sealed class FFmpegReader : MediaReader
             int dstRowBytes = width * bytesPerPixel;
             for (int y = 0; y < height; y++)
             {
-                new ReadOnlySpan<byte>((void*)(filterFrame.Data[0] + y * srcRowBytes), dstRowBytes)
+                new ReadOnlySpan<byte>((void*)(filterFrame.Data[0] + (long)y * srcRowBytes), dstRowBytes)
                     .CopyTo(destination.Slice(y * dstRowBytes));
             }
             return true;

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -286,8 +286,16 @@ public sealed class FFmpegReader : MediaReader
 
         try
         {
-            int byteCount = width * height * bytesPerPixel;
-            Buffer.MemoryCopy(filterFrame.Data[0], (void*)bmp.Data, byteCount, byteCount);
+            int srcRowBytes = filterFrame.Linesize[0];
+            int dstRowBytes = width * bytesPerPixel;
+            for (int y = 0; y < height; y++)
+            {
+                Buffer.MemoryCopy(
+                    (void*)(filterFrame.Data[0] + y * srcRowBytes),
+                    (void*)((byte*)bmp.Data + y * dstRowBytes),
+                    dstRowBytes,
+                    dstRowBytes);
+            }
         }
         catch
         {
@@ -334,7 +342,13 @@ public sealed class FFmpegReader : MediaReader
             if (byteCount > destination.Length)
                 return false;
 
-            new ReadOnlySpan<byte>(filterFrame.Data[0], byteCount).CopyTo(destination);
+            int srcRowBytes = filterFrame.Linesize[0];
+            int dstRowBytes = width * bytesPerPixel;
+            for (int y = 0; y < height; y++)
+            {
+                new ReadOnlySpan<byte>((void*)(filterFrame.Data[0] + y * srcRowBytes), dstRowBytes)
+                    .CopyTo(destination.Slice(y * dstRowBytes));
+            }
             return true;
         }
         finally


### PR DESCRIPTION
Fixes #2073

## What

`ReadVideo` was copying frame data with a flat `Buffer.MemoryCopy` using `width * height * bytesPerPixel`, ignoring `AVFrame->linesize[0]`. FFmpeg pads each row to a 64-byte boundary, so `linesize[0]` is often larger than `width * bytesPerPixel`. The per-row offset error accumulates, producing a diagonal/sheared image.

## Fix

Copy row by row, advancing the source pointer by `linesize[0]` per row. Both the `Bitmap` and `Span` overloads of `ReadVideo` are fixed.

## Reproduction

Any video whose width is not a multiple of 16 (e.g. 1080px, 1752px) triggers the bug. Resizing to a multiple of 16 (e.g. 1088px) avoids it because `linesize[0]` then equals `width * bytesPerPixel` with no padding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of decoded video frames with row padding/stride by copying pixel data row-by-row.
  * Fixed bitmap and buffer outputs to respect source row byte layout and destination row layout, preventing corrupted, incomplete, or misaligned frames in cases where frames are not tightly packed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->