### PR TITLE
fix: keep a lone dock tab visible on :singleitem

### DIFF
--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -4,6 +4,15 @@
         xmlns:core="using:Dock.Model.Core"
         xmlns:dmc="using:Dock.Model.Controls">
     <Styles.Resources>
+        <!--  The default Fluent theme hides PART_ItemsPresenter on :singleitem; keep the lone tab visible so it can be dragged to another zone.  -->
+        <ControlTheme x:Key="{x:Type ToolTabStrip}"
+                      BasedOn="{StaticResource {x:Type ToolTabStrip}}"
+                      TargetType="ToolTabStrip">
+            <Style Selector="^:singleitem /template/ ItemsPresenter#PART_ItemsPresenter">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </ControlTheme>
+
         <ControlTheme x:Key="{x:Type ToolControl}"
                       x:DataType="dmc:IToolDock"
                       TargetType="ToolControl">
@@ -141,11 +150,6 @@
         <Style Selector="^:pointerover /template/ Border#PART_Border">
             <Setter Property="IsVisible" Value="True" />
         </Style>
-    </Style>
-
-    <!--  Always show the single tab so users can drag it to another zone.  -->
-    <Style Selector="ToolTabStrip:singleitem /template/ ItemsPresenter#PART_ItemsPresenter">
-        <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <!--  Tab item states: only Foreground + BorderBrush change between states  -->


### PR DESCRIPTION
## Description
- A tool dock holding a single tab hid its tab because the default Dock Fluent theme collapses PART_ItemsPresenter on :singleitem, leaving no draggable handle (Beutl also hides the ToolChrome grip on docked tools).
- The previous app-level `<Style>` override did not win in the running app. This re-shows the lone tab from the same theme tier by extending the ToolTabStrip control theme via `BasedOn`, which resolves reliably (verified under the Avalonia XAML compiler).
- Removes the superseded app-level override.

## Affected areas
- [x] UI (Beutl.Editor, Beutl.Editor.Components, Beutl.Controls)

## Breaking changes
None

## Test plan
- Pure theme-tier XAML override (no C# logic).
- Verified in-app: single-tab zones and drag-split-created single-tool docks now show the tab (user-confirmed).
- Cross-checked with a faithful headless reproduction of BeutlDockFactory's layout (nested ProportionalDock, GripMode.Hidden, split layouts, 2→1 dynamic transition) + full FluentAvalonia/Dock theme stack.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dock tab bar so a single tab stays visible and can still be dragged as expected.
  * Updated the tab display behavior to be more consistent with the app’s overall theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->