### PR TITLE
test(Animation): fix relative-animation clock test

### DIFF
--- a/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
@@ -1,6 +1,5 @@
 ﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
-using Beutl.Collections;
 using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Engine.Expressions;
@@ -11,23 +10,18 @@ namespace Beutl.UnitTests.Engine;
 [TestFixture]
 public class AnimatablePropertyTests
 {
-    private sealed class TestHierarchicalRoot : Hierarchical, IHierarchicalRoot, IModifiableHierarchical
+    // A non-EngineObject root: an EngineObject root would hijack the owner's time-anchor subscription.
+    private sealed class TestHierarchicalRoot : Hierarchical, IHierarchicalRoot
     {
-        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
-
         public event EventHandler<IHierarchical>? DescendantAttached;
 
         public event EventHandler<IHierarchical>? DescendantDetached;
 
         public void OnDescendantAttached(IHierarchical descendant)
-        {
-            DescendantAttached?.Invoke(this, descendant);
-        }
+            => DescendantAttached?.Invoke(this, descendant);
 
         public void OnDescendantDetached(IHierarchical descendant)
-        {
-            DescendantDetached?.Invoke(this, descendant);
-        }
+            => DescendantDetached?.Invoke(this, descendant);
     }
 
     private static AnimatableProperty<T> Make<T>(T defaultValue, string name = "Value")
@@ -169,7 +163,7 @@ public class AnimatablePropertyTests
         element.AddObject(owner);
         // Attaching to a root caches the parent reference the local clock anchors to.
         var root = new TestHierarchicalRoot();
-        root.HierarchicalChildren.Add(element);
+        ((IModifiableHierarchical)root).AddChild(element);
 
         int midpoint = property.GetValue(new CompositionContext(TimeSpan.FromSeconds(5.5)));
 

--- a/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
+++ b/tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs
@@ -1,5 +1,6 @@
 ﻿using Beutl.Animation;
 using Beutl.Animation.Easings;
+using Beutl.Collections;
 using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Engine.Expressions;
@@ -10,6 +11,25 @@ namespace Beutl.UnitTests.Engine;
 [TestFixture]
 public class AnimatablePropertyTests
 {
+    private sealed class TestHierarchicalRoot : Hierarchical, IHierarchicalRoot, IModifiableHierarchical
+    {
+        public new ICoreList<IHierarchical> HierarchicalChildren => base.HierarchicalChildren;
+
+        public event EventHandler<IHierarchical>? DescendantAttached;
+
+        public event EventHandler<IHierarchical>? DescendantDetached;
+
+        public void OnDescendantAttached(IHierarchical descendant)
+        {
+            DescendantAttached?.Invoke(this, descendant);
+        }
+
+        public void OnDescendantDetached(IHierarchical descendant)
+        {
+            DescendantDetached?.Invoke(this, descendant);
+        }
+    }
+
     private static AnimatableProperty<T> Make<T>(T defaultValue, string name = "Value")
     {
         var property = new AnimatableProperty<T>(defaultValue);
@@ -135,7 +155,7 @@ public class AnimatablePropertyTests
     }
 
     [Test]
-    public void GetValue_WithRelativeAnimation_UsesLogicalParentTimeRangeWithoutRootAttachment()
+    public void GetValue_WithRelativeAnimation_UsesLogicalParentTimeRange()
     {
         var owner = new TestEngineObjectForProperty();
         var property = Make(0);
@@ -147,6 +167,9 @@ public class AnimatablePropertyTests
             Length = TimeSpan.FromSeconds(2)
         };
         element.AddObject(owner);
+        // Attaching to a root caches the parent reference the local clock anchors to.
+        var root = new TestHierarchicalRoot();
+        root.HierarchicalChildren.Add(element);
 
         int midpoint = property.GetValue(new CompositionContext(TimeSpan.FromSeconds(5.5)));
 


### PR DESCRIPTION
## Description
- Fixes the CI Test failure in `AnimatablePropertyTests` introduced when `KeyFrameAnimation<T>.GetAnimatedValue` switched (959253da4) to the parent reference cached on hierarchy attach.
- The relative-animation test assumed a rootless graph, but the cached `_parent` is only set under an `IHierarchicalRoot`, so the local clock no longer anchored to the parent TimeRange and the value read 0 instead of 50.
- Aligns the test with the cached-parent design: adds a minimal `IHierarchicalRoot` and attaches the element to it so the parent reference is cached; renames the test accordingly.

## Affected areas
- [x] Build / CI / docs only

## Breaking changes
None

## Test plan
- Updated `tests/Beutl.UnitTests/Engine/AnimatablePropertyTests.cs`; `AnimatablePropertyTests` passes (14/14).

## Fixed issues / References
- Fixes the Test job failure in Actions run 29001306102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an animation-related unit test to use a hierarchical root attachment during setup.
  * Renamed a test for clearer coverage of relative animation behavior.
  * Added a small test helper to support hierarchical child attachment and descendant change hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->