### PR TITLE
refactor: Migrate SymbolIcon to FluentIcons FluentIcon

### DIFF
--- a/src/Beutl.Controls/ColorPicker/ColorPickerButtonStyles.axaml
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerButtonStyles.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:media="clr-namespace:FluentAvalonia.UI.Media;assembly=FluentAvalonia"
                     xmlns:sys="clr-namespace:System;assembly=netstandard"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
 
@@ -35,11 +36,11 @@
                                 BorderThickness="1"
                                 CornerRadius="{TemplateBinding CornerRadius}" />
 
-                        <ui:SymbolIcon Grid.Column="1"
-                                       Margin="4,6,8,6"
-                                       HorizontalAlignment="Right"
-                                       FontSize="18"
-                                       Symbol="ChevronDown" />
+                        <icons:FluentIcon Grid.Column="1"
+                                          Margin="4,6,8,6"
+                                          HorizontalAlignment="Right"
+                                          FontSize="18"
+                                          Icon="ChevronDown" />
                     </Grid>
                 </Button>
             </ControlTemplate>

--- a/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
@@ -4,6 +4,7 @@
                     xmlns:conv="using:FluentAvalonia.Converters"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:sty="using:FluentAvalonia.Styling"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
                     xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     x:CompileBindings="True">
@@ -571,10 +572,10 @@
                                                                   Mode=TwoWay}"
                                       IsVisible="{TemplateBinding IsMoreButtonVisible}"
                                       Theme="{StaticResource ColorPickerMoreButtonStyle}">
-                            <ui:SymbolIcon Name="MoreButtonIcon"
-                                           VerticalAlignment="Center"
-                                           FontSize="20"
-                                           Symbol="ChevronLeft" />
+                            <icons:FluentIcon Name="MoreButtonIcon"
+                                              VerticalAlignment="Center"
+                                              FontSize="20"
+                                              Icon="ChevronLeft" />
                         </ToggleButton>
 
                         <StackPanel Name="TextEntryArea"
@@ -916,7 +917,7 @@
                 </Style>
             </Style>
 
-            <Style Selector="^ /template/ ui|SymbolIcon#MoreButtonIcon">
+            <Style Selector="^ /template/ icons|FluentIcon#MoreButtonIcon">
                 <Setter Property="RenderTransform" Value="rotate(180deg)" />
             </Style>
         </Style>

--- a/src/Beutl.Controls/DirectoryTreeView.cs
+++ b/src/Beutl.Controls/DirectoryTreeView.cs
@@ -14,6 +14,9 @@ using Beutl.Language;
 
 using FluentAvalonia.UI.Controls;
 
+using FluentIcon = FluentIcons.Avalonia.Fluent.FluentIcon;
+using Icon = FluentIcons.Common.Icon;
+
 namespace Beutl.Controls;
 
 public sealed class DirectoryTreeView : TreeView
@@ -48,45 +51,45 @@ public sealed class DirectoryTreeView : TreeView
         _open = new MenuItem
         {
             Header = Strings.Open,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Open,
+                Icon = Icon.Open,
                 FontSize = 20,
             }
         };
         _copy = new MenuItem
         {
             Header = Strings.Copy,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Copy,
+                Icon = Icon.Copy,
                 FontSize = 20,
             }
         };
         _remove = new MenuItem
         {
             Header = Strings.Remove,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Delete,
+                Icon = Icon.Delete,
                 FontSize = 20,
             }
         };
         _rename = new MenuItem
         {
             Header = Strings.Rename,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Rename,
+                Icon = Icon.Rename,
                 FontSize = 20,
             }
         };
         _addfolder = new MenuItem
         {
             Header = Strings.NewFolder,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Folder,
+                Icon = Icon.Folder,
                 FontSize = 20,
             }
         };

--- a/src/Beutl.Controls/NavItemHelper.cs
+++ b/src/Beutl.Controls/NavItemHelper.cs
@@ -4,6 +4,8 @@ using Avalonia.Xaml.Interactivity;
 
 using FluentAvalonia.UI.Controls;
 
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+
 namespace Beutl.Controls;
 
 public class NavItemHelper : Behavior<NavigationViewItem>
@@ -73,7 +75,7 @@ public class NavItemHelper : Behavior<NavigationViewItem>
         {
             fontIcon.FontSize = 48;
         }
-        else if (iconSource is SymbolIconSource symbolIcon)
+        else if (iconSource is FluentIconSource symbolIcon)
         {
             symbolIcon.FontSize = 48;
         }

--- a/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
+++ b/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
@@ -11,14 +11,13 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
-
 using Beutl.Language;
 using Beutl.Reactive;
 using Beutl.Utilities;
-
 using FluentAvalonia.UI.Controls;
-
 using Reactive.Bindings.Extensions;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Controls.PropertyEditors;
 
@@ -378,9 +377,9 @@ public class GradientStopsSlider : TemplatedControl
                 _deleteMenuItem = new MenuFlyoutItem
                 {
                     Text = Strings.Delete,
-                    IconSource = new SymbolIconSource
+                    IconSource = new FluentIconSource
                     {
-                        Symbol = Symbol.Delete
+                        Icon = Icon.Delete
                     }
                 };
                 _deleteMenuItem.Click += (s, e) =>

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -5,6 +5,7 @@
         xmlns:lang="using:Beutl.Language"
         xmlns:local="using:Beutl.Controls"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
         xmlns:ui="using:FluentAvalonia.UI.Controls">
 
     <Styles.Resources>
@@ -167,6 +168,15 @@
 
     <Style Selector="ui|ContentDialog /template/ ContentControl#Title">
         <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+    </Style>
+
+    <Style Selector=":is(icons|FluentIcon)">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="RenderTransform" Value="translateX(-1px)" />
+    </Style>
+    <Style Selector=":is(icons|SymbolIcon)">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="RenderTransform" Value="translateX(-1px)" />
     </Style>
 
     <StyleInclude Source="avares://Beutl.Controls/Styling/NavigationView.axaml" />

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -2,10 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:b="using:Beutl.Controls.Behaviors"
         xmlns:i="using:Avalonia.Xaml.Interactivity"
+        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
         xmlns:lang="using:Beutl.Language"
         xmlns:local="using:Beutl.Controls"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
         xmlns:ui="using:FluentAvalonia.UI.Controls">
 
     <Styles.Resources>
@@ -172,7 +172,6 @@
 
     <Style Selector=":is(icons|FluentIcon)">
         <Setter Property="FontSize" Value="16" />
-        <Setter Property="RenderTransform" Value="translateX(-1px)" />
     </Style>
 
     <StyleInclude Source="avares://Beutl.Controls/Styling/NavigationView.axaml" />

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -174,10 +174,6 @@
         <Setter Property="FontSize" Value="16" />
         <Setter Property="RenderTransform" Value="translateX(-1px)" />
     </Style>
-    <Style Selector=":is(icons|SymbolIcon)">
-        <Setter Property="FontSize" Value="16" />
-        <Setter Property="RenderTransform" Value="translateX(-1px)" />
-    </Style>
 
     <StyleInclude Source="avares://Beutl.Controls/Styling/NavigationView.axaml" />
     <StyleInclude Source="avares://Beutl.Controls/Styling/Placeholder.axaml" />

--- a/src/Beutl.Controls/Styling/FileInputArea.axaml
+++ b/src/Beutl.Controls/Styling/FileInputArea.axaml
@@ -22,12 +22,12 @@
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
                         Background="{TemplateBinding Background}">
                     <Grid ColumnDefinitions="Auto,*">
-                        <icons:SymbolIcon Grid.RowSpan="2"
+                        <icons:FluentIcon Grid.RowSpan="2"
                                           Margin="0,0,24,0"
                                           HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
                                           FontSize="20"
-                                          Symbol="Open" />
+                                          Icon="Open" />
                         <StackPanel Grid.Column="1" Spacing="8">
                             <TextBlock Text="{TemplateBinding Text}" TextWrapping="Wrap" />
                             <TextBlock Name="PART_SelectedFileDisplay" IsVisible="False" />

--- a/src/Beutl.Controls/Styling/NavigationView.axaml
+++ b/src/Beutl.Controls/Styling/NavigationView.axaml
@@ -10,7 +10,7 @@
                 <ui:NavigationView.MenuItems>
                     <ui:NavigationViewItem Classes="SideNavigationViewItem" Content="Home">
                         <ui:NavigationViewItem.IconSource>
-                            <icons:SymbolIconSource Symbol="Home" />
+                            <icons:FluentIconSource Icon="Home" />
                         </ui:NavigationViewItem.IconSource>
                     </ui:NavigationViewItem>
                 </ui:NavigationView.MenuItems>

--- a/src/Beutl.Controls/Styling/OptionsDisplayItem.axaml
+++ b/src/Beutl.Controls/Styling/OptionsDisplayItem.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:Beutl.Controls"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <!--  https://github.com/amwx/FluentAvalonia/blob/master/FluentAvaloniaSamples/Styles/OptionsDisplayItemStyles.axaml  -->
     <Design.PreviewWith>
@@ -96,9 +97,9 @@
                                     VerticalAlignment="Center"
                                     CornerRadius="{DynamicResource ControlCornerRadius}">
 
-                                <ui:SymbolIcon Name="Chevron"
-                                               Margin="4,4"
-                                               FontSize="20" />
+                                <icons:FluentIcon Name="Chevron"
+                                                  Margin="4,4"
+                                                  FontSize="20" />
                             </Border>
                         </Grid>
                     </Border>
@@ -121,7 +122,7 @@
         <Style Selector="^ /template/ Viewbox#IconHost">
             <Setter Property="IsVisible" Value="False" />
         </Style>
-        <Style Selector="^ /template/ ui|SymbolIcon#Chevron">
+        <Style Selector="^ /template/ icons|FluentIcon#Chevron">
             <Setter Property="IsVisible" Value="False" />
         </Style>
         <Style Selector="^ /template/ ContentPresenter#ExpandedContentPresenter">
@@ -146,9 +147,9 @@
         </Style>
 
         <Style Selector="^:navigates">
-            <Style Selector="^ /template/ ui|SymbolIcon#Chevron">
+            <Style Selector="^ /template/ icons|FluentIcon#Chevron">
                 <Setter Property="IsVisible" Value="True" />
-                <Setter Property="Symbol" Value="ChevronRight" />
+                <Setter Property="Icon" Value="ChevronRight" />
             </Style>
         </Style>
 
@@ -157,9 +158,9 @@
         </Style>
 
         <Style Selector="^:expands">
-            <Style Selector="^ /template/ ui|SymbolIcon#Chevron">
+            <Style Selector="^ /template/ icons|FluentIcon#Chevron">
                 <Setter Property="IsVisible" Value="True" />
-                <Setter Property="Symbol" Value="ChevronDown" />
+                <Setter Property="Icon" Value="ChevronDown" />
                 <Setter Property="RenderTransform" Value="rotate(0deg)" />
                 <Setter Property="Transitions">
                     <Transitions>
@@ -170,8 +171,8 @@
         </Style>
 
         <Style Selector="^:expanded">
-            <Style Selector="^ /template/ ui|SymbolIcon#Chevron">
-                <!--<Setter Property="Symbol" Value="ChevronUp" />-->
+            <Style Selector="^ /template/ icons|FluentIcon#Chevron">
+                <!--<Setter Property="Icon" Value="ChevronUp" />-->
                 <Setter Property="RenderTransform" Value="rotate(180deg)" />
             </Style>
             <Style Selector="^ /template/ ContentPresenter#ExpandedContentPresenter">

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -31,7 +31,7 @@
 
                     <Grid Grid.Row="1" RowDefinitions="Auto,Auto">
                         <Grid.Styles>
-                            <Style Selector="icons|SymbolIcon">
+                            <Style Selector="icons|FluentIcon">
                                 <Setter Property="FontSize" Value="20" />
                             </Style>
                             <Style Selector="TextBox.invalid">
@@ -118,13 +118,13 @@
                             <Button Name="PART_StartButton"
                                     Grid.Column="1"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Previous" />
+                                <icons:FluentIcon Icon="Previous" />
                             </Button>
 
                             <RepeatButton Name="PART_PreviousButton"
                                           Grid.Column="2"
                                           Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Rewind" />
+                                <icons:FluentIcon Icon="Rewind" />
                             </RepeatButton>
 
                             <ToggleButton Name="PART_PlayButton"
@@ -135,14 +135,14 @@
                                     <Style Selector="ToggleButton">
                                         <Setter Property="Content">
                                             <Template>
-                                                <icons:SymbolIcon Symbol="Play" />
+                                                <icons:FluentIcon Icon="Play" />
                                             </Template>
                                         </Setter>
                                     </Style>
                                     <Style Selector="ToggleButton:checked">
                                         <Setter Property="Content">
                                             <Template>
-                                                <icons:SymbolIcon Symbol="Pause" />
+                                                <icons:FluentIcon Icon="Pause" />
                                             </Template>
                                         </Setter>
                                     </Style>
@@ -152,13 +152,13 @@
                             <RepeatButton Name="PART_NextButton"
                                           Grid.Column="4"
                                           Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="FastForward" />
+                                <icons:FluentIcon Icon="FastForward" />
                             </RepeatButton>
 
                             <Button Name="PART_EndButton"
                                     Grid.Column="5"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Next" />
+                                <icons:FluentIcon Icon="Next" />
                             </Button>
 
                             <ToggleButton Name="PART_LoopButton"
@@ -166,7 +166,7 @@
                                           IsChecked="{TemplateBinding IsLoopEnabled, Mode=TwoWay}"
                                           Theme="{StaticResource TransparentToggleButton}"
                                           ToolTip.Tip="Loop">
-                                <icons:SymbolIcon Symbol="ArrowRepeat1" />
+                                <icons:FluentIcon Icon="ArrowRepeat1" />
                             </ToggleButton>
                         </StackPanel>
                     </Grid>

--- a/src/Beutl.Controls/Styling/PropertyEditors/AlignmentXEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/AlignmentXEditor.axaml
@@ -41,13 +41,13 @@
                                     IsEnabled="{TemplateBinding IsReadOnly, Converter={x:Static BoolConverters.Not}}"
                                     Orientation="Horizontal">
                             <RadioButton Name="PART_LeftRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignLeft" />
+                                <icons:FluentIcon Icon="AlignLeft" />
                             </RadioButton>
                             <RadioButton Name="PART_CenterRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignCenterVertical" />
+                                <icons:FluentIcon Icon="AlignCenterVertical" />
                             </RadioButton>
                             <RadioButton Name="PART_RightRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignRight" />
+                                <icons:FluentIcon Icon="AlignRight" />
                             </RadioButton>
                         </StackPanel>
 
@@ -109,17 +109,17 @@
                                 <RadioButton Name="PART_LeftRadioButton"
                                              Grid.Column="0"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignLeft" />
+                                    <icons:FluentIcon Icon="AlignLeft" />
                                 </RadioButton>
                                 <RadioButton Name="PART_CenterRadioButton"
                                              Grid.Column="1"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignCenterVertical" />
+                                    <icons:FluentIcon Icon="AlignCenterVertical" />
                                 </RadioButton>
                                 <RadioButton Name="PART_RightRadioButton"
                                              Grid.Column="2"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignRight" />
+                                    <icons:FluentIcon Icon="AlignRight" />
                                 </RadioButton>
                             </Grid>
 
@@ -150,13 +150,13 @@
                                         IsEnabled="{TemplateBinding IsReadOnly, Converter={x:Static BoolConverters.Not}}"
                                         Orientation="Horizontal">
                                 <RadioButton Name="PART_LeftRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignLeft" />
+                                    <icons:FluentIcon Icon="AlignLeft" />
                                 </RadioButton>
                                 <RadioButton Name="PART_CenterRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignCenterVertical" />
+                                    <icons:FluentIcon Icon="AlignCenterVertical" />
                                 </RadioButton>
                                 <RadioButton Name="PART_RightRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignRight" />
+                                    <icons:FluentIcon Icon="AlignRight" />
                                 </RadioButton>
                             </StackPanel>
 
@@ -166,7 +166,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>
@@ -229,13 +229,13 @@
                                     IsEnabled="{TemplateBinding IsReadOnly, Converter={x:Static BoolConverters.Not}}"
                                     Orientation="Horizontal">
                             <RadioButton Name="PART_TopRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignTop" />
+                                <icons:FluentIcon Icon="AlignTop" />
                             </RadioButton>
                             <RadioButton Name="PART_CenterRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignCenterHorizontal" />
+                                <icons:FluentIcon Icon="AlignCenterHorizontal" />
                             </RadioButton>
                             <RadioButton Name="PART_BottomRadioButton" Padding="12,4">
-                                <icons:SymbolIcon Symbol="AlignBottom" />
+                                <icons:FluentIcon Icon="AlignBottom" />
                             </RadioButton>
                         </StackPanel>
 
@@ -297,17 +297,17 @@
                                 <RadioButton Name="PART_TopRadioButton"
                                              Grid.Column="0"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignTop" />
+                                    <icons:FluentIcon Icon="AlignTop" />
                                 </RadioButton>
                                 <RadioButton Name="PART_CenterRadioButton"
                                              Grid.Column="1"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignCenterHorizontal" />
+                                    <icons:FluentIcon Icon="AlignCenterHorizontal" />
                                 </RadioButton>
                                 <RadioButton Name="PART_BottomRadioButton"
                                              Grid.Column="2"
                                              Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignBottom" />
+                                    <icons:FluentIcon Icon="AlignBottom" />
                                 </RadioButton>
                             </Grid>
 
@@ -338,13 +338,13 @@
                                         IsEnabled="{TemplateBinding IsReadOnly, Converter={x:Static BoolConverters.Not}}"
                                         Orientation="Horizontal">
                                 <RadioButton Name="PART_TopRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignTop" />
+                                    <icons:FluentIcon Icon="AlignTop" />
                                 </RadioButton>
                                 <RadioButton Name="PART_CenterRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignCenterHorizontal" />
+                                    <icons:FluentIcon Icon="AlignCenterHorizontal" />
                                 </RadioButton>
                                 <RadioButton Name="PART_BottomRadioButton" Padding="12,4">
-                                    <icons:SymbolIcon Symbol="AlignBottom" />
+                                    <icons:FluentIcon Icon="AlignBottom" />
                                 </RadioButton>
                             </StackPanel>
 
@@ -354,7 +354,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/BooleanEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/BooleanEditor.axaml
@@ -73,7 +73,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/BrushEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/BrushEditorFlyoutPresenter.axaml
@@ -3,6 +3,7 @@
                     xmlns:behaviors="using:Beutl.Controls.Behaviors"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
     <Design.PreviewWith>
@@ -67,7 +68,7 @@
                                 </ToggleButton>
                                 <ToggleButton Name="DrawableBrushTabButton">
                                     <Border Classes="icon">
-                                        <ui:SymbolIcon Symbol="ImageFilled" />
+                                        <icons:FluentIcon Icon="Image" />
                                     </Border>
                                 </ToggleButton>
                                 <ToggleButton Name="PaletteTabButton">
@@ -102,7 +103,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -110,7 +111,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
 
@@ -263,7 +264,7 @@
                         <Setter Property="RadiusX" Value="1" />
                         <Setter Property="RadiusY" Value="1" />
                     </Style>
-                    <Style Selector="^ &gt; ui|SymbolIcon">
+                    <Style Selector="^ &gt; icons|FluentIcon">
                         <Setter Property="Width" Value="12" />
                         <Setter Property="Height" Value="12" />
                     </Style>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
@@ -48,11 +48,11 @@
                                         BorderThickness="1"
                                         CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                <ui:SymbolIcon Grid.Column="1"
-                                               Margin="4,6,8,6"
-                                               HorizontalAlignment="Right"
-                                               FontSize="18"
-                                               Symbol="ChevronDown" />
+                                <icons:FluentIcon Grid.Column="1"
+                                                  Margin="4,6,8,6"
+                                                  HorizontalAlignment="Right"
+                                                  FontSize="18"
+                                                  Icon="ChevronDown" />
                             </Grid>
                         </Button>
 
@@ -107,11 +107,11 @@
                                             BorderThickness="1"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                    <ui:SymbolIcon Grid.Column="1"
-                                                   Margin="4,6,8,6"
-                                                   HorizontalAlignment="Right"
-                                                   FontSize="18"
-                                                   Symbol="ChevronDown" />
+                                    <icons:FluentIcon Grid.Column="1"
+                                                      Margin="4,6,8,6"
+                                                      HorizontalAlignment="Right"
+                                                      FontSize="18"
+                                                      Icon="ChevronDown" />
                                 </Grid>
                             </Button>
 
@@ -162,11 +162,11 @@
                                             BorderThickness="1"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                    <ui:SymbolIcon Grid.Column="1"
-                                                   Margin="4,6,8,6"
-                                                   HorizontalAlignment="Right"
-                                                   FontSize="18"
-                                                   Symbol="ChevronDown" />
+                                    <icons:FluentIcon Grid.Column="1"
+                                                      Margin="4,6,8,6"
+                                                      HorizontalAlignment="Right"
+                                                      FontSize="18"
+                                                      Icon="ChevronDown" />
                                 </Grid>
                             </Button>
                         </OptionsDisplayItem.ActionButton>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ColorEditor.axaml
@@ -121,7 +121,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/CornerRadiusEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/CornerRadiusEditor.axaml
@@ -197,7 +197,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/DraggablePickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/DraggablePickerFlyoutPresenter.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
     <Design.PreviewWith>
@@ -75,7 +76,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -83,7 +84,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/EnumEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/EnumEditor.axaml
@@ -173,7 +173,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
 
@@ -37,11 +38,11 @@
                                 <RadioButton Name="InputTabButton"
                                              IsChecked="True"
                                              ToolTip.Tip="{x:Static lang:Strings.Expression_Input}">
-                                    <ui:SymbolIcon Symbol="Edit" />
+                                    <icons:FluentIcon Icon="Edit" />
                                 </RadioButton>
                                 <RadioButton Name="HelpTabButton"
                                              ToolTip.Tip="{x:Static lang:Strings.Expression_Help}">
-                                    <ui:SymbolIcon Symbol="Help" />
+                                    <icons:FluentIcon Icon="QuestionCircle" />
                                 </RadioButton>
                             </WrapPanel>
 
@@ -144,7 +145,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -152,7 +153,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
                             </Panel>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
@@ -189,10 +189,6 @@
                 <Setter Property="Height" Value="32" />
                 <Setter Property="Margin" Value="0,0,4,0" />
                 <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
-
-                <Style Selector="^ > ui|FontIcon">
-                    <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
-                </Style>
             </Style>
         </Style>
     </ControlTheme>

--- a/src/Beutl.Controls/Styling/PropertyEditors/FontFamilyEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/FontFamilyEditor.axaml
@@ -145,7 +145,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
@@ -48,11 +48,11 @@
                                         BorderThickness="1"
                                         CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                <ui:SymbolIcon Grid.Column="1"
-                                               Margin="4,6,8,6"
-                                               HorizontalAlignment="Right"
-                                               FontSize="18"
-                                               Symbol="ChevronDown" />
+                                <icons:FluentIcon Grid.Column="1"
+                                                  Margin="4,6,8,6"
+                                                  HorizontalAlignment="Right"
+                                                  FontSize="18"
+                                                  Icon="ChevronDown" />
                             </Grid>
                         </Button>
 
@@ -107,11 +107,11 @@
                                             BorderThickness="1"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                    <ui:SymbolIcon Grid.Column="1"
-                                                   Margin="4,6,8,6"
-                                                   HorizontalAlignment="Right"
-                                                   FontSize="18"
-                                                   Symbol="ChevronDown" />
+                                    <icons:FluentIcon Grid.Column="1"
+                                                      Margin="4,6,8,6"
+                                                      HorizontalAlignment="Right"
+                                                      FontSize="18"
+                                                      Icon="ChevronDown" />
                                 </Grid>
                             </Button>
 
@@ -162,11 +162,11 @@
                                             BorderThickness="1"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                    <ui:SymbolIcon Grid.Column="1"
-                                                   Margin="4,6,8,6"
-                                                   HorizontalAlignment="Right"
-                                                   FontSize="18"
-                                                   Symbol="ChevronDown" />
+                                    <icons:FluentIcon Grid.Column="1"
+                                                      Margin="4,6,8,6"
+                                                      HorizontalAlignment="Right"
+                                                      FontSize="18"
+                                                      Icon="ChevronDown" />
                                 </Grid>
                             </Button>
                         </OptionsDisplayItem.ActionButton>

--- a/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/GradingColorEditor.axaml
@@ -121,7 +121,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
@@ -327,10 +327,6 @@
                 <Setter Property="Height" Value="32" />
                 <Setter Property="Margin" Value="0,0,4,0" />
                 <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
-
-                <Style Selector="^ > ui|FontIcon">
-                    <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
-                </Style>
             </Style>
         </Style>
     </ControlTheme>

--- a/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
@@ -4,6 +4,7 @@
                     xmlns:int="using:Avalonia.Xaml.Interactivity"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
     <ControlTheme x:Key="LibraryItemPicker_ToggleButton"
@@ -50,7 +51,7 @@
                             <int:Interaction.Behaviors>
                                 <behaviors:LibraryItemPickerItemBehavior />
                             </int:Interaction.Behaviors>
-                            <ui:SymbolIcon Symbol="Pin" />
+                            <icons:FluentIcon Icon="Pin" />
                         </ToggleButton>
 
                         <!--
@@ -186,15 +187,15 @@
                               ColumnDefinitions="*,Auto">
                             <WrapPanel Name="TabLayout" Margin="4,4,0,4">
                                 <ToggleButton Name="ShowSearchBoxButton" IsChecked="{TemplateBinding ShowSearchBox, Mode=TwoWay}">
-                                    <ui:SymbolIcon Symbol="Find" />
+                                    <icons:FluentIcon Icon="Search" />
                                 </ToggleButton>
                                 <ToggleButton Name="ShowAllButton" IsChecked="{TemplateBinding ShowAll, Mode=TwoWay}">
-                                    <ui:SymbolIcon Symbol="More" />
+                                    <icons:FluentIcon Icon="MoreHorizontal" />
                                 </ToggleButton>
                                 <ToggleButton Name="ShowReferencesButton"
                                               IsVisible="False"
                                               IsChecked="{TemplateBinding ShowReferences, Mode=TwoWay}">
-                                    <ui:SymbolIcon Symbol="Link" />
+                                    <icons:FluentIcon Icon="Link" />
                                 </ToggleButton>
                             </WrapPanel>
 
@@ -225,7 +226,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -233,7 +234,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -330,10 +330,6 @@
                 <Setter Property="Height" Value="32" />
                 <Setter Property="Margin" Value="0,0,4,0" />
                 <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
-
-                <Style Selector="^ > ui|FontIcon">
-                    <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
-                </Style>
             </Style>
         </Style>
     </ControlTheme>

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -4,6 +4,7 @@
                     xmlns:int="using:Avalonia.Xaml.Interactivity"
                     xmlns:lang="using:Beutl.Language"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
     <ControlTheme x:Key="OutputPicker_ToggleButton"
@@ -57,7 +58,7 @@
                             <int:Interaction.Behaviors>
                                 <behaviors:OutputPickerItemBehavior />
                             </int:Interaction.Behaviors>
-                            <ui:SymbolIcon Symbol="Pin" />
+                            <icons:FluentIcon Icon="Pin" />
                         </ToggleButton>
 
                         <Button Name="MoreItemButton"
@@ -68,7 +69,7 @@
                             <int:Interaction.Behaviors>
                                 <behaviors:OutputPickerItemMoreButtonBehavior />
                             </int:Interaction.Behaviors>
-                            <ui:SymbolIcon Symbol="MoreVertical" />
+                            <icons:FluentIcon Icon="MoreVertical" />
                         </Button>
 
                         <Rectangle Name="SelectionIndicator"
@@ -204,17 +205,17 @@
                               ColumnDefinitions="*,Auto">
                             <WrapPanel Name="TabLayout" Margin="4,4,0,4">
                                 <ToggleButton Name="ShowSearchBoxButton" IsChecked="{TemplateBinding ShowSearchBox, Mode=TwoWay}">
-                                    <ui:SymbolIcon Symbol="Find" />
+                                    <icons:FluentIcon Icon="Search" />
                                 </ToggleButton>
                                 <ToggleButton Name="ProfilesTabButton"
                                               IsChecked="{Binding !$parent[local:OutputPickerFlyoutPresenter].ShowPresets, Mode=OneWay}"
                                               ToolTip.Tip="{x:Static lang:Strings.Profiles}">
-                                    <ui:SymbolIcon Symbol="Document" />
+                                    <icons:FluentIcon Icon="Document" />
                                 </ToggleButton>
                                 <ToggleButton Name="PresetsTabButton"
                                               IsChecked="{Binding $parent[local:OutputPickerFlyoutPresenter].ShowPresets, Mode=OneWay}"
                                               ToolTip.Tip="{x:Static lang:Strings.Presets}">
-                                    <ui:SymbolIcon Symbol="Bookmark" />
+                                    <icons:FluentIcon Icon="Bookmark" />
                                 </ToggleButton>
                             </WrapPanel>
 
@@ -245,7 +246,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -253,7 +254,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/PropertyEditorResources.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/PropertyEditorResources.axaml
@@ -24,7 +24,7 @@
                             HorizontalContentAlignment="Center"
                             VerticalContentAlignment="Center"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Symbol="Compose" />
+                        <icons:FluentIcon Icon="Compose" />
                     </Button>
 
                 </ToggleButton.Tag>-->
@@ -44,7 +44,7 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Tag">
             <Template>
-                <icons:SymbolIcon Margin="0,1,0,0" Symbol="ReOrderDotsVertical" />
+                <icons:FluentIcon Margin="0,1,0,0" Icon="ReOrderDotsVertical" />
             </Template>
         </Setter>
         <Setter Property="Template">
@@ -146,7 +146,7 @@
         <Setter Property="Cursor" Value="SizeNorthSouth" />
         <Setter Property="Child">
             <Template>
-                <icons:SymbolIcon VerticalAlignment="Center" Symbol="ReOrderDotsVertical" />
+                <icons:FluentIcon VerticalAlignment="Center" Icon="ReOrderDotsVertical" />
             </Template>
         </Setter>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPickerFlyoutPresenter.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:behaviors="using:Beutl.Controls.Behaviors"
                     xmlns:local="using:Beutl.Controls.PropertyEditors"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
     <Design.PreviewWith>
@@ -74,7 +75,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="18" Symbol="Checkmark" />
+                                        <icons:FluentIcon FontSize="18" Icon="Checkmark" />
                                     </Button>
                                     <Button Name="DismissButton"
                                             Grid.Column="1"
@@ -82,7 +83,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Stretch"
                                             Theme="{StaticResource FlyoutAcceptDismiss}">
-                                        <ui:SymbolIcon FontSize="16" Symbol="Dismiss" />
+                                        <icons:FluentIcon FontSize="16" Icon="Dismiss" />
                                     </Button>
                                 </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
@@ -215,7 +215,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/StorageFileEditor.axaml
@@ -33,12 +33,12 @@
                         BorderBrush="{DynamicResource TextControlButtonBorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{TemplateBinding CornerRadius}">
-                    <ui:SymbolIcon Name="Glyph"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   FontSize="{StaticResource TextBoxIconFontSize}"
-                                   Foreground="{DynamicResource TextControlButtonForeground}"
-                                   Symbol="Open" />
+                    <icons:FluentIcon Name="Glyph"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      FontSize="{StaticResource TextBoxIconFontSize}"
+                                      Foreground="{DynamicResource TextControlButtonForeground}"
+                                      Icon="Open" />
                 </Border>
             </ControlTemplate>
         </Setter>
@@ -49,7 +49,7 @@
                 <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPointerOver}" />
             </Style>
 
-            <Style Selector="^ /template/ ui|SymbolIcon#Glyph">
+            <Style Selector="^ /template/ icons|FluentIcon#Glyph">
                 <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPointerOver}" />
             </Style>
         </Style>
@@ -60,7 +60,7 @@
                 <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPressed}" />
             </Style>
 
-            <Style Selector="^ /template/ ui|SymbolIcon#Glyph">
+            <Style Selector="^ /template/ icons|FluentIcon#Glyph">
                 <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPressed}" />
             </Style>
         </Style>

--- a/src/Beutl.Controls/Styling/PropertyEditors/StringEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/StringEditor.axaml
@@ -194,7 +194,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon VerticalAlignment="Center" Symbol="Delete" />
+                                <icons:FluentIcon VerticalAlignment="Center" Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/ThicknessEditor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ThicknessEditor.axaml
@@ -47,13 +47,13 @@
                                         BorderBrush="{DynamicResource TextControlBorderBrush}"
                                         BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
                                         CornerRadius="{DynamicResource ControlCornerRadius}" />
-                                <icons:SymbolIcon Name="PART_SelectedSide"
+                                <icons:FluentIcon Name="PART_SelectedSide"
                                                   Width="16"
                                                   Height="16"
                                                   Margin="8,0,12,2"
                                                   ClipToBounds="False"
                                                   FontSize="18"
-                                                  Symbol="BorderNone" />
+                                                  Icon="BorderNone" />
 
                                 <TextBox x:Name="PART_InnerFirstTextBox"
                                          Grid.Column="1"
@@ -138,13 +138,13 @@
                                             BorderBrush="{DynamicResource TextControlBorderBrush}"
                                             BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
-                                    <icons:SymbolIcon Name="PART_SelectedSide"
+                                    <icons:FluentIcon Name="PART_SelectedSide"
                                                       Width="16"
                                                       Height="16"
                                                       Margin="8,0,12,2"
                                                       ClipToBounds="False"
                                                       FontSize="18"
-                                                      Symbol="BorderNone" />
+                                                      Icon="BorderNone" />
 
                                     <TextBox x:Name="PART_InnerFirstTextBox"
                                              Grid.Column="1"
@@ -192,7 +192,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>
@@ -239,12 +239,12 @@
                                                 BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
                                                 CornerRadius="{DynamicResource ControlCornerRadius}" />
 
-                                        <icons:SymbolIcon Width="16"
+                                        <icons:FluentIcon Width="16"
                                                           Height="16"
                                                           Margin="8,0,12,2"
                                                           ClipToBounds="False"
                                                           FontSize="18"
-                                                          Symbol="BorderOutside" />
+                                                          Icon="BorderOutside" />
 
                                         <TextBox x:Name="PART_InnerFirstTextBox"
                                                  Grid.Column="1"
@@ -364,12 +364,12 @@
                                             BorderBrush="{DynamicResource TextControlBorderBrush}"
                                             BorderThickness="{DynamicResource TextControlBorderThemeThickness}"
                                             CornerRadius="{DynamicResource ControlCornerRadius}" />
-                                    <icons:SymbolIcon Width="16"
+                                    <icons:FluentIcon Width="16"
                                                       Height="16"
                                                       Margin="8,0,12,2"
                                                       ClipToBounds="False"
                                                       FontSize="18"
-                                                      Symbol="BorderOutside" />
+                                                      Icon="BorderOutside" />
 
                                     <TextBox x:Name="PART_InnerFirstTextBox"
                                              Grid.Column="1"
@@ -405,17 +405,17 @@
             </Setter>
         </Style>
 
-        <Style Selector="^:focus-1st-textbox /template/ icons|SymbolIcon#PART_SelectedSide">
-            <Setter Property="Symbol" Value="BorderLeft" />
+        <Style Selector="^:focus-1st-textbox /template/ icons|FluentIcon#PART_SelectedSide">
+            <Setter Property="Icon" Value="BorderLeft" />
         </Style>
-        <Style Selector="^:focus-2nd-textbox /template/ icons|SymbolIcon#PART_SelectedSide">
-            <Setter Property="Symbol" Value="BorderTop" />
+        <Style Selector="^:focus-2nd-textbox /template/ icons|FluentIcon#PART_SelectedSide">
+            <Setter Property="Icon" Value="BorderTop" />
         </Style>
-        <Style Selector="^:focus-3rd-textbox /template/ icons|SymbolIcon#PART_SelectedSide">
-            <Setter Property="Symbol" Value="BorderRight" />
+        <Style Selector="^:focus-3rd-textbox /template/ icons|FluentIcon#PART_SelectedSide">
+            <Setter Property="Icon" Value="BorderRight" />
         </Style>
-        <Style Selector="^:focus-4th-textbox /template/ icons|SymbolIcon#PART_SelectedSide">
-            <Setter Property="Symbol" Value="BorderBottom" />
+        <Style Selector="^:focus-4th-textbox /template/ icons|FluentIcon#PART_SelectedSide">
+            <Setter Property="Icon" Value="BorderBottom" />
         </Style>
 
         <Style Selector="^:border-pointerover /template/ Border#PART_BackgroundBorder">

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
@@ -267,7 +267,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector3Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector3Editor.axaml
@@ -208,7 +208,7 @@
                                     Padding="0"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector4Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector4Editor.axaml
@@ -235,7 +235,7 @@
                                     VerticalAlignment="Top"
                                     Classes="size-24x24"
                                     Theme="{StaticResource TransparentButton}">
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </Button>
                         </Grid>
                     </Border>

--- a/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
+++ b/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
@@ -9,13 +9,13 @@
 
             <StackPanel Orientation="Horizontal">
                 <RadioButton Theme="{DynamicResource ColorPickerTypeTransparentToggleButtonStyle}">
-                    <ui:SymbolIcon Symbol="Accept" />
+                    <icons:FluentIcon Icon="Checkmark" />
                 </RadioButton>
                 <RadioButton Theme="{DynamicResource ColorPickerTypeTransparentToggleButtonStyle}">
-                    <ui:SymbolIcon Symbol="Accept" />
+                    <icons:FluentIcon Icon="Checkmark" />
                 </RadioButton>
                 <RadioButton Theme="{DynamicResource ColorPickerTypeTransparentToggleButtonStyle}">
-                    <ui:SymbolIcon Symbol="Accept" />
+                    <icons:FluentIcon Icon="Checkmark" />
                 </RadioButton>
             </StackPanel>
         </Border>

--- a/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
+++ b/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
@@ -43,16 +43,16 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{TemplateBinding CornerRadius}">
-                    <icons:SymbolIcon Name="PART_SymbolIcon"
+                    <icons:FluentIcon Name="PART_SymbolIcon"
                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                      Symbol="EyeOff" />
+                                      Icon="EyeOff" />
                 </Border>
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^:checked /template/ icons|SymbolIcon#PART_SymbolIcon">
-            <Setter Property="Symbol" Value="Eye" />
+        <Style Selector="^:checked /template/ icons|FluentIcon#PART_SymbolIcon">
+            <Setter Property="Icon" Value="Eye" />
         </Style>
 
         <Style Selector="^:pointerover /template/ Border#PART_Root">
@@ -62,14 +62,14 @@
         <Style Selector="^:pressed /template/ Border#PART_Root">
             <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
         </Style>
-        <Style Selector="^:pressed /template/ icons|SymbolIcon#PART_SymbolIcon">
+        <Style Selector="^:pressed /template/ icons|FluentIcon#PART_SymbolIcon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
         </Style>
 
         <Style Selector="^:disabled /template/ Border#PART_Root">
             <Setter Property="Background" Value="{DynamicResource SubtleFillColorDisabledBrush}" />
         </Style>
-        <Style Selector="^:disabled /template/ icons|SymbolIcon#PART_SymbolIcon">
+        <Style Selector="^:disabled /template/ icons|FluentIcon#PART_SymbolIcon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
         </Style>
     </ControlTheme>

--- a/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
+++ b/src/Beutl.Controls/Styling/ToggleButtonStyles.axaml
@@ -46,6 +46,7 @@
                     <icons:FluentIcon Name="PART_SymbolIcon"
                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      FontSize="{TemplateBinding FontSize}"
                                       Icon="EyeOff" />
                 </Border>
             </ControlTemplate>

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
@@ -2,6 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,7 +37,7 @@
                     VerticalAlignment="Center"
                     Theme="{StaticResource TransparentButton}"
                     ToolTip.Tip="{x:Static lang:Strings.Settings}">
-                <ui:SymbolIcon Symbol="Settings" />
+                <icons:FluentIcon Icon="Settings" />
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
                         <Flyout.FlyoutPresenterTheme>
@@ -75,7 +76,7 @@
                             <!-- Header -->
                             <Border Padding="16,12,16,12">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <ui:SymbolIcon Symbol="Settings" FontSize="16" VerticalAlignment="Center" />
+                                    <icons:FluentIcon Icon="Settings" FontSize="16" VerticalAlignment="Center" />
                                     <TextBlock Text="{x:Static lang:Strings.Settings}"
                                                Theme="{StaticResource BodyStrongTextBlockStyle}"
                                                VerticalAlignment="Center" />

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="using:Beutl.Editor.Components.AudioVisualizerTab.ViewModels"
@@ -36,7 +36,7 @@
                     VerticalAlignment="Center"
                     Theme="{StaticResource TransparentButton}"
                     ToolTip.Tip="{x:Static lang:Strings.Settings}">
-                <icons:SymbolIcon Symbol="Settings" />
+                <ui:SymbolIcon Symbol="Settings" />
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
                         <Flyout.FlyoutPresenterTheme>
@@ -75,7 +75,7 @@
                             <!-- Header -->
                             <Border Padding="16,12,16,12">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <icons:SymbolIcon Symbol="Settings" FontSize="16" VerticalAlignment="Center" />
+                                    <ui:SymbolIcon Symbol="Settings" FontSize="16" VerticalAlignment="Center" />
                                     <TextBlock Text="{x:Static lang:Strings.Settings}"
                                                Theme="{StaticResource BodyStrongTextBlockStyle}"
                                                VerticalAlignment="Center" />

--- a/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
+++ b/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
@@ -83,16 +83,16 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{TemplateBinding CornerRadius}">
-                    <icons:SymbolIcon Name="PART_SymbolIcon"
+                    <icons:FluentIcon Name="PART_SymbolIcon"
                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                      Symbol="Edit" />
+                                      Icon="Edit" />
                 </Border>
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^:checked /template/ icons|SymbolIcon#PART_SymbolIcon">
-            <Setter Property="Symbol" Value="EditOff" />
+        <Style Selector="^:checked /template/ icons|FluentIcon#PART_SymbolIcon">
+            <Setter Property="Icon" Value="EditOff" />
         </Style>
 
         <Style Selector="^:pointerover /template/ Border#PART_Root">
@@ -102,14 +102,14 @@
         <Style Selector="^:pressed /template/ Border#PART_Root">
             <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
         </Style>
-        <Style Selector="^:pressed /template/ icons|SymbolIcon#PART_SymbolIcon">
+        <Style Selector="^:pressed /template/ icons|FluentIcon#PART_SymbolIcon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
         </Style>
 
         <Style Selector="^:disabled /template/ Border#PART_Root">
             <Setter Property="Background" Value="{DynamicResource SubtleFillColorDisabledBrush}" />
         </Style>
-        <Style Selector="^:disabled /template/ icons|SymbolIcon#PART_SymbolIcon">
+        <Style Selector="^:disabled /template/ icons|FluentIcon#PART_SymbolIcon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
         </Style>
     </ControlTheme>

--- a/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
+++ b/src/Beutl.Editor.Components/ColorGradingTab/Resources/ColorGradingResources.axaml
@@ -86,6 +86,7 @@
                     <icons:FluentIcon Name="PART_SymbolIcon"
                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      FontSize="{TemplateBinding FontSize}"
                                       Icon="Edit" />
                 </Border>
             </ControlTemplate>

--- a/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
+++ b/src/Beutl.Editor.Components/ColorScopesTab/Views/ColorScopesTabView.axaml
@@ -58,7 +58,7 @@
                     IsVisible="{Binding SelectedScopeType.Value, Converter={x:Static scopes:ScopeTypeConverter.Instance}, ConverterParameter=Zebra}"
                     Theme="{StaticResource TransparentButton}"
                     ToolTip.Tip="{x:Static lang:Strings.Settings}">
-                <icons:SymbolIcon Symbol="Settings" />
+                <icons:FluentIcon Icon="Settings" />
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
                         <Flyout.FlyoutPresenterTheme>
@@ -85,9 +85,9 @@
                             <!--  Header  -->
                             <Border Padding="16,12,16,12">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <icons:SymbolIcon VerticalAlignment="Center"
+                                    <icons:FluentIcon VerticalAlignment="Center"
                                                       FontSize="16"
-                                                      Symbol="Settings" />
+                                                      Icon="Settings" />
                                     <TextBlock VerticalAlignment="Center"
                                                Text="{x:Static lang:Strings.Zebra}"
                                                Theme="{StaticResource BodyStrongTextBlockStyle}" />

--- a/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/Views/EngineObjectPropertyView.axaml
@@ -40,12 +40,12 @@
                     <ContextMenu>
                         <MenuItem Click="Remove_Click" Header="{x:Static lang:Strings.Remove}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Click="SaveAsTemplate_Click" Header="{x:Static lang:Strings.SaveAsTemplate}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="DocumentCopy" />
+                                <icons:FluentIcon Icon="DocumentCopy" />
                             </MenuItem.Icon>
                         </MenuItem>
                     </ContextMenu>
@@ -58,9 +58,9 @@
                             <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
                         </Style>
                     </Border.Styles>
-                    <icons:SymbolIcon VerticalAlignment="Center"
+                    <icons:FluentIcon VerticalAlignment="Center"
                                       FontSize="16"
-                                      Symbol="ReOrderDotsVertical" />
+                                      Icon="ReOrderDotsVertical" />
                 </Border>
 
                 <ToggleButton IsChecked="{Binding IsEnabled.Value}" Theme="{StaticResource VisibilityToggleButtonStyle}" />

--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileSystemItemViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileSystemItemViewModel.cs
@@ -3,7 +3,7 @@ using Avalonia.Media.Imaging;
 using Beutl.Editor.Components.FileBrowserTab.Services;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
-using Symbol = FluentIcons.Common.Symbol;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Editor.Components.FileBrowserTab.ViewModels;
 
@@ -58,7 +58,7 @@ public class FileSystemItemViewModel : IDisposable
 
     public string Extension { get; }
 
-    public Symbol IconSymbol { get; }
+    public Icon IconSymbol { get; }
 
     public ObservableCollection<FileSystemItemViewModel>? Children { get; }
 
@@ -130,46 +130,46 @@ public class FileSystemItemViewModel : IDisposable
         }
     }
 
-    private Symbol GetIconSymbol()
+    private Icon GetIconSymbol()
     {
         if (IsDirectory)
         {
-            return Symbol.Folder;
+            return Icon.Folder;
         }
 
         return Extension switch
         {
             // Image files
             ".png" or ".jpg" or ".jpeg" or ".gif" or ".bmp" or ".webp" or ".ico" or ".tiff" or ".tif" =>
-                Symbol.Image,
+                Icon.Image,
 
             // Video files
             ".mp4" or ".avi" or ".mov" or ".mkv" or ".wmv" or ".flv" or ".webm" =>
-                Symbol.Video,
+                Icon.Video,
 
             // Audio files
             ".mp3" or ".wav" or ".ogg" or ".flac" or ".aac" or ".wma" or ".m4a" =>
-                Symbol.MusicNote1,
+                Icon.MusicNote1,
 
             // Document files
-            ".pdf" => Symbol.DocumentPdf,
-            ".doc" or ".docx" => Symbol.Document,
-            ".txt" or ".md" or ".json" or ".xml" or ".yaml" or ".yml" => Symbol.DocumentText,
+            ".pdf" => Icon.DocumentPdf,
+            ".doc" or ".docx" => Icon.Document,
+            ".txt" or ".md" or ".json" or ".xml" or ".yaml" or ".yml" => Icon.DocumentText,
 
             // Code files
             ".cs" or ".fs" or ".vb" or ".py" or ".js" or ".ts" or ".html" or ".css" or ".xaml" or ".axaml" =>
-                Symbol.Code,
+                Icon.Code,
 
             // Archive files
             ".zip" or ".rar" or ".7z" or ".tar" or ".gz" =>
-                Symbol.FolderZip,
+                Icon.FolderZip,
 
             // Beutl project files
-            ".bepj" => Symbol.Folder,
-            ".besc" => Symbol.Filmstrip,
+            ".bepj" => Icon.Folder,
+            ".besc" => Icon.Filmstrip,
 
             // Default
-            _ => Symbol.Document
+            _ => Icon.Document
         };
     }
 

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
@@ -23,18 +23,18 @@
                 <ContextMenu Opened="OnContextMenuOpened">
                     <MenuItem Click="OnOpenClick" Header="{x:Static lang:Strings.Open}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Open" />
+                            <icons:FluentIcon Icon="Open" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator />
                     <MenuItem Click="OnRenameClick" Header="{x:Static lang:Strings.Rename}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Rename" />
+                            <icons:FluentIcon Icon="Rename" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <MenuItem Click="OnDeleteClick" Header="{x:Static lang:Strings.Delete}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Delete" />
+                            <icons:FluentIcon Icon="Delete" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator />
@@ -42,7 +42,7 @@
                               Header="{x:Static lang:Strings.AddToFavorites}"
                               Tag="FavoriteToggle">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Star" />
+                            <icons:FluentIcon Icon="Star" />
                         </MenuItem.Icon>
                     </MenuItem>
                 </ContextMenu>
@@ -70,9 +70,9 @@
                         <Image IsVisible="{Binding HasThumbnail.Value}"
                                Source="{Binding Thumbnail.Value}"
                                Stretch="Uniform" />
-                        <icons:SymbolIcon FontSize="48"
+                        <icons:FluentIcon FontSize="48"
                                           IsVisible="{Binding !HasThumbnail.Value}"
-                                          Symbol="{Binding IconSymbol}" />
+                                          Icon="{Binding IconSymbol}" />
                     </Panel>
                     <!--  ファイル名  -->
                     <TextBlock Grid.Row="1"
@@ -104,9 +104,9 @@
                         <Image IsVisible="{Binding HasThumbnail.Value}"
                                Source="{Binding Thumbnail.Value}"
                                Stretch="Uniform" />
-                        <icons:SymbolIcon FontSize="20"
+                        <icons:FluentIcon FontSize="20"
                                           IsVisible="{Binding !HasThumbnail.Value}"
-                                          Symbol="{Binding IconSymbol}" />
+                                          Icon="{Binding IconSymbol}" />
                     </Panel>
                     <TextBlock VerticalAlignment="Center"
                                Text="{Binding Name.Value}"
@@ -130,7 +130,7 @@
                         IsVisible="{Binding !IsHomeView.Value}"
                         Theme="{StaticResource TransparentButton}"
                         ToolTip.Tip="{x:Static lang:Strings.OpenFolder}">
-                    <icons:SymbolIcon FontSize="16" Symbol="OpenFolder" />
+                    <icons:FluentIcon FontSize="16" Icon="OpenFolder" />
                 </Button>
 
                 <!--  パス表示（ディレクトリブラウズ時）  -->
@@ -172,15 +172,15 @@
                             Theme="{StaticResource TransparentButton}"
                             ToolTip.Tip="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.ToDisplayName}}">
                         <Panel>
-                            <icons:SymbolIcon FontSize="16"
+                            <icons:FluentIcon FontSize="16"
                                               IsVisible="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.IsList}}"
-                                              Symbol="TextBulletList" />
-                            <icons:SymbolIcon FontSize="16"
+                                              Icon="TextBulletList" />
+                            <icons:FluentIcon FontSize="16"
                                               IsVisible="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.IsTree}}"
-                                              Symbol="TextBulletListTree" />
-                            <icons:SymbolIcon FontSize="16"
+                                              Icon="TextBulletListTree" />
+                            <icons:FluentIcon FontSize="16"
                                               IsVisible="{Binding ViewMode.Value, Converter={x:Static vm:FileBrowserViewModeConverters.IsIcon}}"
-                                              Symbol="Grid" />
+                                              Icon="Grid" />
                         </Panel>
                     </Button>
 
@@ -190,7 +190,7 @@
                             IsVisible="{Binding !IsHomeView.Value}"
                             Theme="{StaticResource TransparentButton}"
                             ToolTip.Tip="{x:Static lang:Strings.NewFolder}">
-                        <icons:SymbolIcon FontSize="16" Symbol="FolderAdd" />
+                        <icons:FluentIcon FontSize="16" Icon="FolderAdd" />
                     </Button>
 
                     <!--  更新  -->
@@ -198,7 +198,7 @@
                             Click="OnRefreshClick"
                             Theme="{StaticResource TransparentButton}"
                             ToolTip.Tip="{x:Static lang:Strings.Refresh}">
-                        <icons:SymbolIcon FontSize="16" Symbol="ArrowClockwise" />
+                        <icons:FluentIcon FontSize="16" Icon="ArrowClockwise" />
                     </Button>
 
                     <!--  ホームボタン  -->
@@ -206,7 +206,7 @@
                             Click="OnHomeClick"
                             Theme="{StaticResource TransparentButton}"
                             ToolTip.Tip="{x:Static lang:Strings.Home}">
-                        <icons:SymbolIcon FontSize="16" Symbol="Home" />
+                        <icons:FluentIcon FontSize="16" Icon="Home" />
                     </Button>
                 </StackPanel>
             </Grid>
@@ -229,12 +229,12 @@
                                               IsChecked="{Binding IsFavoritesIconView.Value}"
                                               Theme="{StaticResource TransparentButton}">
                                     <Panel>
-                                        <icons:SymbolIcon FontSize="14"
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding IsFavoritesIconView.Value}"
-                                                          Symbol="Grid" />
-                                        <icons:SymbolIcon FontSize="14"
+                                                          Icon="Grid" />
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding !IsFavoritesIconView.Value}"
-                                                          Symbol="TextBulletList" />
+                                                          Icon="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>
@@ -296,12 +296,12 @@
                                               IsChecked="{Binding IsProjectDirIconView.Value}"
                                               Theme="{StaticResource TransparentButton}">
                                     <Panel>
-                                        <icons:SymbolIcon FontSize="14"
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding IsProjectDirIconView.Value}"
-                                                          Symbol="Grid" />
-                                        <icons:SymbolIcon FontSize="14"
+                                                          Icon="Grid" />
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding !IsProjectDirIconView.Value}"
-                                                          Symbol="TextBulletList" />
+                                                          Icon="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>
@@ -358,12 +358,12 @@
                                               IsChecked="{Binding IsMediaFilesIconView.Value}"
                                               Theme="{StaticResource TransparentButton}">
                                     <Panel>
-                                        <icons:SymbolIcon FontSize="14"
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding IsMediaFilesIconView.Value}"
-                                                          Symbol="Grid" />
-                                        <icons:SymbolIcon FontSize="14"
+                                                          Icon="Grid" />
+                                        <icons:FluentIcon FontSize="14"
                                                           IsVisible="{Binding !IsMediaFilesIconView.Value}"
-                                                          Symbol="TextBulletList" />
+                                                          Icon="TextBulletList" />
                                     </Panel>
                                 </ToggleButton>
                             </ToggleButton.Tag>
@@ -500,9 +500,9 @@
                                         <Image IsVisible="{Binding HasThumbnail.Value}"
                                                Source="{Binding Thumbnail.Value}"
                                                Stretch="Uniform" />
-                                        <icons:SymbolIcon FontSize="20"
+                                        <icons:FluentIcon FontSize="20"
                                                           IsVisible="{Binding !HasThumbnail.Value}"
-                                                          Symbol="{Binding IconSymbol}" />
+                                                          Icon="{Binding IconSymbol}" />
                                     </Panel>
                                     <TextBlock VerticalAlignment="Center" Text="{Binding Name.Value}" />
                                 </StackPanel>

--- a/src/Beutl.Editor.Components/GraphEditorTab/Resources/GraphEditorResources.axaml
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Resources/GraphEditorResources.axaml
@@ -100,17 +100,17 @@
                             <ContextMenu>
                                 <MenuItem Command="{Binding CopyCommand}" Header="{x:Static lang:Strings.Copy}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="Copy" />
+                                        <icons:FluentIcon Icon="Copy" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                                 <MenuItem Command="{Binding PasteCommand}" Header="{x:Static lang:Strings.Paste}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="ClipboardPaste" />
+                                        <icons:FluentIcon Icon="ClipboardPaste" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                                 <MenuItem Command="{Binding RemoveCommand}" Header="{x:Static lang:Strings.Delete}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="Delete" />
+                                        <icons:FluentIcon Icon="Delete" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                             </ContextMenu>

--- a/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorTabView.axaml
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorTabView.axaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:view="using:Beutl.Editor.Components.GraphEditorTab.Views"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModels="using:Beutl.Editor.Components.GraphEditorTab.ViewModels"
              xmlns:lang="using:Beutl.Language"
@@ -29,7 +30,7 @@
                     </Style>
                 </StackPanel.Styles>
                 <Button Command="{Binding Refresh}" Theme="{StaticResource TransparentButton}">
-                    <ui:SymbolIcon Symbol="Refresh" />
+                    <icons:FluentIcon Icon="ArrowClockwise" />
                 </Button>
                 <RadioButton Click="ToggleDragModeClick"
                              GroupName="PathEditor_DragMode"

--- a/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml
+++ b/src/Beutl.Editor.Components/GraphEditorTab/Views/GraphEditorView.axaml
@@ -60,17 +60,17 @@
                     <ContextMenu>
                         <MenuItem Command="{Binding CopyAllKeyFramesCommand}" Header="{x:Static lang:Strings.CopyAll}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="DocumentCopy" />
+                                <icons:FluentIcon Icon="DocumentCopy" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Command="{Binding PasteKeyFrameAtCurrentPositionCommand}" Header="{x:Static lang:Strings.Paste}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="ClipboardPaste" />
+                                <icons:FluentIcon Icon="ClipboardPaste" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Header="{x:Static lang:Strings.TimelineZoom}" MenuItem.Click="ZoomClick">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="ZoomIn" />
+                                <icons:FluentIcon Icon="ZoomIn" />
                             </MenuItem.Icon>
                             <MenuItem CommandParameter="8.75" Header="875%" />
                             <MenuItem CommandParameter="7.0" Header="700%" />
@@ -116,7 +116,7 @@
                         </MenuItem>
                         <MenuItem Click="ShowBpmGridFlyout" Header="{x:Static lang:Strings.BpmGrid}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="MusicNote1" />
+                                <icons:FluentIcon Icon="MusicNote1" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Command="{Binding ToggleUseGlobalClock}"

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml
@@ -49,7 +49,7 @@
                                     <Setter Property="IsVisible" Value="{Binding $parent[TabStripItem].IsSelected}" />
                                     <Setter Property="VerticalAlignment" Value="Center" />
                                 </Style>
-                                <Style Selector="^ > icons|SymbolIcon">
+                                <Style Selector="^ > icons|FluentIcon">
                                     <Setter Property="FontSize" Value="20" />
                                 </Style>
                             </Style>
@@ -61,7 +61,7 @@
                         Click="MoreButton_Click"
                         FontSize="20"
                         Theme="{StaticResource LiteButtonStyle}">
-                    <icons:SymbolIcon Symbol="MoreHorizontal" />
+                    <icons:FluentIcon Icon="MoreHorizontal" />
                 </Button>
             </StackPanel>
         </ScrollViewer>

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
@@ -13,20 +13,19 @@ using Beutl.Editor.Components.LibraryTab.Views.LibraryViews;
 using Beutl.Utilities;
 
 using FluentAvalonia.UI.Controls;
-
-using Symbol = FluentIcons.Common.Symbol;
-using SymbolIcon = FluentIcons.Avalonia.Fluent.SymbolIcon;
+using FluentIcons.Avalonia.Fluent;
+using FluentIcons.Common;
 
 namespace Beutl.Editor.Components.LibraryTab.Views;
 
 public sealed partial class LibraryTabView : UserControl
 {
-    private static readonly (Symbol Icon, string Text, string Id, Func<Control> Create)[] s_tabItems =
+    private static readonly (Icon Icon, string Text, string Id, Func<Control> Create)[] s_tabItems =
     [
-        (Symbol.Search, Strings.Search, "Search", () => new SearchView()),
-        (Symbol.BezierCurveSquare, Strings.Easings, "Easings", () => new EasingsView()),
-        (Symbol.Library, Strings.Library, "Library", () => new LibraryView()),
-        (Symbol.Flow, Strings.NodeGraph, "Nodes", () => new NodesView()),
+        (Icon.Search, Strings.Search, "Search", () => new SearchView()),
+        (Icon.BezierCurveSquare, Strings.Easings, "Easings", () => new EasingsView()),
+        (Icon.Library, Strings.Library, "Library", () => new LibraryView()),
+        (Icon.Flow, Strings.NodeGraph, "Nodes", () => new NodesView()),
     ];
 
     public LibraryTabView()
@@ -46,7 +45,7 @@ public sealed partial class LibraryTabView : UserControl
                 {
                     Children =
                     {
-                        new SymbolIcon { Symbol = item.Icon },
+                        new FluentIcon { Icon = item.Icon },
                         new TextBlock { Text = item.Text }
                     }
                 };

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
@@ -39,12 +39,12 @@
                                        InputGesture="Delete"
                                        Text="{x:Static lang:Strings.Delete}">
                         <ui:MenuFlyoutItem.IconSource>
-                            <icons:SymbolIconSource Symbol="Delete" />
+                            <icons:FluentIconSource Icon="Delete" />
                         </ui:MenuFlyoutItem.IconSource>
                     </ui:MenuFlyoutItem>
                     <ui:MenuFlyoutItem Click="RenameClick" Text="{x:Static lang:Strings.Rename}">
                         <ui:MenuFlyoutItem.IconSource>
-                            <icons:SymbolIconSource Symbol="Rename" />
+                            <icons:FluentIconSource Icon="Rename" />
                         </ui:MenuFlyoutItem.IconSource>
                     </ui:MenuFlyoutItem>
                 </ui:FAMenuFlyout>
@@ -70,7 +70,7 @@
                         Click="OpenNodeClick"
                         IsVisible="{Binding IsGroupNode}"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Symbol="Open" />
+                    <icons:FluentIcon Icon="Open" />
                 </Button>
             </Grid>
         </Border>

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/NodePortView.axaml.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/NodePortView.axaml.cs
@@ -227,9 +227,9 @@ public partial class NodePortView : UserControl
             {
                 Header = Strings.Rename,
                 Command = new ReactiveCommand().WithSubscribe(RenameClick),
-                Icon = new SymbolIcon
+                Icon = new FluentIcon
                 {
-                    Symbol = Symbol.Rename
+                    Icon = Icon.Rename
                 }
             });
         }

--- a/src/Beutl.Editor.Components/ObjectPropertyTab/Views/ObjectPropertyTabView.axaml
+++ b/src/Beutl.Editor.Components/ObjectPropertyTab/Views/ObjectPropertyTabView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.Editor.Components.ObjectPropertyTab.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -15,7 +16,7 @@
                         Padding="8"
                         BorderThickness="0"
                         Background="Transparent">
-                    <ui:SymbolIcon Symbol="Back" FontSize="16" />
+                    <icons:FluentIcon Icon="ArrowLeft" FontSize="16" />
                 </Button>
             </StackPanel>
 

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
@@ -131,7 +131,7 @@
                           HorizontalAlignment="Center"
                           IsChecked="True"
                           Theme="{StaticResource TransparentToggleButton}">
-                <icons:SymbolIcon Symbol="InkStroke" />
+                <icons:FluentIcon Icon="InkStroke" />
             </ToggleButton>
             <ToggleButton Name="FillToggleButton"
                           Margin="0,4,0,0"
@@ -139,7 +139,7 @@
                           HorizontalAlignment="Center"
                           IsChecked="True"
                           Theme="{StaticResource TransparentToggleButton}">
-                <icons:SymbolIcon Symbol="InkingToolAccent" />
+                <icons:FluentIcon Icon="InkingToolAccent" />
             </ToggleButton>
         </StackPanel>
     </Panel>

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
@@ -22,6 +22,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings.Extensions;
 using BtlPoint = Beutl.Graphics.Point;
 using BtlVector = Beutl.Graphics.Vector;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Editor.Components.PathEditorTab.Views;
 
@@ -442,7 +444,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
         var delete = new MenuFlyoutItem
         {
             Text = Strings.Delete,
-            IconSource = new SymbolIconSource { Symbol = Symbol.Delete }
+            IconSource = new FluentIconSource { Icon = Icon.Delete }
         };
         delete.Click += OnDeleteClicked;
         flyout.ItemsSource = new[] { delete };

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
@@ -16,11 +16,11 @@ using Beutl.Editor.Services;
 using Beutl.Engine;
 using Beutl.Media;
 using FluentAvalonia.UI.Controls;
-
 using Microsoft.Extensions.DependencyInjection;
 using Reactive.Bindings.Extensions;
-
 using BtlPoint = Beutl.Graphics.Point;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Editor.Components.PathEditorTab.Views;
 
@@ -185,9 +185,9 @@ public partial class PathEditorView : UserControl, IPathEditorView
         var delete = new MenuFlyoutItem
         {
             Text = Strings.Delete,
-            IconSource = new SymbolIconSource
+            IconSource = new FluentIconSource
             {
-                Symbol = Symbol.Delete
+                Icon = Icon.Delete
             }
         };
         delete.Click += OnDeleteClicked;

--- a/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <ControlTheme x:Key="LayerHeaderColorPickerButtonTheme"
                   TargetType="ui:ColorPickerButton"
@@ -23,11 +24,11 @@
                                 BorderThickness="1"
                                 CornerRadius="{TemplateBinding CornerRadius}" />
 
-                        <ui:SymbolIcon Grid.Column="1"
-                                       Margin="0,0,8,0"
-                                       HorizontalAlignment="Right"
-                                       FontSize="18"
-                                       Symbol="ChevronDown" />
+                        <icons:FluentIcon Grid.Column="1"
+                                          Margin="0,0,8,0"
+                                          HorizontalAlignment="Right"
+                                          FontSize="18"
+                                          Icon="ChevronDown" />
                     </Grid>
                 </Button>
             </ControlTemplate>

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -64,13 +64,13 @@
                                                                             ExtensionType={x:Type p:TimelineTabExtension}}"
                                          Text="{x:Static lang:Strings.RazorTool}">
                     <ui:ToggleMenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="Cut" />
+                        <icons:FluentIconSource Icon="Cut" />
                     </ui:ToggleMenuFlyoutItem.IconSource>
                 </ui:ToggleMenuFlyoutItem>
                 <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutItem Command="{Binding Split}" Text="{x:Static lang:Strings.Split}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="SplitVertical" />
+                        <icons:FluentIconSource Icon="SplitVertical" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem x:Name="splitByCurrent"
@@ -83,7 +83,7 @@
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Cut}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="Cut" />
+                        <icons:FluentIconSource Icon="Cut" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem Command="{Binding Copy}"
@@ -91,7 +91,7 @@
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Copy}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="Copy" />
+                        <icons:FluentIconSource Icon="Copy" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem Command="{Binding Delete}"
@@ -99,7 +99,7 @@
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Delete}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="DeleteDismiss" />
+                        <icons:FluentIconSource Icon="DeleteDismiss" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem Command="{Binding Exclude}"
@@ -107,7 +107,7 @@
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Exclude}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="Delete" />
+                        <icons:FluentIconSource Icon="Delete" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem x:Name="groupSelectedElements"
@@ -121,7 +121,7 @@
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Rename}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="Rename" />
+                        <icons:FluentIconSource Icon="Rename" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutItem x:Name="change2OriginalDuration"
@@ -138,7 +138,7 @@
                 <ui:MenuFlyoutSeparator />
                 <ui:MenuFlyoutItem Click="SaveAsTemplate_Click" Text="{x:Static lang:Strings.SaveAsTemplate}">
                     <ui:MenuFlyoutItem.IconSource>
-                        <icons:SymbolIconSource Symbol="DocumentCopy" />
+                        <icons:FluentIconSource Icon="DocumentCopy" />
                     </ui:MenuFlyoutItem.IconSource>
                 </ui:MenuFlyoutItem>
                 <ui:MenuFlyoutSeparator />

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayer.axaml
@@ -21,17 +21,17 @@
         <ContextMenu>
             <MenuItem Command="{Binding CopyAllKeyFramesCommand}" Header="{x:Static lang:Strings.CopyAll}">
                 <MenuItem.Icon>
-                    <icons:SymbolIcon Symbol="Copy" />
+                    <icons:FluentIcon Icon="Copy" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding PasteKeyFrameAtCurrentPositionCommand}" Header="{x:Static lang:Strings.Paste}">
                 <MenuItem.Icon>
-                    <icons:SymbolIcon Symbol="ClipboardPaste" />
+                    <icons:FluentIcon Icon="ClipboardPaste" />
                 </MenuItem.Icon>
             </MenuItem>
             <MenuItem Command="{Binding DeleteCurrentAnimationCommand}" Header="{x:Static lang:Strings.Delete}">
                 <MenuItem.Icon>
-                    <icons:SymbolIcon Symbol="Delete" />
+                    <icons:FluentIcon Icon="Delete" />
                 </MenuItem.Icon>
             </MenuItem>
         </ContextMenu>
@@ -77,17 +77,17 @@
                             <ContextMenu>
                                 <MenuItem Command="{Binding CopyCommand}" Header="{x:Static lang:Strings.Copy}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="Copy" />
+                                        <icons:FluentIcon Icon="Copy" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                                 <MenuItem Command="{Binding PasteCommand}" Header="{x:Static lang:Strings.Paste}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="ClipboardPaste" />
+                                        <icons:FluentIcon Icon="ClipboardPaste" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                                 <MenuItem Command="{Binding RemoveCommand}" Header="{x:Static lang:Strings.Delete}">
                                     <MenuItem.Icon>
-                                        <icons:SymbolIcon Symbol="Delete" />
+                                        <icons:FluentIcon Icon="Delete" />
                                     </MenuItem.Icon>
                                 </MenuItem>
                             </ContextMenu>

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml
@@ -25,23 +25,23 @@
                     <Setter Property="Cursor" Value="SizeNorthSouth" />
                 </Style>
             </Border.Styles>
-            <icons:SymbolIcon VerticalAlignment="Center"
+            <icons:FluentIcon VerticalAlignment="Center"
                               FontSize="14"
-                              Symbol="ReOrderDotsVertical" />
+                              Icon="ReOrderDotsVertical" />
         </Border>
 
         <Button Grid.Column="2"
                 Width="22"
                 Theme="{StaticResource LayerHeaderButtonTheme}"
                 Command="{CompiledBinding Close}">
-            <ui:SymbolIcon Symbol="Dismiss" />
+            <icons:FluentIcon Icon="Dismiss" />
         </Button>
 
         <Button Grid.Column="3"
                 Width="30"
                 Theme="{StaticResource LayerHeaderButtonTheme}"
                 Click="OpenTab_Click">
-            <ui:SymbolIcon Symbol="Open" />
+            <icons:FluentIcon Icon="Open" />
         </Button>
 
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/LayerHeader.axaml
@@ -35,9 +35,9 @@
                     <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
                 </Style>
             </Border.Styles>
-            <icons:SymbolIcon VerticalAlignment="Center"
+            <icons:FluentIcon VerticalAlignment="Center"
                               FontSize="14"
-                              Symbol="ReOrderDotsVertical" />
+                              Icon="ReOrderDotsVertical" />
         </Border>
 
         <ToggleButton Grid.Column="1"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -130,9 +130,9 @@
                 IsVisible="{CompiledBinding IsRazorMode.Value}"
                 ZIndex="100">
             <StackPanel Orientation="Horizontal" Spacing="4">
-                <icons:SymbolIcon FontSize="14"
+                <icons:FluentIcon FontSize="14"
                                   Foreground="White"
-                                  Symbol="Cut" />
+                                  Icon="Cut" />
                 <TextBlock FontSize="12"
                            FontWeight="SemiBold"
                            Foreground="White"
@@ -164,7 +164,7 @@
                                                                                     ExtensionType={x:Type p:TimelineTabExtension}}"
                                                  Text="{x:Static lang:Strings.RazorTool}">
                             <ui:ToggleMenuFlyoutItem.IconSource>
-                                <icons:SymbolIconSource Symbol="Cut" />
+                                <icons:FluentIconSource Icon="Cut" />
                             </ui:ToggleMenuFlyoutItem.IconSource>
                         </ui:ToggleMenuFlyoutItem>
                         <ui:MenuFlyoutSeparator />
@@ -172,14 +172,14 @@
                         <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
                         <ui:MenuFlyoutItem Click="AddAdjustmentLayerClick" Text="{x:Static lang:Strings.AddAdjustmentLayer}">
                             <ui:MenuFlyoutItem.IconSource>
-                                <icons:SymbolIconSource Symbol="Color" />
+                                <icons:FluentIconSource Icon="Color" />
                             </ui:MenuFlyoutItem.IconSource>
                         </ui:MenuFlyoutItem>
                         <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{h:GetCommandGesture Paste}"
                                            Text="{x:Static lang:Strings.Paste}">
                             <ui:MenuFlyoutItem.IconSource>
-                                <icons:SymbolIconSource Symbol="ClipboardPaste" />
+                                <icons:FluentIconSource Icon="ClipboardPaste" />
                             </ui:MenuFlyoutItem.IconSource>
                         </ui:MenuFlyoutItem>
                         <ui:MenuFlyoutSeparator />
@@ -194,19 +194,19 @@
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutItem Click="ShowSceneSettings" Text="{x:Static lang:Strings.Settings}">
                             <ui:MenuFlyoutItem.IconSource>
-                                <icons:SymbolIconSource Symbol="Settings" />
+                                <icons:FluentIconSource Icon="Settings" />
                             </ui:MenuFlyoutItem.IconSource>
                         </ui:MenuFlyoutItem>
                         <ui:MenuFlyoutItem x:Name="BpmGridMenuItem"
                                            Click="ShowBpmGridFlyout"
                                            Text="{x:Static lang:Strings.BpmGrid}">
                             <ui:MenuFlyoutItem.IconSource>
-                                <icons:SymbolIconSource Symbol="MusicNote1" />
+                                <icons:FluentIconSource Icon="MusicNote1" />
                             </ui:MenuFlyoutItem.IconSource>
                         </ui:MenuFlyoutItem>
                         <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.TimelineZoom}">
                             <ui:MenuFlyoutSubItem.IconSource>
-                                <icons:SymbolIconSource Symbol="ZoomIn" />
+                                <icons:FluentIconSource Icon="ZoomIn" />
                             </ui:MenuFlyoutSubItem.IconSource>
                             <ui:MenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="2.0"

--- a/src/Beutl.Editor.Components/Views/MarkerEditFlyout.cs
+++ b/src/Beutl.Editor.Components/Views/MarkerEditFlyout.cs
@@ -7,6 +7,8 @@ using Beutl.Editor.Components.Helpers;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Controls.Primitives;
 using AvaColor = Avalonia.Media.Color;
+using FluentIcon = FluentIcons.Avalonia.Fluent.FluentIcon;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Editor.Components.Views;
 
@@ -88,7 +90,7 @@ public sealed class MarkerEditFlyout : PickerFlyoutBase
                 Spacing = 6,
                 Children =
                 {
-                    new SymbolIcon { Symbol = Symbol.Delete, FontSize = 14 },
+                    new FluentIcon { Icon = Icon.Delete, FontSize = 14 },
                     new TextBlock { Text = Strings.Delete, VerticalAlignment = VerticalAlignment.Center },
                 },
             },

--- a/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
@@ -7,6 +7,7 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        xmlns:models="using:Beutl.PackageTools.UI.Models"
                        xmlns:res="using:Beutl.PackageTools.UI.Resources"
+                       xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                        xmlns:ui="using:FluentAvalonia.UI.Controls"
                        xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                        xmlns:viewModels="using:Beutl.PackageTools.UI.ViewModels"
@@ -40,15 +41,15 @@
                     <Grid HorizontalAlignment="Left" ColumnDefinitions="*,6,Auto">
                         <TextBlock Text="{Binding Id}" TextTrimming="CharacterEllipsis" />
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
-                            <ui:SymbolIcon Symbol="Folder">
-                                <ui:SymbolIcon.IsVisible>
+                            <icons:FluentIcon Icon="Folder">
+                                <icons:FluentIcon.IsVisible>
                                     <MultiBinding Converter="{x:Static BoolConverters.Or}">
                                         <Binding Converter="{x:Static BoolConverters.Not}" Path="IsRemote" />
                                         <Binding Path="Conflict" />
                                     </MultiBinding>
-                                </ui:SymbolIcon.IsVisible>
-                            </ui:SymbolIcon>
-                            <ui:SymbolIcon IsVisible="{Binding IsRemote}" Symbol="Cloud" />
+                                </icons:FluentIcon.IsVisible>
+                            </icons:FluentIcon>
+                            <icons:FluentIcon IsVisible="{Binding IsRemote}" Icon="Cloud" />
                         </StackPanel>
                     </Grid>
 

--- a/src/Beutl.WaitingDialog/MainWindow.axaml.cs
+++ b/src/Beutl.WaitingDialog/MainWindow.axaml.cs
@@ -11,7 +11,7 @@ using Avalonia.Threading;
 using FluentAvalonia.Styling;
 using FluentAvalonia.UI.Windowing;
 
-using Symbol = FluentIcons.Common.Symbol;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.WaitingDialog;
 
@@ -66,13 +66,13 @@ public partial class MainWindow : AppWindow
         }
 
         string? icon = result.GetValue(iconOption);
-        if (icon != null && Enum.TryParse(icon, out Symbol iconSymbol))
+        if (icon != null && Enum.TryParse(icon, out Icon iconSymbol))
         {
             subheaderRoot.IsVisible = true;
             iconHost.IsVisible = true;
-            iconSourceElement.IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource
+            iconSourceElement.IconSource = new FluentIcons.Avalonia.Fluent.FluentIconSource
             {
-                Symbol = iconSymbol,
+                Icon = iconSymbol,
             };
         }
 

--- a/src/Beutl/Pages/ExtensionsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPage.axaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:lang="using:Beutl.Language"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
         xmlns:ui="using:FluentAvalonia.UI.Controls"
         Title="{x:Static lang:Strings.Extensions}"
         Width="800"
@@ -33,7 +34,7 @@
                          Watermark="{x:Static lang:Strings.Search}">
                     <TextBox.InnerRightContent>
                         <Button Click="Search_Click" Theme="{StaticResource TransparentButton}">
-                            <ui:SymbolIcon Symbol="Find" />
+                            <icons:FluentIcon Icon="Search" />
                         </Button>
                     </TextBox.InnerRightContent>
                 </TextBox>

--- a/src/Beutl/Pages/ExtensionsPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPage.axaml.cs
@@ -12,6 +12,8 @@ using FluentAvalonia.UI.Navigation;
 
 using Microsoft.Extensions.Logging;
 
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+
 namespace Beutl.Pages;
 
 public sealed partial class ExtensionsPage : Window
@@ -62,18 +64,18 @@ public sealed partial class ExtensionsPage : Window
             {
                 Content = "Home",
                 Tag = typeof(DiscoverPage),
-                IconSource = new SymbolIconSource
+                IconSource = new FluentIconSource
                 {
-                    Symbol = Symbol.Home
+                    Icon = FluentIcons.Common.Icon.Home
                 }
             },
             new NavigationViewItem()
             {
                 Content = "Library",
                 Tag = typeof(LibraryPage),
-                IconSource = new SymbolIconSource
+                IconSource = new FluentIconSource
                 {
-                    Symbol = Symbol.Library
+                    Icon = FluentIcons.Common.Icon.Library
                 }
             },
         ];

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml
@@ -54,7 +54,7 @@
                                             Click="Package_Click">
                                         <Grid Margin="16" RowDefinitions="Auto,16,*">
                                             <Border Width="120" Height="120">
-                                                <icons:SymbolIcon FontSize="32" Symbol="MoreHorizontal" />
+                                                <icons:FluentIcon FontSize="32" Icon="MoreHorizontal" />
                                             </Border>
 
                                             <TextBlock Grid.Row="2"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml
@@ -197,9 +197,9 @@
 
                         <StackPanel Margin="16" Spacing="16">
                             <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
-                                <icons:SymbolIcon Margin="0,0,8,0"
+                                <icons:FluentIcon Margin="0,0,8,0"
                                                   VerticalAlignment="Bottom"
-                                                  Symbol="Tag" />
+                                                  Icon="Tag" />
                                 <TextBlock Grid.Column="1" Text="{x:Static lang:ExtensionsStrings.Package_Tags}" />
 
                                 <ItemsRepeater Grid.Row="1"
@@ -221,9 +221,9 @@
                                 </ItemsRepeater>
                             </Grid>
                             <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
-                                <icons:SymbolIcon Margin="0,0,8,0"
+                                <icons:FluentIcon Margin="0,0,8,0"
                                                   VerticalAlignment="Bottom"
-                                                  Symbol="Link" />
+                                                  Icon="Link" />
                                 <TextBlock Grid.Column="1" Text="{x:Static lang:Strings.Link}" />
 
                                 <HyperlinkButton Grid.Row="1"
@@ -233,9 +233,9 @@
                                                  IsVisible="{Binding Package.WebSite.Value, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             </Grid>
                             <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
-                                <icons:SymbolIcon Margin="0,0,8,0"
+                                <icons:FluentIcon Margin="0,0,8,0"
                                                   VerticalAlignment="Bottom"
-                                                  Symbol="Bookmark" />
+                                                  Icon="Bookmark" />
                                 <TextBlock Grid.Column="1" Text="{x:Static lang:ExtensionsStrings.Package_LatestVersion}" />
 
                                 <TextBlock Grid.Row="1"
@@ -245,9 +245,9 @@
                                            Text="{Binding LatestRelease.Value.Version.Value}" />
                             </Grid>
                             <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
-                                <icons:SymbolIcon Margin="0,0,8,0"
+                                <icons:FluentIcon Margin="0,0,8,0"
                                                   VerticalAlignment="Bottom"
-                                                  Symbol="ArrowMinimize" />
+                                                  Icon="ArrowMinimize" />
                                 <TextBlock Grid.Column="1" Text="{x:Static lang:ExtensionsStrings.Release_TargetVersion}" />
 
                                 <TextBlock Grid.Row="1"
@@ -258,9 +258,9 @@
                             <Grid ColumnDefinitions="Auto,*"
                                   IsVisible="{Binding CurrentRelease.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                                   RowDefinitions="Auto,Auto">
-                                <icons:SymbolIcon Margin="0,0,8,0"
+                                <icons:FluentIcon Margin="0,0,8,0"
                                                   VerticalAlignment="Bottom"
-                                                  Symbol="ArrowDownload" />
+                                                  Icon="ArrowDownload" />
                                 <TextBlock Grid.Column="1" Text="{x:Static lang:ExtensionsStrings.Package_InstalledVersion}" />
 
                                 <TextBlock Grid.Row="1"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
@@ -57,7 +57,7 @@
                                                 Click="Package_Click">
                                             <Grid Margin="16" ColumnDefinitions="Auto,16,*">
                                                 <Border Width="80" Height="80">
-                                                    <icons:SymbolIcon FontSize="32" Symbol="MoreHorizontal" />
+                                                    <icons:FluentIcon FontSize="32" Icon="MoreHorizontal" />
                                                 </Border>
 
                                                 <TextBlock Grid.Column="2"

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
@@ -100,7 +100,7 @@
                                                 Click="Package_Click">
                                             <Grid Margin="16" ColumnDefinitions="Auto,16,*">
                                                 <Border Width="80" Height="80">
-                                                    <icons:SymbolIcon FontSize="32" Symbol="MoreHorizontal" />
+                                                    <icons:FluentIcon FontSize="32" Icon="MoreHorizontal" />
                                                 </Border>
 
                                                 <TextBlock Grid.Column="2"

--- a/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
@@ -132,7 +132,7 @@
                                                       IsVisible="{Binding IsRemote}" />
                                         </ContextMenu>
                                     </Button.ContextMenu>
-                                    <icons:SymbolIcon FontSize="20" Symbol="MoreHorizontal" />
+                                    <icons:FluentIcon FontSize="20" Icon="MoreHorizontal" />
                                 </Button>
                             </Grid>
                         </Button>

--- a/src/Beutl/Pages/SettingsDialog.axaml.cs
+++ b/src/Beutl/Pages/SettingsDialog.axaml.cs
@@ -119,18 +119,18 @@ public sealed partial class SettingsDialog : AppWindow
             {
                 Content = Strings.Extensions,
                 Tag = typeof(ExtensionsSettingsPage),
-                IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource()
+                IconSource = new FluentIcons.Avalonia.Fluent.FluentIconSource()
                 {
-                    Symbol = FluentIcons.Common.Symbol.PuzzlePiece
+                    Icon = FluentIcons.Common.Icon.PuzzlePiece
                 }
             },
             new NavigationViewItem()
             {
                 Content = Strings.Info,
                 Tag = typeof(InformationPage),
-                IconSource = new FluentIcons.Avalonia.Fluent.SymbolIconSource()
+                IconSource = new FluentIcons.Avalonia.Fluent.FluentIconSource()
                 {
-                    Symbol = FluentIcons.Common.Symbol.Info
+                    Icon = FluentIcons.Common.Icon.Info
                 }
             }
         ];

--- a/src/Beutl/Pages/SettingsDialog.axaml.cs
+++ b/src/Beutl/Pages/SettingsDialog.axaml.cs
@@ -9,6 +9,7 @@ using FluentAvalonia.UI.Media.Animation;
 using FluentAvalonia.UI.Navigation;
 using FluentAvalonia.UI.Windowing;
 using Microsoft.Extensions.Logging;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
 
 namespace Beutl.Pages;
 
@@ -89,37 +90,37 @@ public sealed partial class SettingsDialog : AppWindow
             {
                 Content = SettingsStrings.Account,
                 Tag = typeof(AccountSettingsPage),
-                IconSource = new SymbolIconSource { Symbol = Symbol.People }
+                IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.People }
             },
             new NavigationViewItem()
             {
                 Content = Strings.View,
                 Tag = typeof(ViewSettingsPage),
-                IconSource = new SymbolIconSource { Symbol = Symbol.View }
+                IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Eye }
             },
             new NavigationViewItem()
             {
                 Content = Strings.Editor,
                 Tag = typeof(EditorSettingsPage),
-                IconSource = new SymbolIconSource { Symbol = Symbol.Edit }
+                IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Edit }
             },
             new NavigationViewItem()
             {
                 Content = SettingsStrings.Keymap,
                 Tag = typeof(KeyMapSettingsPage),
-                IconSource = new SymbolIconSource { Symbol = Symbol.Keyboard }
+                IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Keyboard }
             },
             new NavigationViewItem()
             {
                 Content = SettingsStrings.Font,
                 Tag = typeof(FontSettingsPage),
-                IconSource = new SymbolIconSource { Symbol = Symbol.Font }
+                IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.TextFont }
             },
             new NavigationViewItem()
             {
                 Content = Strings.Extensions,
                 Tag = typeof(ExtensionsSettingsPage),
-                IconSource = new FluentIcons.Avalonia.Fluent.FluentIconSource()
+                IconSource = new FluentIconSource()
                 {
                     Icon = FluentIcons.Common.Icon.PuzzlePiece
                 }
@@ -128,7 +129,7 @@ public sealed partial class SettingsDialog : AppWindow
             {
                 Content = Strings.Info,
                 Tag = typeof(InformationPage),
-                IconSource = new FluentIcons.Avalonia.Fluent.FluentIconSource()
+                IconSource = new FluentIconSource()
                 {
                     Icon = FluentIcons.Common.Icon.Info
                 }

--- a/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
+++ b/src/Beutl/Pages/SettingsPages/AccountSettingsScreen.axaml
@@ -29,9 +29,9 @@
                         CornerRadius="32"
                         IsVisible="{Binding ProfileImage.Value, Converter={x:Static StringConverters.IsNullOrEmpty}}">
 
-                    <icons:SymbolIcon VerticalAlignment="Center"
+                    <icons:FluentIcon VerticalAlignment="Center"
                                       FontSize="30"
-                                      Symbol="Person" />
+                                      Icon="Person" />
                 </Border>
                 <asyncImage:AdvancedImage Width="64"
                                           Height="64"
@@ -62,7 +62,7 @@
                         Command="{Binding SignOut}"
                         Theme="{StaticResource TransparentButton}">
                     <Grid ColumnDefinitions="Auto,8,Auto">
-                        <icons:SymbolIcon FontSize="20" Symbol="SignOut" />
+                        <icons:FluentIcon FontSize="20" Icon="SignOut" />
                         <TextBlock Grid.Column="2"
                                    VerticalAlignment="Center"
                                    FontSize="12"
@@ -77,7 +77,7 @@
                                       NavigationCommand="{Binding OpenAccountSettings}">
 
                 <ctrls:OptionsDisplayItem.Icon>
-                    <icons:SymbolIcon Symbol="Open" />
+                    <icons:FluentIcon Icon="Open" />
                 </ctrls:OptionsDisplayItem.Icon>
             </ctrls:OptionsDisplayItem>
         </StackPanel>

--- a/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ExtensionsSettingsPage.axaml
@@ -29,7 +29,7 @@
                                           Navigates="True"
                                           NavigationCommand="{Binding NavigateToEditorPriority}">
                     <ctrls:OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="TabDesktop" />
+                        <icons:FluentIcon Icon="TabDesktop" />
                     </ctrls:OptionsDisplayItem.Icon>
 
                 </ctrls:OptionsDisplayItem>
@@ -44,7 +44,7 @@
                         </Style>
                     </ctrls:OptionsDisplayItem.Styles>
                     <ctrls:OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="Settings" />
+                        <icons:FluentIcon Icon="Settings" />
                     </ctrls:OptionsDisplayItem.Icon>
 
                     <ctrls:OptionsDisplayItem.Content>

--- a/src/Beutl/Pages/SettingsPages/InformationPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/InformationPage.axaml
@@ -60,7 +60,7 @@
                                       Navigates="True"
                                       NavigationCommand="{Binding NavigateToTelemetry}">
                 <ctrls:OptionsDisplayItem.Icon>
-                    <icons:SymbolIcon Symbol="LockClosed" />
+                    <icons:FluentIcon Icon="LockClosed" />
                 </ctrls:OptionsDisplayItem.Icon>
             </ctrls:OptionsDisplayItem>
 
@@ -85,7 +85,7 @@
                                       Header="{x:Static lang:SettingsStrings.DeviceInformation}"
                                       IsExpanded="True">
                 <ctrls:OptionsDisplayItem.Icon>
-                    <icons:SymbolIcon Symbol="Desktop" />
+                    <icons:FluentIcon Icon="Desktop" />
                 </ctrls:OptionsDisplayItem.Icon>
                 <ctrls:OptionsDisplayItem.Content>
                     <StackPanel Margin="32,16">

--- a/src/Beutl/Pages/SettingsPages/InformationPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/InformationPage.axaml
@@ -37,7 +37,7 @@
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Theme="{StaticResource TransparentButton}">
                     <StackPanel Orientation="Horizontal" Spacing="4">
-                        <ui:SymbolIcon Symbol="Copy" />
+                        <icons:FluentIcon Icon="Copy" />
                         <TextBlock Text="{x:Static lang:SettingsStrings.CopyVersionInfo}" Theme="{StaticResource CaptionTextBlockStyle}" />
                     </StackPanel>
                 </Button>

--- a/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
@@ -8,6 +8,8 @@ using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Controls.Primitives;
 using Reactive.Bindings;
+using FluentIcon = FluentIcons.Avalonia.Fluent.FluentIcon;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Pages.SettingsPages;
 
@@ -69,7 +71,7 @@ public sealed class KeyMapFlyout : PickerFlyoutBase
         textBox.IsReadOnly = true;
         var deleteButton = new Button
         {
-            Content = new SymbolIcon { Symbol = Symbol.Delete },
+            Content = new FluentIcon { Icon = Icon.Delete },
             Theme = Application.Current?.FindResource("TransparentButton") as ControlTheme,
             Margin = new(4, 0, 0, 0)
         };

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -40,7 +40,7 @@
 
                 <ctrls:OptionsDisplayItem Header="{x:Static lang:SettingsStrings.Language}">
                     <ctrls:OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="LocalLanguage" />
+                        <icons:FluentIcon Icon="LocalLanguage" />
                     </ctrls:OptionsDisplayItem.Icon>
 
                     <ctrls:OptionsDisplayItem.ActionButton>
@@ -58,7 +58,7 @@
 
                 <ctrls:OptionsDisplayItem Expands="True" Header="{x:Static lang:SettingsStrings.AccentColor}">
                     <ctrls:OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="Color" />
+                        <icons:FluentIcon Icon="Color" />
                     </ctrls:OptionsDisplayItem.Icon>
                     <ctrls:OptionsDisplayItem.Content>
                         <StackPanel Margin="40,0">

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -107,9 +107,9 @@
                                                             HorizontalAlignment="Right"
                                                             VerticalAlignment="Top"
                                                             Background="{DynamicResource FocusStrokeColorOuter}">
-                                                        <ui:SymbolIcon FontSize="18"
-                                                                       Foreground="{DynamicResource SystemAccentColor}"
-                                                                       Symbol="Checkmark" />
+                                                        <icons:FluentIcon FontSize="18"
+                                                                          Foreground="{DynamicResource SystemAccentColor}"
+                                                                          Icon="Checkmark" />
                                                     </Border>
                                                 </Panel>
                                             </ControlTemplate>

--- a/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
@@ -4,8 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Beutl.ViewModels;
 using FluentAvalonia.UI.Controls;
-using Symbol = FluentIcons.Common.Symbol;
-using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
+using Icon = FluentIcons.Common.Icon;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
 
 namespace Beutl.Services.PrimitiveImpls;
 
@@ -21,7 +21,7 @@ public sealed class ExtensionsToolWindowExtension : ToolWindowExtension
     public override ToolWindowMode Mode => ToolWindowMode.Dialog;
 
     public override IconSource? GetIcon()
-        => new SymbolIconSource() { Symbol = Symbol.PuzzlePiece };
+        => new FluentIconSource() { Icon = Icon.PuzzlePiece };
 
     public override bool TryCreateContent([NotNullWhen(true)] out Window? window)
     {

--- a/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
@@ -4,8 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Beutl.ViewModels;
 using FluentAvalonia.UI.Controls;
-using Icon = FluentIcons.Common.Icon;
 using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Services.PrimitiveImpls;
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -7,8 +7,8 @@ using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 using Beutl.Views;
 using FluentAvalonia.UI.Controls;
-using Icon = FluentIcons.Common.Icon;
 using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Services.PrimitiveImpls;
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -7,8 +7,8 @@ using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 using Beutl.Views;
 using FluentAvalonia.UI.Controls;
-using Symbol = FluentIcons.Common.Symbol;
-using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
+using Icon = FluentIcons.Common.Icon;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
 
 namespace Beutl.Services.PrimitiveImpls;
 
@@ -136,7 +136,7 @@ public sealed class SceneEditorExtension : EditorExtension
 
     public override IconSource? GetIcon()
     {
-        return new SymbolIconSource { Symbol = Symbol.Document };
+        return new FluentIconSource { Icon = Icon.Document };
     }
 
     public override FilePickerFileType GetFilePickerFileType()

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -30,7 +30,7 @@
                 <TextBox Text="{CompiledBinding Location.Value, Mode=TwoWay}">
                     <TextBox.InnerRightContent>
                         <Button Click="PickLocation" Theme="{StaticResource TransparentButton}">
-                            <icons:SymbolIcon Symbol="OpenFolder" />
+                            <icons:FluentIcon Icon="OpenFolder" />
                         </Button>
                     </TextBox.InnerRightContent>
                 </TextBox>

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml
@@ -30,7 +30,7 @@
                     Background="Transparent"
                     BorderThickness="0"
                     Click="PickLocation">
-                <icons:SymbolIcon Symbol="OpenFolder" />
+                <icons:FluentIcon Icon="OpenFolder" />
             </Button>
         </Panel>
 

--- a/src/Beutl/Views/Dialogs/TelemetryDialog.axaml
+++ b/src/Beutl/Views/Dialogs/TelemetryDialog.axaml
@@ -4,6 +4,7 @@
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:lang="using:Beutl.Language"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                   xmlns:ui="using:FluentAvalonia.UI.Controls"
                   Title="{x:Static lang:SettingsStrings.Telemetry}"
                   d:DesignHeight="450"
@@ -23,9 +24,9 @@
                 Click="ShowDetail_Click"
                 ToolTip.Tip="https://beutl.beditor.net/about/telemetry">
             <Grid ColumnDefinitions="48,*">
-                <ui:SymbolIcon Height="48"
-                               FontSize="16"
-                               Symbol="Open" />
+                <icons:FluentIcon Height="48"
+                                  FontSize="16"
+                                  Icon="Open" />
 
                 <TextBlock Grid.Column="1"
                            VerticalAlignment="Center"

--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -34,7 +34,7 @@
                                     Navigates="True"
                                     NavigationRequested="OpenContext">
                     <OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="New" />
+                        <icons:FluentIcon Icon="New" />
                     </OptionsDisplayItem.Icon>
                     <OptionsDisplayItem.ContextMenu>
                         <ContextMenu Placement="AnchorAndGravity"
@@ -52,7 +52,7 @@
                                     Navigates="True"
                                     NavigationRequested="OpenContext">
                     <OptionsDisplayItem.Icon>
-                        <icons:SymbolIcon Symbol="Open" />
+                        <icons:FluentIcon Icon="Open" />
                     </OptionsDisplayItem.Icon>
                     <OptionsDisplayItem.ContextMenu>
                         <ContextMenu Placement="AnchorAndGravity"

--- a/src/Beutl/Views/EditorHostFallback.axaml
+++ b/src/Beutl/Views/EditorHostFallback.axaml
@@ -70,7 +70,7 @@
                                     Navigates="True"
                                     NavigationRequested="StartTutorial_Click">
                     <OptionsDisplayItem.Icon>
-                        <ui:SymbolIcon Symbol="Help" />
+                        <icons:FluentIcon Icon="QuestionCircle" />
                     </OptionsDisplayItem.Icon>
                 </OptionsDisplayItem>
             </WrapPanel>
@@ -164,10 +164,10 @@
                     AutomationProperties.Name="{x:Static lang:Strings.Website}"
                     Tag="Url"
                     ToolTip.Tip="{x:Static lang:Strings.Website}">
-                <ui:SymbolIcon Width="24"
-                               Height="24"
-                               FontSize="20"
-                               Symbol="Link" />
+                <icons:FluentIcon Width="24"
+                                  Height="24"
+                                  FontSize="20"
+                                  Icon="Link" />
             </Button>
         </StackPanel>
     </Grid>

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -42,16 +42,16 @@
                             Classes="size-24x24"
                             Click="Tag_Click"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Classes.add="{Binding IsGroup.Value}">
-                            <icons:SymbolIcon.Styles>
-                                <Style Selector="icons|SymbolIcon">
-                                    <Setter Property="Symbol" Value="Compose" />
+                        <icons:FluentIcon Classes.add="{Binding IsGroup.Value}">
+                            <icons:FluentIcon.Styles>
+                                <Style Selector="icons|FluentIcon">
+                                    <Setter Property="Icon" Value="Compose" />
                                 </Style>
-                                <Style Selector="icons|SymbolIcon.add">
-                                    <Setter Property="Symbol" Value="Add" />
+                                <Style Selector="icons|FluentIcon.add">
+                                    <Setter Property="Icon" Value="Add" />
                                 </Style>
-                            </icons:SymbolIcon.Styles>
-                        </icons:SymbolIcon>
+                            </icons:FluentIcon.Styles>
+                        </icons:FluentIcon>
                     </Button>
                 </StackPanel>
             </ToggleButton.Tag>

--- a/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectListItemEditor.axaml
@@ -33,7 +33,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -88,7 +88,7 @@
                                                         Text="{x:Static lang:Strings.Null}" />
                             </ui:FAMenuFlyout>
                         </Button.ContextFlyout>
-                        <icons:SymbolIcon Symbol="Compose" />
+                        <icons:FluentIcon Icon="Compose" />
                     </Button>
                 </Grid>
             </ToggleButton.Tag>
@@ -141,7 +141,7 @@
                                                     Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
-                    <icons:SymbolIcon Symbol="MoreVertical" />
+                    <icons:FluentIcon Icon="MoreVertical" />
                 </Button>
             </pe:ReferenceEditor.MenuContent>
         </pe:ReferenceEditor>

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -37,7 +37,7 @@
                         Classes="size-24x24"
                         Click="NewClick"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Symbol="New" />
+                    <icons:FluentIcon Icon="New" />
                 </Button>
             </ToggleButton.Tag>
             <TextBlock Text="{Binding Header}" />
@@ -62,7 +62,7 @@
                             <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
-                    <icons:SymbolIcon Symbol="MoreVertical" />
+                    <icons:FluentIcon Icon="MoreVertical" />
                 </Button>
             </pe:ReferenceEditor.MenuContent>
         </pe:ReferenceEditor>

--- a/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectListItemEditor.axaml
@@ -32,7 +32,7 @@
                     Classes="size-24x24"
                     Click="NewClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="New" />
+                <icons:FluentIcon Icon="New" />
             </Button>
 
             <Button Grid.Column="2"
@@ -41,7 +41,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 
@@ -64,7 +64,7 @@
                             Classes="size-24x24"
                             Click="DeleteClick"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Symbol="Delete" />
+                        <icons:FluentIcon Icon="Delete" />
                     </Button>
                 </StackPanel>
             </pe:ReferenceEditor.MenuContent>

--- a/src/Beutl/Views/Editors/CurveMapEditor.axaml
+++ b/src/Beutl/Views/Editors/CurveMapEditor.axaml
@@ -37,7 +37,7 @@
                 Click="OpenCurvesTab_Click"
                 IsEnabled="{Binding CanEdit.Value}">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <icons:SymbolIcon VerticalAlignment="Center" Symbol="Edit" />
+                <icons:FluentIcon VerticalAlignment="Center" Icon="Edit" />
                 <TextBlock Text="{x:Static lang:Strings.Curves}" />
             </StackPanel>
         </Button>

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -59,7 +59,7 @@
                         Classes="size-24x24"
                         Click="Tag_Click"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Symbol="Compose" />
+                    <icons:FluentIcon Icon="Compose" />
                 </Button>
             </ToggleButton.Tag>
             <TextBlock Text="{Binding Header, FallbackValue=Transform}" />

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -45,16 +45,16 @@
                             Classes="size-24x24"
                             Click="Tag_Click"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Classes.add="{Binding IsGroup.Value}">
-                            <icons:SymbolIcon.Styles>
-                                <Style Selector="icons|SymbolIcon">
-                                    <Setter Property="Symbol" Value="Compose" />
+                        <icons:FluentIcon Classes.add="{Binding IsGroup.Value}">
+                            <icons:FluentIcon.Styles>
+                                <Style Selector="icons|FluentIcon">
+                                    <Setter Property="Icon" Value="Compose" />
                                 </Style>
-                                <Style Selector="icons|SymbolIcon.add">
-                                    <Setter Property="Symbol" Value="Add" />
+                                <Style Selector="icons|FluentIcon.add">
+                                    <Setter Property="Icon" Value="Add" />
                                 </Style>
-                            </icons:SymbolIcon.Styles>
-                        </icons:SymbolIcon>
+                            </icons:FluentIcon.Styles>
+                        </icons:FluentIcon>
                     </Button>
                 </StackPanel>
             </ToggleButton.Tag>
@@ -85,7 +85,7 @@
                             <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
-                    <icons:SymbolIcon Symbol="MoreVertical" />
+                    <icons:FluentIcon Icon="MoreVertical" />
                 </Button>
             </pe:ReferenceEditor.MenuContent>
         </pe:ReferenceEditor>

--- a/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectListItemEditor.axaml
@@ -36,7 +36,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 
@@ -59,7 +59,7 @@
                             Classes="size-24x24"
                             Click="DeleteClick"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Symbol="Delete" />
+                        <icons:FluentIcon Icon="Delete" />
                     </Button>
                 </StackPanel>
             </pe:ReferenceEditor.MenuContent>

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -38,16 +38,16 @@
                         Classes="size-24x24"
                         Click="Tag_Click"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Classes.add="{Binding IsGroup.Value}">
-                        <icons:SymbolIcon.Styles>
-                            <Style Selector="icons|SymbolIcon">
-                                <Setter Property="Symbol" Value="Compose" />
+                    <icons:FluentIcon Classes.add="{Binding IsGroup.Value}">
+                        <icons:FluentIcon.Styles>
+                            <Style Selector="icons|FluentIcon">
+                                <Setter Property="Icon" Value="Compose" />
                             </Style>
-                            <Style Selector="icons|SymbolIcon.add">
-                                <Setter Property="Symbol" Value="Add" />
+                            <Style Selector="icons|FluentIcon.add">
+                                <Setter Property="Icon" Value="Add" />
                             </Style>
-                        </icons:SymbolIcon.Styles>
-                    </icons:SymbolIcon>
+                        </icons:FluentIcon.Styles>
+                    </icons:FluentIcon>
                 </Button>
             </ToggleButton.Tag>
             <WrapPanel Orientation="Horizontal">

--- a/src/Beutl/Views/Editors/GradientStopsEditor.axaml
+++ b/src/Beutl/Views/Editors/GradientStopsEditor.axaml
@@ -5,6 +5,7 @@
              xmlns:local="using:Beutl.Views.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:pe="using:Beutl.Controls.PropertyEditors"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:vm="using:Beutl.ViewModels.Editors"
              Padding="4,0"
@@ -38,7 +39,7 @@
             <Button Width="37"
                     Height="37"
                     Click="Delete_Click">
-                <ui:SymbolIcon FontSize="16" Symbol="Delete" />
+                <icons:FluentIcon FontSize="16" Icon="Delete" />
             </Button>
 
             <ui:ColorPickerButton x:Name="colorPicker"

--- a/src/Beutl/Views/Editors/GraphModelEditor.axaml
+++ b/src/Beutl/Views/Editors/GraphModelEditor.axaml
@@ -39,7 +39,7 @@
                     Click="OpenNodeGraphTab_Click"
                     IsEnabled="{Binding CanEdit.Value}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
-                    <icons:SymbolIcon VerticalAlignment="Center" Symbol="Flow" />
+                    <icons:FluentIcon VerticalAlignment="Center" Icon="Flow" />
                     <TextBlock Text="{x:Static lang:Strings.OpenInTab}" />
                 </StackPanel>
             </Button>

--- a/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml
+++ b/src/Beutl/Views/Editors/GraphModelNodeMemberView.axaml
@@ -17,18 +17,18 @@
                           IsChecked="{Binding IsExpanded.Value}"
                           Theme="{StaticResource ListEditorMiniExpanderToggleButton}">
                 <ToggleButton.Tag>
-                    <icons:SymbolIcon Margin="0,1,0,0" Symbol="ChevronUpDown" />
+                    <icons:FluentIcon Margin="0,1,0,0" Icon="ChevronUpDown" />
                 </ToggleButton.Tag>
                 <ToggleButton.ContextMenu>
                     <ContextMenu>
                         <MenuItem Click="Remove_Click" Header="{x:Static lang:Strings.Remove}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Delete" />
+                                <icons:FluentIcon Icon="Delete" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Click="RenameClick" Header="{x:Static lang:Strings.Rename}">
                             <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Rename" />
+                                <icons:FluentIcon Icon="Rename" />
                             </MenuItem.Icon>
                         </MenuItem>
                     </ContextMenu>
@@ -41,7 +41,7 @@
                     Classes="size-24x24"
                     Click="Remove_Click"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 

--- a/src/Beutl/Views/Editors/ListEditor.axaml
+++ b/src/Beutl/Views/Editors/ListEditor.axaml
@@ -32,16 +32,16 @@
                             <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
-                    <icons:SymbolIcon Classes.add="{Binding List.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
-                        <icons:SymbolIcon.Styles>
-                            <Style Selector="icons|SymbolIcon">
-                                <Setter Property="Symbol" Value="MoreVertical" />
+                    <icons:FluentIcon Classes.add="{Binding List.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
+                        <icons:FluentIcon.Styles>
+                            <Style Selector="icons|FluentIcon">
+                                <Setter Property="Icon" Value="MoreVertical" />
                             </Style>
-                            <Style Selector="icons|SymbolIcon.add">
-                                <Setter Property="Symbol" Value="Add" />
+                            <Style Selector="icons|FluentIcon.add">
+                                <Setter Property="Icon" Value="Add" />
                             </Style>
-                        </icons:SymbolIcon.Styles>
-                    </icons:SymbolIcon>
+                        </icons:FluentIcon.Styles>
+                    </icons:FluentIcon>
                 </Button>
             </ToggleButton.Tag>
         </ToggleButton>

--- a/src/Beutl/Views/Editors/ListItemEditorHost.axaml
+++ b/src/Beutl/Views/Editors/ListItemEditorHost.axaml
@@ -25,7 +25,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon VerticalAlignment="Center" Symbol="Delete" />
+                <icons:FluentIcon VerticalAlignment="Center" Icon="Delete" />
             </Button>
         </Grid>
 

--- a/src/Beutl/Views/Editors/NavigateButton.axaml
+++ b/src/Beutl/Views/Editors/NavigateButton.axaml
@@ -26,7 +26,7 @@
                 Click="Navigate_Click"
                 IsVisible="{Binding IsSet.Value}">
             <StackPanel Orientation="Horizontal" Spacing="16">
-                <ui:SymbolIcon Symbol="Open" />
+                <icons:FluentIcon Icon="Open" />
                 <TextBlock Text="{x:Static lang:Strings.Edit}" />
             </StackPanel>
         </Button>
@@ -39,7 +39,7 @@
                 IsEnabled="{Binding CanEdit.Value}"
                 IsVisible="{Binding IsNotSetAndCanWrite.Value}">
             <StackPanel Orientation="Horizontal" Spacing="16">
-                <ui:SymbolIcon Symbol="New" />
+                <icons:FluentIcon Icon="New" />
                 <TextBlock Text="{x:Static lang:Strings.CreateNew}" />
             </StackPanel>
         </Button>

--- a/src/Beutl/Views/Editors/NavigateButton.axaml
+++ b/src/Beutl/Views/Editors/NavigateButton.axaml
@@ -63,7 +63,7 @@
                               IsEnabled="{Binding CanWrite}" />
                 </ContextMenu>
             </Button.ContextMenu>
-            <icons:SymbolIcon Symbol="MoreVertical" />
+            <icons:FluentIcon Icon="MoreVertical" />
         </Button>
     </Grid>
 </UserControl>

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
@@ -27,9 +27,9 @@
                                        IsVisible="{Binding PreviewPath.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
                                        RenderTransform="scale(0.7)" />
 
-                        <icons:SymbolIcon Margin="0,1,0,0"
+                        <icons:FluentIcon Margin="0,1,0,0"
                                           IsVisible="{Binding PreviewPath.Value, Converter={x:Static ObjectConverters.IsNull}}"
-                                          Symbol="ReOrderDotsVertical" />
+                                          Icon="ReOrderDotsVertical" />
                     </Panel>
                 </ToggleButton.Tag>
                 <TextBlock Text="{x:Static lang:Strings.Figure}" />
@@ -61,7 +61,7 @@
                         Classes="size-24x24"
                         Click="Tag_Click"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Symbol="Add" />
+                    <icons:FluentIcon Icon="Add" />
                     <Button.ContextFlyout>
                         <ui:FAMenuFlyout>
                             <ui:MenuFlyoutItem Click="AddClick"
@@ -86,7 +86,7 @@
                         Classes="size-24x24"
                         Click="DeleteClick"
                         Theme="{StaticResource TransparentButton}">
-                    <icons:SymbolIcon Symbol="Delete" />
+                    <icons:FluentIcon Icon="Delete" />
                 </Button>
             </StackPanel>
         </Grid>

--- a/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/PathOperationListItemEditor.axaml
@@ -25,7 +25,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -38,7 +38,7 @@
                             <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
-                    <icons:SymbolIcon Symbol="Compose" />
+                    <icons:FluentIcon Icon="Compose" />
                 </Button>
             </ToggleButton.Tag>
         </ToggleButton>

--- a/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorGroup.axaml
@@ -30,7 +30,7 @@
                     Classes="size-24x24"
                     Click="ShowClick"
                     Theme="{DynamicResource TransparentButton}">
-                <icons:SymbolIcon Symbol="ChevronUpDown" />
+                <icons:FluentIcon Icon="ChevronUpDown" />
             </Button>
         </Panel>
 

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
@@ -67,23 +67,23 @@
                                    Text="{x:Static lang:Strings.CopyGetPropertyCode}" />
             </ui:FAMenuFlyout>
         </Button.ContextFlyout>
-        <icons:SymbolIcon x:Name="symbolIcon"
+        <icons:FluentIcon x:Name="symbolIcon"
                           Classes.hasAnimation="{Binding HasAnimation.Value}"
                           Classes.hasExpression="{Binding HasExpression.Value}"
                           IconVariant="{Binding SymbolIconVariant.Value}">
-            <icons:SymbolIcon.Styles>
-                <Style Selector="icons|SymbolIcon">
-                    <Setter Property="Symbol" Value="MoreVertical" />
+            <icons:FluentIcon.Styles>
+                <Style Selector="icons|FluentIcon">
+                    <Setter Property="Icon" Value="MoreVertical" />
                 </Style>
-                <Style Selector="icons|SymbolIcon.hasAnimation">
-                    <Setter Property="Symbol" Value="Diamond" />
+                <Style Selector="icons|FluentIcon.hasAnimation">
+                    <Setter Property="Icon" Value="Diamond" />
                     <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCaution}" />
                 </Style>
-                <Style Selector="icons|SymbolIcon.hasExpression">
-                    <Setter Property="Symbol" Value="MathFormula" />
+                <Style Selector="icons|FluentIcon.hasExpression">
+                    <Setter Property="Icon" Value="MathFormula" />
                     <Setter Property="Foreground" Value="{DynamicResource SystemFillColorSuccess}" />
                 </Style>
-            </icons:SymbolIcon.Styles>
-        </icons:SymbolIcon>
+            </icons:FluentIcon.Styles>
+        </icons:FluentIcon>
     </Button>
 </UserControl>

--- a/src/Beutl/Views/Editors/SceneEditor.axaml
+++ b/src/Beutl/Views/Editors/SceneEditor.axaml
@@ -22,7 +22,7 @@
                         <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                     </ui:FAMenuFlyout>
                 </Button.Flyout>
-                <icons:SymbolIcon Symbol="MoreVertical" />
+                <icons:FluentIcon Icon="MoreVertical" />
             </Button>
         </pe:ReferenceEditor.MenuContent>
     </pe:ReferenceEditor>

--- a/src/Beutl/Views/Editors/TextureSourceEditor.axaml
+++ b/src/Beutl/Views/Editors/TextureSourceEditor.axaml
@@ -44,7 +44,7 @@
                                                     Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
-                    <icons:SymbolIcon Symbol="Compose" />
+                    <icons:FluentIcon Icon="Compose" />
                 </Button>
             </ToggleButton.Tag>
         </ToggleButton>

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -44,16 +44,16 @@
                             Classes="size-24x24"
                             Click="Tag_Click"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Classes.add="{Binding IsGroup.Value}">
-                            <icons:SymbolIcon.Styles>
-                                <Style Selector="icons|SymbolIcon">
-                                    <Setter Property="Symbol" Value="Compose" />
+                        <icons:FluentIcon Classes.add="{Binding IsGroup.Value}">
+                            <icons:FluentIcon.Styles>
+                                <Style Selector="icons|FluentIcon">
+                                    <Setter Property="Icon" Value="Compose" />
                                 </Style>
-                                <Style Selector="icons|SymbolIcon.add">
-                                    <Setter Property="Symbol" Value="Add" />
+                                <Style Selector="icons|FluentIcon.add">
+                                    <Setter Property="Icon" Value="Add" />
                                 </Style>
-                            </icons:SymbolIcon.Styles>
-                        </icons:SymbolIcon>
+                            </icons:FluentIcon.Styles>
+                        </icons:FluentIcon>
                     </Button>
                 </StackPanel>
             </ToggleButton.Tag>
@@ -79,7 +79,7 @@
                             <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
-                    <icons:SymbolIcon Symbol="MoreVertical" />
+                    <icons:FluentIcon Icon="MoreVertical" />
                 </Button>
             </pe:ReferenceEditor.MenuContent>
         </pe:ReferenceEditor>

--- a/src/Beutl/Views/Editors/TransformListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformListItemEditor.axaml
@@ -41,7 +41,7 @@
                     Classes="size-24x24"
                     Click="DeleteClick"
                     Theme="{StaticResource TransparentButton}">
-                <icons:SymbolIcon Symbol="Delete" />
+                <icons:FluentIcon Icon="Delete" />
             </Button>
         </Grid>
 
@@ -64,7 +64,7 @@
                             Classes="size-24x24"
                             Click="DeleteClick"
                             Theme="{StaticResource TransparentButton}">
-                        <icons:SymbolIcon Symbol="Delete" />
+                        <icons:FluentIcon Icon="Delete" />
                     </Button>
                 </StackPanel>
             </pe:ReferenceEditor.MenuContent>

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -267,9 +267,9 @@
                         </Flyout>
                     </Button.Flyout>
                     <Panel>
-                        <ui:SymbolIcon HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       Symbol="Alert" />
+                        <icons:FluentIcon HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Icon="Alert" />
                         <ui:InfoBadge Width="8"
                                       Height="8"
                                       Margin="0,4,4,0"

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -57,7 +57,7 @@
                     <!--  新規作成  -->
                     <MenuItem Header="{x:Static lang:Strings.CreateNew}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="New" />
+                            <icons:FluentIcon Icon="New" />
                         </MenuItem.Icon>
                         <!--  プロジェクト  -->
                         <MenuItem Command="{CompiledBinding MenuBar.CreateNewProject}"
@@ -74,7 +74,7 @@
                     <!--  開く  -->
                     <MenuItem Header="{x:Static lang:Strings.Open}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Open" />
+                            <icons:FluentIcon Icon="Open" />
                         </MenuItem.Icon>
                         <!--  プロジェクト  -->
                         <MenuItem Command="{CompiledBinding MenuBar.OpenProject}"
@@ -102,7 +102,7 @@
                                                                  ExtensionType={x:Type p:MainViewExtension}}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="Save" />
+                            <icons:FluentIcon Icon="Save" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <!--  すべて保存  -->
@@ -112,7 +112,7 @@
                                                                  ExtensionType={x:Type p:MainViewExtension}}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="SaveMultiple" />
+                            <icons:FluentIcon Icon="SaveMultiple" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator />
@@ -121,14 +121,14 @@
                               Header="{x:Static lang:Strings.ExportProject}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="ArrowExport" />
+                            <icons:FluentIcon Icon="ArrowExport" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <!--  プロジェクトをインポート  -->
                     <MenuItem Command="{CompiledBinding MenuBar.ImportProject}"
                               Header="{x:Static lang:Strings.ImportProject}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="ArrowImport" />
+                            <icons:FluentIcon Icon="ArrowImport" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <Separator />
@@ -154,7 +154,7 @@
                                                                  ExtensionType={x:Type p:MainViewExtension}}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="ArrowUndo" />
+                            <icons:FluentIcon Icon="ArrowUndo" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <!--  やり直し  -->
@@ -164,7 +164,7 @@
                                                                  ExtensionType={x:Type p:MainViewExtension}}"
                               IsEnabled="{CompiledBinding IsProjectOpened.Value}">
                         <MenuItem.Icon>
-                            <icons:SymbolIcon Symbol="ArrowRedo" />
+                            <icons:FluentIcon Icon="ArrowRedo" />
                         </MenuItem.Icon>
                     </MenuItem>
                 </MenuItem>
@@ -250,7 +250,7 @@
                         Click="OpenFeedbackClick"
                         ToolTip.Tip="{x:Static lang:Strings.Feedback}"
                         Theme="{StaticResource TitleBarButtonStyle}">
-                    <icons:SymbolIcon Symbol="Chat" Margin="0,0,0,2" />
+                    <icons:FluentIcon Icon="Chat" Margin="0,0,0,2" />
                 </Button>
 
                 <Button x:Name="OpenNotificationsButton"

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -536,7 +536,7 @@ public sealed partial class MainView : UserControl
     }
 
     private void OpenFeedbackClick(object? sender, RoutedEventArgs e)
-    {//FluentIcons.Common.Symbol.Chat
+    {
         string url = $"https://beutl.beditor.net/feedback?traceId={Telemetry.Instance._sessionId}";
         Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
     }

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -128,7 +128,7 @@
             </StackPanel>
         </Player.InnerLeftContent>
         <Player.InnerRightContent>
-            <Button Padding="7,6,5,6"
+            <Button Padding="5,6,5,6"
                     VerticalAlignment="Top"
                     Command="{Binding OpenPreviewSettings}"
                     Theme="{StaticResource TransparentButton}"

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -37,16 +37,16 @@
                     </Style>
                 </StackPanel.Styles>
                 <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Move}" IsChecked="{Binding IsMoveMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Move}">
-                    <icons:SymbolIcon FontSize="16" Symbol="Cursor" />
+                    <icons:FluentIcon Icon="Cursor" />
                 </RadioButton>
                 <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Hand}" IsChecked="{Binding IsHandMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Hand}">
-                    <icons:SymbolIcon FontSize="16" Symbol="HandLeft" />
+                    <icons:FluentIcon Icon="HandLeft" />
                 </RadioButton>
                 <RadioButton AutomationProperties.Name="{x:Static lang:Strings.CropSelection}" IsChecked="{Binding IsCropMode.Value}" ToolTip.Tip="{x:Static lang:Strings.CropSelection}">
-                    <icons:SymbolIcon FontSize="16" Symbol="Crop" />
+                    <icons:FluentIcon Icon="Crop" />
                 </RadioButton>
                 <RadioButton AutomationProperties.Name="{x:Static lang:Strings.Camera3DControl}" IsChecked="{Binding IsCameraMode.Value}" ToolTip.Tip="{x:Static lang:Strings.Camera3DControl}">
-                    <icons:SymbolIcon FontSize="16" Symbol="Video" />
+                    <icons:FluentIcon Icon="Video" />
                 </RadioButton>
                 <!--  Gizmo Mode Selection (visible only in Camera Mode)  -->
                 <Border Margin="0,8,0,0"
@@ -59,21 +59,21 @@
                              IsVisible="{Binding IsCameraMode.Value}"
                              AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Translate}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Translate}">
-                    <icons:SymbolIcon FontSize="16" Symbol="ArrowMove" />
+                    <icons:FluentIcon Icon="ArrowMove" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsRotate}}"
                              IsVisible="{Binding IsCameraMode.Value}"
                              AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Rotate}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Rotate}">
-                    <icons:SymbolIcon FontSize="16" Symbol="ArrowRotateClockwise" />
+                    <icons:FluentIcon Icon="ArrowRotateClockwise" />
                 </RadioButton>
                 <RadioButton GroupName="GizmoMode"
                              IsChecked="{Binding SelectedGizmoMode.Value, Converter={x:Static converters:GizmoModeConverters.IsScale}}"
                              IsVisible="{Binding IsCameraMode.Value}"
                              AutomationProperties.Name="{x:Static lang:Strings.Gizmo_Scale}"
                              ToolTip.Tip="{x:Static lang:Strings.Gizmo_Scale}">
-                    <icons:SymbolIcon FontSize="16" Symbol="ArrowExpand" />
+                    <icons:FluentIcon Icon="ArrowExpand" />
                 </RadioButton>
                 <Border Margin="0,8,0,0"
                         BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
@@ -134,7 +134,7 @@
                     Theme="{StaticResource TransparentButton}"
                     AutomationProperties.Name="{x:Static lang:Strings.PreviewSettings}"
                     ToolTip.Tip="{x:Static lang:Strings.PreviewSettings}">
-                <icons:SymbolIcon FontSize="16" Symbol="Settings" />
+                <icons:FluentIcon Icon="Settings" />
             </Button>
         </Player.InnerRightContent>
         <Player.Content>

--- a/src/Beutl/Views/PlayerView.axaml.FrameContextMenu.cs
+++ b/src/Beutl/Views/PlayerView.axaml.FrameContextMenu.cs
@@ -16,6 +16,9 @@ using FluentAvalonia.UI.Controls;
 
 using Microsoft.Extensions.Logging;
 
+using FluentIcon = FluentIcons.Avalonia.Fluent.FluentIcon;
+using Icon = FluentIcons.Common.Icon;
+
 namespace Beutl.Views;
 
 public partial class PlayerView
@@ -33,9 +36,9 @@ public partial class PlayerView
         _saveFrameAsImage = new MenuItem
         {
             Header = Strings.SaveFrameAsImage,
-            Icon = new SymbolIcon
+            Icon = new FluentIcon
             {
-                Symbol = Symbol.Image
+                Icon = Icon.Image
             },
         };
         _saveFrameAsImage.Click += OnSaveFrameAsImageClick;

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -1006,7 +1006,7 @@ public partial class PlayerView
                     var saveAsImage = new MenuFlyoutItem()
                     {
                         Text = Strings.SaveAsImage,
-                        IconSource = new FluentIconSource() { Icon = Icon.SaveEdit }
+                        IconSource = new FluentIconSource() { Icon = Icon.SaveImage }
                     };
                     copyAsString.Click += (s, e) =>
                     {

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -34,6 +34,8 @@ using BtlMatrix = Beutl.Graphics.Matrix;
 using BtlPoint = Beutl.Graphics.Point;
 using BtlRect = Beutl.Graphics.Rect;
 using BtlSize = Beutl.Graphics.Size;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Views;
 
@@ -999,12 +1001,12 @@ public partial class PlayerView
                     var copyAsString = new MenuFlyoutItem()
                     {
                         Text = Strings.Copy,
-                        IconSource = new SymbolIconSource() { Symbol = Symbol.Copy }
+                        IconSource = new FluentIconSource() { Icon = Icon.Copy }
                     };
                     var saveAsImage = new MenuFlyoutItem()
                     {
                         Text = Strings.SaveAsImage,
-                        IconSource = new SymbolIconSource() { Symbol = Symbol.SaveAs }
+                        IconSource = new FluentIconSource() { Icon = Icon.SaveEdit }
                     };
                     copyAsString.Click += (s, e) =>
                     {
@@ -1045,7 +1047,7 @@ public partial class PlayerView
                         var copyAsImage = new MenuFlyoutItem()
                         {
                             Text = Strings.CopyAsImage,
-                            IconSource = new SymbolIconSource() { Symbol = Symbol.ImageCopy }
+                            IconSource = new FluentIconSource() { Icon = Icon.ImageCopy }
                         };
                         copyAsImage.Click += (s, e) => OnCopyAsImageClicked(rect);
 

--- a/src/Beutl/Views/TitleBreadcrumbBar.axaml
+++ b/src/Beutl/Views/TitleBreadcrumbBar.axaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
              xmlns:viewModels="using:Beutl.ViewModels"
              x:Name="Root"
@@ -40,9 +41,9 @@
                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                    Text="{Binding ProjectName.Value}" />
 
-        <ui:SymbolIcon VerticalAlignment="Center"
-                       IsVisible="{Binding IsProjectOpened.Value}"
-                       Symbol="ChevronRight" />
+        <icons:FluentIcon VerticalAlignment="Center"
+                          IsVisible="{Binding IsProjectOpened.Value}"
+                          Icon="ChevronRight" />
 
         <Button Name="FileButton"
                 VerticalAlignment="Center"
@@ -76,16 +77,16 @@
                                                 Command="{ReflectionBinding #Root.DataContext.CloseOrRemoveFile}"
                                                 CommandParameter="{Binding .}"
                                                 Theme="{StaticResource TransparentButton}">
-                                            <ui:SymbolIcon Classes.delete="{ReflectionBinding #Root.DataContext.IsProjectOpened.Value}">
-                                                <ui:SymbolIcon.Styles>
-                                                    <Style Selector="ui|SymbolIcon">
-                                                        <Setter Property="Symbol" Value="Clear" />
+                                            <icons:FluentIcon Classes.delete="{ReflectionBinding #Root.DataContext.IsProjectOpened.Value}">
+                                                <icons:FluentIcon.Styles>
+                                                    <Style Selector="icons|FluentIcon">
+                                                        <Setter Property="Icon" Value="Dismiss" />
                                                     </Style>
-                                                    <Style Selector="ui|SymbolIcon.delete">
-                                                        <Setter Property="Symbol" Value="Delete" />
+                                                    <Style Selector="icons|FluentIcon.delete">
+                                                        <Setter Property="Icon" Value="Delete" />
                                                     </Style>
-                                                </ui:SymbolIcon.Styles>
-                                            </ui:SymbolIcon>
+                                                </icons:FluentIcon.Styles>
+                                            </icons:FluentIcon>
                                         </Button>
                                     </Grid>
                                 </DataTemplate>

--- a/src/Beutl/Views/Tools/HistoryView.axaml
+++ b/src/Beutl/Views/Tools/HistoryView.axaml
@@ -5,6 +5,7 @@
              xmlns:editor="using:Beutl.Editor"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModels="using:Beutl.ViewModels.Tools"
              d:DesignHeight="450"
@@ -52,7 +53,7 @@
                     Click="OnUndoClick"
                     Theme="{StaticResource TransparentButton}"
                     ToolTip.Tip="{x:Static lang:Strings.Undo}">
-                <ui:SymbolIcon Symbol="Undo" />
+                <icons:FluentIcon Icon="ArrowUndo" />
             </Button>
             <Button Grid.Column="1"
                     Margin="4,0,0,0"
@@ -60,7 +61,7 @@
                     Click="OnRedoClick"
                     Theme="{StaticResource TransparentButton}"
                     ToolTip.Tip="{x:Static lang:Strings.Redo}">
-                <ui:SymbolIcon Symbol="Redo" />
+                <icons:FluentIcon Icon="ArrowRedo" />
             </Button>
             <TextBlock Grid.Column="2"
                        Margin="8,0,0,0"

--- a/src/Beutl/Views/Tools/OutputTab.axaml
+++ b/src/Beutl/Views/Tools/OutputTab.axaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModels="using:Beutl.ViewModels.Tools"
              Name="Root"
@@ -26,7 +27,7 @@
                         Click="OnAddClick"
                         Theme="{StaticResource TransparentButton}"
                         ToolTip.Tip="{x:Static lang:Strings.Add}">
-                    <ui:SymbolIcon Symbol="Add" />
+                    <icons:FluentIcon Icon="Add" />
                 </Button>
                 <Button Name="MoreButton"
                         Grid.Column="4"
@@ -49,7 +50,7 @@
                                                Text="{x:Static lang:Strings.Convert_to_preset}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
-                    <ui:SymbolIcon Symbol="MoreVertical" />
+                    <icons:FluentIcon Icon="MoreVertical" />
                 </Button>
             </Grid>
 

--- a/src/Beutl/Views/Tools/OutputTab.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputTab.axaml.cs
@@ -11,6 +11,8 @@ using Beutl.ViewModels.Dialogs;
 using Beutl.ViewModels.Tools;
 using FluentAvalonia.UI.Controls;
 using AddOutputProfileDialog = Beutl.Views.Dialogs.AddOutputProfileDialog;
+using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
+using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Views.Tools;
 
@@ -170,7 +172,7 @@ public partial class OutputTab : UserControl
                     var removeItem = new MenuFlyoutItem
                     {
                         Text = Language.Strings.Remove,
-                        IconSource = new SymbolIconSource { Symbol = Symbol.Delete }
+                        IconSource = new FluentIconSource { Icon = Icon.Delete }
                     };
                     removeItem.Click += (_, _) =>
                     {
@@ -197,7 +199,7 @@ public partial class OutputTab : UserControl
                     var removeItem = new MenuFlyoutItem
                     {
                         Text = Language.Strings.Remove,
-                        IconSource = new SymbolIconSource { Symbol = Symbol.Delete }
+                        IconSource = new FluentIconSource { Icon = Icon.Delete }
                     };
                     removeItem.Click += (_, _) =>
                     {


### PR DESCRIPTION
## Description
- Complete the migration started in #2058 by replacing every `FluentAvalonia` `SymbolIcon` usage with `FluentIcons` `FluentIcon` (`Symbol="…"` → `Icon="…"`) across XAML and code-behind.
- Add a global `:is(icons|FluentIcon)` style (FontSize 16) so migrated icons keep a consistent default size, and refine icon styling / button padding to match the previous visual weight.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None (internal UI markup only; no public API change).

## Test plan
- Manual visual verification: icons render at the correct size across the main menu, property editors, timeline, extensions/settings pages, and player controls.
- Existing headless UI tests continue to pass; no logic changed.

## Fixed issues / References
- Follow-up to #2058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated many app, editor, settings, and tool interfaces to use a consistent Fluent icon set across buttons, menus, tabs, dialogs, flyouts, and context menus.
  * Standardized icon rendering by swapping from symbol-based icons to Fluent Icons for common actions (e.g., Open, Delete, Copy/Paste, Settings, Navigation, Undo/Redo, More).
  * Refreshed icon sizes and visual-state styling (checked/pressed/disabled) to keep alignment and appearance consistent throughout the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->