### PR TITLE
ci: free disk space before .NET build to stop intermittent 'No space left on device'

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,6 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # ubuntu-latest ships ~19GB of pre-installed tooling this .NET-only job never
+      # uses (Android SDK, Haskell/GHC, CodeQL, cached Docker images). When a runner
+      # starts with little headroom the build+test+coverage run exhausts the disk and
+      # aborts with "No space left on device". Reclaiming it up front keeps the job's
+      # free space consistent across runners.
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Checkout
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

The `.NET` workflow (`dotnet.yml`) intermittently fails on `ubuntu-latest` with `System.IO.IOException: No space left on device` during the build/test/coverage run (e.g. run [29028510213](https://github.com/b-editor/beutl/actions/runs/29028510213) on `main`).

The failure is **flaky, not a code issue**: the exact same commit passes when re-run. Concrete evidence from the run history — commit on `loop/clip-lock`:
- run `29032667630` failed at **2m20s** (aborts early on disk exhaustion)
- re-run `29034293540` succeeded at **6m2s**

All disk-full failures share the ~2min early-abort signature; healthy runs take 6–7min. The root cause is variance in how much free disk a GitHub-hosted runner starts with.

## Fix

Add a `Free disk space` step at the top of the job that removes ~19GB of pre-installed tooling this .NET-only job never uses — Android SDK, Haskell/GHC, CodeQL, and cached Docker images — before checkout/build. This gives the build+test+coverage run consistent headroom.

The removals are static (no untrusted input) and only touch tooling unrelated to the .NET build.

## Notes

This touches a CI workflow (`AGENTS.md` mandatory rule #5); changed with explicit user approval to address the recurring failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by freeing disk space before automated build, test, and coverage tasks.
  * Added disk usage checks before and after cleanup to help monitor available storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->