### PR TITLE
fix: correct package update button visibility in extensions pages

### DIFF
--- a/src/Beutl.Api/Services/InstalledPackageRepository.cs
+++ b/src/Beutl.Api/Services/InstalledPackageRepository.cs
@@ -290,7 +290,7 @@ public class InstalledPackageRepository : IBeutlApiResource
         {
             if (_packageIdentity != null)
             {
-                if (_packageIdentity == obj.Package)
+                if (PackageIdentity.Comparer.Equals(_packageIdentity, obj.Package))
                 {
                     PublishNext(obj.Exists);
                 }

--- a/src/Beutl.Api/Services/InstalledPackageRepository.cs
+++ b/src/Beutl.Api/Services/InstalledPackageRepository.cs
@@ -164,6 +164,16 @@ public class InstalledPackageRepository : IBeutlApiResource
         return new _Observable(this, name, version);
     }
 
+    public IObservable<PackageIdentity?> GetPackageObservable(string name)
+    {
+        return new _PackageObservable(this, name);
+    }
+
+    public static bool IsNewerThanInstalled(string releaseVersion, PackageIdentity? installed)
+    {
+        return installed is null || NuGetVersion.Parse(releaseVersion) > installed.Version;
+    }
+
     public PackageIdentity[] GetPackagesNeedingDependencyReResolution()
     {
         string currentVersion = BeutlApplication.Version;
@@ -283,11 +293,62 @@ public class InstalledPackageRepository : IBeutlApiResource
 
         private void OnReceived((PackageIdentity Package, bool Exists) obj)
         {
-            if ((_packageIdentity != null && _packageIdentity == obj.Package)
-                || StringComparer.OrdinalIgnoreCase.Equals(obj.Package.Id, _name))
+            if (_packageIdentity != null)
             {
-                PublishNext(obj.Exists);
+                if (_packageIdentity == obj.Package)
+                {
+                    PublishNext(obj.Exists);
+                }
             }
+            else if (StringComparer.OrdinalIgnoreCase.Equals(obj.Package.Id, _name))
+            {
+                // Per-event Exists is unreliable for name-only observers; re-evaluate the aggregate.
+                PublishNext(_repository.ExistsPackage(_name));
+            }
+        }
+    }
+
+    private sealed class _PackageObservable : LightweightObservableBase<PackageIdentity?>
+    {
+        private readonly InstalledPackageRepository _repository;
+        private readonly string _name;
+        private IDisposable? _disposable;
+
+        public _PackageObservable(InstalledPackageRepository repository, string name)
+        {
+            _repository = repository;
+            _name = name;
+        }
+
+        protected override void Subscribed(IObserver<PackageIdentity?> observer, bool first)
+        {
+            observer.OnNext(GetLatestInstalled());
+        }
+
+        protected override void Deinitialize()
+        {
+            _disposable?.Dispose();
+            _disposable = null;
+        }
+
+        protected override void Initialize()
+        {
+            _disposable = _repository._subject.Subscribe(OnReceived);
+        }
+
+        private void OnReceived((PackageIdentity Package, bool Exists) obj)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(obj.Package.Id, _name))
+            {
+                PublishNext(GetLatestInstalled());
+            }
+        }
+
+        private PackageIdentity? GetLatestInstalled()
+        {
+            return _repository.GetLocalPackages(_name)
+                .OrderByDescending(x => x.Version)
+                .FirstOrDefault();
         }
     }
 }

--- a/src/Beutl.Api/Services/InstalledPackageRepository.cs
+++ b/src/Beutl.Api/Services/InstalledPackageRepository.cs
@@ -169,11 +169,6 @@ public class InstalledPackageRepository : IBeutlApiResource
         return new _PackageObservable(this, name);
     }
 
-    public static bool IsNewerThanInstalled(string releaseVersion, PackageIdentity? installed)
-    {
-        return installed is null || NuGetVersion.Parse(releaseVersion) > installed.Version;
-    }
-
     public PackageIdentity[] GetPackagesNeedingDependencyReResolution()
     {
         string currentVersion = BeutlApplication.Version;

--- a/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml
@@ -105,6 +105,15 @@
                                         Command="{Binding Update}"
                                         Content="{Binding StatusText.Value, TargetNullValue={x:Static lang:ExtensionsStrings.Update}}" />
 
+                                <Button Name="operationStatusButton"
+                                        Grid.Column="4"
+                                        Padding="40,5,40,6"
+                                        HorizontalAlignment="Stretch"
+                                        Classes.transparent="{Binding !IsBusy.Value}"
+                                        Classes.shimmer="{Binding IsBusy.Value}"
+                                        Content="{Binding StatusText.Value}"
+                                        IsHitTestVisible="False" />
+
                                 <Button Grid.Column="4"
                                         Padding="40,5,40,6"
                                         HorizontalAlignment="Stretch"

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Beutl.Api;
+﻿using System.Reactive.Subjects;
+using Beutl.Api;
 using Beutl.Api.Objects;
 using Beutl.Api.Services;
 using Beutl.Logging;
@@ -25,6 +26,9 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         _app = app;
         _handler = new PackageOperationHandler(app, editorService, projectService);
         _library = app.GetResource<LibraryService>();
+        var releaseResolutionRequests = new Subject<PackageIdentity?>();
+        PackageIdentity? installedPackage = null;
+        bool hasInstalledPackageEmission = false;
 
         DisplayName = package.DisplayName
             .Select(x => !string.IsNullOrWhiteSpace(x) ? x : Package.Name)
@@ -74,11 +78,10 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     IsBusy.Value = false;
+                    releaseResolutionRequests.OnNext(installedPackage);
                 }
             })
             .DisposeWith(_disposables);
-
-        Refresh.Execute();
 
         IObservable<PackageChangesQueue.EventType> observable = _handler.Queue.GetObservable(package.Name);
         CanCancel = observable.Select(x => x != PackageChangesQueue.EventType.None)
@@ -112,7 +115,25 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
         _handler.InstalledPackageRepository
             .GetPackageObservable(package.Name)
-            .Subscribe(id => _ = ResolveCurrentReleaseAsync(id))
+            .Subscribe(id =>
+            {
+                installedPackage = id;
+                if (hasInstalledPackageEmission)
+                {
+                    releaseResolutionRequests.OnNext(id);
+                }
+
+                hasInstalledPackageEmission = true;
+            })
+            .DisposeWith(_disposables);
+
+        PackageReleaseResolver.ObserveLatest(
+                releaseResolutionRequests,
+                () => SelectedRelease.Value,
+                () => AllReleases,
+                Package.GetReleaseAsync,
+                ex => _logger.LogWarning(ex, "Failed to resolve installed release for {PackageId}.", Package.Name))
+            .Subscribe(release => CurrentRelease.Value = release)
             .DisposeWith(_disposables);
 
         IsUpdateButtonVisible = CurrentRelease.CombineLatest(SelectedRelease)
@@ -325,6 +346,8 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 }
             })
             .DisposeWith(_disposables);
+
+        Refresh.Execute();
     }
 
     private async Task<Release> AcquireRelease()
@@ -341,40 +364,6 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         }
 
         return (await Package.GetReleasesAsync())[0];
-    }
-
-    private async Task ResolveCurrentReleaseAsync(PackageIdentity? id)
-    {
-        if (id is null)
-        {
-            CurrentRelease.Value = null;
-            return;
-        }
-
-        string versionStr = id.Version.ToString();
-        if (SelectedRelease.Value is { } selected && selected.Version.Value == versionStr)
-        {
-            CurrentRelease.Value = selected;
-            return;
-        }
-
-        foreach (Release r in AllReleases)
-        {
-            if (r.Version.Value == versionStr)
-            {
-                CurrentRelease.Value = r;
-                return;
-            }
-        }
-
-        try
-        {
-            CurrentRelease.Value = await Package.GetReleaseAsync(versionStr);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to resolve installed release for {PackageId}.", Package.Name);
-        }
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Reactive.Bindings;
+using ReactiveUI.Avalonia;
 using LibraryService = Beutl.Api.Services.LibraryService;
 
 namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
@@ -115,6 +116,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
         _handler.InstalledPackageRepository
             .GetPackageObservable(package.Name)
+            .ObserveOn(AvaloniaScheduler.Instance)
             .Subscribe(id =>
             {
                 installedPackage = id;
@@ -129,6 +131,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
         PackageReleaseResolver.ObserveLatest(
                 releaseResolutionRequests,
+                AvaloniaScheduler.Instance,
                 () => SelectedRelease.Value,
                 () => AllReleases,
                 Package.GetReleaseAsync,

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -27,9 +27,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         _app = app;
         _handler = new PackageOperationHandler(app, editorService, projectService);
         _library = app.GetResource<LibraryService>();
-        var releaseResolutionRequests = new Subject<PackageIdentity?>();
-        PackageIdentity? installedPackage = null;
-        bool hasInstalledPackageEmission = false;
+        var releasesReady = new BehaviorSubject<bool>(false);
 
         DisplayName = package.DisplayName
             .Select(x => !string.IsNullOrWhiteSpace(x) ? x : Package.Name)
@@ -47,6 +45,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         IsBusy.Value = true;
+                        releasesReady.OnNext(false);
                         AllReleases.Clear();
                         LatestRelease.Value = null;
                         await Package.RefreshAsync();
@@ -79,7 +78,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     IsBusy.Value = false;
-                    releaseResolutionRequests.OnNext(installedPackage);
+                    releasesReady.OnNext(true);
                 }
             })
             .DisposeWith(_disposables);
@@ -114,20 +113,11 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        _handler.InstalledPackageRepository
-            .GetPackageObservable(package.Name)
-            .ObserveOn(AvaloniaScheduler.Instance)
-            .Subscribe(id =>
-            {
-                installedPackage = id;
-                if (hasInstalledPackageEmission)
-                {
-                    releaseResolutionRequests.OnNext(id);
-                }
-
-                hasInstalledPackageEmission = true;
-            })
-            .DisposeWith(_disposables);
+        IObservable<PackageIdentity?> releaseResolutionRequests =
+            PackageReleaseResolver.ObserveWhenReleasesReady(
+                _handler.InstalledPackageRepository.GetPackageObservable(package.Name),
+                releasesReady,
+                AvaloniaScheduler.Instance);
 
         PackageReleaseResolver.ObserveLatest(
                 releaseResolutionRequests,

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -63,14 +63,6 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                             totalCount += array.Length;
                             prevCount = array.Length;
                         } while (prevCount == 30);
-
-                        if (_handler.InstalledPackageRepository.ExistsPackage(package.Name))
-                        {
-                            PackageIdentity mostLatested = _handler.InstalledPackageRepository.GetLocalPackages(package.Name)
-                                .Aggregate((x, y) => x.Version > y.Version ? x : y);
-
-                            CurrentRelease.Value = await package.GetReleaseAsync(mostLatested.Version.ToString());
-                        }
                     }
                 }
                 catch (Exception e)
@@ -112,19 +104,25 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             .DisposeWith(_disposables);
 
         IObservable<bool> installed = _handler.InstalledPackageRepository.GetObservable(package.Name);
+        IObservable<bool> notBusy = IsBusy.Not();
         IsInstallButtonVisible = installed.Not()
-            .AreTrue(CanCancel.Not(), CanInstallOrUpdate)
+            .AreTrue(CanCancel.Not(), CanInstallOrUpdate, notBusy)
             .ToReadOnlyReactivePropertySlim()
+            .DisposeWith(_disposables);
+
+        _handler.InstalledPackageRepository
+            .GetPackageObservable(package.Name)
+            .Subscribe(id => _ = ResolveCurrentReleaseAsync(id))
             .DisposeWith(_disposables);
 
         IsUpdateButtonVisible = CurrentRelease.CombineLatest(SelectedRelease)
             .Select(x => x.First != null && x.First.Version.Value != x.Second?.Version.Value)
-            .AreTrue(CanCancel.Not(), CanInstallOrUpdate)
+            .AreTrue(CanCancel.Not(), CanInstallOrUpdate, notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
         IsUninstallButtonVisible = installed
-            .AreTrue(CanCancel.Not())
+            .AreTrue(CanCancel.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
@@ -169,6 +167,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                         return;
                     }
 
+                    IsBusy.Value = true;
                     StatusText.Value = ExtensionsStrings.Installing;
                     using (await _app.Lock.LockAsync())
                     {
@@ -204,6 +203,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     StatusText.Value = null;
+                    IsBusy.Value = false;
                 }
             })
             .DisposeWith(_disposables);
@@ -215,6 +215,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
 
                 try
                 {
+                    IsBusy.Value = true;
                     if (!await _handler.EnsureProjectClosed())
                         return;
 
@@ -255,6 +256,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     StatusText.Value = null;
+                    IsBusy.Value = false;
                 }
             })
             .DisposeWith(_disposables);
@@ -264,6 +266,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
             {
                 try
                 {
+                    IsBusy.Value = true;
                     if (!await _handler.EnsureProjectClosed())
                         return;
 
@@ -298,6 +301,7 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     StatusText.Value = null;
+                    IsBusy.Value = false;
                 }
             })
             .DisposeWith(_disposables);
@@ -337,6 +341,40 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
         }
 
         return (await Package.GetReleasesAsync())[0];
+    }
+
+    private async Task ResolveCurrentReleaseAsync(PackageIdentity? id)
+    {
+        if (id is null)
+        {
+            CurrentRelease.Value = null;
+            return;
+        }
+
+        string versionStr = id.Version.ToString();
+        if (SelectedRelease.Value is { } selected && selected.Version.Value == versionStr)
+        {
+            CurrentRelease.Value = selected;
+            return;
+        }
+
+        foreach (Release r in AllReleases)
+        {
+            if (r.Version.Value == versionStr)
+            {
+                CurrentRelease.Value = r;
+                return;
+            }
+        }
+
+        try
+        {
+            CurrentRelease.Value = await Package.GetReleaseAsync(versionStr);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve installed release for {PackageId}.", Package.Name);
+        }
     }
 
     public Package Package { get; }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageDetailsPageViewModel.cs
@@ -45,28 +45,21 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                     {
                         activity?.AddEvent(new("Entered_AsyncLock"));
                         IsBusy.Value = true;
-                        releasesReady.OnNext(false);
-                        AllReleases.Clear();
-                        LatestRelease.Value = null;
-                        await Package.RefreshAsync();
-
-                        int totalCount = 0;
-                        int prevCount = 0;
-
-                        do
-                        {
-                            Release[] array = await package.GetReleasesAsync(totalCount, 30);
-                            AllReleases.AddRange(array);
-
-                            if (LatestRelease.Value == null && array.FirstOrDefault() is { } publicRelease)
+                        await PackageReleaseRefreshCoordinator.RefreshAsync(
+                            releasesReady,
+                            Package.RefreshAsync,
+                            package.GetReleasesAsync,
+                            releases =>
                             {
-                                LatestRelease.Value = publicRelease;
-                                SelectedRelease.Value = publicRelease;
-                            }
+                                AllReleases.Clear();
+                                AllReleases.AddRange(releases);
 
-                            totalCount += array.Length;
-                            prevCount = array.Length;
-                        } while (prevCount == 30);
+                                LatestRelease.Value = releases.FirstOrDefault();
+                                if (LatestRelease.Value is { } publicRelease)
+                                {
+                                    SelectedRelease.Value = publicRelease;
+                                }
+                            });
                     }
                 }
                 catch (Exception e)
@@ -78,7 +71,6 @@ public sealed class PackageDetailsPageViewModel : BasePageViewModel, ISupportRef
                 finally
                 {
                     IsBusy.Value = false;
-                    releasesReady.OnNext(true);
                 }
             })
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseRefreshCoordinator.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseRefreshCoordinator.cs
@@ -1,0 +1,47 @@
+﻿using System.Reactive.Subjects;
+
+using Beutl.Api.Objects;
+
+namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
+
+internal static class PackageReleaseRefreshCoordinator
+{
+    private const int PageSize = 30;
+
+    public static async Task RefreshAsync(
+        BehaviorSubject<bool> releasesReady,
+        Func<Task> refreshPackageAsync,
+        Func<int, int, Task<Release[]>> getReleasesAsync,
+        Action<Release[]> publishReleases)
+    {
+        bool wasReady = releasesReady.Value;
+        releasesReady.OnNext(false);
+        bool publicationStarted = false;
+
+        try
+        {
+            await refreshPackageAsync();
+
+            var releases = new List<Release>();
+            Release[] page;
+            do
+            {
+                page = await getReleasesAsync(releases.Count, PageSize);
+                releases.AddRange(page);
+            } while (page.Length == PageSize);
+
+            publicationStarted = true;
+            publishReleases([.. releases]);
+            releasesReady.OnNext(true);
+        }
+        catch
+        {
+            if (!publicationStarted && wasReady)
+            {
+                releasesReady.OnNext(true);
+            }
+
+            throw;
+        }
+    }
+}

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseRefreshCoordinator.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseRefreshCoordinator.cs
@@ -16,7 +16,7 @@ internal static class PackageReleaseRefreshCoordinator
     {
         bool wasReady = releasesReady.Value;
         releasesReady.OnNext(false);
-        bool publicationStarted = false;
+        bool publicationCompleted = false;
 
         try
         {
@@ -30,13 +30,13 @@ internal static class PackageReleaseRefreshCoordinator
                 releases.AddRange(page);
             } while (page.Length == PageSize);
 
-            publicationStarted = true;
             publishReleases([.. releases]);
+            publicationCompleted = true;
             releasesReady.OnNext(true);
         }
         catch
         {
-            if (!publicationStarted && wasReady)
+            if (!publicationCompleted && wasReady)
             {
                 releasesReady.OnNext(true);
             }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
@@ -2,11 +2,26 @@
 
 using Beutl.Api.Objects;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
 
 internal static class PackageReleaseResolver
 {
+    public static IObservable<PackageIdentity?> ObserveWhenReleasesReady(
+        IObservable<PackageIdentity?> installedPackages,
+        IObservable<bool> releasesReady,
+        IScheduler stateScheduler)
+    {
+        return installedPackages
+            .ObserveOn(stateScheduler)
+            .CombineLatest(
+                releasesReady.ObserveOn(stateScheduler),
+                (installedPackage, isReady) => (InstalledPackage: installedPackage, IsReady: isReady))
+            .Where(x => x.IsReady)
+            .Select(x => x.InstalledPackage);
+    }
+
     public static IObservable<Release?> ObserveLatest(
         IObservable<PackageIdentity?> requests,
         IScheduler stateScheduler,
@@ -62,13 +77,14 @@ internal static class PackageReleaseResolver
                 return null;
             }
 
-            string version = request.InstalledPackage.Version.ToString();
-            if (request.SelectedRelease is { } selected && selected.Version.Value == version)
+            NuGetVersion installedVersion = request.InstalledPackage.Version;
+            string version = installedVersion.ToString();
+            if (request.SelectedRelease is { } selected && MatchesVersion(selected, installedVersion))
             {
                 return selected;
             }
 
-            Release? cached = request.AllReleases.FirstOrDefault(x => x.Version.Value == version);
+            Release? cached = request.AllReleases.FirstOrDefault(x => MatchesVersion(x, installedVersion));
             return cached ?? await getReleaseAsync(version);
         }
         catch (Exception ex)
@@ -76,6 +92,12 @@ internal static class PackageReleaseResolver
             onError(ex);
             return null;
         }
+    }
+
+    private static bool MatchesVersion(Release release, NuGetVersion installedVersion)
+    {
+        return NuGetVersion.TryParse(release.Version.Value, out NuGetVersion? releaseVersion)
+            && VersionComparer.VersionRelease.Equals(releaseVersion, installedVersion);
     }
 
     private sealed record ResolutionRequest(

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Api.Objects;
+﻿using System.Reactive.Concurrency;
+
+using Beutl.Api.Objects;
 using NuGet.Packaging.Core;
 
 namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
@@ -7,42 +9,66 @@ internal static class PackageReleaseResolver
 {
     public static IObservable<Release?> ObserveLatest(
         IObservable<PackageIdentity?> requests,
+        IScheduler stateScheduler,
         Func<Release?> getSelectedRelease,
         Func<IEnumerable<Release>> getAllReleases,
         Func<string, Task<Release>> getReleaseAsync,
         Action<Exception> onError)
     {
         return requests
-            .Select(id => Observable.FromAsync(() => ResolveAsync(
+            .ObserveOn(stateScheduler)
+            .Select(id => CaptureState(
                 id,
                 getSelectedRelease,
                 getAllReleases,
+                onError))
+            .Select(request => Observable.FromAsync(() => ResolveAsync(
+                request,
                 getReleaseAsync,
                 onError)))
-            .Switch();
+            .Switch()
+            .ObserveOn(stateScheduler);
     }
 
-    private static async Task<Release?> ResolveAsync(
+    private static ResolutionRequest CaptureState(
         PackageIdentity? id,
         Func<Release?> getSelectedRelease,
         Func<IEnumerable<Release>> getAllReleases,
+        Action<Exception> onError)
+    {
+        try
+        {
+            return new ResolutionRequest(
+                id,
+                getSelectedRelease(),
+                [.. getAllReleases()]);
+        }
+        catch (Exception ex)
+        {
+            onError(ex);
+            return new ResolutionRequest(null, null, []);
+        }
+    }
+
+    private static async Task<Release?> ResolveAsync(
+        ResolutionRequest request,
         Func<string, Task<Release>> getReleaseAsync,
         Action<Exception> onError)
     {
         try
         {
-            if (id is null)
+            if (request.InstalledPackage is null)
             {
                 return null;
             }
 
-            string version = id.Version.ToString();
-            if (getSelectedRelease() is { } selected && selected.Version.Value == version)
+            string version = request.InstalledPackage.Version.ToString();
+            if (request.SelectedRelease is { } selected && selected.Version.Value == version)
             {
                 return selected;
             }
 
-            Release? cached = getAllReleases().FirstOrDefault(x => x.Version.Value == version);
+            Release? cached = request.AllReleases.FirstOrDefault(x => x.Version.Value == version);
             return cached ?? await getReleaseAsync(version);
         }
         catch (Exception ex)
@@ -51,4 +77,9 @@ internal static class PackageReleaseResolver
             return null;
         }
     }
+
+    private sealed record ResolutionRequest(
+        PackageIdentity? InstalledPackage,
+        Release? SelectedRelease,
+        Release[] AllReleases);
 }

--- a/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/DiscoverPages/PackageReleaseResolver.cs
@@ -1,0 +1,54 @@
+﻿using Beutl.Api.Objects;
+using NuGet.Packaging.Core;
+
+namespace Beutl.ViewModels.ExtensionsPages.DiscoverPages;
+
+internal static class PackageReleaseResolver
+{
+    public static IObservable<Release?> ObserveLatest(
+        IObservable<PackageIdentity?> requests,
+        Func<Release?> getSelectedRelease,
+        Func<IEnumerable<Release>> getAllReleases,
+        Func<string, Task<Release>> getReleaseAsync,
+        Action<Exception> onError)
+    {
+        return requests
+            .Select(id => Observable.FromAsync(() => ResolveAsync(
+                id,
+                getSelectedRelease,
+                getAllReleases,
+                getReleaseAsync,
+                onError)))
+            .Switch();
+    }
+
+    private static async Task<Release?> ResolveAsync(
+        PackageIdentity? id,
+        Func<Release?> getSelectedRelease,
+        Func<IEnumerable<Release>> getAllReleases,
+        Func<string, Task<Release>> getReleaseAsync,
+        Action<Exception> onError)
+    {
+        try
+        {
+            if (id is null)
+            {
+                return null;
+            }
+
+            string version = id.Version.ToString();
+            if (getSelectedRelease() is { } selected && selected.Version.Value == version)
+            {
+                return selected;
+            }
+
+            Release? cached = getAllReleases().FirstOrDefault(x => x.Version.Value == version);
+            return cached ?? await getReleaseAsync(version);
+        }
+        catch (Exception ex)
+        {
+            onError(ex);
+            return null;
+        }
+    }
+}

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -32,19 +32,23 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
             .DisposeWith(_disposables);
 
         IObservable<bool> installed = _handler.InstalledPackageRepository.GetObservable(package.Name);
+        IObservable<bool> notBusy = IsBusy.Not();
         IsInstallButtonVisible = installed
             .AnyTrue(CanCancel)
             .Not()
+            .AreTrue(notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        IsUpdateButtonVisible = LatestRelease.Select(x => x != null)
-            .AreTrue(CanCancel.Not())
+        IObservable<PackageIdentity?> installedPackage = _handler.InstalledPackageRepository.GetPackageObservable(package.Name);
+        IsUpdateButtonVisible = LatestRelease.CombineLatest(installedPackage)
+            .Select(x => x.First is { } latest && InstalledPackageRepository.IsNewerThanInstalled(latest.Version.Value, x.Second))
+            .AreTrue(CanCancel.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
         IsUninstallButtonVisible = installed
-            .AreTrue(CanCancel.Not(), IsUpdateButtonVisible.Not())
+            .AreTrue(CanCancel.Not(), IsUpdateButtonVisible.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 

--- a/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/LocalUserPackageViewModel.cs
@@ -42,7 +42,7 @@ public sealed class LocalUserPackageViewModel : BaseViewModel, IUserPackageViewM
 
         IObservable<PackageIdentity?> installedPackage = _handler.InstalledPackageRepository.GetPackageObservable(package.Name);
         IsUpdateButtonVisible = LatestRelease.CombineLatest(installedPackage)
-            .Select(x => x.First is { } latest && InstalledPackageRepository.IsNewerThanInstalled(latest.Version.Value, x.Second))
+            .Select(x => PackageUpdateAvailability.IsAvailable(x.First?.Version.Value, x.Second))
             .AreTrue(CanCancel.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageUpdateAvailability.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageUpdateAvailability.cs
@@ -1,0 +1,14 @@
+﻿using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Beutl.ViewModels.ExtensionsPages;
+
+internal static class PackageUpdateAvailability
+{
+    public static bool IsAvailable(string? releaseVersion, PackageIdentity? installedPackage)
+    {
+        return installedPackage is not null
+            && NuGetVersion.TryParse(releaseVersion, out NuGetVersion? parsedVersion)
+            && parsedVersion > installedPackage.Version;
+    }
+}

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -46,7 +46,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
 
         IObservable<PackageIdentity?> installedPackage = _handler.InstalledPackageRepository.GetPackageObservable(package.Name);
         IsUpdateButtonVisible = LatestRelease.CombineLatest(installedPackage)
-            .Select(x => x.First is { } latest && InstalledPackageRepository.IsNewerThanInstalled(latest.Version.Value, x.Second))
+            .Select(x => PackageUpdateAvailability.IsAvailable(x.First?.Version.Value, x.Second))
             .AreTrue(CanCancel.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -36,19 +36,23 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
             .DisposeWith(_disposables);
 
         IObservable<bool> installed = _handler.InstalledPackageRepository.GetObservable(package.Name);
+        IObservable<bool> notBusy = IsBusy.Not();
         IsInstallButtonVisible = installed
             .AnyTrue(CanCancel)
             .Not()
+            .AreTrue(notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
-        IsUpdateButtonVisible = LatestRelease.Select(x => x != null)
-            .AreTrue(CanCancel.Not())
+        IObservable<PackageIdentity?> installedPackage = _handler.InstalledPackageRepository.GetPackageObservable(package.Name);
+        IsUpdateButtonVisible = LatestRelease.CombineLatest(installedPackage)
+            .Select(x => x.First is { } latest && InstalledPackageRepository.IsNewerThanInstalled(latest.Version.Value, x.Second))
+            .AreTrue(CanCancel.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 
         IsUninstallButtonVisible = installed
-            .AreTrue(CanCancel.Not(), IsUpdateButtonVisible.Not())
+            .AreTrue(CanCancel.Not(), IsUpdateButtonVisible.Not(), notBusy)
             .ToReadOnlyReactivePropertySlim()
             .DisposeWith(_disposables);
 

--- a/tests/Beutl.HeadlessUITests/LibraryPageOperationStatusTests.cs
+++ b/tests/Beutl.HeadlessUITests/LibraryPageOperationStatusTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Reactive.Linq;
+
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+
+using Beutl.Pages.ExtensionsPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.ExtensionsPages;
+
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class LibraryPageOperationStatusTests
+{
+    [AvaloniaTest]
+    public void BusyCard_ShowsOperationStatusWhileActionButtonsAreHidden()
+    {
+        using var viewModel = new StubUserPackageViewModel();
+        var page = new LibraryPage();
+        var template = (IDataTemplate)page.Resources["UserPackageItemTemplate"]!;
+        Control content = new ContentPresenter
+        {
+            Content = viewModel,
+            ContentTemplate = template,
+        };
+        var window = new Window { Content = content, Width = 800, Height = 300 };
+
+        try
+        {
+            viewModel.StatusText.Value = "Updating";
+            viewModel.IsBusy.Value = true;
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            List<Button> buttons = content.GetVisualDescendants().OfType<Button>().ToList();
+            Assert.That(
+                buttons.Any(x => x.Command is null && Equals(x.Content, "Updating")),
+                Is.True,
+                string.Join(Environment.NewLine, buttons.Select(x => $"Name={x.Name}; Content={x.Content}; Command={x.Command}; Classes={x.Classes}")));
+            Button statusButton = buttons.Single(x => x.Command is null && Equals(x.Content, "Updating"));
+
+            Assert.That(statusButton.Classes, Does.Not.Contain("transparent"));
+            Assert.That(statusButton.Classes, Does.Contain("shimmer"));
+            Assert.That(statusButton.Content, Is.EqualTo("Updating"));
+            Assert.That(statusButton.IsHitTestVisible, Is.False);
+
+            Assert.That(buttons.Single(x => x.Command == viewModel.Install).Classes, Does.Contain("transparent"));
+            Assert.That(buttons.Single(x => x.Command == viewModel.Update).Classes, Does.Contain("transparent"));
+            Assert.That(buttons.Single(x => x.Command == viewModel.Uninstall).Classes, Does.Contain("transparent"));
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private sealed class StubUserPackageViewModel : IUserPackageViewModel
+    {
+        public StubUserPackageViewModel()
+        {
+            DisplayName = Observable.Return<string?>("Package").ToReadOnlyReactivePropertySlim();
+            LogoUrl = Observable.Return<string?>(null).ToReadOnlyReactivePropertySlim();
+            IsInstallButtonVisible = Observable.Return(false).ToReadOnlyReactivePropertySlim();
+            IsUninstallButtonVisible = Observable.Return(false).ToReadOnlyReactivePropertySlim();
+            IsUpdateButtonVisible = Observable.Return(false).ToReadOnlyReactivePropertySlim();
+            CanCancel = Observable.Return(false).ToReadOnlyReactivePropertySlim();
+        }
+
+        public string Name => "Package";
+
+        public IReadOnlyReactiveProperty<string?> DisplayName { get; }
+
+        public IReadOnlyReactiveProperty<string?> LogoUrl { get; }
+
+        public string Publisher => "Publisher";
+
+        public bool IsRemote => false;
+
+        public ReadOnlyReactivePropertySlim<bool> IsInstallButtonVisible { get; }
+
+        public ReadOnlyReactivePropertySlim<bool> IsUninstallButtonVisible { get; }
+
+        public IReadOnlyReactiveProperty<bool> IsUpdateButtonVisible { get; }
+
+        public ReadOnlyReactivePropertySlim<bool> CanCancel { get; }
+
+        public AsyncReactiveCommand Install { get; } = new();
+
+        public AsyncReactiveCommand Update { get; } = new();
+
+        public AsyncReactiveCommand Uninstall { get; } = new();
+
+        public AsyncReactiveCommand Cancel { get; } = new();
+
+        public ReactivePropertySlim<bool> IsBusy { get; } = new();
+
+        public ReactivePropertySlim<string?> StatusText { get; } = new();
+
+        public void Dispose()
+        {
+            DisplayName.Dispose();
+            LogoUrl.Dispose();
+            IsInstallButtonVisible.Dispose();
+            IsUninstallButtonVisible.Dispose();
+            IsUpdateButtonVisible.Dispose();
+            CanCancel.Dispose();
+            Install.Dispose();
+            Update.Dispose();
+            Uninstall.Dispose();
+            Cancel.Dispose();
+            IsBusy.Dispose();
+            StatusText.Dispose();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
@@ -1,0 +1,120 @@
+﻿using System.Net.Http;
+using System.Reactive.Subjects;
+
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PackageReleaseRefreshCoordinatorTests
+{
+    [TestCase(true)]
+    [TestCase(false)]
+    public void RefreshAsync_DoesNotPublishPartialPagesAndRestoresOnlyPreviousReadinessOnFailure(bool wasReady)
+    {
+        using var releasesReady = new BehaviorSubject<bool>(wasReady);
+        Release previousRelease = CreateRelease("0.9.0");
+        Release[] publishedReleases = [previousRelease];
+        var requestedOffsets = new List<int>();
+        var readyStates = new List<bool>();
+        using IDisposable subscription = releasesReady.Subscribe(readyStates.Add);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => PackageReleaseRefreshCoordinator.RefreshAsync(
+            releasesReady,
+            () => Task.CompletedTask,
+            (start, _) =>
+            {
+                requestedOffsets.Add(start);
+                return start == 0
+                    ? Task.FromResult(Enumerable.Range(1, 30).Select(x => CreateRelease($"1.0.{x}")).ToArray())
+                    : Task.FromException<Release[]>(new InvalidOperationException("second page failed"));
+            },
+            releases => publishedReleases = releases));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestedOffsets, Is.EqualTo(new[] { 0, 30 }));
+            Assert.That(publishedReleases, Is.EqualTo(new[] { previousRelease }));
+            Assert.That(readyStates, Is.EqualTo(wasReady ? new[] { true, false, true } : new[] { false, false }));
+            Assert.That(releasesReady.Value, Is.EqualTo(wasReady));
+        });
+    }
+
+    [Test]
+    public async Task RefreshAsync_PublishesCompleteSnapshotBeforeSignalingReady()
+    {
+        using var releasesReady = new BehaviorSubject<bool>(false);
+        Release[] firstPage = Enumerable.Range(1, 30).Select(x => CreateRelease($"1.0.{x}")).ToArray();
+        Release finalRelease = CreateRelease("2.0.0");
+        Release[]? publishedReleases = null;
+        bool? readyWhilePublishing = null;
+        var readyStates = new List<bool>();
+        using IDisposable subscription = releasesReady.Subscribe(readyStates.Add);
+
+        await PackageReleaseRefreshCoordinator.RefreshAsync(
+            releasesReady,
+            () => Task.CompletedTask,
+            (start, _) => Task.FromResult(start == 0 ? firstPage : new[] { finalRelease }),
+            releases =>
+            {
+                publishedReleases = releases;
+                readyWhilePublishing = releasesReady.Value;
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(publishedReleases, Is.EqualTo(firstPage.Append(finalRelease)));
+            Assert.That(readyWhilePublishing, Is.False);
+            Assert.That(readyStates, Is.EqualTo(new[] { false, false, true }));
+            Assert.That(releasesReady.Value, Is.True);
+        });
+    }
+
+    private static Release CreateRelease(string version)
+    {
+        var clients = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
+        var ownerResponse = new ProfileResponse
+        {
+            Id = "owner",
+            Name = "owner",
+            DisplayName = "Owner",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var owner = new Profile(ownerResponse, clients);
+        var package = new Package(owner, new PackageResponse
+        {
+            Id = "package",
+            Owner = ownerResponse,
+            Name = "Package",
+            DisplayName = "Package",
+            Description = "",
+            ShortDescription = "",
+            WebSite = "",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = true,
+        }, clients);
+
+        return new Release(package, new ReleaseResponse
+        {
+            Id = version,
+            Version = version,
+            Title = version,
+            Description = "",
+            TargetVersion = null,
+            FileId = null,
+            FileUrl = null,
+        }, clients);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseRefreshCoordinatorTests.cs
@@ -12,6 +12,21 @@ namespace Beutl.HeadlessUITests;
 [TestFixture]
 public class PackageReleaseRefreshCoordinatorTests
 {
+    private readonly HttpClient _httpClient;
+    private readonly BeutlApiApplication _clients;
+
+    public PackageReleaseRefreshCoordinatorTests()
+    {
+        _httpClient = new HttpClient();
+        _clients = new BeutlApiApplication(_httpClient, new ExtensionProvider());
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _httpClient.Dispose();
+    }
+
     [TestCase(true)]
     [TestCase(false)]
     public void RefreshAsync_DoesNotPublishPartialPagesAndRestoresOnlyPreviousReadinessOnFailure(bool wasReady)
@@ -74,9 +89,29 @@ public class PackageReleaseRefreshCoordinatorTests
         });
     }
 
-    private static Release CreateRelease(string version)
+    [TestCase(true)]
+    [TestCase(false)]
+    public void RefreshAsync_RestoresOnlyPreviousReadinessWhenPublicationFails(bool wasReady)
     {
-        var clients = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
+        using var releasesReady = new BehaviorSubject<bool>(wasReady);
+        var readyStates = new List<bool>();
+        using IDisposable subscription = releasesReady.Subscribe(readyStates.Add);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => PackageReleaseRefreshCoordinator.RefreshAsync(
+            releasesReady,
+            () => Task.CompletedTask,
+            (_, _) => Task.FromResult(Array.Empty<Release>()),
+            _ => throw new InvalidOperationException("publication failed")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(readyStates, Is.EqualTo(wasReady ? new[] { true, false, true } : new[] { false, false }));
+            Assert.That(releasesReady.Value, Is.EqualTo(wasReady));
+        });
+    }
+
+    private Release CreateRelease(string version)
+    {
         var ownerResponse = new ProfileResponse
         {
             Id = "owner",
@@ -86,7 +121,7 @@ public class PackageReleaseRefreshCoordinatorTests
             IconId = null,
             IconUrl = null,
         };
-        var owner = new Profile(ownerResponse, clients);
+        var owner = new Profile(ownerResponse, _clients);
         var package = new Package(owner, new PackageResponse
         {
             Id = "package",
@@ -104,7 +139,7 @@ public class PackageReleaseRefreshCoordinatorTests
             Price = null,
             Paid = false,
             Owned = true,
-        }, clients);
+        }, _clients);
 
         return new Release(package, new ReleaseResponse
         {
@@ -115,6 +150,6 @@ public class PackageReleaseRefreshCoordinatorTests
             TargetVersion = null,
             FileId = null,
             FileUrl = null,
-        }, clients);
+        }, _clients);
     }
 }

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -121,6 +121,64 @@ public class PackageReleaseResolverTests
     }
 
     [Test]
+    public async Task ObserveLatest_UsesSemanticallyEquivalentCachedReleaseWithoutNetworkRequest()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        Release cached = CreateRelease("1.0.0");
+        var observed = new TaskCompletionSource<Release?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int requestCount = 0;
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                ImmediateScheduler.Instance,
+                () => null,
+                () => [cached],
+                _ =>
+                {
+                    requestCount++;
+                    return Task.FromResult(cached);
+                },
+                ex => Assert.Fail(ex.ToString()))
+            .Subscribe(release => observed.TrySetResult(release));
+
+        requests.OnNext(CreateIdentity("1.0"));
+        Release? result = await observed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(result, Is.SameAs(cached));
+        Assert.That(requestCount, Is.Zero);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ObserveWhenReleasesReady_EmitsAfterBothInputsRegardlessOfOrder(bool readyFirst)
+    {
+        using var installedPackages = new Subject<PackageIdentity?>();
+        using var releasesReady = new BehaviorSubject<bool>(false);
+        PackageIdentity installed = CreateIdentity("1.0.0");
+        var observed = new List<PackageIdentity?>();
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveWhenReleasesReady(
+                installedPackages,
+                releasesReady,
+                ImmediateScheduler.Instance)
+            .Subscribe(observed.Add);
+
+        if (readyFirst)
+        {
+            releasesReady.OnNext(true);
+            installedPackages.OnNext(installed);
+        }
+        else
+        {
+            installedPackages.OnNext(installed);
+            Assert.That(observed, Is.Empty);
+            releasesReady.OnNext(true);
+        }
+
+        Assert.That(observed, Is.EqualTo(new[] { installed }));
+    }
+
+    [Test]
     public async Task ObserveLatest_CapturesStateAndEmitsOnProvidedScheduler()
     {
         using var requests = new Subject<PackageIdentity?>();

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -1,0 +1,172 @@
+﻿using System.Net.Http;
+using System.Reactive.Subjects;
+
+using Beutl.Api;
+using Beutl.Api.Clients;
+using Beutl.Api.Objects;
+using Beutl.Api.Services;
+using Beutl.ViewModels.ExtensionsPages.DiscoverPages;
+
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PackageReleaseResolverTests
+{
+    [Test]
+    public async Task ObserveLatest_IgnoresCompletionFromSupersededRequest()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        var first = new TaskCompletionSource<Release>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TaskCompletionSource<Release>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Release firstRelease = CreateRelease("1.0.0");
+        Release secondRelease = CreateRelease("2.0.0");
+        var observed = new List<Release?>();
+        var latestObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                () => null,
+                () => [],
+                version => version == "1.0.0" ? first.Task : second.Task,
+                ex => Assert.Fail(ex.ToString()))
+            .Subscribe(release =>
+            {
+                observed.Add(release);
+                latestObserved.TrySetResult();
+            });
+
+        requests.OnNext(CreateIdentity("1.0.0"));
+        requests.OnNext(CreateIdentity("2.0.0"));
+        second.SetResult(secondRelease);
+        await latestObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        first.SetResult(firstRelease);
+        await Task.Delay(50);
+
+        Assert.That(observed, Is.EqualTo(new[] { secondRelease }));
+    }
+
+    [Test]
+    public async Task ObserveLatest_EmitsNullOnFailureAndContinues()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        Release recovered = CreateRelease("2.0.0");
+        var observed = new List<Release?>();
+        var errors = new List<Exception>();
+        var twoResults = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                () => null,
+                () => [],
+                version => version == "1.0.0"
+                    ? Task.FromException<Release>(new InvalidOperationException("lookup failed"))
+                    : Task.FromResult(recovered),
+                errors.Add)
+            .Subscribe(release =>
+            {
+                observed.Add(release);
+                if (observed.Count == 2)
+                {
+                    twoResults.TrySetResult();
+                }
+            });
+
+        requests.OnNext(CreateIdentity("1.0.0"));
+        await WaitForAsync(() => observed.Count == 1);
+        requests.OnNext(CreateIdentity("2.0.0"));
+        await twoResults.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(observed[0], Is.Null);
+        Assert.That(observed[1], Is.SameAs(recovered));
+        Assert.That(errors, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ObserveLatest_UsesCachedReleaseWithoutNetworkRequest()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        Release cached = CreateRelease("1.0.0");
+        var observed = new TaskCompletionSource<Release?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int requestCount = 0;
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                () => null,
+                () => [cached],
+                _ =>
+                {
+                    requestCount++;
+                    return Task.FromResult(cached);
+                },
+                ex => Assert.Fail(ex.ToString()))
+            .Subscribe(release => observed.TrySetResult(release));
+
+        requests.OnNext(CreateIdentity("1.0.0"));
+        Release? result = await observed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(result, Is.SameAs(cached));
+        Assert.That(requestCount, Is.Zero);
+    }
+
+    private static PackageIdentity CreateIdentity(string version)
+    {
+        return new PackageIdentity("Package", NuGetVersion.Parse(version));
+    }
+
+    private static Release CreateRelease(string version)
+    {
+        var clients = new BeutlApiApplication(new HttpClient(), new ExtensionProvider());
+        var ownerResponse = new ProfileResponse
+        {
+            Id = "owner",
+            Name = "owner",
+            DisplayName = "Owner",
+            Bio = null,
+            IconId = null,
+            IconUrl = null,
+        };
+        var owner = new Profile(ownerResponse, clients);
+        var package = new Package(owner, new PackageResponse
+        {
+            Id = "package",
+            Owner = ownerResponse,
+            Name = "Package",
+            DisplayName = "Package",
+            Description = "",
+            ShortDescription = "",
+            WebSite = "",
+            Tags = [],
+            LogoId = null,
+            LogoUrl = null,
+            Screenshots = [],
+            Currency = null,
+            Price = null,
+            Paid = false,
+            Owned = true,
+        }, clients);
+
+        return new Release(package, new ReleaseResponse
+        {
+            Id = version,
+            Version = version,
+            Title = version,
+            Description = "",
+            TargetVersion = null,
+            FileId = null,
+            FileUrl = null,
+        }, clients);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!condition())
+        {
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageReleaseResolverTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 
 using Beutl.Api;
@@ -25,9 +26,11 @@ public class PackageReleaseResolverTests
         Release secondRelease = CreateRelease("2.0.0");
         var observed = new List<Release?>();
         var latestObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var streamCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
                 requests,
+                ImmediateScheduler.Instance,
                 () => null,
                 () => [],
                 version => version == "1.0.0" ? first.Task : second.Task,
@@ -36,7 +39,9 @@ public class PackageReleaseResolverTests
             {
                 observed.Add(release);
                 latestObserved.TrySetResult();
-            });
+            },
+            ex => Assert.Fail(ex.ToString()),
+            () => streamCompleted.TrySetResult());
 
         requests.OnNext(CreateIdentity("1.0.0"));
         requests.OnNext(CreateIdentity("2.0.0"));
@@ -44,7 +49,8 @@ public class PackageReleaseResolverTests
         await latestObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         first.SetResult(firstRelease);
-        await Task.Delay(50);
+        requests.OnCompleted();
+        await streamCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.That(observed, Is.EqualTo(new[] { secondRelease }));
     }
@@ -60,6 +66,7 @@ public class PackageReleaseResolverTests
 
         using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
                 requests,
+                ImmediateScheduler.Instance,
                 () => null,
                 () => [],
                 version => version == "1.0.0"
@@ -95,6 +102,7 @@ public class PackageReleaseResolverTests
 
         using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
                 requests,
+                ImmediateScheduler.Instance,
                 () => null,
                 () => [cached],
                 _ =>
@@ -110,6 +118,94 @@ public class PackageReleaseResolverTests
 
         Assert.That(result, Is.SameAs(cached));
         Assert.That(requestCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task ObserveLatest_CapturesStateAndEmitsOnProvidedScheduler()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        using var scheduler = new EventLoopScheduler();
+        Release cached = CreateRelease("1.0.0");
+        var schedulerThread = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observed = new TaskCompletionSource<Release?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int selectedReleaseThread = 0;
+        int allReleasesThread = 0;
+        int observerThread = 0;
+
+        scheduler.Schedule(() => schedulerThread.TrySetResult(Environment.CurrentManagedThreadId));
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                scheduler,
+                () =>
+                {
+                    selectedReleaseThread = Environment.CurrentManagedThreadId;
+                    return null;
+                },
+                () =>
+                {
+                    allReleasesThread = Environment.CurrentManagedThreadId;
+                    return [cached];
+                },
+                _ => Task.FromResult(cached),
+                ex => Assert.Fail(ex.ToString()))
+            .Subscribe(release =>
+            {
+                observerThread = Environment.CurrentManagedThreadId;
+                observed.TrySetResult(release);
+            });
+
+        requests.OnNext(CreateIdentity("1.0.0"));
+        Release? result = await observed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        int expectedThread = await schedulerThread.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(cached));
+            Assert.That(selectedReleaseThread, Is.EqualTo(expectedThread));
+            Assert.That(allReleasesThread, Is.EqualTo(expectedThread));
+            Assert.That(observerThread, Is.EqualTo(expectedThread));
+        });
+    }
+
+    [Test]
+    public async Task ObserveLatest_EmitsNullWhenStateCaptureFailsAndContinues()
+    {
+        using var requests = new Subject<PackageIdentity?>();
+        Release recovered = CreateRelease("2.0.0");
+        var observed = new List<Release?>();
+        var errors = new List<Exception>();
+        var twoResults = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int captureCount = 0;
+
+        using IDisposable subscription = PackageReleaseResolver.ObserveLatest(
+                requests,
+                ImmediateScheduler.Instance,
+                () => null,
+                () => ++captureCount == 1
+                    ? throw new InvalidOperationException("collection changed")
+                    : [recovered],
+                _ => Task.FromResult(recovered),
+                errors.Add)
+            .Subscribe(release =>
+            {
+                observed.Add(release);
+                if (observed.Count == 2)
+                {
+                    twoResults.TrySetResult();
+                }
+            });
+
+        requests.OnNext(CreateIdentity("1.0.0"));
+        requests.OnNext(CreateIdentity("2.0.0"));
+        await twoResults.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed[0], Is.Null);
+            Assert.That(observed[1], Is.SameAs(recovered));
+            Assert.That(errors, Has.Count.EqualTo(1));
+        });
     }
 
     private static PackageIdentity CreateIdentity(string version)

--- a/tests/Beutl.HeadlessUITests/PackageUpdateAvailabilityTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageUpdateAvailabilityTests.cs
@@ -1,0 +1,27 @@
+﻿using Beutl.ViewModels.ExtensionsPages;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PackageUpdateAvailabilityTests
+{
+    [TestCase(null, "1.0.0", false)]
+    [TestCase("2.0.0", null, false)]
+    [TestCase("not-a-version", "1.0.0", false)]
+    [TestCase("1.0.0", "1.0.0", false)]
+    [TestCase("0.9.0", "1.0.0", false)]
+    [TestCase("2.0.0", "1.0.0", true)]
+    public void IsAvailable_RequiresInstalledPackageAndNewerValidVersion(
+        string? releaseVersion,
+        string? installedVersion,
+        bool expected)
+    {
+        PackageIdentity? installed = installedVersion is null
+            ? null
+            : new PackageIdentity("Package", NuGetVersion.Parse(installedVersion));
+
+        Assert.That(PackageUpdateAvailability.IsAvailable(releaseVersion, installed), Is.EqualTo(expected));
+    }
+}

--- a/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
+++ b/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
@@ -45,21 +45,6 @@ public class InstalledPackageRepositoryTests
         && Helper.AppRoot.StartsWith(_tempHome, StringComparison.OrdinalIgnoreCase);
 
     [Test]
-    public void IsNewerThanInstalled_NullInstalled_ReturnsTrue()
-    {
-        Assert.That(InstalledPackageRepository.IsNewerThanInstalled("1.0.0", null), Is.True);
-    }
-
-    [TestCase("2.0.0", "1.0.0", true)]
-    [TestCase("1.0.0", "1.0.0", false)]
-    [TestCase("0.9.0", "1.0.0", false)]
-    public void IsNewerThanInstalled_ComparesVersions(string release, string installed, bool expected)
-    {
-        var installedId = new PackageIdentity("P", NuGetVersion.Parse(installed));
-        Assert.That(InstalledPackageRepository.IsNewerThanInstalled(release, installedId), Is.EqualTo(expected));
-    }
-
-    [Test]
     public void GetPackageObservable_EmitsNull_WhenNotInstalled()
     {
         if (!IsHomeIsolated)

--- a/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
+++ b/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
@@ -101,4 +101,24 @@ public class InstalledPackageRepositoryTests
 
         Assert.That(emissions, Does.Not.Contains(false));
     }
+
+    [Test]
+    public void GetObservable_ForVersion_TracksEquivalentIdentityInstances()
+    {
+        if (!IsHomeIsolated)
+        {
+            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
+        }
+
+        const string name = "Beutl.Package.UpdateTest.Version";
+        const string version = "1.0.0";
+        var repo = new InstalledPackageRepository();
+        var emissions = new List<bool>();
+        repo.GetObservable(name, version).Subscribe(emissions.Add);
+
+        repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse(version)));
+        repo.RemovePackage(new PackageIdentity(name, NuGetVersion.Parse(version)));
+
+        Assert.That(emissions, Is.EqualTo(new[] { false, true, false }));
+    }
 }

--- a/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
+++ b/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
@@ -1,0 +1,119 @@
+﻿using Beutl.Api.Services;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+[NonParallelizable]
+public class InstalledPackageRepositoryTests
+{
+    private string? _previousHome;
+    private string? _tempHome;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _previousHome = Environment.GetEnvironmentVariable("BEUTL_HOME");
+        _tempHome = Path.Combine(Path.GetTempPath(), $"beutl-repo-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempHome);
+        Environment.SetEnvironmentVariable("BEUTL_HOME", _tempHome);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        Environment.SetEnvironmentVariable("BEUTL_HOME", _previousHome);
+        try
+        {
+            if (_tempHome is not null && Directory.Exists(_tempHome))
+            {
+                Directory.Delete(_tempHome, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    // Helper.AppRoot is pinned by its static ctor at first use; skip I/O tests when isolation
+    // took effect too late, so they never write to the developer's real ~/.beutl.
+    private bool IsHomeIsolated => _tempHome is not null
+        && Helper.AppRoot.StartsWith(_tempHome, StringComparison.OrdinalIgnoreCase);
+
+    [Test]
+    public void IsNewerThanInstalled_NullInstalled_ReturnsTrue()
+    {
+        Assert.That(InstalledPackageRepository.IsNewerThanInstalled("1.0.0", null), Is.True);
+    }
+
+    [TestCase("2.0.0", "1.0.0", true)]
+    [TestCase("1.0.0", "1.0.0", false)]
+    [TestCase("0.9.0", "1.0.0", false)]
+    public void IsNewerThanInstalled_ComparesVersions(string release, string installed, bool expected)
+    {
+        var installedId = new PackageIdentity("P", NuGetVersion.Parse(installed));
+        Assert.That(InstalledPackageRepository.IsNewerThanInstalled(release, installedId), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void GetPackageObservable_EmitsNull_WhenNotInstalled()
+    {
+        if (!IsHomeIsolated)
+        {
+            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
+        }
+
+        const string name = "Beutl.Package.UpdateTest.None";
+        var repo = new InstalledPackageRepository();
+
+        PackageIdentity? emitted = new(name, NuGetVersion.Parse("0.0.0"));
+        repo.GetPackageObservable(name).Subscribe(x => emitted = x);
+
+        Assert.That(emitted, Is.Null);
+    }
+
+    [Test]
+    public void GetPackageObservable_EmitsInstalledIdentity_AfterUpgrade()
+    {
+        if (!IsHomeIsolated)
+        {
+            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
+        }
+
+        const string name = "Beutl.Package.UpdateTest.Upgrade";
+        var repo = new InstalledPackageRepository();
+
+        PackageIdentity? emitted = new(name, NuGetVersion.Parse("0.0.0"));
+        repo.GetPackageObservable(name).Subscribe(x => emitted = x);
+
+        repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse("1.0.0")));
+        Assert.That(emitted?.Version.ToString(), Is.EqualTo("1.0.0"));
+
+        repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse("2.0.0")));
+        Assert.That(emitted?.Version.ToString(), Is.EqualTo("2.0.0"));
+    }
+
+    [Test]
+    public void GetObservable_Bool_DoesNotFlashFalse_DuringUpgrade()
+    {
+        if (!IsHomeIsolated)
+        {
+            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
+        }
+
+        const string name = "Beutl.Package.UpdateTest.Flash";
+        var repo = new InstalledPackageRepository();
+        repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse("1.0.0")));
+
+        var emissions = new List<bool>();
+        repo.GetObservable(name).Subscribe(x => emissions.Add(x));
+
+        repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse("2.0.0")));
+
+        Assert.That(emissions, Does.Not.Contains(false));
+    }
+}


### PR DESCRIPTION
## Description
- The update button stayed visible after a successful in-app package update because `IsUpdateButtonVisible` depended on `LatestRelease != null` (set once by `CheckUpdate`) instead of the installed version, and `CurrentRelease` was only refreshed on `Refresh`.
- The install button appeared during an update because `DeleteOldVersionFiles` removes the old version from `InstalledPackageRepository` before the new one downloads (a sustained `installed=false` gap), and the details-page action commands never set `IsBusy`, so the visibility gate was inert.
- Both are fixed by anchoring button visibility to the installed version (new `GetPackageObservable` / `IsNewerThanInstalled`) and gating all action buttons on `IsBusy`; the details page now manages `IsBusy` across install/update/uninstall and drives `CurrentRelease` reactively from the installed package observable.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`) — app-shell ViewModels under `src/Beutl/ViewModels/ExtensionsPages`
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [x] `Beutl.Api` (server API client) — `InstalledPackageRepository`
- [ ] Build / CI / docs only

## Breaking changes
None. `GetPackageObservable` / `IsNewerThanInstalled` are additive. The `_Observable` name-only behavior change (re-evaluate aggregate existence instead of trusting the per-event flag) is a bug fix — callers already expected the truthful aggregate, and the per-event `(old, false)` during an upgrade was a latent flash bug.

## Test plan
- Unit: `tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs` — `IsNewerThanInstalled` version comparison; `GetPackageObservable` emits the installed identity (and null when not installed); the name-only `GetObservable` does not emit `false` during an upgrade.
- Build: `dotnet build Beutl.slnx` succeeds for `Beutl.Api`, `src/Beutl`, and `Beutl.UnitTests`.
- Headless UI: `ExtensionsPageLayoutTests` + `SearchPageCardLayoutTests` pass (pages still load with the ViewModel changes).
- Manual: on the Extensions page, update an installed package — the update button disappears after completion and the install button no longer appears during the download; on the details page the installed-version display updates without a flash.

## Fixed issues / References
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package details now reactively track the latest installed package and resolve the matching release.
  * Added an operation status indicator on the library package tile while actions are suppressed during busy states.
* **Bug Fixes**
  * Install/update/uninstall visibility now correctly respects in-progress operations.
  * “Update” now appears only when a valid, strictly newer release version is available compared to the installed version.
  * Improved refresh to avoid incorrect/transient current release states.
* **Tests**
  * Added/expanded unit and headless UI tests for observable behavior, release resolution, update availability, caching, and scheduler correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->