### PR TITLE
fix: render extensions dialog first tab on open

### DIFF
--- a/src/Beutl/Pages/ExtensionsPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPage.axaml.cs
@@ -34,11 +34,13 @@ public sealed partial class ExtensionsPage : Window
         nav.BackRequested += Nav_BackRequested;
 
         nav.SelectedItem = selected;
+
+        Loaded += OnFirstLoaded;
     }
 
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    private void OnFirstLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnAttachedToVisualTree(e);
+        Loaded -= OnFirstLoaded;
         if (nav.SelectedItem is NavigationViewItem selected)
         {
             OnItemInvoked(selected);

--- a/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
@@ -26,9 +26,8 @@ public class ExtensionsPageInitialNavigationTests
         await TestReset.ResetShellAsync();
         MainViewModel mainViewModel = TestShell.MainViewModel;
 
-        var clients = new BeutlApiApplication(
-            new HttpClient(new EmptyJsonArrayHandler()),
-            new ExtensionProvider());
+        using var httpClient = new HttpClient(new EmptyJsonArrayHandler());
+        var clients = new BeutlApiApplication(httpClient, new ExtensionProvider());
         var vm = new ExtensionsPageViewModel(
             clients,
             mainViewModel.EditorService,

--- a/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
@@ -1,0 +1,47 @@
+﻿using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Pages;
+using Beutl.Pages.ExtensionsPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using NUnit.Framework;
+
+namespace Beutl.HeadlessUITests;
+
+// Guards that the extensions dialog shows the first tab's content immediately on open, without the
+// user having to click a tab. Regression: the initial frame.Navigate ran in OnAttachedToVisualTree,
+// before the child Frame's template was applied, so the first page never rendered until a tab switch
+// retried navigation from a ready Frame.
+[TestFixture]
+public class ExtensionsPageInitialNavigationTests
+{
+    [AvaloniaTest]
+    public async Task Opens_with_first_tab_rendered_without_tab_switch()
+    {
+        await TestReset.ResetShellAsync();
+        MainViewModel mainViewModel = TestShell.MainViewModel;
+        var vm = new ExtensionsPageViewModel(
+            mainViewModel._beutlClients,
+            mainViewModel.EditorService,
+            mainViewModel.ProjectService);
+
+        var page = new ExtensionsPage { DataContext = vm };
+        try
+        {
+            page.Show();
+            HeadlessTestHelpers.Render();
+
+            bool discoverRendered = page.GetVisualDescendants().OfType<DiscoverPage>().Any();
+            Assert.That(
+                discoverRendered,
+                Is.True,
+                "the first tab (Discover) must render on open without a manual tab switch");
+        }
+        finally
+        {
+            page.Close();
+            vm.Dispose();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs
@@ -1,5 +1,10 @@
-﻿using Avalonia.Headless.NUnit;
+﻿using System.Net;
+using System.Net.Http;
+using System.Text;
+using Avalonia.Headless.NUnit;
 using Avalonia.VisualTree;
+using Beutl.Api;
+using Beutl.Api.Services;
 using Beutl.Pages;
 using Beutl.Pages.ExtensionsPages;
 using Beutl.Testing.Headless;
@@ -20,8 +25,12 @@ public class ExtensionsPageInitialNavigationTests
     {
         await TestReset.ResetShellAsync();
         MainViewModel mainViewModel = TestShell.MainViewModel;
+
+        var clients = new BeutlApiApplication(
+            new HttpClient(new EmptyJsonArrayHandler()),
+            new ExtensionProvider());
         var vm = new ExtensionsPageViewModel(
-            mainViewModel._beutlClients,
+            clients,
             mainViewModel.EditorService,
             mainViewModel.ProjectService);
 
@@ -42,6 +51,20 @@ public class ExtensionsPageInitialNavigationTests
             page.Close();
             vm.Dispose();
             HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private sealed class EmptyJsonArrayHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+            };
+            return Task.FromResult(response);
         }
     }
 }


### PR DESCRIPTION
## Description
- Fix the extensions dialog (`ExtensionsPage`) showing a blank first tab until the user manually clicks a tab.
- Root cause: the initial `frame.Navigate` ran in `OnAttachedToVisualTree`, before the child `Frame`'s template was applied, so the navigated page never rendered. Move it to a one-shot `Loaded` handler so navigation runs after the Frame is ready. `CheckForPackageUpdatesTask`'s update-notification path (Library tab) relied on the same path and benefits too.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None

## Test plan
- Added `tests/Beutl.HeadlessUITests/ExtensionsPageInitialNavigationTests.cs`: opens `ExtensionsPage` with a real `ExtensionsPageViewModel` and asserts the first tab (`DiscoverPage`) renders without a manual tab switch. Verified red on pre-fix code, green after.
- ExtensionsPage family headless run: 3 passed, 0 failed.
- `dotnet format` applied to edited files.
- Manual: open the dialog from the menu / update notification; first tab content is visible immediately, no tab click required.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Extensions page so the default tab content (Discover) renders immediately upon opening.
  * Improved initial navigation behavior so the currently selected section is displayed without requiring a manual tab switch.
* **Tests**
  * Added a headless UI regression test to verify the Discover page is present right after the Extensions page opens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->