### PR TITLE
refactor!: enforce missing-stream guards in MediaReader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,6 +386,7 @@ telemetry-data.json
 .codex/.last-self-review
 .claude/worktrees/
 .claude/loop-memory/
+.omo/
 
 # `.mcp.json` is team-shared (see docs/ai-workflow/README.md); override any global gitignore
 !.mcp.json

--- a/src/Beutl.AgentToolkit/Rendering/AudioRhythmAnalyzer.cs
+++ b/src/Beutl.AgentToolkit/Rendering/AudioRhythmAnalyzer.cs
@@ -76,9 +76,14 @@ public sealed class AudioRhythmAnalyzer
             DisableResourceShare = true
         });
 
-        if (resource.MediaReader is null || resource.SampleRate <= 0)
+        if (resource.MediaReader is null)
         {
             throw new CodecUnavailableException($"No audio decoder could open '{fullPath}'.");
+        }
+
+        if (!resource.MediaReader.HasAudio || resource.SampleRate <= 0)
+        {
+            throw new CodecUnavailableException($"'{fullPath}' has no audio stream.");
         }
 
         int sampleRate = resource.SampleRate;

--- a/src/Beutl.Engine/Audio/Sound.cs
+++ b/src/Beutl.Engine/Audio/Sound.cs
@@ -48,7 +48,9 @@ public abstract partial class Sound : EngineObject
         }
 
         var soundSource = resource.GetSoundSource();
-        if (soundSource == null)
+        // SampleRate <= 0 (no audio stream / failed load) must not reach ResampleNode: it would
+        // propagate a 0 Hz AudioProcessContext and crash SourceNode's buffer allocation.
+        if (soundSource == null || soundSource.SampleRate <= 0)
         {
             context.Clear();
             return;

--- a/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedImageReader.cs
@@ -40,7 +40,7 @@ public class AnimatedImageReader : MediaReader
 
     public override bool HasAudio => false;
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
         if (_codec == null)
@@ -177,7 +177,7 @@ public class AnimatedImageReader : MediaReader
         return frameBitmap;
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
         return false;

--- a/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/AnimatedPngReader.cs
@@ -52,7 +52,7 @@ public class AnimatedPngReader : MediaReader
 
     public override bool HasAudio => false;
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
 
@@ -229,7 +229,7 @@ public class AnimatedPngReader : MediaReader
         return frameBitmap;
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
         return false;

--- a/src/Beutl.Engine/Media/Decoding/MediaReader.cs
+++ b/src/Beutl.Engine/Media/Decoding/MediaReader.cs
@@ -58,7 +58,22 @@ public abstract class MediaReader : IDisposable
         throw new FileNotFoundException(null, file);
     }
 
-    public abstract bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image);
+    public bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    {
+        if (!HasVideo)
+        {
+            image = null;
+            return false;
+        }
+
+        return ReadVideoCore(frame, out image);
+    }
+
+    /// <summary>
+    /// Implements <see cref="ReadVideo"/>. Called only when <see cref="HasVideo"/> is
+    /// <see langword="true"/>, so implementations may access <see cref="VideoInfo"/> freely.
+    /// </summary>
+    protected abstract bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image);
 
     /// <summary>
     /// Decodes audio samples starting at <paramref name="start"/>.
@@ -89,7 +104,22 @@ public abstract class MediaReader : IDisposable
     /// disposed, has no audio stream, or hit an unrecoverable decode/transport error. End-of-stream is
     /// not reported via <see langword="false"/>; use <see cref="IPcm.NumSamples"/> for that.
     /// </returns>
-    public abstract bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound);
+    public bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    {
+        if (!HasAudio)
+        {
+            sound = null;
+            return false;
+        }
+
+        return ReadAudioCore(start, length, out sound);
+    }
+
+    /// <summary>
+    /// Implements <see cref="ReadAudio"/>. Called only when <see cref="HasAudio"/> is
+    /// <see langword="true"/>, so implementations may access <see cref="AudioInfo"/> freely.
+    /// </summary>
+    protected abstract bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound);
 
     public void Dispose()
     {

--- a/src/Beutl.Engine/Media/Proxy/ProxyMediaReader.cs
+++ b/src/Beutl.Engine/Media/Proxy/ProxyMediaReader.cs
@@ -20,12 +20,12 @@ internal sealed class ProxyMediaReader(
 
     public override ProxyResolution? ProxyResolution => resolution;
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         return inner.ReadVideo(frame, out image);
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         return inner.ReadAudio(start, length, out sound);
     }

--- a/src/Beutl.Engine/Media/Source/SoundSource.cs
+++ b/src/Beutl.Engine/Media/Source/SoundSource.cs
@@ -150,9 +150,19 @@ public sealed class SoundSource : MediaSource
                     }
                 }
 
-                Duration = TimeSpan.FromSeconds(_counter.Value.AudioInfo.Duration.ToDouble());
-                SampleRate = _counter.Value.AudioInfo.SampleRate;
-                NumChannels = _counter.Value.AudioInfo.NumChannels;
+                if (_counter.Value.HasAudio)
+                {
+                    var ai = _counter.Value.AudioInfo;
+                    Duration = TimeSpan.FromSeconds(ai.Duration.ToDouble());
+                    SampleRate = ai.SampleRate;
+                    NumChannels = ai.NumChannels;
+                }
+                else
+                {
+                    Duration = TimeSpan.Zero;
+                    SampleRate = 0;
+                    NumChannels = 0;
+                }
                 _loadedUri = soundSource.Uri;
 
                 if (!updateOnly)

--- a/src/Beutl.Engine/Media/Source/VideoSource.cs
+++ b/src/Beutl.Engine/Media/Source/VideoSource.cs
@@ -205,9 +205,20 @@ public sealed class VideoSource : MediaSource
 
                 ProxyResolution = _counter.Value.ProxyResolution;
 
-                Duration = TimeSpan.FromSeconds(_counter.Value.VideoInfo.Duration.ToDouble());
-                FrameRate = _counter.Value.VideoInfo.FrameRate;
-                FrameSize = _counter.Value.VideoInfo.FrameSize;
+                if (_counter.Value.HasVideo)
+                {
+                    var vi = _counter.Value.VideoInfo;
+                    Duration = TimeSpan.FromSeconds(vi.Duration.ToDouble());
+                    FrameRate = vi.FrameRate;
+                    FrameSize = vi.FrameSize;
+                }
+                else
+                {
+                    // Missing-stream sentinels; keep in sync with SoundSource's SampleRate = 0 convention.
+                    Duration = TimeSpan.Zero;
+                    FrameRate = new Rational(0, 1);
+                    FrameSize = default;
+                }
                 LogicalFrameSize = ProxyResolution?.OriginalLogicalFrameSize ?? FrameSize;
                 _loadedUri = videoSource.Uri;
                 _loadedPreferProxy = context.PreferProxy;

--- a/src/Beutl.Engine/Media/Wave/WaveReader.cs
+++ b/src/Beutl.Engine/Media/Wave/WaveReader.cs
@@ -35,7 +35,7 @@ public sealed class WaveReader : MediaReader
 
     public override bool HasAudio => true;
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
         if (IsDisposed)
@@ -46,7 +46,7 @@ public sealed class WaveReader : MediaReader
         return true;
     }
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
         return false;

--- a/src/Beutl.Extensions.AVFoundation/Decoding/AVFReader.cs
+++ b/src/Beutl.Extensions.AVFoundation/Decoding/AVFReader.cs
@@ -100,10 +100,10 @@ public sealed class AVFReader : MediaReader
 
     public override bool HasAudio { get; }
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
-        if (!HasVideo || _handle == null || _handle.IsClosed || _handle.IsInvalid)
+        if (_handle == null || _handle.IsClosed || _handle.IsInvalid)
         {
             return false;
         }
@@ -134,10 +134,10 @@ public sealed class AVFReader : MediaReader
         }
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
-        if (!HasAudio || _handle == null || _handle.IsClosed || _handle.IsInvalid)
+        if (_handle == null || _handle.IsClosed || _handle.IsInvalid)
         {
             return false;
         }

--- a/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
+++ b/src/Beutl.Extensions.FFmpeg/Decoding/FFmpegReaderProxy.cs
@@ -62,15 +62,15 @@ public sealed class FFmpegReaderProxy : MediaReader
         }
     }
 
-    public override VideoStreamInfo VideoInfo => field ?? throw new Exception("The stream does not exist.");
+    public override VideoStreamInfo VideoInfo => field ?? throw new InvalidOperationException("The video stream does not exist.");
 
-    public override AudioStreamInfo AudioInfo => field ?? throw new Exception("The stream does not exist.");
+    public override AudioStreamInfo AudioInfo => field ?? throw new InvalidOperationException("The audio stream does not exist.");
 
     public override bool HasVideo => _openResponse.HasVideo;
 
     public override bool HasAudio => _openResponse.HasAudio;
 
-    public override unsafe bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override unsafe bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         var request = new ReadVideoRequest { ReaderId = _readerId, Frame = frame };
         var response = _connection.RequestAsync<ReadVideoRequest, ReadVideoResponse>(
@@ -122,7 +122,7 @@ public sealed class FFmpegReaderProxy : MediaReader
         }
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         int sampleRate = AudioInfo.SampleRate;
 
@@ -132,10 +132,10 @@ public sealed class FFmpegReaderProxy : MediaReader
             return ReadAudioChunked(start, length, sampleRate, out sound);
         }
 
-        return ReadAudioCore(start, length, out sound);
+        return ReadAudioChunk(start, length, out sound);
     }
 
-    private unsafe bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    private unsafe bool ReadAudioChunk(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         var request = new ReadAudioRequest { ReaderId = _readerId, Start = start, Length = length };
         var response = _connection.RequestAsync<ReadAudioRequest, ReadAudioResponse>(
@@ -175,7 +175,7 @@ public sealed class FFmpegReaderProxy : MediaReader
             {
                 int currentChunk = Math.Min(chunkSize, length - offset);
 
-                if (!ReadAudioCore(start + offset, currentChunk, out Ref<IPcm>? chunkRef))
+                if (!ReadAudioChunk(start + offset, currentChunk, out Ref<IPcm>? chunkRef))
                 {
                     // A genuine failure (IPC error / disposed) aborts the whole request.
                     scratch.Dispose();

--- a/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
+++ b/src/Beutl.Extensions.MediaFoundation/Decoding/MFReader.cs
@@ -134,21 +134,21 @@ public class MFReader : MediaReader
 
     public override bool HasAudio { get; }
 
-    public override unsafe bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override unsafe bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         if (MFThread.Dispatcher.CheckAccess())
         {
-            return ReadVideoCore(frame, out image);
+            return ReadVideoOnce(frame, out image);
         }
         else
         {
             image = null;
-            if (!HasVideo || _decoder == null || IsDisposed)
+            if (_decoder == null || IsDisposed)
                 return false;
 
             (bool result, Ref<Bitmap>? image1) = MFThread.Dispatcher.Invoke(() =>
             {
-                bool ret = ReadVideoCore(frame, out Ref<Bitmap>? image1);
+                bool ret = ReadVideoOnce(frame, out Ref<Bitmap>? image1);
                 return (ret, image1);
             });
             image = image1!;
@@ -156,10 +156,10 @@ public class MFReader : MediaReader
         }
     }
 
-    private unsafe bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    private unsafe bool ReadVideoOnce(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
-        if (!HasVideo || _decoder == null || IsDisposed)
+        if (_decoder == null || IsDisposed)
             return false;
 
         MFMediaInfo info = _decoder.GetMediaInfo();
@@ -198,11 +198,11 @@ public class MFReader : MediaReader
         }
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         if (MFThread.Dispatcher.CheckAccess())
         {
-            return ReadAudioCore(start, length, out sound);
+            return ReadAudioOnce(start, length, out sound);
         }
         else
         {
@@ -212,7 +212,7 @@ public class MFReader : MediaReader
 
             (bool result, Ref<IPcm>? sound1) = MFThread.Dispatcher.Invoke(() =>
             {
-                bool ret = ReadAudioCore(start, length, out Ref<IPcm>? sound1);
+                bool ret = ReadAudioOnce(start, length, out Ref<IPcm>? sound1);
                 return (ret, sound1);
             });
             sound = sound1!;
@@ -220,7 +220,7 @@ public class MFReader : MediaReader
         }
     }
 
-    private bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    private bool ReadAudioOnce(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
         if (IsDisposed || _audioReader == null || _waveFormat == null || _provider == null)

--- a/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
+++ b/src/Beutl.FFmpegWorker/Decoding/FFmpegReader.cs
@@ -139,15 +139,15 @@ public sealed class FFmpegReader : MediaReader
 
     private MediaFrame? ActiveVideoFrame => _isHWDecoding ? _swVideoFrame : _currentVideoFrame;
 
-    public override VideoStreamInfo VideoInfo => field ?? throw new Exception("The stream does not exist.");
+    public override VideoStreamInfo VideoInfo => field ?? throw new InvalidOperationException("The video stream does not exist.");
 
-    public override AudioStreamInfo AudioInfo => field ?? throw new Exception("The stream does not exist.");
+    public override AudioStreamInfo AudioInfo => field ?? throw new InvalidOperationException("The audio stream does not exist.");
 
     public override bool HasVideo => _hasVideo;
 
     public override bool HasAudio => _hasAudio;
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? result)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? result)
     {
         // Decoder側でResampleされるかのチェックのため
         if (length == 0)
@@ -175,6 +175,10 @@ public sealed class FFmpegReader : MediaReader
     public unsafe bool ReadAudio(int start, int length, Span<byte> destination, out AudioFrameInfo info)
     {
         info = default;
+
+        // The IPC handler calls this overload directly, bypassing MediaReader.ReadAudio's HasAudio guard.
+        if (!HasAudio)
+            return false;
 
         if (length == 0)
         {
@@ -269,11 +273,11 @@ public sealed class FFmpegReader : MediaReader
         }
     }
 
-    public override unsafe bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override unsafe bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
 
-        MediaFrame? filterFrame = ReadVideoCore(frame);
+        MediaFrame? filterFrame = DecodeVideoFrame(frame);
         if (filterFrame == null) return false;
 
         // フレームの色空間を取得
@@ -315,7 +319,7 @@ public sealed class FFmpegReader : MediaReader
     {
         info = default;
 
-        MediaFrame? filterFrame = ReadVideoCore(frame);
+        MediaFrame? filterFrame = DecodeVideoFrame(frame);
         if (filterFrame == null) return false;
 
         try
@@ -357,7 +361,7 @@ public sealed class FFmpegReader : MediaReader
         }
     }
 
-    private MediaFrame? ReadVideoCore(int frame)
+    private MediaFrame? DecodeVideoFrame(int frame)
     {
         var videoFrame = ActiveVideoFrame;
         if (_videoStream == null || _videoDecoder == null || videoFrame == null)

--- a/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
+++ b/tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs
@@ -7,14 +7,13 @@ namespace Beutl.FFmpegIpc.Tests;
 /// <summary>
 /// Process-level IPC contract test: spawns the real GPL <c>Beutl.FFmpegWorker</c> (via the MIT
 /// <see cref="FFmpegDecoderInfo"/> / <c>FFmpegReaderProxy</c> path) and pins the audio-only
-/// <c>ReadVideo</c> error contract.
+/// <c>ReadVideo</c> contract.
 /// <para>
-/// <c>DecodingHandler.HandleReadVideo</c> answers a <c>ReadVideo</c> request against an audio-only
-/// reader with <c>IpcMessage.CreateError(...)</c> (no ring buffer, <c>HasVideo == false</c>). The
-/// transport surfaces that error message as a thrown <see cref="FFmpegWorkerException"/>, so
-/// <c>FFmpegReaderProxy.ReadVideo</c> throws rather than silently returning <c>false</c>. This test
-/// pins that end-to-end contract so a future regression (e.g. swapping the error for a
-/// <c>Success = false</c> response) is caught.
+/// <c>MediaReader.ReadVideo</c> short-circuits to <c>false</c> when <c>HasVideo == false</c>, so an
+/// audio-only reader never issues the per-frame IPC round-trip (and never reaches
+/// <c>DecodingHandler.HandleReadVideo</c>'s audio-only <c>IpcMessage.CreateError(...)</c> branch,
+/// which remains only as a guard for direct IPC clients). This test pins that end-to-end contract so
+/// a future regression (e.g. reintroducing a throwing "stream does not exist" path) is caught.
 /// </para>
 /// <para>
 /// The worker binary is copied into the test output by the <c>CopyWorkerBinary</c> MSBuild target
@@ -53,7 +52,7 @@ public class FFmpegReaderProxyReadVideoContractTests
     }
 
     [Test]
-    public void ReadVideo_OnAudioOnlyFile_ThrowsFFmpegWorkerException()
+    public void ReadVideo_OnAudioOnlyFile_ReturnsFalse()
     {
         if (!WorkerBinaryPresent())
         {
@@ -91,10 +90,14 @@ public class FFmpegReaderProxyReadVideoContractTests
             Assert.That(reader.HasVideo, Is.False, "the WAV fixture must be audio-only (no video stream)");
         });
 
-        Assert.That(
-            () => reader!.ReadVideo(0, out _),
-            Throws.TypeOf<FFmpegWorkerException>(),
-            "ReadVideo on an audio-only reader must surface the worker's CreateError as a thrown FFmpegWorkerException, not a silent false");
+        bool result = reader!.ReadVideo(0, out var image);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                result, Is.False,
+                "ReadVideo on an audio-only reader must return false via the HasVideo short-circuit, not throw");
+            Assert.That(image, Is.Null);
+        });
     }
 
     // CopyWorkerBinary lays the worker flat into the test bin dir, but Nuke publish isolates it under an

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/TestMediaHelper.cs
@@ -168,7 +168,7 @@ internal sealed class TestMediaReader : MediaReader
 
     public override bool HasAudio => false;
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         if (frame < 0 || frame >= _frameCount)
         {
@@ -185,7 +185,7 @@ internal sealed class TestMediaReader : MediaReader
         return true;
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         sound = null;
         return false;
@@ -217,13 +217,13 @@ internal sealed class TestAudioReader : MediaReader
 
     public override bool HasAudio => true;
 
-    public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+    protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
     {
         image = null;
         return false;
     }
 
-    public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+    protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
     {
         if (length <= 0)
         {

--- a/tests/Beutl.UnitTests/Engine/Media/Source/MissingStreamGuardTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Media/Source/MissingStreamGuardTests.cs
@@ -1,0 +1,268 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Beutl.Animation;
+using Beutl.Audio;
+using Beutl.Audio.Graph;
+using Beutl.Composition;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Beutl.Media.Source;
+
+namespace Beutl.UnitTests.Engine.Media.Source;
+
+/// <summary>
+/// Regression tests for the "The stream does not exist." bug (Project #9 item 213326624).
+/// When a media file is opened in Video mode but has no video stream (or Audio mode but
+/// has no audio stream), VideoSource.Resource / SoundSource.Resource previously accessed
+/// MediaReader.VideoInfo / AudioInfo without a HasVideo / HasAudio guard, throwing a
+/// generic Exception that crashed the timeline clip operation.
+/// </summary>
+[TestFixture]
+public class MissingStreamGuardTests
+{
+    private static bool s_decoderRegistered;
+    private readonly List<string> _tempFiles = [];
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (!s_decoderRegistered)
+        {
+            DecoderRegistry.Register(new MissingStreamDecoderInfo());
+            s_decoderRegistered = true;
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (string path in _tempFiles)
+        {
+            File.Delete(path);
+        }
+
+        _tempFiles.Clear();
+    }
+
+    /// <summary>
+    /// A MediaReader whose stream-info accessors throw for absent streams, mirroring
+    /// FFmpegReaderProxy — the behavior the missing-stream guards must survive.
+    /// </summary>
+    private sealed class StubMediaReader(bool hasVideo, bool hasAudio) : MediaReader
+    {
+        private readonly VideoStreamInfo _videoInfo = new(
+            "test", 60, new PixelSize(80, 80), new Rational(30, 1));
+
+        private readonly AudioStreamInfo _audioInfo = new(
+            "test", new Rational(2, 1), 44100, 2);
+
+        public override VideoStreamInfo VideoInfo => hasVideo
+            ? _videoInfo
+            : throw new InvalidOperationException("The video stream does not exist.");
+
+        public override AudioStreamInfo AudioInfo => hasAudio
+            ? _audioInfo
+            : throw new InvalidOperationException("The audio stream does not exist.");
+
+        public override bool HasVideo => hasVideo;
+        public override bool HasAudio => hasAudio;
+
+        protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+        {
+            image = null;
+            return false;
+        }
+
+        protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+        {
+            sound = null;
+            return false;
+        }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    private sealed class MissingStreamDecoderInfo : IDecoderInfo
+    {
+        public string Name => "Missing Stream Test Decoder";
+
+        public MediaReader? Open(string file, MediaOptions options)
+        {
+            if (file.EndsWith(".no-stream", StringComparison.OrdinalIgnoreCase))
+                return new StubMediaReader(hasVideo: false, hasAudio: false);
+            if (file.EndsWith(".video-only", StringComparison.OrdinalIgnoreCase))
+                return new StubMediaReader(hasVideo: true, hasAudio: false);
+            if (file.EndsWith(".audio-only", StringComparison.OrdinalIgnoreCase))
+                return new StubMediaReader(hasVideo: false, hasAudio: true);
+            return null;
+        }
+
+        public bool IsSupported(string file)
+        {
+            return file.EndsWith(".no-stream", StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(".video-only", StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(".audio-only", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public IEnumerable<string> VideoExtensions() => [".video-only"];
+        public IEnumerable<string> AudioExtensions() => [".audio-only"];
+    }
+
+    private string CreateTempFile(string extension)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"missing-stream-{Guid.NewGuid():N}{extension}");
+        File.WriteAllBytes(path, []);
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// VideoSource with a file that has no video stream should not throw when
+    /// ToResource is called — it should gracefully set default values.
+    /// </summary>
+    [Test]
+    public void VideoSource_NoVideoStream_DoesNotThrow()
+    {
+        string path = CreateTempFile(".no-stream");
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(path));
+
+        using var resource = videoSource.ToResource(CompositionContext.Default);
+
+        // MediaReader should be non-null (the file opened successfully),
+        // but HasVideo is false, so the resource should have default values.
+        Assert.That(resource.MediaReader, Is.Not.Null);
+        Assert.That(resource.MediaReader!.HasVideo, Is.False);
+        Assert.That(resource.Duration, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(resource.FrameRate, Is.EqualTo(new Rational(0, 1)));
+    }
+
+    /// <summary>
+    /// SoundSource with a file that has no audio stream should not throw when
+    /// ToResource is called — it should gracefully set default values.
+    /// </summary>
+    [Test]
+    public void SoundSource_NoAudioStream_DoesNotThrow()
+    {
+        string path = CreateTempFile(".no-stream");
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        using var resource = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(resource.MediaReader, Is.Not.Null);
+        Assert.That(resource.MediaReader!.HasAudio, Is.False);
+        Assert.That(resource.Duration, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(resource.SampleRate, Is.EqualTo(0));
+        Assert.That(resource.NumChannels, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// SoundSource with a video-only file (HasAudio=false) should not throw
+    /// when ToResource is called.
+    /// </summary>
+    [Test]
+    public void SoundSource_VideoOnlyFile_DoesNotThrow()
+    {
+        string path = CreateTempFile(".video-only");
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        using var resource = soundSource.ToResource(CompositionContext.Default);
+
+        Assert.That(resource.MediaReader, Is.Not.Null);
+        Assert.That(resource.MediaReader!.HasAudio, Is.False);
+        Assert.That(resource.SampleRate, Is.EqualTo(0));
+        Assert.That(resource.NumChannels, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// VideoSource with an audio-only file (HasVideo=false) should not throw
+    /// when ToResource is called.
+    /// </summary>
+    [Test]
+    public void VideoSource_AudioOnlyFile_DoesNotThrow()
+    {
+        string path = CreateTempFile(".audio-only");
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(path));
+
+        using var resource = videoSource.ToResource(CompositionContext.Default);
+
+        Assert.That(resource.MediaReader, Is.Not.Null);
+        Assert.That(resource.MediaReader!.HasVideo, Is.False);
+        Assert.That(resource.Duration, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    /// <summary>
+    /// ReadAudio on a reader with no audio stream should return false
+    /// instead of throwing "The stream does not exist."
+    /// </summary>
+    [Test]
+    public void ReadAudio_NoAudioStream_ReturnsFalse()
+    {
+        string path = CreateTempFile(".video-only");
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        using var resource = soundSource.ToResource(CompositionContext.Default);
+
+        // Even if the reader exists, Read should return false when there's no audio stream.
+        bool result = resource.Read(0, 100, out _);
+        Assert.That(result, Is.False);
+    }
+
+    /// <summary>
+    /// ReadVideo on a reader with no video stream should return false; the base-class
+    /// HasVideo guard must short-circuit before the implementation runs.
+    /// </summary>
+    [Test]
+    public void ReadVideo_NoVideoStream_ReturnsFalse()
+    {
+        string path = CreateTempFile(".audio-only");
+        var videoSource = new VideoSource();
+        videoSource.ReadFrom(new Uri(path));
+
+        using var resource = videoSource.ToResource(CompositionContext.Default);
+
+        bool result = resource.Read(0, out _);
+        Assert.That(result, Is.False);
+    }
+
+    /// <summary>
+    /// A SoundSource whose file has no audio stream (SampleRate == 0) must compose as
+    /// silence. Previously Sound.Compose built a resample graph with SourceSampleRate = 0,
+    /// which propagated a 0 Hz AudioProcessContext into SourceNode and crashed AudioBuffer
+    /// allocation with ArgumentOutOfRangeException at render time.
+    /// </summary>
+    [Test]
+    public void SourceSound_NoAudioStream_ComposesAsSilence()
+    {
+        string path = CreateTempFile(".no-stream");
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        var sound = new SourceSound
+        {
+            Source = { CurrentValue = soundSource },
+            TimeRange = new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)),
+        };
+
+        using var resource = (SourceSound.Resource)sound.ToResource(CompositionContext.Default);
+        using var context = new AudioContext(44100, 2);
+
+        sound.Compose(context, resource);
+
+        var processContext = new AudioProcessContext(
+            new TimeRange(TimeSpan.Zero, TimeSpan.FromSeconds(1)), 44100, new AnimationSampler(), null);
+        foreach (AudioNode outputNode in context.GetOutputNodes())
+        {
+            using AudioBuffer buffer = outputNode.Process(processContext);
+            for (int ch = 0; ch < buffer.ChannelCount; ch++)
+            {
+                Assert.That(buffer.GetChannelData(ch).ToArray(), Is.All.Zero);
+            }
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Graphics;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Beutl.Graphics;
 using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
@@ -148,13 +150,13 @@ public sealed class ProxyMediaReaderTests
         public override bool HasVideo => true;
         public override bool HasAudio => false;
 
-        public override bool ReadVideo(int frame, out Ref<Bitmap>? image)
+        protected override bool ReadVideoCore(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
         {
             image = null;
             return false;
         }
 
-        public override bool ReadAudio(int start, int length, out Ref<IPcm>? sound)
+        protected override bool ReadAudioCore(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
         {
             sound = null;
             return false;


### PR DESCRIPTION
## Description
- Fixes the "The stream does not exist." crash family (Project #9 error-triage item 213326624): opening a media file whose expected stream is absent (audio-only file in Video mode, or vice versa) threw a generic exception from `VideoInfo`/`AudioInfo` and crashed the timeline clip operation.
- Makes `MediaReader.ReadVideo`/`ReadAudio` non-virtual template methods that short-circuit to `false` when `HasVideo`/`HasAudio` is false, delegating to new `protected abstract ReadVideoCore`/`ReadAudioCore`. This enforces the documented "return false when the stream is absent" contract structurally instead of via hand-copied guards (previously duplicated in AVFReader, ad-hoc in MFReader, missing in the FFmpeg readers), and eliminates a wasted per-frame blocking IPC round-trip for video-less files.
- Fixes the follow-on render-time crash: a loaded `SoundSource` with `SampleRate == 0` reached `Sound.Compose`, propagating a 0 Hz `AudioProcessContext` that crashed `AudioBuffer` allocation. `Sound.Compose` now composes silence for unreadable sources.
- `SoundSource`/`VideoSource.Update` set honest missing-stream sentinels (`SampleRate = 0`, `FrameRate = 0/1`, `FrameSize = default`) instead of throwing or fabricating 30 fps metadata; `AudioRhythmAnalyzer` now distinguishes "no audio stream" from "no decoder" in its error messages.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [x] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
- `MediaReader.ReadVideo`/`ReadAudio` are no longer `abstract`. Out-of-tree `MediaReader` subclasses must rename their overrides to `protected override ReadVideoCore`/`ReadAudioCore`; callers are unaffected. (Parallel edits applied on both sides of the GPL/MIT IPC boundary; no new project references.)
- `FFmpegReaderProxy.ReadVideo` on a video-less reader now returns `false` (no IPC round-trip) instead of surfacing the worker's error as a thrown `FFmpegWorkerException`. The worker-side `CreateError` branch remains for direct IPC clients.

## Test plan
- `tests/Beutl.UnitTests/Engine/Media/Source/MissingStreamGuardTests.cs` (new): 7 tests covering VideoSource/SoundSource resource loading for no-stream / video-only / audio-only files, Read guard short-circuits, and a compose-path regression test (`SourceSound_NoAudioStream_ComposesAsSilence`) verified red against the unguarded `Sound.Compose` (throws from `CreateResampleNode`) and green with the fix.
- `tests/Beutl.FFmpegIpc.Tests/FFmpegReaderProxyReadVideoContractTests.cs`: process-level contract re-pinned from "throws FFmpegWorkerException" to "returns false via the HasVideo short-circuit".
- Full runs green: Beutl.UnitTests 4694, FFmpegIpc.Tests 56, AgentToolkit.Tests 482, AVFoundation.Tests 12, FFmpegWorker.Tests 1; `dotnet build Beutl.slnx` 0 errors; `dotnet format` applied to edited files.

## Fixed issues / References
- Project board: b-editor/projects/9 ("The stream does not exist." error-triage item)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of media files without audio or video streams.
  * Missing streams now return safe defaults instead of causing errors.
  * Invalid audio metadata no longer causes crashes during composition.
  * Audio-only and video-only files are handled more reliably.
  * Decoder errors now provide clearer messages.

* **Tests**
  * Added coverage for missing-stream behavior and silent audio composition.
  * Updated media-reading tests to verify safe failure responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->