### PR TITLE
feat!: Allow extensions to provide custom themes

### DIFF
--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -160,7 +160,7 @@ public sealed class ViewConfig : ConfigurationBase
         }
         else
         {
-            Theme = NormalizeThemeIdString(context.GetValue<string>(nameof(Theme)));
+            Theme = BuiltinThemeIds.Normalize(context.GetValue<string>(nameof(Theme)));
         }
 
         // 古い settings.json や手動編集後のファイルでこれらのキーが欠落していると
@@ -231,8 +231,9 @@ public sealed class ViewConfig : ConfigurationBase
         }
     }
 
-    // Migrate legacy <2.0 ViewTheme enum values (int 0-3 or PascalCase name) to the stable
-    // lowercase id. Unknown ids (custom themes) are kept as-is.
+    // Migrate legacy <2.0 ViewTheme enum values (a JSON number, or a PascalCase name) to the stable
+    // lowercase id. The rule lives in BuiltinThemeIds because ThemeRegistry validates extension ids
+    // against it — the two must not drift.
     private static string NormalizeThemeId(JsonNode? node)
     {
         if (node is not JsonValue value)
@@ -240,50 +241,14 @@ public sealed class ViewConfig : ConfigurationBase
             return BuiltinThemeIds.Dark;
         }
 
+        // A JSON number is only ever the legacy enum; ids are persisted as strings.
         if (value.TryGetValue(out int legacyEnum))
         {
-            return NormalizeLegacyEnum(legacyEnum);
+            return BuiltinThemeIds.FromLegacyEnum(legacyEnum);
         }
 
-        return value.TryGetValue(out string? raw) ? NormalizeThemeIdString(raw) : BuiltinThemeIds.Dark;
+        return value.TryGetValue(out string? raw) ? BuiltinThemeIds.Normalize(raw) : BuiltinThemeIds.Dark;
     }
-
-    private static string NormalizeThemeIdString(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            return BuiltinThemeIds.Dark;
-        }
-
-        raw = raw.Trim();
-
-        // <2.0 wrote the enum as a JSON number, but a hand-edited settings.json may quote it. Only
-        // the values the enum actually had migrate: theme ids are otherwise arbitrary strings, so a
-        // custom id that merely looks numeric ("2026") must survive as itself.
-        if (int.TryParse(raw, CultureInfo.InvariantCulture, out int legacyEnum)
-            && legacyEnum is >= 0 and <= 3)
-        {
-            return NormalizeLegacyEnum(legacyEnum);
-        }
-
-        return raw.ToLowerInvariant() switch
-        {
-            "light" => BuiltinThemeIds.Light,
-            "dark" => BuiltinThemeIds.Dark,
-            "highcontrast" => BuiltinThemeIds.HighContrast,
-            "system" => BuiltinThemeIds.System,
-            _ => raw,
-        };
-    }
-
-    private static string NormalizeLegacyEnum(int value) => value switch
-    {
-        0 => BuiltinThemeIds.Light,
-        1 => BuiltinThemeIds.Dark,
-        2 => BuiltinThemeIds.HighContrast,
-        3 => BuiltinThemeIds.System,
-        _ => BuiltinThemeIds.Dark,
-    };
 
     private record WindowPositionRecord(int X, int Y);
 

--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
+using System.Text.Json.Nodes;
 using Beutl.Collections;
 using Beutl.Serialization;
 
@@ -7,7 +8,7 @@ namespace Beutl.Configuration;
 
 public sealed class ViewConfig : ConfigurationBase
 {
-    public static readonly CoreProperty<ViewTheme> ThemeProperty;
+    public static readonly CoreProperty<string> ThemeProperty;
     public static readonly CoreProperty<CultureInfo> UICultureProperty;
     public static readonly CoreProperty<(int X, int Y)?> WindowPositionProperty;
     public static readonly CoreProperty<(int Width, int Height)?> WindowSizeProperty;
@@ -24,8 +25,8 @@ public sealed class ViewConfig : ConfigurationBase
 
     static ViewConfig()
     {
-        ThemeProperty = ConfigureProperty<ViewTheme, ViewConfig>(nameof(Theme))
-            .DefaultValue(ViewTheme.Dark)
+        ThemeProperty = ConfigureProperty<string, ViewConfig>(nameof(Theme))
+            .DefaultValue(BuiltinThemeIds.Dark)
             .Register();
 
         UICultureProperty = ConfigureProperty<CultureInfo, ViewConfig>(nameof(UICulture))
@@ -76,7 +77,8 @@ public sealed class ViewConfig : ConfigurationBase
         _recentProjects.CollectionChanged += (_, _) => OnChanged();
     }
 
-    public ViewTheme Theme
+    [NotAutoSerialized]
+    public string Theme
     {
         get => GetValue(ThemeProperty);
         set => SetValue(ThemeProperty, value);
@@ -146,17 +148,15 @@ public sealed class ViewConfig : ConfigurationBase
         set => SetValue(LastOpenedProjectFileProperty, value);
     }
 
-    public enum ViewTheme
-    {
-        Light,
-        Dark,
-        HighContrast,
-        System
-    }
-
     public override void Deserialize(ICoreSerializationContext context)
     {
         base.Deserialize(context);
+
+        if (context is JsonSerializationContext jsonContext)
+        {
+            Theme = NormalizeThemeId(jsonContext.GetNode(nameof(Theme)));
+        }
+
         // 古い settings.json や手動編集後のファイルでこれらのキーが欠落していると
         // GetValue が null を返す。null! を素通りさせると _recentFiles.Replace(null) で
         // ArgumentNullException が起き、後続の Editor/Graphics/Tutorial 設定の
@@ -187,6 +187,7 @@ public sealed class ViewConfig : ConfigurationBase
     public override void Serialize(ICoreSerializationContext context)
     {
         base.Serialize(context);
+        context.SetValue(nameof(Theme), Theme);
         context.SetValue(nameof(RecentFiles), RecentFiles);
         context.SetValue(nameof(RecentProjects), RecentProjects);
 
@@ -222,6 +223,47 @@ public sealed class ViewConfig : ConfigurationBase
         {
             OnChanged();
         }
+    }
+
+    // Migrate legacy <2.0 ViewTheme enum values (int 0-3 or PascalCase name) to the stable
+    // lowercase id. Unknown ids (custom themes) are kept as-is.
+    private static string NormalizeThemeId(JsonNode? node)
+    {
+        if (node is not JsonValue value)
+        {
+            return BuiltinThemeIds.Dark;
+        }
+
+        return NormalizeThemeIdString(value.ToJsonString().Trim('"'));
+    }
+
+    private static string NormalizeThemeIdString(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return BuiltinThemeIds.Dark;
+        }
+
+        if (int.TryParse(raw, out int legacyEnum))
+        {
+            return legacyEnum switch
+            {
+                0 => BuiltinThemeIds.Light,
+                1 => BuiltinThemeIds.Dark,
+                2 => BuiltinThemeIds.HighContrast,
+                3 => BuiltinThemeIds.System,
+                _ => BuiltinThemeIds.Dark,
+            };
+        }
+
+        return raw.ToLowerInvariant() switch
+        {
+            "light" => BuiltinThemeIds.Light,
+            "dark" => BuiltinThemeIds.Dark,
+            "highcontrast" => BuiltinThemeIds.HighContrast,
+            "system" => BuiltinThemeIds.System,
+            _ => raw,
+        };
     }
 
     private record WindowPositionRecord(int X, int Y);

--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -152,9 +152,15 @@ public sealed class ViewConfig : ConfigurationBase
     {
         base.Deserialize(context);
 
-        if (context is JsonSerializationContext jsonContext)
+        // The raw node is needed only to tell a legacy JSON number from a string id; any other
+        // context can only carry the string form.
+        if (context is IJsonSerializationContext jsonContext)
         {
             Theme = NormalizeThemeId(jsonContext.GetNode(nameof(Theme)));
+        }
+        else
+        {
+            Theme = NormalizeThemeIdString(context.GetValue<string>(nameof(Theme)));
         }
 
         // 古い settings.json や手動編集後のファイルでこれらのキーが欠落していると
@@ -234,26 +240,27 @@ public sealed class ViewConfig : ConfigurationBase
             return BuiltinThemeIds.Dark;
         }
 
-        return NormalizeThemeIdString(value.ToJsonString().Trim('"'));
+        if (value.TryGetValue(out int legacyEnum))
+        {
+            return NormalizeLegacyEnum(legacyEnum);
+        }
+
+        return value.TryGetValue(out string? raw) ? NormalizeThemeIdString(raw) : BuiltinThemeIds.Dark;
     }
 
-    private static string NormalizeThemeIdString(string raw)
+    private static string NormalizeThemeIdString(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw))
         {
             return BuiltinThemeIds.Dark;
         }
 
-        if (int.TryParse(raw, out int legacyEnum))
+        raw = raw.Trim();
+
+        // <2.0 wrote the enum as a JSON number, but a hand-edited settings.json may quote it.
+        if (int.TryParse(raw, CultureInfo.InvariantCulture, out int legacyEnum))
         {
-            return legacyEnum switch
-            {
-                0 => BuiltinThemeIds.Light,
-                1 => BuiltinThemeIds.Dark,
-                2 => BuiltinThemeIds.HighContrast,
-                3 => BuiltinThemeIds.System,
-                _ => BuiltinThemeIds.Dark,
-            };
+            return NormalizeLegacyEnum(legacyEnum);
         }
 
         return raw.ToLowerInvariant() switch
@@ -265,6 +272,15 @@ public sealed class ViewConfig : ConfigurationBase
             _ => raw,
         };
     }
+
+    private static string NormalizeLegacyEnum(int value) => value switch
+    {
+        0 => BuiltinThemeIds.Light,
+        1 => BuiltinThemeIds.Dark,
+        2 => BuiltinThemeIds.HighContrast,
+        3 => BuiltinThemeIds.System,
+        _ => BuiltinThemeIds.Dark,
+    };
 
     private record WindowPositionRecord(int X, int Y);
 

--- a/src/Beutl.Configuration/ViewConfig.cs
+++ b/src/Beutl.Configuration/ViewConfig.cs
@@ -257,8 +257,11 @@ public sealed class ViewConfig : ConfigurationBase
 
         raw = raw.Trim();
 
-        // <2.0 wrote the enum as a JSON number, but a hand-edited settings.json may quote it.
-        if (int.TryParse(raw, CultureInfo.InvariantCulture, out int legacyEnum))
+        // <2.0 wrote the enum as a JSON number, but a hand-edited settings.json may quote it. Only
+        // the values the enum actually had migrate: theme ids are otherwise arbitrary strings, so a
+        // custom id that merely looks numeric ("2026") must survive as itself.
+        if (int.TryParse(raw, CultureInfo.InvariantCulture, out int legacyEnum)
+            && legacyEnum is >= 0 and <= 3)
         {
             return NormalizeLegacyEnum(legacyEnum);
         }

--- a/src/Beutl.Core/BuiltinThemeIds.cs
+++ b/src/Beutl.Core/BuiltinThemeIds.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Frozen;
+using System.Globalization;
 
 namespace Beutl;
 
@@ -13,8 +14,10 @@ public static class BuiltinThemeIds
     public const string HighContrast = "highcontrast";
     public const string System = "system";
 
-    public static IReadOnlySet<string> All { get; } =
-        new HashSet<string>(StringComparer.Ordinal) { Light, Dark, HighContrast, System };
+    // Frozen rather than a HashSet behind IReadOnlySet: this gates ThemeRegistry's reserved-id
+    // enforcement, so a caller must not be able to downcast and mutate it.
+    public static FrozenSet<string> All { get; } =
+        FrozenSet.ToFrozenSet([Light, Dark, HighContrast, System], StringComparer.Ordinal);
 
     // <2.0 persisted the ViewTheme enum, whose only members were 0-3.
     public static string FromLegacyEnum(int value) => value switch

--- a/src/Beutl.Core/BuiltinThemeIds.cs
+++ b/src/Beutl.Core/BuiltinThemeIds.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Beutl;
 

--- a/src/Beutl.Core/BuiltinThemeIds.cs
+++ b/src/Beutl.Core/BuiltinThemeIds.cs
@@ -1,0 +1,11 @@
+﻿namespace Beutl;
+
+// Persisted in settings.json (ViewConfig.Theme) — these ids must never change. Extensions pick their own.
+// In Beutl.Core so Beutl.Configuration and Beutl.Extensibility both see it without a cycle.
+public static class BuiltinThemeIds
+{
+    public const string Light = "light";
+    public const string Dark = "dark";
+    public const string HighContrast = "highcontrast";
+    public const string System = "system";
+}

--- a/src/Beutl.Core/BuiltinThemeIds.cs
+++ b/src/Beutl.Core/BuiltinThemeIds.cs
@@ -1,11 +1,68 @@
-﻿namespace Beutl;
+using System.Globalization;
+
+namespace Beutl;
 
 // Persisted in settings.json (ViewConfig.Theme) — these ids must never change. Extensions pick their own.
-// In Beutl.Core so Beutl.Configuration and Beutl.Extensibility both see it without a cycle.
+// In Beutl.Core so Beutl.Configuration and Beutl.Extensibility both see it without a cycle: settings
+// normalization and registry validation must agree on what counts as a built-in id, or an extension
+// could register an id that settings then rewrites out from under it.
 public static class BuiltinThemeIds
 {
     public const string Light = "light";
     public const string Dark = "dark";
     public const string HighContrast = "highcontrast";
     public const string System = "system";
+
+    public static IReadOnlySet<string> All { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { Light, Dark, HighContrast, System };
+
+    // <2.0 persisted the ViewTheme enum, whose only members were 0-3.
+    public static string FromLegacyEnum(int value) => value switch
+    {
+        0 => Light,
+        1 => Dark,
+        2 => HighContrast,
+        3 => System,
+        _ => Dark,
+    };
+
+    /// <summary>
+    /// The canonical id for a persisted value: legacy &lt;2.0 forms (the enum as 0-3, or a PascalCase
+    /// name) become the stable id, anything else is a custom id returned trimmed, and an empty or
+    /// missing value falls back to <see cref="Dark"/>.
+    /// </summary>
+    public static string Normalize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return Dark;
+        }
+
+        raw = raw.Trim();
+
+        // A hand-edited settings.json may quote the legacy number. Ids are otherwise arbitrary
+        // strings, so one that merely looks numeric ("2026") is custom and must survive.
+        if (int.TryParse(raw, CultureInfo.InvariantCulture, out int legacyEnum)
+            && legacyEnum is >= 0 and <= 3)
+        {
+            return FromLegacyEnum(legacyEnum);
+        }
+
+        return raw.ToLowerInvariant() switch
+        {
+            Light => Light,
+            Dark => Dark,
+            HighContrast => HighContrast,
+            System => System,
+            _ => raw,
+        };
+    }
+
+    /// <summary>
+    /// True when <see cref="Normalize"/> would turn <paramref name="id"/> into a built-in — a
+    /// built-in id or one of its legacy aliases ("Dark", "2"). An extension must not register such an
+    /// id: settings would rewrite the user's selection to the built-in on the next load, silently
+    /// dropping the extension's theme.
+    /// </summary>
+    public static bool IsReserved(string? id) => All.Contains(Normalize(id));
 }

--- a/src/Beutl.Extensibility/ThemeApplyContext.cs
+++ b/src/Beutl.Extensibility/ThemeApplyContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Beutl.Extensibility;
+
+// Passed to ThemeExtension.OnApplied. Currently exposes only the applied descriptor; the class
+// shape (init-only required property) lets future apply-time data be added without breaking
+// existing overrides.
+public sealed class ThemeApplyContext
+{
+    public required ThemeDescriptor Descriptor { get; init; }
+}

--- a/src/Beutl.Extensibility/ThemeDescriptor.cs
+++ b/src/Beutl.Extensibility/ThemeDescriptor.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Styling;
+
+namespace Beutl.Extensibility;
+
+// A custom theme layers a brush-override ResourceDictionary (ResourceUri) on a base ThemeVariant;
+// built-ins are registered by the host and extensions register their own via ThemeExtension.
+public sealed record ThemeDescriptor(
+    string Id,
+    string DisplayName,
+    ThemeVariant BaseVariant,
+    Uri? ResourceUri = null,
+    bool IsSystemFollowing = false);

--- a/src/Beutl.Extensibility/ThemeExtension.cs
+++ b/src/Beutl.Extensibility/ThemeExtension.cs
@@ -1,0 +1,40 @@
+﻿namespace Beutl.Extensibility;
+
+// Register a ThemeDescriptor into ThemeRegistry at Load; an extension ships a theme by overriding
+// GetThemeDescriptor with its id, base variant, and optional brush-override ResourceDictionary Uri.
+// OnApplied/OnReverted are invoked by the host when this theme becomes active/inactive, so an
+// extension can add apply-time side effects (telemetry, dynamic accent, resource recomputation).
+public abstract class ThemeExtension : Extension
+{
+    private ThemeDescriptor? _descriptor;
+
+    // The descriptor registered at Load, or null before Load / after Unload.
+    public ThemeDescriptor? Descriptor => _descriptor;
+
+    public abstract ThemeDescriptor GetThemeDescriptor();
+
+    public override void Load()
+    {
+        _descriptor = GetThemeDescriptor();
+        ThemeRegistry.Register(_descriptor, this);
+    }
+
+    public override void Unload()
+    {
+        if (_descriptor != null)
+        {
+            ThemeRegistry.Unregister(_descriptor);
+            _descriptor = null;
+        }
+    }
+
+    // Called by the host when this theme becomes the active theme. Default is a no-op.
+    public virtual void OnApplied(ThemeApplyContext context)
+    {
+    }
+
+    // Called by the host when this theme is no longer the active theme. Default is a no-op.
+    public virtual void OnReverted()
+    {
+    }
+}

--- a/src/Beutl.Extensibility/ThemeExtension.cs
+++ b/src/Beutl.Extensibility/ThemeExtension.cs
@@ -15,8 +15,11 @@ public abstract class ThemeExtension : Extension
 
     public override void Load()
     {
-        _descriptor = GetThemeDescriptor();
-        ThemeRegistry.Register(_descriptor, this);
+        // Assigned only once Register accepts it, so a rejected descriptor (e.g. an id the host
+        // owns) leaves Descriptor null rather than naming a theme this extension does not have.
+        ThemeDescriptor descriptor = GetThemeDescriptor();
+        ThemeRegistry.Register(descriptor, this);
+        _descriptor = descriptor;
     }
 
     public override void Unload()

--- a/src/Beutl.Extensibility/ThemeNotifier.cs
+++ b/src/Beutl.Extensibility/ThemeNotifier.cs
@@ -6,39 +6,47 @@ namespace Beutl.Extensibility;
 
 // Notifies the ThemeExtension that owns a descriptor of apply/revert. Pure (no Application access),
 // so it is unit-testable; ThemeService calls it from its apply path.
+//
+// The owner is a parameter rather than a ThemeRegistry lookup because by revert time the id may be
+// unregistered (owner gone, OnReverted skipped) or re-registered by a different extension (which
+// would receive callbacks for a descriptor it never supplied). Callers capture it at apply time.
 public static class ThemeNotifier
 {
     private static readonly ILogger s_logger = Log.CreateLogger(nameof(ThemeNotifier));
 
-    public static void NotifyApplied(ThemeDescriptor descriptor)
+    public static void NotifyApplied(ThemeDescriptor descriptor, ThemeExtension? extension)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
-        if (ThemeRegistry.GetExtension(descriptor.Id) is { } extension)
+        if (extension == null)
         {
-            try
-            {
-                extension.OnApplied(new ThemeApplyContext { Descriptor = descriptor });
-            }
-            catch (Exception ex)
-            {
-                s_logger.LogWarning(ex, "ThemeExtension.OnApplied for '{Id}' threw; continuing.", descriptor.Id);
-            }
+            return;
+        }
+
+        try
+        {
+            extension.OnApplied(new ThemeApplyContext { Descriptor = descriptor });
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "ThemeExtension.OnApplied for '{Id}' threw; continuing.", descriptor.Id);
         }
     }
 
-    public static void NotifyReverted(ThemeDescriptor descriptor)
+    public static void NotifyReverted(ThemeDescriptor descriptor, ThemeExtension? extension)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
-        if (ThemeRegistry.GetExtension(descriptor.Id) is { } extension)
+        if (extension == null)
         {
-            try
-            {
-                extension.OnReverted();
-            }
-            catch (Exception ex)
-            {
-                s_logger.LogWarning(ex, "ThemeExtension.OnReverted for '{Id}' threw; continuing.", descriptor.Id);
-            }
+            return;
+        }
+
+        try
+        {
+            extension.OnReverted();
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "ThemeExtension.OnReverted for '{Id}' threw; continuing.", descriptor.Id);
         }
     }
 }

--- a/src/Beutl.Extensibility/ThemeNotifier.cs
+++ b/src/Beutl.Extensibility/ThemeNotifier.cs
@@ -1,0 +1,44 @@
+﻿using Beutl.Logging;
+
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Extensibility;
+
+// Notifies the ThemeExtension that owns a descriptor of apply/revert. Pure (no Application access),
+// so it is unit-testable; ThemeService calls it from its apply path.
+public static class ThemeNotifier
+{
+    private static readonly ILogger s_logger = Log.CreateLogger(nameof(ThemeNotifier));
+
+    public static void NotifyApplied(ThemeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        if (ThemeRegistry.GetExtension(descriptor.Id) is { } extension)
+        {
+            try
+            {
+                extension.OnApplied(new ThemeApplyContext { Descriptor = descriptor });
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(ex, "ThemeExtension.OnApplied for '{Id}' threw; continuing.", descriptor.Id);
+            }
+        }
+    }
+
+    public static void NotifyReverted(ThemeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        if (ThemeRegistry.GetExtension(descriptor.Id) is { } extension)
+        {
+            try
+            {
+                extension.OnReverted();
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(ex, "ThemeExtension.OnReverted for '{Id}' threw; continuing.", descriptor.Id);
+            }
+        }
+    }
+}

--- a/src/Beutl.Extensibility/ThemeRegistry.cs
+++ b/src/Beutl.Extensibility/ThemeRegistry.cs
@@ -7,11 +7,12 @@ namespace Beutl.Extensibility;
 // Static registry of ThemeDescriptor instances. A ThemeExtension registers its descriptor at
 // Load() and unregisters at Unload(); the host resolves the selected theme id and re-applies when
 // the set changes. Ids are unique and a repeat Register overwrites, so a re-Load after a rolled-back
-// partial init is idempotent — except that an extension cannot overwrite a host-registered id.
-// Registration is keyed on the descriptor instance, not the record's value: only the instance that
-// registered an id may Unregister it, so an extension replaced by another cannot evict its
-// successor. The owning ThemeExtension is kept alongside the descriptor so the host can notify it on
-// apply/revert without a separate lookup; null means the host registered it.
+// partial init is idempotent; the ids reserved for built-ins (BuiltinThemeIds.IsReserved) are the
+// exception and an extension cannot claim one. Registration is keyed on the descriptor instance, not
+// the record's value: only the instance that registered an id may Unregister it, so an extension
+// replaced by another cannot evict its successor. The owning ThemeExtension is kept alongside the
+// descriptor so the host can notify it on apply/revert without a separate lookup; null means the
+// host registered it.
 public static class ThemeRegistry
 {
     private static readonly ILogger s_logger = Log.CreateLogger(nameof(ThemeRegistry));
@@ -35,20 +36,18 @@ public static class ThemeRegistry
                 nameof(descriptor));
         }
 
+        // Checked against the reserved-id rule rather than what is currently registered, so the
+        // outcome does not depend on whether the host has seeded the built-ins yet: extensions load
+        // on background threads and can reach this before ThemeService.Start does.
+        if (extension != null && BuiltinThemeIds.IsReserved(descriptor.Id))
+        {
+            throw new ArgumentException(
+                $"Theme id '{descriptor.Id}' is reserved for a built-in theme and cannot be registered by an extension. Choose an id unique to the extension.",
+                nameof(descriptor));
+        }
+
         lock (s_lock)
         {
-            // An extension may not take over a host-registered theme. It would win the id, and its
-            // Unload would then evict the built-in entirely — ResolveOrDefault's Dark fallback and
-            // the settings picker would lose it until restart.
-            if (extension != null
-                && s_themes.TryGetValue(descriptor.Id, out var existing)
-                && existing.Extension == null)
-            {
-                throw new ArgumentException(
-                    $"Theme id '{descriptor.Id}' is registered by the host and cannot be replaced by an extension. Choose an id unique to the extension.",
-                    nameof(descriptor));
-            }
-
             s_themes[descriptor.Id] = (descriptor, extension);
         }
 

--- a/src/Beutl.Extensibility/ThemeRegistry.cs
+++ b/src/Beutl.Extensibility/ThemeRegistry.cs
@@ -87,6 +87,24 @@ public static class ThemeRegistry
     }
 
     /// <summary>
+    /// The <see cref="ThemeExtension"/> that registered this exact <paramref name="descriptor"/>, or
+    /// null when it is a host-registered built-in or no longer the registration under its id.
+    /// Prefer this over <see cref="GetExtension(string?)"/> when holding a descriptor: an id lookup
+    /// can hand back the owner of a replacement registered since the descriptor was resolved.
+    /// </summary>
+    public static ThemeExtension? GetOwner(ThemeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        lock (s_lock)
+        {
+            return s_themes.TryGetValue(descriptor.Id, out var entry)
+                   && ReferenceEquals(entry.Descriptor, descriptor)
+                ? entry.Extension
+                : null;
+        }
+    }
+
+    /// <summary>
     /// Resolves <paramref name="id"/>, falling back to the built-in Dark, then to the first
     /// registered non-system-following theme. Returns null only when nothing is registered yet
     /// (early startup, before the host registers the built-ins).

--- a/src/Beutl.Extensibility/ThemeRegistry.cs
+++ b/src/Beutl.Extensibility/ThemeRegistry.cs
@@ -1,0 +1,128 @@
+﻿using Beutl.Logging;
+
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Extensibility;
+
+// Static registry of ThemeDescriptor instances. A ThemeExtension registers its descriptor at
+// Load() and unregisters at Unload(); the host resolves the selected theme id and re-applies when
+// the set changes. Ids are unique: a repeat Register for the same id overwrites, so a re-Load after
+// a rolled-back partial init is idempotent. The optional ThemeExtension is kept alongside the
+// descriptor so the host can notify the owning extension on apply/revert without a separate lookup.
+public static class ThemeRegistry
+{
+    private static readonly ILogger s_logger = Log.CreateLogger(nameof(ThemeRegistry));
+    private static readonly Dictionary<string, (ThemeDescriptor Descriptor, ThemeExtension? Extension)> s_themes = [];
+    private static readonly object s_lock = new();
+
+    /// <summary>
+    /// Raised after the set of registered themes changes. The host re-applies the current theme so
+    /// an extension that registers/unregisters a theme is reflected live. Fired outside the internal
+    /// lock, so a handler may safely re-enter <see cref="Enumerate"/>/<see cref="Resolve"/>.
+    /// </summary>
+    public static event EventHandler? Changed;
+
+    public static void Register(ThemeDescriptor descriptor, ThemeExtension? extension = null)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        if (descriptor.IsSystemFollowing && descriptor.ResourceUri != null)
+        {
+            throw new ArgumentException(
+                "A system-following theme cannot specify ResourceUri: the host applies the OS-resolved variant and cannot honor per-variant resources.",
+                nameof(descriptor));
+        }
+
+        lock (s_lock)
+        {
+            s_themes[descriptor.Id] = (descriptor, extension);
+        }
+
+        RaiseChanged();
+    }
+
+    public static bool Unregister(ThemeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        bool removed;
+        lock (s_lock)
+        {
+            removed = s_themes.Remove(descriptor.Id);
+        }
+
+        if (removed)
+            RaiseChanged();
+
+        return removed;
+    }
+
+    public static ThemeDescriptor? Resolve(string? id)
+    {
+        if (string.IsNullOrEmpty(id))
+            return null;
+
+        lock (s_lock)
+        {
+            return s_themes.TryGetValue(id, out var entry) ? entry.Descriptor : null;
+        }
+    }
+
+    // The ThemeExtension that registered the descriptor, or null for a host-registered built-in.
+    public static ThemeExtension? GetExtension(string? id)
+    {
+        if (string.IsNullOrEmpty(id))
+            return null;
+
+        lock (s_lock)
+        {
+            return s_themes.TryGetValue(id, out var entry) ? entry.Extension : null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="id"/>, falling back to the built-in Dark, then to the first
+    /// registered non-system-following theme. Returns null only when nothing is registered yet
+    /// (early startup, before the host registers the built-ins).
+    /// </summary>
+    public static ThemeDescriptor? ResolveOrDefault(string? id)
+    {
+        if (Resolve(id) is { } direct)
+            return direct;
+
+        if (Resolve(BuiltinThemeIds.Dark) is { } dark)
+            return dark;
+
+        lock (s_lock)
+        {
+            return s_themes.Values.FirstOrDefault(x => !x.Descriptor.IsSystemFollowing).Descriptor;
+        }
+    }
+
+    public static IReadOnlyList<ThemeDescriptor> Enumerate()
+    {
+        lock (s_lock)
+        {
+            return s_themes.Values.Select(x => x.Descriptor).ToArray();
+        }
+    }
+
+    // Isolate each subscriber: a throwing Changed handler (during extension load/unload) must not
+    // abort the registry mutation or prevent the other subscribers — e.g. the host re-apply — from
+    // running.
+    private static void RaiseChanged()
+    {
+        if (Changed is not { } handler)
+            return;
+
+        foreach (Delegate subscriber in handler.GetInvocationList())
+        {
+            try
+            {
+                ((EventHandler)subscriber)(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                s_logger.LogWarning(ex, "A ThemeRegistry.Changed subscriber threw; continuing with the rest.");
+            }
+        }
+    }
+}

--- a/src/Beutl.Extensibility/ThemeRegistry.cs
+++ b/src/Beutl.Extensibility/ThemeRegistry.cs
@@ -40,13 +40,21 @@ public static class ThemeRegistry
         RaiseChanged();
     }
 
+    /// <summary>
+    /// Removes <paramref name="descriptor"/> only when it is still the instance registered under its
+    /// id, so an extension unloading after another one overwrote its id cannot evict the replacement.
+    /// Identity is reference equality, not the record's structural equality: two owners may supply
+    /// equal-valued descriptors, and only the one that registered may remove it.
+    /// </summary>
     public static bool Unregister(ThemeDescriptor descriptor)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         bool removed;
         lock (s_lock)
         {
-            removed = s_themes.Remove(descriptor.Id);
+            removed = s_themes.TryGetValue(descriptor.Id, out var entry)
+                      && ReferenceEquals(entry.Descriptor, descriptor)
+                      && s_themes.Remove(descriptor.Id);
         }
 
         if (removed)

--- a/src/Beutl.Extensibility/ThemeRegistry.cs
+++ b/src/Beutl.Extensibility/ThemeRegistry.cs
@@ -6,9 +6,12 @@ namespace Beutl.Extensibility;
 
 // Static registry of ThemeDescriptor instances. A ThemeExtension registers its descriptor at
 // Load() and unregisters at Unload(); the host resolves the selected theme id and re-applies when
-// the set changes. Ids are unique: a repeat Register for the same id overwrites, so a re-Load after
-// a rolled-back partial init is idempotent. The optional ThemeExtension is kept alongside the
-// descriptor so the host can notify the owning extension on apply/revert without a separate lookup.
+// the set changes. Ids are unique and a repeat Register overwrites, so a re-Load after a rolled-back
+// partial init is idempotent — except that an extension cannot overwrite a host-registered id.
+// Registration is keyed on the descriptor instance, not the record's value: only the instance that
+// registered an id may Unregister it, so an extension replaced by another cannot evict its
+// successor. The owning ThemeExtension is kept alongside the descriptor so the host can notify it on
+// apply/revert without a separate lookup; null means the host registered it.
 public static class ThemeRegistry
 {
     private static readonly ILogger s_logger = Log.CreateLogger(nameof(ThemeRegistry));
@@ -34,6 +37,18 @@ public static class ThemeRegistry
 
         lock (s_lock)
         {
+            // An extension may not take over a host-registered theme. It would win the id, and its
+            // Unload would then evict the built-in entirely — ResolveOrDefault's Dark fallback and
+            // the settings picker would lose it until restart.
+            if (extension != null
+                && s_themes.TryGetValue(descriptor.Id, out var existing)
+                && existing.Extension == null)
+            {
+                throw new ArgumentException(
+                    $"Theme id '{descriptor.Id}' is registered by the host and cannot be replaced by an extension. Choose an id unique to the extension.",
+                    nameof(descriptor));
+            }
+
             s_themes[descriptor.Id] = (descriptor, extension);
         }
 

--- a/src/Beutl.PackageTools.UI/App.axaml.cs
+++ b/src/Beutl.PackageTools.UI/App.axaml.cs
@@ -26,17 +26,22 @@ public partial class App : Application
 
         switch (view.Theme)
         {
-            case ViewConfig.ViewTheme.Light:
+            case BuiltinThemeIds.Light:
                 RequestedThemeVariant = ThemeVariant.Light;
                 break;
-            case ViewConfig.ViewTheme.Dark:
+            case BuiltinThemeIds.Dark:
                 RequestedThemeVariant = ThemeVariant.Dark;
                 break;
-            case ViewConfig.ViewTheme.HighContrast:
+            case BuiltinThemeIds.HighContrast:
                 RequestedThemeVariant = FluentAvaloniaTheme.HighContrastTheme;
                 break;
-            case ViewConfig.ViewTheme.System:
+            case BuiltinThemeIds.System:
                 theme.PreferSystemTheme = true;
+                break;
+            default:
+                // PackageTools.UI loads no extensions/ThemeRegistry, so a custom theme id can't be
+                // resolved here — fall back to Dark rather than carry an unknown variant.
+                RequestedThemeVariant = ThemeVariant.Dark;
                 break;
         }
 

--- a/src/Beutl/App.axaml.cs
+++ b/src/Beutl/App.axaml.cs
@@ -32,6 +32,7 @@ public sealed class App : Application
     private static readonly ILogger s_logger = Log.CreateLogger<App>();
     private readonly TaskCompletionSource _windowOpenTcs = new();
     private FluentAvaloniaTheme? _theme;
+    private ThemeService? _themeService;
     private MainViewModel? _mainViewModel;
     private Startup? _startUp;
 
@@ -58,27 +59,8 @@ public sealed class App : Application
 
         activity?.AddEvent(new ActivityEvent("Xaml_Loaded"));
 
-        view.GetObservable(ViewConfig.ThemeProperty).Subscribe(v =>
-        {
-            Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                switch (v)
-                {
-                    case ViewConfig.ViewTheme.Light:
-                        RequestedThemeVariant = ThemeVariant.Light;
-                        break;
-                    case ViewConfig.ViewTheme.Dark:
-                        RequestedThemeVariant = ThemeVariant.Dark;
-                        break;
-                    case ViewConfig.ViewTheme.HighContrast:
-                        RequestedThemeVariant = FluentAvaloniaTheme.HighContrastTheme;
-                        break;
-                    case ViewConfig.ViewTheme.System:
-                        _theme.PreferSystemTheme = true;
-                        break;
-                }
-            }, DispatcherPriority.Send);
-        });
+        _themeService = new ThemeService(_theme!, view);
+        _themeService.Start();
 
         if (!OperatingSystem.IsWindows())
         {

--- a/src/Beutl/Helpers/OutProcessDialog.cs
+++ b/src/Beutl/Helpers/OutProcessDialog.cs
@@ -1,6 +1,8 @@
-﻿using Beutl.Configuration;
-
+﻿using Avalonia.Styling;
+using Beutl.Configuration;
+using Beutl.Extensibility;
 using DynamicData;
+using FluentAvalonia.Styling;
 
 namespace Beutl.Helpers;
 
@@ -38,16 +40,15 @@ public static class OutProcessDialog
             startInfo.ArgumentList.Add("--closable");
 
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
-        if (viewConfig.Theme != ViewConfig.ViewTheme.System)
+        if (viewConfig.Theme != BuiltinThemeIds.System)
         {
-            startInfo.ArgumentList.AddRange(["--theme",
-                viewConfig.Theme switch
-                {
-                    ViewConfig.ViewTheme.Light => "light",
-                    ViewConfig.ViewTheme.Dark => "dark",
-                    ViewConfig.ViewTheme.HighContrast => "highcontrast",
-                    ViewConfig.ViewTheme.System or _ => "auto",
-                }]);
+            // The waiting dialog runs in a separate process with no ThemeRegistry/extensions, so
+            // translate the theme id to a base variant it understands. Custom themes fall back to
+            // their descriptor's BaseVariant; "system" is excluded above and stays OS-following.
+            string themeArg = ThemeRegistry.ResolveOrDefault(viewConfig.Theme) is { } descriptor
+                ? ToThemeArg(descriptor)
+                : "auto";
+            startInfo.ArgumentList.AddRange(["--theme", themeArg]);
         }
 
         var process = Process.Start(startInfo);
@@ -60,5 +61,30 @@ public static class OutProcessDialog
         }
 
         return Disposable.Create(ProcessExit);
+    }
+
+    private static string ToThemeArg(ThemeDescriptor descriptor)
+    {
+        if (descriptor.IsSystemFollowing)
+        {
+            return "auto";
+        }
+
+        if (descriptor.BaseVariant == ThemeVariant.Light)
+        {
+            return "light";
+        }
+
+        if (descriptor.BaseVariant == ThemeVariant.Dark)
+        {
+            return "dark";
+        }
+
+        if (descriptor.BaseVariant == FluentAvaloniaTheme.HighContrastTheme)
+        {
+            return "highcontrast";
+        }
+
+        return "dark";
     }
 }

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ext="using:Beutl.Extensibility"
              xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:vm="using:Beutl.ViewModels.SettingsPages"
              x:Name="root"
+             x:CompileBindings="True"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="vm:ViewSettingsPageViewModel"
@@ -29,11 +31,14 @@
                                           Icon="DarkTheme">
 
                     <ctrls:OptionsDisplayItem.ActionButton>
-                        <ComboBox MinWidth="250" SelectedIndex="{CompiledBinding SelectedTheme.Value}">
-                            <ComboBoxItem Content="{x:Static lang:SettingsStrings.Light}" />
-                            <ComboBoxItem Content="{x:Static lang:SettingsStrings.Dark}" />
-                            <ComboBoxItem Content="{x:Static lang:SettingsStrings.HighContrast}" />
-                            <ComboBoxItem Content="{x:Static lang:SettingsStrings.FollowSystem}" />
+                        <ComboBox MinWidth="250"
+                                  ItemsSource="{CompiledBinding AvailableThemes}"
+                                  SelectedItem="{CompiledBinding SelectedThemeDescriptor.Value}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="ext:ThemeDescriptor">
+                                    <TextBlock Text="{CompiledBinding DisplayName}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
                         </ComboBox>
                     </ctrls:OptionsDisplayItem.ActionButton>
                 </ctrls:OptionsDisplayItem>

--- a/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/ViewSettingsPage.axaml
@@ -4,6 +4,7 @@
              xmlns:ctrls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ext="using:Beutl.Extensibility"
+             xmlns:glob="using:System.Globalization"
              xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -53,8 +54,8 @@
                                   ItemsSource="{CompiledBinding Cultures}"
                                   SelectedItem="{CompiledBinding SelectedLanguage.Value}">
                             <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding DisplayName}" />
+                                <DataTemplate x:DataType="glob:CultureInfo">
+                                    <TextBlock Text="{CompiledBinding DisplayName}" />
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -83,10 +83,31 @@ internal sealed class ThemeService : IDisposable
             return; // nothing registered yet (very early startup)
         }
 
-        ApplyCore(descriptor);
+        if (ApplyCore(descriptor))
+        {
+            return;
+        }
+
+        // The selected theme could not be applied. Keeping the current one is right only while it is
+        // still registered — at first apply there is none (the app would stay unthemed, and nothing
+        // guarantees another trigger), and a failed candidate may have replaced the applied
+        // descriptor's id, which would leave an evicted theme active with its owner never reverted.
+        if (_appliedDescriptor != null
+            && ReferenceEquals(ThemeRegistry.Resolve(_appliedDescriptor.Id), _appliedDescriptor))
+        {
+            return;
+        }
+
+        if (ThemeRegistry.Resolve(BuiltinThemeIds.Dark) is { } fallback
+            && !ReferenceEquals(fallback, descriptor))
+        {
+            ApplyCore(fallback);
+        }
     }
 
-    private void ApplyCore(ThemeDescriptor descriptor)
+    // False when the descriptor could not be applied and the caller should fall back; skipping an
+    // already-applied descriptor counts as applied.
+    private bool ApplyCore(ThemeDescriptor descriptor)
     {
         // Skip when the resolved descriptor is unchanged — re-applying on unrelated
         // ThemeRegistry.Changed (extension load/unload) would flicker. Identity rather than the
@@ -95,7 +116,7 @@ internal sealed class ThemeService : IDisposable
         // resolves to the same instance, so this still skips.
         if (ReferenceEquals(_appliedDescriptor, descriptor))
         {
-            return;
+            return true;
         }
 
         // Owner of this exact instance: ThemeRegistry cannot map the id back to the extension after
@@ -113,9 +134,8 @@ internal sealed class ThemeService : IDisposable
         }
         catch (Exception ex)
         {
-            s_logger.LogWarning(
-                ex, "Failed to load resources for theme '{Id}'; keeping the current theme.", descriptor.Id);
-            return;
+            s_logger.LogWarning(ex, "Failed to load resources for theme '{Id}'.", descriptor.Id);
+            return false;
         }
 
         ThemeDescriptor? previous = _appliedDescriptor;
@@ -141,6 +161,7 @@ internal sealed class ThemeService : IDisposable
         }
 
         ThemeNotifier.NotifyApplied(descriptor, extension);
+        return true;
     }
 
     private static IResourceProvider? LoadResources(ThemeDescriptor descriptor)

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -75,15 +75,19 @@ internal sealed class ThemeService : IDisposable
     private void ApplyCore(ThemeDescriptor descriptor)
     {
         // Skip when the resolved descriptor is unchanged — re-applying on unrelated
-        // ThemeRegistry.Changed (extension load/unload) would flicker.
-        if (_appliedDescriptor == descriptor)
+        // ThemeRegistry.Changed (extension load/unload) would flicker. Identity rather than the
+        // record's structural equality, matching how ThemeRegistry keys ownership: an equal-valued
+        // re-registration is a new owner that still needs its OnApplied. An untouched registry
+        // resolves to the same instance, so this still skips.
+        if (ReferenceEquals(_appliedDescriptor, descriptor))
         {
             return;
         }
 
-        // Capture the owner now: ThemeRegistry can no longer map the id back to this extension once
-        // it unregisters, which is exactly when the revert notification is due.
-        ThemeExtension? extension = ThemeRegistry.GetExtension(descriptor.Id);
+        // Owner of this exact instance, resolved once: ThemeRegistry cannot map the id back to the
+        // extension after it unregisters (which is when the revert notification is due), and by now
+        // the id may belong to a replacement registered since ApplyTheme queued this call.
+        ThemeExtension? extension = ThemeRegistry.GetOwner(descriptor);
 
         // ResourceUri is extension-controlled and may be missing or malformed. Load before touching
         // any state so a failure leaves the current theme intact — committing _appliedDescriptor
@@ -143,8 +147,8 @@ internal sealed class ThemeService : IDisposable
         // routes it through the caller's catch, so the current theme survives and the extension
         // author gets the offending type.
         throw new InvalidOperationException(
-            $"Theme '{descriptor.Id}' resource '{uri}' must be a ResourceDictionary, but loaded as " +
-            $"'{loaded?.GetType().FullName ?? "null"}'.");
+            $"Theme '{descriptor.Id}' resource '{uri}' must be a ResourceDictionary (or another " +
+            $"{nameof(IResourceProvider)}), but loaded as '{loaded?.GetType().FullName ?? "null"}'.");
     }
 
     private void SwapResources(IResourceProvider? next)

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -125,8 +125,27 @@ internal sealed class ThemeService : IDisposable
         ThemeNotifier.NotifyApplied(descriptor, extension);
     }
 
-    private static IResourceProvider? LoadResources(ThemeDescriptor descriptor) =>
-        descriptor.ResourceUri is { } uri ? AvaloniaXamlLoader.Load(uri, null) as IResourceProvider : null;
+    private static IResourceProvider? LoadResources(ThemeDescriptor descriptor)
+    {
+        if (descriptor.ResourceUri is not { } uri)
+        {
+            return null;
+        }
+
+        object? loaded = AvaloniaXamlLoader.Load(uri, null);
+        if (loaded is IResourceProvider resources)
+        {
+            return resources;
+        }
+
+        // A root that is not a ResourceDictionary would otherwise be indistinguishable from "this
+        // theme has no resources", which silently drops the previous theme's overrides. Throwing
+        // routes it through the caller's catch, so the current theme survives and the extension
+        // author gets the offending type.
+        throw new InvalidOperationException(
+            $"Theme '{descriptor.Id}' resource '{uri}' must be a ResourceDictionary, but loaded as " +
+            $"'{loaded?.GetType().FullName ?? "null"}'.");
+    }
 
     private void SwapResources(IResourceProvider? next)
     {

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -61,15 +61,19 @@ internal sealed class ThemeService : IDisposable
         ApplyTheme(_viewConfig.Theme);
     }
 
-    private void ApplyTheme(string themeId)
+    // Resolve on the UI thread rather than here: the registry can change between a background-thread
+    // resolve and the queued callback, which would apply a descriptor that is already superseded.
+    private void ApplyTheme(string themeId) =>
+        Dispatcher.UIThread.InvokeAsync(() => ResolveAndApply(themeId), DispatcherPriority.Send);
+
+    private void ResolveAndApply(string themeId)
     {
-        ThemeDescriptor? descriptor = ThemeRegistry.ResolveOrDefault(themeId);
-        if (descriptor == null)
+        if (ThemeRegistry.ResolveOrDefault(themeId) is not { } descriptor)
         {
             return; // nothing registered yet (very early startup)
         }
 
-        Dispatcher.UIThread.InvokeAsync(() => ApplyCore(descriptor), DispatcherPriority.Send);
+        ApplyCore(descriptor);
     }
 
     private void ApplyCore(ThemeDescriptor descriptor)

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -1,0 +1,130 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Beutl.Configuration;
+using Beutl.Extensibility;
+using Beutl.Language;
+using FluentAvalonia.Styling;
+using Reactive.Bindings;
+
+namespace Beutl.Services;
+
+// Applies the selected theme id to the running app: resolves it via ThemeRegistry, sets
+// RequestedThemeVariant (or PreferSystemTheme for the system theme), and merges the descriptor's
+// brush-override resources. Re-applies on ViewConfig.Theme changes and ThemeRegistry.Changed.
+internal sealed class ThemeService : IDisposable
+{
+    private readonly FluentAvaloniaTheme _theme;
+    private readonly ViewConfig _viewConfig;
+    private IResourceProvider? _currentResources;
+    private ThemeDescriptor? _appliedDescriptor;
+    private IDisposable? _themeSubscription;
+    private bool _changedSubscribed;
+
+    public ThemeService(FluentAvaloniaTheme theme, ViewConfig viewConfig)
+    {
+        _theme = theme;
+        _viewConfig = viewConfig;
+    }
+
+    public void Start()
+    {
+        foreach (ThemeDescriptor descriptor in GetBuiltinThemes())
+        {
+            ThemeRegistry.Register(descriptor);
+        }
+
+        _themeSubscription = _viewConfig.GetObservable(ViewConfig.ThemeProperty)
+            .Subscribe(ApplyTheme);
+        ThemeRegistry.Changed += OnThemeRegistryChanged;
+        _changedSubscribed = true;
+        ApplyTheme(_viewConfig.Theme);
+    }
+
+    private static ThemeDescriptor[] GetBuiltinThemes() =>
+    [
+        new(BuiltinThemeIds.Light, SettingsStrings.Light, ThemeVariant.Light),
+        new(BuiltinThemeIds.Dark, SettingsStrings.Dark, ThemeVariant.Dark),
+        new(BuiltinThemeIds.HighContrast, SettingsStrings.HighContrast, FluentAvaloniaTheme.HighContrastTheme),
+        new(BuiltinThemeIds.System, SettingsStrings.FollowSystem, ThemeVariant.Default, IsSystemFollowing: true),
+    ];
+
+    private void OnThemeRegistryChanged(object? sender, EventArgs e)
+    {
+        // The selected theme may have just been registered or removed (ResolveOrDefault falls back to Dark).
+        ApplyTheme(_viewConfig.Theme);
+    }
+
+    private void ApplyTheme(string themeId)
+    {
+        ThemeDescriptor? descriptor = ThemeRegistry.ResolveOrDefault(themeId);
+        if (descriptor == null)
+        {
+            return; // nothing registered yet (very early startup)
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => ApplyCore(descriptor), DispatcherPriority.Send);
+    }
+
+    private void ApplyCore(ThemeDescriptor descriptor)
+    {
+        // Skip when the resolved descriptor is unchanged — re-applying on unrelated
+        // ThemeRegistry.Changed (extension load/unload) would flicker.
+        if (_appliedDescriptor == descriptor)
+        {
+            return;
+        }
+
+        ThemeDescriptor? previous = _appliedDescriptor;
+        _appliedDescriptor = descriptor;
+
+        if (descriptor.IsSystemFollowing)
+        {
+            _theme.PreferSystemTheme = true;
+        }
+        else
+        {
+            _theme.PreferSystemTheme = false;
+            Application.Current!.RequestedThemeVariant = descriptor.BaseVariant;
+        }
+
+        ApplyResources(descriptor);
+
+        if (previous != null)
+        {
+            ThemeNotifier.NotifyReverted(previous);
+        }
+
+        ThemeNotifier.NotifyApplied(descriptor);
+    }
+
+    private void ApplyResources(ThemeDescriptor descriptor)
+    {
+        var merged = Application.Current!.Resources.MergedDictionaries;
+        if (_currentResources != null)
+        {
+            merged.Remove(_currentResources);
+            _currentResources = null;
+        }
+
+        if (descriptor.ResourceUri is { } uri)
+        {
+            if (AvaloniaXamlLoader.Load(uri, null) is IResourceProvider resource)
+            {
+                _currentResources = resource;
+                merged.Add(resource);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _themeSubscription?.Dispose();
+        if (_changedSubscribed)
+        {
+            ThemeRegistry.Changed -= OnThemeRegistryChanged;
+        }
+    }
+}

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -26,6 +26,7 @@ internal sealed class ThemeService : IDisposable
     private ThemeExtension? _appliedExtension;
     private IDisposable? _themeSubscription;
     private bool _changedSubscribed;
+    private int _applyQueued;
 
     public ThemeService(FluentAvaloniaTheme theme, ViewConfig viewConfig)
     {
@@ -41,10 +42,10 @@ internal sealed class ThemeService : IDisposable
         }
 
         _themeSubscription = _viewConfig.GetObservable(ViewConfig.ThemeProperty)
-            .Subscribe(ApplyTheme);
+            .Subscribe(_ => ScheduleApply());
         ThemeRegistry.Changed += OnThemeRegistryChanged;
         _changedSubscribed = true;
-        ApplyTheme(_viewConfig.Theme);
+        ScheduleApply();
     }
 
     private static ThemeDescriptor[] GetBuiltinThemes() =>
@@ -55,20 +56,29 @@ internal sealed class ThemeService : IDisposable
         new(BuiltinThemeIds.System, SettingsStrings.FollowSystem, ThemeVariant.Default, IsSystemFollowing: true),
     ];
 
-    private void OnThemeRegistryChanged(object? sender, EventArgs e)
+    // The selected theme may have just been registered or removed (ResolveOrDefault falls back to Dark).
+    private void OnThemeRegistryChanged(object? sender, EventArgs e) => ScheduleApply();
+
+    // Every trigger wants the same thing — apply whatever the config now names — so a burst of them
+    // (Parallel.ForEach extension loading registers themes one by one) collapses into a single
+    // pending job instead of one Send-priority callback each.
+    private void ScheduleApply()
     {
-        // The selected theme may have just been registered or removed (ResolveOrDefault falls back to Dark).
-        ApplyTheme(_viewConfig.Theme);
+        if (Interlocked.Exchange(ref _applyQueued, 1) != 0)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(ResolveAndApply, DispatcherPriority.Send);
     }
 
-    // Resolve on the UI thread rather than here: the registry can change between a background-thread
-    // resolve and the queued callback, which would apply a descriptor that is already superseded.
-    private void ApplyTheme(string themeId) =>
-        Dispatcher.UIThread.InvokeAsync(() => ResolveAndApply(themeId), DispatcherPriority.Send);
-
-    private void ResolveAndApply(string themeId)
+    // Both the config value and the registry are read here rather than at schedule time: either can
+    // change between the trigger and this callback, and only the state at apply time is right.
+    private void ResolveAndApply()
     {
-        if (ThemeRegistry.ResolveOrDefault(themeId) is not { } descriptor)
+        Interlocked.Exchange(ref _applyQueued, 0);
+
+        if (ThemeRegistry.ResolveOrDefault(_viewConfig.Theme) is not { } descriptor)
         {
             return; // nothing registered yet (very early startup)
         }
@@ -88,9 +98,9 @@ internal sealed class ThemeService : IDisposable
             return;
         }
 
-        // Owner of this exact instance, resolved once: ThemeRegistry cannot map the id back to the
-        // extension after it unregisters (which is when the revert notification is due), and by now
-        // the id may belong to a replacement registered since ApplyTheme queued this call.
+        // Owner of this exact instance: ThemeRegistry cannot map the id back to the extension after
+        // it unregisters, which is when the revert notification is due, and an id lookup could by
+        // then belong to a replacement registered on a background thread.
         ThemeExtension? extension = ThemeRegistry.GetOwner(descriptor);
 
         // ResourceUri is extension-controlled and may be missing or malformed. Load before touching

--- a/src/Beutl/Services/ThemeService.cs
+++ b/src/Beutl/Services/ThemeService.cs
@@ -6,7 +6,9 @@ using Avalonia.Threading;
 using Beutl.Configuration;
 using Beutl.Extensibility;
 using Beutl.Language;
+using Beutl.Logging;
 using FluentAvalonia.Styling;
+using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 
 namespace Beutl.Services;
@@ -16,10 +18,12 @@ namespace Beutl.Services;
 // brush-override resources. Re-applies on ViewConfig.Theme changes and ThemeRegistry.Changed.
 internal sealed class ThemeService : IDisposable
 {
+    private static readonly ILogger s_logger = Log.CreateLogger<ThemeService>();
     private readonly FluentAvaloniaTheme _theme;
     private readonly ViewConfig _viewConfig;
     private IResourceProvider? _currentResources;
     private ThemeDescriptor? _appliedDescriptor;
+    private ThemeExtension? _appliedExtension;
     private IDisposable? _themeSubscription;
     private bool _changedSubscribed;
 
@@ -77,8 +81,29 @@ internal sealed class ThemeService : IDisposable
             return;
         }
 
+        // Capture the owner now: ThemeRegistry can no longer map the id back to this extension once
+        // it unregisters, which is exactly when the revert notification is due.
+        ThemeExtension? extension = ThemeRegistry.GetExtension(descriptor.Id);
+
+        // ResourceUri is extension-controlled and may be missing or malformed. Load before touching
+        // any state so a failure leaves the current theme intact — committing _appliedDescriptor
+        // first would also make every later attempt at this descriptor a no-op.
+        IResourceProvider? nextResources;
+        try
+        {
+            nextResources = LoadResources(descriptor);
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(
+                ex, "Failed to load resources for theme '{Id}'; keeping the current theme.", descriptor.Id);
+            return;
+        }
+
         ThemeDescriptor? previous = _appliedDescriptor;
+        ThemeExtension? previousExtension = _appliedExtension;
         _appliedDescriptor = descriptor;
+        _appliedExtension = extension;
 
         if (descriptor.IsSystemFollowing)
         {
@@ -90,32 +115,31 @@ internal sealed class ThemeService : IDisposable
             Application.Current!.RequestedThemeVariant = descriptor.BaseVariant;
         }
 
-        ApplyResources(descriptor);
+        SwapResources(nextResources);
 
         if (previous != null)
         {
-            ThemeNotifier.NotifyReverted(previous);
+            ThemeNotifier.NotifyReverted(previous, previousExtension);
         }
 
-        ThemeNotifier.NotifyApplied(descriptor);
+        ThemeNotifier.NotifyApplied(descriptor, extension);
     }
 
-    private void ApplyResources(ThemeDescriptor descriptor)
+    private static IResourceProvider? LoadResources(ThemeDescriptor descriptor) =>
+        descriptor.ResourceUri is { } uri ? AvaloniaXamlLoader.Load(uri, null) as IResourceProvider : null;
+
+    private void SwapResources(IResourceProvider? next)
     {
         var merged = Application.Current!.Resources.MergedDictionaries;
         if (_currentResources != null)
         {
             merged.Remove(_currentResources);
-            _currentResources = null;
         }
 
-        if (descriptor.ResourceUri is { } uri)
+        _currentResources = next;
+        if (next != null)
         {
-            if (AvaloniaXamlLoader.Load(uri, null) is IResourceProvider resource)
-            {
-                _currentResources = resource;
-                merged.Add(resource);
-            }
+            merged.Add(next);
         }
     }
 

--- a/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Beutl.Configuration;
 using Beutl.Controls.Navigation;
 using Beutl.Extensibility;
@@ -15,17 +16,20 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
     // 一部の設定を移動したので、ナビゲーションするために
     private readonly Lazy<EditorSettingsPageViewModel> _editorSettings;
     private readonly CompositeDisposable _disposables = [];
+    private bool _disposed;
 
     public ViewSettingsPageViewModel(Lazy<EditorSettingsPageViewModel> editorSettings)
     {
         _config = GlobalConfiguration.Instance.ViewConfig;
         _editorSettings = editorSettings;
 
+        // Created before the first refresh: RefreshAvailableThemes restores the selection through it.
+        SelectedThemeDescriptor = new ReactiveProperty<ThemeDescriptor?>(ThemeRegistry.Resolve(_config.Theme))
+            .DisposeWith(_disposables);
+
         RefreshAvailableThemes();
         ThemeRegistry.Changed += OnThemeRegistryChanged;
 
-        SelectedThemeDescriptor = new ReactiveProperty<ThemeDescriptor?>(ThemeRegistry.Resolve(_config.Theme))
-            .DisposeWith(_disposables);
         SelectedThemeDescriptor.Subscribe(d =>
             {
                 if (d is { } descriptor && _config.Theme != descriptor.Id)
@@ -197,9 +201,24 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
         {
             AvailableThemes.Add(descriptor);
         }
+
+        // Clearing the collection makes the bound ComboBox push null into the selection, and a theme
+        // registered after this page was constructed never resolved in the first place. Re-resolve
+        // from the config so the picker keeps showing the configured theme.
+        SelectedThemeDescriptor.Value = ThemeRegistry.Resolve(_config.Theme);
     }
 
-    private void OnThemeRegistryChanged(object? sender, EventArgs e) => RefreshAvailableThemes();
+    // ThemeRegistry.Changed fires synchronously on whichever thread registered the theme, and
+    // extensions load on background threads (Task.Run / Parallel.ForEach), so mutating the bound
+    // collection has to be marshalled to the UI thread.
+    private void OnThemeRegistryChanged(object? sender, EventArgs e) =>
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!_disposed)
+            {
+                RefreshAvailableThemes();
+            }
+        });
 
     private static void UpdateAppAccentColor(Color? color)
     {
@@ -216,6 +235,8 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
 
     public void Dispose()
     {
+        // Unsubscribing does not cancel a refresh already queued on the dispatcher.
+        _disposed = true;
         ThemeRegistry.Changed -= OnThemeRegistryChanged;
         _disposables.Dispose();
     }

--- a/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/ViewSettingsPageViewModel.cs
@@ -1,6 +1,8 @@
-﻿using Avalonia.Media;
+﻿using System.Collections.ObjectModel;
+using Avalonia.Media;
 using Beutl.Configuration;
 using Beutl.Controls.Navigation;
+using Beutl.Extensibility;
 using FluentAvalonia.Styling;
 using Reactive.Bindings;
 
@@ -19,10 +21,29 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
         _config = GlobalConfiguration.Instance.ViewConfig;
         _editorSettings = editorSettings;
 
-        SelectedTheme = _config.GetObservable(ViewConfig.ThemeProperty).Select(x => (int)x)
-            .ToReactiveProperty()
+        RefreshAvailableThemes();
+        ThemeRegistry.Changed += OnThemeRegistryChanged;
+
+        SelectedThemeDescriptor = new ReactiveProperty<ThemeDescriptor?>(ThemeRegistry.Resolve(_config.Theme))
             .DisposeWith(_disposables);
-        SelectedTheme.Subscribe(v => _config.Theme = (ViewConfig.ViewTheme)v)
+        SelectedThemeDescriptor.Subscribe(d =>
+            {
+                if (d is { } descriptor && _config.Theme != descriptor.Id)
+                {
+                    _config.Theme = descriptor.Id;
+                }
+            })
+            .DisposeWith(_disposables);
+
+        _config.GetObservable(ViewConfig.ThemeProperty)
+            .Subscribe(id =>
+            {
+                if (ThemeRegistry.Resolve(id) is { } descriptor
+                    && SelectedThemeDescriptor.Value?.Id != descriptor.Id)
+                {
+                    SelectedThemeDescriptor.Value = descriptor;
+                }
+            })
             .DisposeWith(_disposables);
 
         SelectedLanguage = _config.GetObservable(ViewConfig.UICultureProperty)
@@ -95,7 +116,9 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
             .DisposeWith(_disposables);
     }
 
-    public ReactiveProperty<int> SelectedTheme { get; }
+    public ObservableCollection<ThemeDescriptor> AvailableThemes { get; } = new();
+
+    public ReactiveProperty<ThemeDescriptor?> SelectedThemeDescriptor { get; }
 
     public ReactiveProperty<CultureInfo> SelectedLanguage { get; }
 
@@ -167,6 +190,17 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
         ];
     }
 
+    private void RefreshAvailableThemes()
+    {
+        AvailableThemes.Clear();
+        foreach (ThemeDescriptor descriptor in ThemeRegistry.Enumerate())
+        {
+            AvailableThemes.Add(descriptor);
+        }
+    }
+
+    private void OnThemeRegistryChanged(object? sender, EventArgs e) => RefreshAvailableThemes();
+
     private static void UpdateAppAccentColor(Color? color)
     {
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
@@ -182,6 +216,7 @@ public sealed class ViewSettingsPageViewModel : PageContext, IDisposable
 
     public void Dispose()
     {
+        ThemeRegistry.Changed -= OnThemeRegistryChanged;
         _disposables.Dispose();
     }
 }

--- a/tests/Beutl.HeadlessUITests/Assets/NotAResourceDictionary.axaml
+++ b/tests/Beutl.HeadlessUITests/Assets/NotAResourceDictionary.axaml
@@ -1,0 +1,4 @@
+<!--  A ThemeDescriptor.ResourceUri pointing at a root that is not a ResourceDictionary.  -->
+<TextBlock xmlns="https://github.com/avaloniaui"
+           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+           Text="not a resource dictionary" />

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Linq;
+using Avalonia;
+using Avalonia.Headless.NUnit;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Beutl.Configuration;
+using Beutl.Extensibility;
+using Beutl.Services;
+using FluentAvalonia.Styling;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ThemeServiceTests
+{
+    [AvaloniaTest]
+    public void ApplyTheme_WhenResourceFailsToLoad_LeavesCurrentThemeIntact()
+    {
+        // A theme whose ResourceUri cannot be loaded must not be applied at all. Committing the
+        // variant before the load means a bad extension release half-applies: the base variant
+        // switches and the previous theme's resources are gone, but its brush overrides never merge.
+        using var scope = new ThemeScope();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var broken = new ThemeDescriptor(
+            "test.broken", "Broken", ThemeVariant.Light, new Uri("avares://NoSuchAssembly/Missing.axaml"));
+        ThemeRegistry.Register(broken);
+
+        scope.Config.Theme = "test.broken";
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.That(Application.Current.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Dark));
+    }
+
+    [AvaloniaTest]
+    public void ApplyTheme_AfterFailedLoad_StillAppliesAnotherTheme()
+    {
+        using var scope = new ThemeScope();
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var broken = new ThemeDescriptor(
+            "test.broken2", "Broken", ThemeVariant.Light, new Uri("avares://NoSuchAssembly/Missing.axaml"));
+        ThemeRegistry.Register(broken);
+
+        scope.Config.Theme = "test.broken2";
+        Dispatcher.UIThread.RunJobs();
+
+        scope.Config.Theme = BuiltinThemeIds.Light;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.That(Application.Current!.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Light));
+    }
+
+    [AvaloniaTest]
+    public void UnregisteringActiveTheme_NotifiesItsOwner()
+    {
+        // Unload removes the theme from the registry before the host reverts, so resolving the owner
+        // by id at notification time finds nothing and the extension never gets to release whatever
+        // it set up in OnApplied.
+        using var scope = new ThemeScope();
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var ext = new RecordingThemeExtension("test.owned", "Owned");
+        ext.Load();
+        scope.Config.Theme = "test.owned";
+        Dispatcher.UIThread.RunJobs();
+        Assert.That(ext.AppliedCount, Is.EqualTo(1), "precondition: the extension's theme was applied");
+
+        ext.Unload();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.That(ext.RevertedCount, Is.EqualTo(1));
+    }
+
+    private sealed class RecordingThemeExtension(string id, string name) : ThemeExtension
+    {
+        private readonly ThemeDescriptor _descriptor = new(id, name, ThemeVariant.Dark);
+        public int AppliedCount;
+        public int RevertedCount;
+
+        public override ThemeDescriptor GetThemeDescriptor() => _descriptor;
+
+        public override void OnApplied(ThemeApplyContext context) => AppliedCount++;
+
+        public override void OnReverted() => RevertedCount++;
+    }
+
+    // ThemeRegistry is a static global and ThemeService.Start seeds it with the built-ins, so each
+    // test has to hand back an empty registry.
+    private sealed class ThemeScope : IDisposable
+    {
+        public ThemeScope()
+        {
+            FluentAvaloniaTheme theme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
+            Config = new ViewConfig();
+            Service = new ThemeService(theme, Config);
+        }
+
+        public ViewConfig Config { get; }
+
+        public ThemeService Service { get; }
+
+        public void Dispose()
+        {
+            Service.Dispose();
+            foreach (ThemeDescriptor descriptor in ThemeRegistry.Enumerate())
+            {
+                ThemeRegistry.Unregister(descriptor);
+            }
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -35,6 +35,54 @@ public class ThemeServiceTests
     }
 
     [AvaloniaTest]
+    public void StartWithABrokenSelectedTheme_FallsBackToDark()
+    {
+        // Extensions load before ThemeService.Start, so the selected theme can already be registered
+        // — and broken — at the first apply. There is no current theme to keep and nothing
+        // guarantees another trigger, so bailing out would leave the app unthemed.
+        using var scope = new ThemeScope();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Light;
+
+        var broken = new ThemeDescriptor(
+            "test.brokenstartup", "Broken", ThemeVariant.Light, new Uri("avares://NoSuchAssembly/Missing.axaml"));
+        ThemeRegistry.Register(broken);
+        scope.Config.Theme = "test.brokenstartup";
+
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.That(Application.Current.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Dark));
+    }
+
+    [AvaloniaTest]
+    public void FailedReplacementOfTheActiveTheme_FallsBackInsteadOfKeepingTheEvictedOne()
+    {
+        // A second extension takes over the applied id with a broken theme. Keeping the old
+        // descriptor would leave an evicted theme active — and its owner would never be reverted,
+        // because the stale Unregister at its Unload raises no Changed.
+        using var scope = new ThemeScope();
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var first = new RecordingThemeExtension("test.evicted", "First");
+        first.Load();
+        scope.Config.Theme = "test.evicted";
+        Dispatcher.UIThread.RunJobs();
+        Assert.That(first.AppliedCount, Is.EqualTo(1), "precondition: the first owner's theme was applied");
+
+        ThemeRegistry.Register(
+            new ThemeDescriptor(
+                "test.evicted", "Broken", ThemeVariant.Light, new Uri("avares://NoSuchAssembly/Missing.axaml")));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Application.Current!.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Dark));
+            Assert.That(first.RevertedCount, Is.EqualTo(1), "the evicted owner should be reverted");
+        });
+    }
+
+    [AvaloniaTest]
     public void ApplyTheme_AfterFailedLoad_StillAppliesAnotherTheme()
     {
         using var scope = new ThemeScope();

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -114,8 +114,13 @@ public class ThemeServiceTests
         Assert.That(first.AppliedCount, Is.EqualTo(1), "precondition: the first owner's theme was applied");
 
         var second = new RecordingThemeExtension("test.reload", "Reload");
-        Assert.That(second.GetThemeDescriptor(), Is.EqualTo(first.GetThemeDescriptor()),
-            "precondition: the descriptors are equal-valued but distinct instances");
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.GetThemeDescriptor(), Is.EqualTo(first.GetThemeDescriptor()),
+                "precondition: the descriptors are equal-valued");
+            Assert.That(second.GetThemeDescriptor(), Is.Not.SameAs(first.GetThemeDescriptor()),
+                "precondition: the descriptors are distinct instances");
+        });
         second.Load();
         Dispatcher.UIThread.RunJobs();
 

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -55,6 +55,27 @@ public class ThemeServiceTests
     }
 
     [AvaloniaTest]
+    public void ApplyTheme_WhenResourceIsNotAResourceDictionary_LeavesCurrentThemeIntact()
+    {
+        // A root that loads but is not an IResourceProvider is a broken theme, not a theme without
+        // resources: treating it as the latter drops the previous overrides and applies none.
+        using var scope = new ThemeScope();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var wrongRoot = new ThemeDescriptor(
+            "test.wrongroot", "WrongRoot", ThemeVariant.Light,
+            new Uri("avares://Beutl.HeadlessUITests/Assets/NotAResourceDictionary.axaml"));
+        ThemeRegistry.Register(wrongRoot);
+
+        scope.Config.Theme = "test.wrongroot";
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.That(Application.Current.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Dark));
+    }
+
+    [AvaloniaTest]
     public void UnregisteringActiveTheme_NotifiesItsOwner()
     {
         // Unload removes the theme from the registry before the host reverts, so resolving the owner
@@ -89,12 +110,13 @@ public class ThemeServiceTests
         public override void OnReverted() => RevertedCount++;
     }
 
-    // ThemeRegistry is a static global and ThemeService.Start seeds it with the built-ins, so each
-    // test has to hand back an empty registry.
+    // ThemeRegistry is a static global that ThemeService.Start seeds with the built-ins, so each
+    // test both starts from and hands back an empty registry.
     private sealed class ThemeScope : IDisposable
     {
         public ThemeScope()
         {
+            ClearRegistry();
             FluentAvaloniaTheme theme = Application.Current!.Styles.OfType<FluentAvaloniaTheme>().Single();
             Config = new ViewConfig();
             Service = new ThemeService(theme, Config);
@@ -107,6 +129,11 @@ public class ThemeServiceTests
         public void Dispose()
         {
             Service.Dispose();
+            ClearRegistry();
+        }
+
+        private static void ClearRegistry()
+        {
             foreach (ThemeDescriptor descriptor in ThemeRegistry.Enumerate())
             {
                 ThemeRegistry.Unregister(descriptor);

--- a/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeServiceTests.cs
@@ -97,6 +97,35 @@ public class ThemeServiceTests
         Assert.That(ext.RevertedCount, Is.EqualTo(1));
     }
 
+    [AvaloniaTest]
+    public void ReregisteringActiveThemeWithNewOwner_NotifiesBothOwners()
+    {
+        // A package reload re-registers an equal-valued descriptor under the same id. The registry
+        // keys ownership on the instance, so this is a new owner: the outgoing one must be reverted
+        // and the incoming one applied, rather than the whole apply being skipped as "unchanged".
+        using var scope = new ThemeScope();
+        scope.Service.Start();
+        Dispatcher.UIThread.RunJobs();
+
+        var first = new RecordingThemeExtension("test.reload", "Reload");
+        first.Load();
+        scope.Config.Theme = "test.reload";
+        Dispatcher.UIThread.RunJobs();
+        Assert.That(first.AppliedCount, Is.EqualTo(1), "precondition: the first owner's theme was applied");
+
+        var second = new RecordingThemeExtension("test.reload", "Reload");
+        Assert.That(second.GetThemeDescriptor(), Is.EqualTo(first.GetThemeDescriptor()),
+            "precondition: the descriptors are equal-valued but distinct instances");
+        second.Load();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.AppliedCount, Is.EqualTo(1), "the new owner should be applied");
+            Assert.That(first.RevertedCount, Is.EqualTo(1), "the outgoing owner should be reverted");
+        });
+    }
+
     private sealed class RecordingThemeExtension(string id, string name) : ThemeExtension
     {
         private readonly ThemeDescriptor _descriptor = new(id, name, ThemeVariant.Dark);

--- a/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
+++ b/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Beutl.Configuration;
+using Beutl.Controls;
+using Beutl.Pages.SettingsPages;
+using Beutl.ViewModels.SettingsPages;
+
+namespace Beutl.HeadlessUITests;
+
+// This page enabled x:CompileBindings at the root, which changes how every {Binding} in the file is
+// resolved — including the accent palette's untyped item bindings, whose DataContext is a Color and
+// not the page's x:DataType. Inflate the real page and read a swatch back.
+[TestFixture]
+public class ViewSettingsPagePaletteTests
+{
+    [AvaloniaTest]
+    public void AccentPaletteSwatches_BindToTheirColorItem()
+    {
+        GlobalConfiguration.Instance.ViewConfig.UseCustomAccentColor = true;
+
+        var viewModel = new ViewSettingsPageViewModel(
+            new Lazy<EditorSettingsPageViewModel>(() => new EditorSettingsPageViewModel()));
+        var page = new ViewSettingsPage { DataContext = viewModel };
+        var window = new Window { Content = page, Width = 900, Height = 700 };
+
+        window.Show();
+        viewModel.UseCustomAccent.Value = true;
+
+        // The palette lives inside the collapsed accent OptionsDisplayItem, so its containers are
+        // not realized until it expands.
+        foreach (OptionsDisplayItem item in page.GetLogicalDescendants().OfType<OptionsDisplayItem>()
+                     .Where(x => x.Expands))
+        {
+            item.IsExpanded = true;
+        }
+
+        window.UpdateLayout();
+
+        ListBox palette = page.GetLogicalDescendants().OfType<ListBox>()
+            .First(x => ReferenceEquals(x.ItemsSource, viewModel.PredefinedColors));
+        palette.UpdateLayout();
+
+        Color expected = viewModel.PredefinedColors[0];
+        var container = palette.ContainerFromIndex(0) as ListBoxItem;
+        Assert.That(container, Is.Not.Null, "the palette should realize its item containers once expanded");
+        container!.ApplyTemplate();
+
+        SolidColorBrush?[] brushes = container.GetVisualDescendants()
+            .OfType<Border>()
+            .Select(x => x.Background as SolidColorBrush)
+            .Where(x => x != null)
+            .ToArray();
+
+        Assert.That(brushes, Is.Not.Empty, "the swatch template should produce a SolidColorBrush");
+        Assert.That(
+            brushes.Select(x => x!.Color), Does.Contain(expected),
+            $"a swatch should paint its own palette color ({expected}), not the page's DataContext");
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
+++ b/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Headless.NUnit;

--- a/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
+++ b/tests/Beutl.HeadlessUITests/ViewSettingsPagePaletteTests.cs
@@ -21,8 +21,26 @@ public class ViewSettingsPagePaletteTests
     [AvaloniaTest]
     public void AccentPaletteSwatches_BindToTheirColorItem()
     {
-        GlobalConfiguration.Instance.ViewConfig.UseCustomAccentColor = true;
+        // ViewSettingsPageViewModel reads the ViewConfig singleton, so reset it here (not in
+        // SetUp/TearDown, which run off the UI thread) and hand it back unchanged.
+        ViewConfig config = GlobalConfiguration.Instance.ViewConfig;
+        bool useCustomAccent = config.UseCustomAccentColor;
+        string? customAccentColor = config.CustomAccentColor;
+        config.UseCustomAccentColor = true;
 
+        try
+        {
+            AssertSwatchesBindToTheirColorItem();
+        }
+        finally
+        {
+            config.UseCustomAccentColor = useCustomAccent;
+            config.CustomAccentColor = customAccentColor;
+        }
+    }
+
+    private static void AssertSwatchesBindToTheirColorItem()
+    {
         var viewModel = new ViewSettingsPageViewModel(
             new Lazy<EditorSettingsPageViewModel>(() => new EditorSettingsPageViewModel()));
         var page = new ViewSettingsPage { DataContext = viewModel };

--- a/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
+++ b/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
@@ -48,6 +48,47 @@ public class ViewConfigThemeMigrationTests
         Assert.That(config.Theme, Is.EqualTo(expected));
     }
 
+    // A custom id survives a JSON round-trip only if it is decoded rather than read as raw JSON
+    // text: System.Text.Json escapes these on write, and the escapes must not reach the registry.
+    [TestCase("plugin.\"quoted\"")]
+    [TestCase("plugin.back\\slash")]
+    [TestCase("plugin.日本語")]
+    [TestCase("plugin.tab\there")]
+    public void DecodesEscapedCustomThemeId(string themeId)
+    {
+        var config = new ViewConfig { Theme = themeId };
+
+        JsonObject json = CoreSerializer.SerializeToJsonObject(config);
+        var restored = new ViewConfig();
+        CoreSerializer.PopulateFromJsonObject(restored, json);
+
+        Assert.That(restored.Theme, Is.EqualTo(themeId));
+    }
+
+    [TestCase("  dark  ", BuiltinThemeIds.Dark)]
+    [TestCase("\tSystem\n", BuiltinThemeIds.System)]
+    [TestCase(" 2 ", BuiltinThemeIds.HighContrast)]
+    public void NormalizesWhitespacePaddedThemeId(string raw, string expected)
+    {
+        var json = new JsonObject { ["Theme"] = JsonValue.Create(raw) };
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void DefaultsToDark_WhenThemeNull()
+    {
+        var json = new JsonObject { ["Theme"] = null };
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(BuiltinThemeIds.Dark));
+    }
+
     [Test]
     public void DefaultsToDark_WhenThemeMissing()
     {

--- a/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
+++ b/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Configuration;
+using Beutl.Serialization;
+
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Configuration;
+
+[TestFixture]
+public class ViewConfigThemeMigrationTests
+{
+    // Legacy <2.0 settings.json stored the old ViewTheme enum as an int (0-3) or PascalCase name.
+    // The string id persisted by >=2.0 and unknown ids (custom themes) must round-trip unchanged.
+    [TestCase("0", BuiltinThemeIds.Light)]
+    [TestCase("1", BuiltinThemeIds.Dark)]
+    [TestCase("2", BuiltinThemeIds.HighContrast)]
+    [TestCase("3", BuiltinThemeIds.System)]
+    [TestCase("Light", BuiltinThemeIds.Light)]
+    [TestCase("Dark", BuiltinThemeIds.Dark)]
+    [TestCase("HighContrast", BuiltinThemeIds.HighContrast)]
+    [TestCase("System", BuiltinThemeIds.System)]
+    [TestCase("light", BuiltinThemeIds.Light)]
+    [TestCase("dark", BuiltinThemeIds.Dark)]
+    [TestCase("highcontrast", BuiltinThemeIds.HighContrast)]
+    [TestCase("system", BuiltinThemeIds.System)]
+    [TestCase("plugin.solarized", "plugin.solarized")]
+    public void MigratesLegacyThemeValue_AsString(string raw, string expected)
+    {
+        var json = new JsonObject { ["Theme"] = JsonValue.Create(raw) };
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(expected));
+    }
+
+    [TestCase(0, BuiltinThemeIds.Light)]
+    [TestCase(1, BuiltinThemeIds.Dark)]
+    [TestCase(2, BuiltinThemeIds.HighContrast)]
+    [TestCase(3, BuiltinThemeIds.System)]
+    public void MigratesLegacyThemeValue_AsNumber(int raw, string expected)
+    {
+        var json = new JsonObject { ["Theme"] = JsonValue.Create(raw) };
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void DefaultsToDark_WhenThemeMissing()
+    {
+        var json = new JsonObject();
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(BuiltinThemeIds.Dark));
+    }
+
+    [Test]
+    public void RoundTripsCustomThemeId()
+    {
+        var config = new ViewConfig { Theme = "plugin.custom" };
+
+        JsonObject json = CoreSerializer.SerializeToJsonObject(config);
+        var restored = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(restored, json);
+
+        Assert.That(restored.Theme, Is.EqualTo("plugin.custom"));
+    }
+}

--- a/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
+++ b/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
@@ -58,7 +58,10 @@ public class ViewConfigThemeMigrationTests
     {
         var config = new ViewConfig { Theme = themeId };
 
-        JsonObject json = CoreSerializer.SerializeToJsonObject(config);
+        // Round-trip through JSON *text*, the way settings.json actually persists: escaping only
+        // happens on write, so handing the in-memory JsonObject straight back would skip it.
+        JsonObject serialized = CoreSerializer.SerializeToJsonObject(config);
+        var json = JsonNode.Parse(serialized.ToJsonString())!.AsObject();
         var restored = new ViewConfig();
         CoreSerializer.PopulateFromJsonObject(restored, json);
 

--- a/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
+++ b/tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs
@@ -68,6 +68,21 @@ public class ViewConfigThemeMigrationTests
         Assert.That(restored.Theme, Is.EqualTo(themeId));
     }
 
+    // Only 0-3 were ever ViewTheme members. A custom id that merely looks numeric is a normal id and
+    // must not be swallowed by the legacy-enum path.
+    [TestCase("2026")]
+    [TestCase("4")]
+    [TestCase("-1")]
+    public void KeepsNumericLookingCustomThemeId(string themeId)
+    {
+        var json = new JsonObject { ["Theme"] = JsonValue.Create(themeId) };
+        var config = new ViewConfig();
+
+        CoreSerializer.PopulateFromJsonObject(config, json);
+
+        Assert.That(config.Theme, Is.EqualTo(themeId));
+    }
+
     [TestCase("  dark  ", BuiltinThemeIds.Dark)]
     [TestCase("\tSystem\n", BuiltinThemeIds.System)]
     [TestCase(" 2 ", BuiltinThemeIds.HighContrast)]

--- a/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
@@ -1,0 +1,207 @@
+﻿using Avalonia.Styling;
+using Beutl.Extensibility;
+
+using NUnit.Framework;
+
+namespace Beutl.UnitTests.Extensibility;
+
+[TestFixture]
+public class ThemeRegistryTests
+{
+    [TearDown]
+    public void TearDown()
+    {
+        // ThemeRegistry is a static global; clear anything this test registered so tests do not leak.
+        foreach (ThemeDescriptor descriptor in ThemeRegistry.Enumerate())
+        {
+            ThemeRegistry.Unregister(descriptor);
+        }
+    }
+
+    [Test]
+    public void Register_Resolve_Unregister()
+    {
+        var descriptor = new ThemeDescriptor("test.custom", "Custom", ThemeVariant.Dark);
+
+        ThemeRegistry.Register(descriptor);
+
+        Assert.That(ThemeRegistry.Resolve("test.custom"), Is.SameAs(descriptor));
+        Assert.That(ThemeRegistry.Enumerate(), Contains.Item(descriptor));
+
+        Assert.That(ThemeRegistry.Unregister(descriptor), Is.True);
+        Assert.That(ThemeRegistry.Resolve("test.custom"), Is.Null);
+        Assert.That(ThemeRegistry.Unregister(descriptor), Is.False);
+    }
+
+    [Test]
+    public void Register_OverwritesSameId_AndIsIdempotent()
+    {
+        var first = new ThemeDescriptor("test.dup", "First", ThemeVariant.Dark);
+        var second = new ThemeDescriptor("test.dup", "Second", ThemeVariant.Light);
+
+        ThemeRegistry.Register(first);
+        ThemeRegistry.Register(second);
+
+        Assert.That(ThemeRegistry.Resolve("test.dup"), Is.SameAs(second));
+
+        // Re-registering the same descriptor (re-Load after a rolled-back init) must not error.
+        ThemeRegistry.Register(second);
+        Assert.That(ThemeRegistry.Resolve("test.dup"), Is.SameAs(second));
+    }
+
+    [Test]
+    public void Register_RejectsSystemFollowingWithResourceUri()
+    {
+        var descriptor = new ThemeDescriptor(
+            "test.sys", "Sys", ThemeVariant.Default, new Uri("avares://test/x"), IsSystemFollowing: true);
+
+        Assert.Throws<ArgumentException>(() => ThemeRegistry.Register(descriptor));
+        Assert.That(ThemeRegistry.Resolve("test.sys"), Is.Null);
+    }
+
+    [Test]
+    public void Register_KeepsExtension_AndGetExtension_ReturnsIt()
+    {
+        var ext = new TestThemeExtension("test.ext", "Ext");
+        ext.Load();
+
+        Assert.That(ThemeRegistry.GetExtension("test.ext"), Is.SameAs(ext));
+        Assert.That(ThemeRegistry.GetExtension("nonexistent"), Is.Null);
+        Assert.That(ext.Descriptor?.Id, Is.EqualTo("test.ext"));
+
+        ext.Unload();
+        Assert.That(ThemeRegistry.GetExtension("test.ext"), Is.Null);
+    }
+
+    [Test]
+    public void NotifyApplied_CallsOnApplied_AndNotifyReverted_CallsOnReverted()
+    {
+        var ext = new TestThemeExtension("test.notify", "Notify");
+        ext.Load();
+        ThemeDescriptor descriptor = ThemeRegistry.Resolve("test.notify")!;
+
+        ThemeNotifier.NotifyApplied(descriptor);
+        Assert.That(ext.AppliedCount, Is.EqualTo(1));
+        Assert.That(ext.LastApplied?.Id, Is.EqualTo("test.notify"));
+
+        ThemeNotifier.NotifyReverted(descriptor);
+        Assert.That(ext.RevertedCount, Is.EqualTo(1));
+
+        // Built-in (no extension) must not throw.
+        ThemeNotifier.NotifyApplied(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark));
+        ThemeNotifier.NotifyReverted(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark));
+
+        ext.Unload();
+    }
+
+    [Test]
+    public void NotifyApplied_SwallowsExtensionException()
+    {
+        var ext = new ThrowingThemeExtension("test.throw", "Throw");
+        ext.Load();
+        ThemeDescriptor descriptor = ThemeRegistry.Resolve("test.throw")!;
+
+        Assert.DoesNotThrow(() => ThemeNotifier.NotifyApplied(descriptor));
+        Assert.DoesNotThrow(() => ThemeNotifier.NotifyReverted(descriptor));
+
+        ext.Unload();
+    }
+
+    private sealed class TestThemeExtension : ThemeExtension
+    {
+        private readonly ThemeDescriptor _descriptor;
+        public int AppliedCount;
+        public int RevertedCount;
+        public ThemeDescriptor? LastApplied;
+
+        public TestThemeExtension(string id, string name)
+        {
+            _descriptor = new ThemeDescriptor(id, name, ThemeVariant.Dark);
+        }
+
+        public override ThemeDescriptor GetThemeDescriptor() => _descriptor;
+        public override void OnApplied(ThemeApplyContext context) { AppliedCount++; LastApplied = context.Descriptor; }
+        public override void OnReverted() => RevertedCount++;
+    }
+
+    private sealed class ThrowingThemeExtension : ThemeExtension
+    {
+        private readonly ThemeDescriptor _descriptor;
+        public ThrowingThemeExtension(string id, string name) => _descriptor = new ThemeDescriptor(id, name, ThemeVariant.Dark);
+        public override ThemeDescriptor GetThemeDescriptor() => _descriptor;
+        public override void OnApplied(ThemeApplyContext context) => throw new InvalidOperationException("boom");
+        public override void OnReverted() => throw new InvalidOperationException("boom");
+    }
+
+    [Test]
+    public void ResolveOrDefault_FallsBackToDark_WhenIdUnknown()
+    {
+        var dark = new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark);
+        ThemeRegistry.Register(dark);
+
+        Assert.That(ThemeRegistry.ResolveOrDefault("nonexistent"), Is.SameAs(dark));
+        Assert.That(ThemeRegistry.ResolveOrDefault(null), Is.SameAs(dark));
+    }
+
+    [Test]
+    public void ResolveOrDefault_FallsBackToFirstNonSystem_WhenDarkMissing()
+    {
+        var custom = new ThemeDescriptor("custom.x", "X", ThemeVariant.Light);
+        ThemeRegistry.Register(custom);
+
+        Assert.That(ThemeRegistry.ResolveOrDefault("nonexistent"), Is.SameAs(custom));
+    }
+
+    [Test]
+    public void ResolveOrDefault_ReturnsNull_WhenEmpty()
+    {
+        Assert.That(ThemeRegistry.ResolveOrDefault("anything"), Is.Null);
+    }
+
+    [Test]
+    public void ResolveOrDefault_SkipsSystemFollowing_WhenDarkMissing()
+    {
+        var system = new ThemeDescriptor(BuiltinThemeIds.System, "System", ThemeVariant.Default, IsSystemFollowing: true);
+        ThemeRegistry.Register(system);
+
+        // System is the only theme, but it is system-following and must not be the fallback.
+        Assert.That(ThemeRegistry.ResolveOrDefault("nonexistent"), Is.Null);
+    }
+
+    [Test]
+    public void Changed_RaisedOnRegister_AndUnregister()
+    {
+        int calls = 0;
+        ThemeRegistry.Changed += OnChanged;
+        try
+        {
+            var descriptor = new ThemeDescriptor("test.changed", "C", ThemeVariant.Dark);
+            calls = 0;
+            ThemeRegistry.Register(descriptor);
+            Assert.That(calls, Is.EqualTo(1));
+
+            calls = 0;
+            ThemeRegistry.Unregister(descriptor);
+            Assert.That(calls, Is.EqualTo(1));
+
+            // Unregistering a descriptor that was never registered must not raise.
+            calls = 0;
+            ThemeRegistry.Unregister(descriptor);
+            Assert.That(calls, Is.EqualTo(0));
+        }
+        finally
+        {
+            ThemeRegistry.Changed -= OnChanged;
+        }
+
+        void OnChanged(object? sender, EventArgs e) => calls++;
+    }
+
+    [Test]
+    public void Resolve_ReturnsNull_ForNullOrEmptyId()
+    {
+        Assert.That(ThemeRegistry.Resolve(null), Is.Null);
+        Assert.That(ThemeRegistry.Resolve(""), Is.Null);
+        Assert.That(ThemeRegistry.Resolve("   "), Is.Null);
+    }
+}

--- a/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
@@ -106,7 +106,7 @@ public class ThemeRegistryTests
     }
 
     [Test]
-    public void Register_RejectsExtensionTakingOverAHostRegisteredId()
+    public void Register_RejectsExtensionTakingOverABuiltinId()
     {
         // Letting an extension win a built-in id means its Unload evicts the built-in: the identity
         // check in Unregister cannot help, because by then the extension's descriptor is the entry.
@@ -122,6 +122,45 @@ public class ThemeRegistryTests
             Assert.That(ThemeRegistry.GetExtension(BuiltinThemeIds.Dark), Is.Null);
             Assert.That(hijacker.Descriptor, Is.Null, "a rejected Load must not leave a descriptor behind");
         });
+    }
+
+    [Test]
+    public void Register_RejectsBuiltinId_EvenBeforeTheHostSeedsIt()
+    {
+        // Extensions load on background threads and can reach Register before ThemeService.Start.
+        // An order-dependent rule would accept the id here and let the host silently overwrite it.
+        Assert.That(ThemeRegistry.Resolve(BuiltinThemeIds.Dark), Is.Null, "precondition: nothing seeded");
+
+        var hijacker = new TestThemeExtension(BuiltinThemeIds.Dark, "Early");
+
+        Assert.Throws<ArgumentException>(() => hijacker.Load());
+    }
+
+    // Settings normalization rewrites these to the built-in on load, so accepting one would mean the
+    // user's selection silently reverts to the built-in after a restart.
+    [TestCase("Dark")]
+    [TestCase("LIGHT")]
+    [TestCase("HighContrast")]
+    [TestCase("  system  ")]
+    [TestCase("2")]
+    [TestCase("0")]
+    public void Register_RejectsExtensionUsingALegacyAliasOfABuiltinId(string id)
+    {
+        var ext = new TestThemeExtension(id, "Alias");
+
+        Assert.Throws<ArgumentException>(() => ext.Load());
+    }
+
+    [TestCase("plugin.solarized")]
+    [TestCase("2026")]
+    [TestCase("darker")]
+    [TestCase("my.dark")]
+    public void Register_AcceptsExtensionIdsThatOnlyResembleBuiltins(string id)
+    {
+        var ext = new TestThemeExtension(id, "Custom");
+
+        Assert.DoesNotThrow(() => ext.Load());
+        Assert.That(ThemeRegistry.GetExtension(id), Is.SameAs(ext));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
@@ -106,6 +106,36 @@ public class ThemeRegistryTests
     }
 
     [Test]
+    public void GetOwner_ReturnsNull_ForAReplacedDescriptor()
+    {
+        // A holder of an already-replaced descriptor must not be handed the replacement's owner —
+        // that would route OnApplied/OnReverted to an extension that never supplied it.
+        var firstExt = new TestThemeExtension("test.owner", "First");
+        firstExt.Load();
+        ThemeDescriptor firstDescriptor = firstExt.Descriptor!;
+
+        var secondExt = new TestThemeExtension("test.owner", "Second");
+        secondExt.Load();
+
+        Assert.That(ThemeRegistry.GetOwner(firstDescriptor), Is.Null);
+        Assert.That(ThemeRegistry.GetOwner(secondExt.Descriptor!), Is.SameAs(secondExt));
+
+        // GetExtension is id-based and cannot make this distinction; that is why GetOwner exists.
+        Assert.That(ThemeRegistry.GetExtension("test.owner"), Is.SameAs(secondExt));
+    }
+
+    [Test]
+    public void GetOwner_ReturnsNull_ForBuiltinAndUnregistered()
+    {
+        var builtin = new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark);
+        ThemeRegistry.Register(builtin);
+
+        Assert.That(ThemeRegistry.GetOwner(builtin), Is.Null);
+        Assert.That(
+            ThemeRegistry.GetOwner(new ThemeDescriptor("test.absent", "Absent", ThemeVariant.Dark)), Is.Null);
+    }
+
+    [Test]
     public void Register_RejectsSystemFollowingWithResourceUri()
     {
         var descriptor = new ThemeDescriptor(

--- a/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
@@ -106,6 +106,51 @@ public class ThemeRegistryTests
     }
 
     [Test]
+    public void Register_RejectsExtensionTakingOverAHostRegisteredId()
+    {
+        // Letting an extension win a built-in id means its Unload evicts the built-in: the identity
+        // check in Unregister cannot help, because by then the extension's descriptor is the entry.
+        var builtin = new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark);
+        ThemeRegistry.Register(builtin);
+
+        var hijacker = new TestThemeExtension(BuiltinThemeIds.Dark, "Hijacked");
+
+        Assert.Throws<ArgumentException>(() => hijacker.Load());
+        Assert.Multiple(() =>
+        {
+            Assert.That(ThemeRegistry.Resolve(BuiltinThemeIds.Dark), Is.SameAs(builtin));
+            Assert.That(ThemeRegistry.GetExtension(BuiltinThemeIds.Dark), Is.Null);
+            Assert.That(hijacker.Descriptor, Is.Null, "a rejected Load must not leave a descriptor behind");
+        });
+    }
+
+    [Test]
+    public void Register_AllowsHostToReregisterItsOwnBuiltin()
+    {
+        // Two ThemeService instances (or a restart of one) re-seed the built-ins; host-over-host is
+        // not a takeover.
+        var first = new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark);
+        var second = new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark);
+        ThemeRegistry.Register(first);
+
+        Assert.DoesNotThrow(() => ThemeRegistry.Register(second));
+        Assert.That(ThemeRegistry.Resolve(BuiltinThemeIds.Dark), Is.SameAs(second));
+    }
+
+    [Test]
+    public void Register_AllowsExtensionToReplaceAnotherExtensionsId()
+    {
+        // Only the host is protected: extension-over-extension stays allowed and is handled by the
+        // identity check in Unregister.
+        var first = new TestThemeExtension("test.shared", "First");
+        var second = new TestThemeExtension("test.shared", "Second");
+        first.Load();
+
+        Assert.DoesNotThrow(() => second.Load());
+        Assert.That(ThemeRegistry.GetExtension("test.shared"), Is.SameAs(second));
+    }
+
+    [Test]
     public void GetOwner_ReturnsNull_ForAReplacedDescriptor()
     {
         // A holder of an already-replaced descriptor must not be handed the replacement's owner —

--- a/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
+++ b/tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs
@@ -50,6 +50,62 @@ public class ThemeRegistryTests
     }
 
     [Test]
+    public void Unregister_StaleDescriptor_KeepsReplacement()
+    {
+        // The first owner unloads after a second one took over the id: removing purely by id would
+        // evict the replacement and leave the theme picker without a theme that is still live.
+        var first = new ThemeDescriptor("test.stale", "First", ThemeVariant.Dark);
+        var second = new ThemeDescriptor("test.stale", "Second", ThemeVariant.Light);
+
+        ThemeRegistry.Register(first);
+        ThemeRegistry.Register(second);
+
+        Assert.That(ThemeRegistry.Unregister(first), Is.False);
+        Assert.That(ThemeRegistry.Resolve("test.stale"), Is.SameAs(second));
+
+        Assert.That(ThemeRegistry.Unregister(second), Is.True);
+        Assert.That(ThemeRegistry.Resolve("test.stale"), Is.Null);
+    }
+
+    [Test]
+    public void Unregister_EqualValuedDescriptor_DoesNotEvictRegisteredInstance()
+    {
+        // ThemeDescriptor is a record, so an unrelated owner can hold a structurally equal value.
+        // Only the instance that actually registered may remove the entry.
+        var registered = new ThemeDescriptor("test.equal", "Same", ThemeVariant.Dark);
+        var equalCopy = new ThemeDescriptor("test.equal", "Same", ThemeVariant.Dark);
+        Assert.That(equalCopy, Is.EqualTo(registered));
+
+        ThemeRegistry.Register(registered);
+
+        Assert.That(ThemeRegistry.Unregister(equalCopy), Is.False);
+        Assert.That(ThemeRegistry.Resolve("test.equal"), Is.SameAs(registered));
+    }
+
+    [Test]
+    public void Unregister_StaleDescriptor_DoesNotRaiseChanged()
+    {
+        var first = new ThemeDescriptor("test.stalechanged", "First", ThemeVariant.Dark);
+        var second = new ThemeDescriptor("test.stalechanged", "Second", ThemeVariant.Light);
+        ThemeRegistry.Register(first);
+        ThemeRegistry.Register(second);
+
+        int calls = 0;
+        ThemeRegistry.Changed += OnChanged;
+        try
+        {
+            Assert.That(ThemeRegistry.Unregister(first), Is.False);
+            Assert.That(calls, Is.EqualTo(0));
+        }
+        finally
+        {
+            ThemeRegistry.Changed -= OnChanged;
+        }
+
+        void OnChanged(object? sender, EventArgs e) => calls++;
+    }
+
+    [Test]
     public void Register_RejectsSystemFollowingWithResourceUri()
     {
         var descriptor = new ThemeDescriptor(
@@ -80,18 +136,36 @@ public class ThemeRegistryTests
         ext.Load();
         ThemeDescriptor descriptor = ThemeRegistry.Resolve("test.notify")!;
 
-        ThemeNotifier.NotifyApplied(descriptor);
+        ThemeNotifier.NotifyApplied(descriptor, ext);
         Assert.That(ext.AppliedCount, Is.EqualTo(1));
         Assert.That(ext.LastApplied?.Id, Is.EqualTo("test.notify"));
 
-        ThemeNotifier.NotifyReverted(descriptor);
+        ThemeNotifier.NotifyReverted(descriptor, ext);
         Assert.That(ext.RevertedCount, Is.EqualTo(1));
 
-        // Built-in (no extension) must not throw.
-        ThemeNotifier.NotifyApplied(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark));
-        ThemeNotifier.NotifyReverted(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark));
+        // Built-in (no owning extension) must not throw.
+        ThemeNotifier.NotifyApplied(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark), null);
+        ThemeNotifier.NotifyReverted(new ThemeDescriptor(BuiltinThemeIds.Dark, "Dark", ThemeVariant.Dark), null);
 
         ext.Unload();
+    }
+
+    [Test]
+    public void NotifyReverted_UsesCapturedOwner_AfterUnregister()
+    {
+        // ThemeService captures the owner at apply time, then reverts once the extension has already
+        // removed the theme from the registry. An id-based lookup would find nothing here, so
+        // OnReverted would never fire and the extension could not release its apply-time resources.
+        var ext = new TestThemeExtension("test.revert", "Revert");
+        ext.Load();
+        ThemeDescriptor descriptor = ThemeRegistry.Resolve("test.revert")!;
+
+        ext.Unload();
+        Assert.That(ThemeRegistry.GetExtension("test.revert"), Is.Null);
+
+        ThemeNotifier.NotifyReverted(descriptor, ext);
+
+        Assert.That(ext.RevertedCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -101,8 +175,8 @@ public class ThemeRegistryTests
         ext.Load();
         ThemeDescriptor descriptor = ThemeRegistry.Resolve("test.throw")!;
 
-        Assert.DoesNotThrow(() => ThemeNotifier.NotifyApplied(descriptor));
-        Assert.DoesNotThrow(() => ThemeNotifier.NotifyReverted(descriptor));
+        Assert.DoesNotThrow(() => ThemeNotifier.NotifyApplied(descriptor, ext));
+        Assert.DoesNotThrow(() => ThemeNotifier.NotifyReverted(descriptor, ext));
 
         ext.Unload();
     }


### PR DESCRIPTION
## Description
- Add a `ThemeExtension` extensibility point so extension packages can ship their own themes alongside the built-in Light/Dark/HighContrast/System.
- A theme is a `ThemeDescriptor` (id, display name, base `ThemeVariant`, optional FluentAvalonia brush-override `ResourceDictionary`) registered into a new static `ThemeRegistry` at `Load()`/`Unload()` — mirroring `ProxyExtension`/`ProxyGeneratorRegistry`. `ThemeService` resolves the selected id, applies `RequestedThemeVariant`/`PreferSystemTheme`, merges/unmerges the resource dictionary, and notifies the owning extension via `OnApplied`/`OnReverted`.
- The settings page theme picker is generalized to `ItemsSource`+`SelectedItem` so extension themes appear live; `OutProcessDialog` translates the id to a base variant for the separate-process `WaitingDialog`.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`) — settings page + app shell
- [x] `Beutl.Extensibility` (plugin abstractions) — ThemeExtension/ThemeRegistry/ThemeDescriptor/ThemeApplyContext/ThemeNotifier

## Breaking changes
- `ViewConfig.Theme` changed from the `ViewTheme` enum to a `string` theme id; the `ViewConfig.ViewTheme` enum is removed. In-tree call sites (`App.axaml.cs`, `ViewSettingsPageViewModel`, `OutProcessDialog`, `Beutl.PackageTools.UI/App.axaml.cs`) are migrated in this PR.
- `settings.json` is migrated automatically in `ViewConfig.Deserialize`: legacy `int` (0-3), PascalCase enum names (`"Light"`…), and lowercase ids normalize to the stable lowercase id; unknown ids (custom themes) round-trip unchanged.
- Affected projects: `Beutl.Configuration`, `Beutl`, `Beutl.PackageTools.UI`.

## Test plan
- `tests/Beutl.UnitTests/Extensibility/ThemeRegistryTests.cs` — register/unregister/resolve, idempotent re-Load, `ResolveOrDefault` fallback (Dark → first non-system), `IsSystemFollowing`+`ResourceUri` rejection, `GetExtension`, `ThemeNotifier.NotifyApplied`/`NotifyReverted` (incl. extension-exception isolation).
- `tests/Beutl.UnitTests/Configuration/ViewConfigThemeMigrationTests.cs` — legacy int(0-3)/PascalCase/lowercase → stable id, missing-key default, custom-id round-trip.
- Full `Beutl.UnitTests` (4714 passed, incl. 31 theme tests) and `Beutl.HeadlessUITests` (107 passed) green — app-shell startup with `ThemeService.Start` verified headlessly.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme preferences now store stable lowercase string theme ids (Light, Dark, High Contrast, System), with custom themes supported.
  * Introduced a theme descriptor/extension model with a registry and automatic apply/revert notifications, plus dynamic theme synchronization across the app.
  * Settings UI now lists available themes from the registry.
* **Bug Fixes**
  * Improved migration of legacy theme values (string/numeric/malformed) to the new id system, including safer handling of unresolved themes and clearer fallback behavior.
* **Tests**
  * Expanded migration, registry, notification, and theme-application headless UI scenario coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->