### PR TITLE
fix: Show preview render errors in the preview

### DIFF
--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -5,7 +5,6 @@ using Beutl.Logging;
 using Beutl.Media;
 using Beutl.Media.Source;
 using Beutl.ProjectSystem;
-using Beutl.Services;
 using Beutl.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,7 +12,7 @@ using Reactive.Bindings;
 
 namespace Beutl.Models;
 
-public sealed class BufferedPlayer : IPlayer
+internal sealed class BufferedPlayer : IPlayer
 {
     private readonly ILogger _logger = Log.CreateLogger<BufferedPlayer>();
     private readonly ConcurrentQueue<IPlayer.Frame> _queue = new();
@@ -21,11 +20,13 @@ public sealed class BufferedPlayer : IPlayer
     private readonly IEditorClock _editorClock;
     private readonly Scene _scene;
     private readonly IReadOnlyReactiveProperty<bool> _isPlaying;
+    private readonly CancellationToken _playbackToken;
     private readonly int _rate;
     private readonly BufferedPlayerWaitGate _waitRenderGate;
     private readonly BufferedPlayerWaitGate _waitTimerGate;
     private readonly IDisposable _disposable;
     private int? _requestedFrame;
+    private RenderFailure? _renderFailure;
     private volatile bool _isDisposed;
 
     // Set true whenever the producer (Start's dispatched loop) is no longer running. The consumer waits on a
@@ -37,15 +38,19 @@ public sealed class BufferedPlayer : IPlayer
 
     public bool ProducerStopped => _producerStopped;
 
+    internal RenderFailure? Failure => Volatile.Read(ref _renderFailure);
+
     public BufferedPlayer(
         EditViewModel editViewModel, Scene scene,
-        IReactiveProperty<bool> isPlaying, int rate)
+        IReactiveProperty<bool> isPlaying, int rate,
+        CancellationToken playbackToken)
     {
         _editViewModel = editViewModel;
         _editorClock = editViewModel.GetRequiredService<IEditorClock>();
         _scene = scene;
         _isPlaying = isPlaying;
         _rate = rate;
+        _playbackToken = playbackToken;
         _waitRenderGate = new(() => _isDisposed || _producerStopped);
         _waitTimerGate = new(() => _isDisposed);
 
@@ -63,15 +68,22 @@ public sealed class BufferedPlayer : IPlayer
 
         RenderThread.Dispatcher.Dispatch(() =>
         {
+            Volatile.Write(ref _renderFailure, null);
             _producerStopped = false;
+            int frame = startFrame;
+            SceneRenderer? activeRenderer = null;
+            FrameCacheManager? activeCacheManager = null;
             try
             {
+                if (_isDisposed || _playbackToken.IsCancellationRequested)
+                    return;
+
                 _logger.LogInformation("Start rendering from frame {StartFrame} to {DurationFrame}", startFrame,
                     durationFrame);
                 int endFrame = (int)_scene.Start.ToFrameNumber(_rate) + durationFrame;
-                for (int frame = startFrame; frame < endFrame; frame++)
+                for (; frame < endFrame; frame++)
                 {
-                    if (!_isPlaying.Value)
+                    if (_isDisposed || _playbackToken.IsCancellationRequested || !_isPlaying.Value)
                     {
                         _logger.LogInformation("Rendering stopped at frame {Frame}", frame);
                         break;
@@ -82,16 +94,16 @@ public sealed class BufferedPlayer : IPlayer
                         WaitTimer();
                     }
 
-                    if (!_isPlaying.Value)
+                    if (_isDisposed || _playbackToken.IsCancellationRequested || !_isPlaying.Value)
                     {
                         _logger.LogInformation("Rendering stopped at frame {Frame}", frame);
                         break;
                     }
 
                     // Re-read the pair each frame; a rebuild-by-replacement may have disposed the old instances.
-                    SceneRenderer renderer = _editViewModel.Renderer.Value;
-                    FrameCacheManager frameCacheManager = _editViewModel.FrameCacheManager.Value;
-                    if (renderer.IsDisposed || frameCacheManager.IsDisposed)
+                    activeRenderer = _editViewModel.Renderer.Value;
+                    activeCacheManager = _editViewModel.FrameCacheManager.Value;
+                    if (activeRenderer.IsDisposed || activeCacheManager.IsDisposed)
                     {
                         _logger.LogInformation(
                             "Renderer rebuilt mid-playback; stopping the playback producer at frame {Frame}", frame);
@@ -102,23 +114,35 @@ public sealed class BufferedPlayer : IPlayer
 
                     // キャッシュを探す
                     // cacheは参照を既に追加されている
-                    if (frameCacheManager.TryGet(frame, out Ref<Bitmap>? cache))
+                    if (activeCacheManager.TryGet(frame, out Ref<Bitmap>? cache))
                     {
+                        if (_isDisposed || _playbackToken.IsCancellationRequested)
+                        {
+                            cache.Dispose();
+                            break;
+                        }
+
                         _queue.Enqueue(new(cache, frame));
                     }
                     else
                     {
-                        var compositionFrame = renderer.Compositor.EvaluateGraphics(time);
-                        renderer.Render(compositionFrame);
-                        using (Ref<Bitmap> bitmap = Ref<Bitmap>.Create(renderer.Snapshot()))
+                        var compositionFrame = activeRenderer.Compositor.EvaluateGraphics(time);
+                        activeRenderer.Render(compositionFrame);
+                        if (_isDisposed || _playbackToken.IsCancellationRequested)
+                            break;
+
+                        using (Ref<Bitmap> bitmap = Ref<Bitmap>.Create(activeRenderer.Snapshot()))
                         {
+                            if (_isDisposed || _playbackToken.IsCancellationRequested)
+                                break;
+
                             _queue.Enqueue(new(bitmap.Clone(), frame));
-                            frameCacheManager.Add(frame, bitmap);
+                            activeCacheManager.Add(frame, bitmap);
                         }
                     }
 
                     _waitRenderGate.Cancel();
-                    if (_isPlaying.Value)
+                    if (!_isDisposed && !_playbackToken.IsCancellationRequested && _isPlaying.Value)
                         _editViewModel.BufferStatus.EndTime.Value = time;
 
                     int? requestedFrame = _requestedFrame;
@@ -134,7 +158,10 @@ public sealed class BufferedPlayer : IPlayer
 
                 _logger.LogInformation("Rendering completed.");
             }
-            catch (ObjectDisposedException ex)
+            catch (ObjectDisposedException ex) when (
+                _isDisposed
+                || activeRenderer?.IsDisposed == true
+                || activeCacheManager?.IsDisposed == true)
             {
                 // A concurrent rebuild disposed the renderer/cache between the IsDisposed re-check and
                 // Render()/Snapshot() — a TOCTOU the per-frame re-read narrows but cannot close, since disposal
@@ -145,9 +172,8 @@ public sealed class BufferedPlayer : IPlayer
             }
             catch (Exception ex)
             {
-                NotificationService.ShowError(MessageStrings.UnexpectedError,
-                    MessageStrings.FrameDrawingException);
                 _logger.LogError(ex, "An exception occurred while drawing the frame.");
+                Volatile.Write(ref _renderFailure, new RenderFailure(ex, frame));
             }
             finally
             {
@@ -158,6 +184,13 @@ public sealed class BufferedPlayer : IPlayer
                 _producerStopped = true;
                 _waitRenderGate.Cancel();
                 _waitTimerGate.Cancel();
+                if (_isDisposed)
+                {
+                    while (_queue.TryDequeue(out IPlayer.Frame queuedFrame))
+                    {
+                        queuedFrame.Bitmap.Dispose();
+                    }
+                }
             }
         }, Threading.DispatchPriority.High);
     }
@@ -223,4 +256,6 @@ public sealed class BufferedPlayer : IPlayer
             _logger.LogError(ex, "An exception occurred while disposing.");
         }
     }
+
+    internal sealed record RenderFailure(Exception Exception, int Frame);
 }

--- a/src/Beutl/Models/BufferedPlayer.cs
+++ b/src/Beutl/Models/BufferedPlayer.cs
@@ -172,8 +172,11 @@ internal sealed class BufferedPlayer : IPlayer
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occurred while drawing the frame.");
-                Volatile.Write(ref _renderFailure, new RenderFailure(ex, frame));
+                _logger.LogError(ex, "An exception occurred while drawing frame {Frame}.", frame);
+                if (!_isDisposed && !_playbackToken.IsCancellationRequested && _isPlaying.Value)
+                {
+                    Volatile.Write(ref _renderFailure, new RenderFailure(ex, frame));
+                }
             }
             finally
             {

--- a/src/Beutl/Models/IPlayer.cs
+++ b/src/Beutl/Models/IPlayer.cs
@@ -3,7 +3,7 @@ using Beutl.Media.Source;
 
 namespace Beutl.Models;
 
-public interface IPlayer : IDisposable
+internal interface IPlayer : IDisposable
 {
     public record struct Frame(Ref<Bitmap> Bitmap, int Time);
 

--- a/src/Beutl/ViewModels/PlaybackSessionGuard.cs
+++ b/src/Beutl/ViewModels/PlaybackSessionGuard.cs
@@ -7,15 +7,52 @@
 // cannot stomp the session that replaced it when it finally unblocks.
 internal sealed class PlaybackSessionGuard
 {
+    private readonly object _sync = new();
     private int _generation;
 
     // Claim a fresh session and return the token that identifies the claiming task.
-    public int Claim() => Interlocked.Increment(ref _generation);
+    public int Claim() => Claim(static () => { });
+
+    // Claim and initialize the shared session state atomically with respect to a prior owner's
+    // final guarded write. This prevents a late failure from clearing the new owner's state.
+    public int Claim(Action initialize)
+    {
+        ArgumentNullException.ThrowIfNull(initialize);
+        lock (_sync)
+        {
+            int token = Interlocked.Increment(ref _generation);
+            initialize();
+            return token;
+        }
+    }
 
     // True only while <paramref name="token"/> is still the current session (no later Claim/Disown).
     public bool Owns(int token) => Volatile.Read(ref _generation) == token;
 
     // Disown the current owner (a Pause() timeout abandoning a stuck task) so its late restore
     // becomes a no-op; the next Claim() starts a new session.
-    public void Disown() => Interlocked.Increment(ref _generation);
+    public void Disown() => Disown(static () => { });
+
+    public void Disown(Action restore)
+    {
+        ArgumentNullException.ThrowIfNull(restore);
+        lock (_sync)
+        {
+            Interlocked.Increment(ref _generation);
+            restore();
+        }
+    }
+
+    public bool TryApply(int token, Action update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        lock (_sync)
+        {
+            if (_generation != token)
+                return false;
+
+            update();
+            return true;
+        }
+    }
 }

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -629,8 +629,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         failure,
                         rate,
                         () => _sessionGuard.Owns(generation));
-                    tcs.TrySetResult(true);
                 });
+                tcs.TrySetResult(true);
                 return true;
             }
 
@@ -1273,7 +1273,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
         }
 
-        try
+        async Task PlaybackLoop()
         {
             PrepareBuffer(primaryBuffer);
 
@@ -1325,6 +1325,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 AnchorClock();
             }
         }
+
+        try
+        {
+            await RunAudioPlaybackWithImmediateStopAsync(cts.Token, source.Stop, PlaybackLoop)
+                .ConfigureAwait(false);
+        }
         catch (OperationCanceledException)
         {
             source.Stop();
@@ -1335,6 +1341,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             primaryBuffer.Dispose();
             secondaryBuffer.Dispose();
         }
+    }
+
+    internal static async Task RunAudioPlaybackWithImmediateStopAsync(
+        CancellationToken token, Action stop, Func<Task> playback)
+    {
+        using CancellationTokenRegistration stopPlayback = token.Register(stop);
+        await playback().ConfigureAwait(false);
     }
 
     private async Task PlayWithOpenAL(AudioContext audioContext, Scene scene,
@@ -1968,7 +1981,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 token);
         }
 
-        previousCts?.Cancel();
+        if (previousCts is not null)
+        {
+            try
+            {
+                previousCts.Cancel();
+            }
+            finally
+            {
+                previousCts.Dispose();
+            }
+        }
     }
 
     private void UpdateCurrentFrame(TimeSpan timeSpan)

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -57,11 +57,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     private readonly IEditorClock _editorClock;
     private readonly IEditorSelection _editorSelection;
     private IDisposable? _currentFrameSubscription;
+    private readonly object _renderRequestLock = new();
     private CancellationTokenSource? _cts;
+    private bool _isDisposing;
     private Size _maxFrameSize;
     private Task _playbackTask = Task.CompletedTask;
     private bool _isShuttling;
     private readonly PlaybackSessionGuard _sessionGuard = new();
+    private readonly ReactivePropertySlim<string?> _previewRenderError = new();
+    private long _previewRenderErrorIssuedVersion;
+    private long _previewRenderErrorAppliedVersion;
     // Serializes RestoreStoppedPreviewState so PlayInternal's finally and Pause()'s timeout path
     // cannot interleave the dispose/resubscribe and Scene.Edited unhook/hook steps across threads.
     private readonly object _restoreLock = new();
@@ -351,6 +356,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactivePropertySlim<Ref<Bitmap>?> PreviewImage { get; } = new();
 
+    public IReadOnlyReactiveProperty<string?> PreviewRenderError => _previewRenderError;
+
     IReadOnlyReactiveProperty<Ref<Bitmap>?> IPreviewPlayer.PreviewImage => PreviewImage;
 
     IObservable<Unit> IPreviewPlayer.AfterRendered => AfterRendered;
@@ -497,9 +504,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         PlaybackDirection.Value = ViewModels.PlaybackDirection.Forward;
         // Mark playing before publishing _playbackTask so a Pause() in the startup window
         // (before PlayInternal runs) signals the loop to stop instead of awaiting forever.
-        _stopRequested = false;
-        IsPlaying.Value = true;
-        int generation = _sessionGuard.Claim();
+        int generation = _sessionGuard.Claim(() =>
+        {
+            _stopRequested = false;
+            IsPlaying.Value = true;
+        });
 
         _playbackTask = Task.Run(async () =>
         {
@@ -509,7 +518,12 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             bool restart;
             do
             {
-                restart = await PlayInternal(generation);
+                using var playbackCts = new CancellationTokenSource();
+                using IDisposable cancelPlayback = IsPlaying
+                    .Where(static value => !value)
+                    .Take(1)
+                    .Subscribe(_ => playbackCts.Cancel());
+                restart = await PlayInternal(generation, playbackCts.Token);
                 // Stop restarting on a boundary-window pause (_stopRequested set without flipping
                 // IsPlaying), or when a Pause() timeout disowned this task and a newer session took
                 // over — a stale task must not re-arm and stomp the session that replaced it.
@@ -518,55 +532,65 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     restart = false;
                 }
 
-                if (restart)
+                if (restart && !_sessionGuard.TryApply(
+                        generation,
+                        () => IsPlaying.Value = true))
                 {
-                    // Re-arm IsPlaying for the next PlayInternal, which no longer sets it.
-                    IsPlaying.Value = true;
+                    restart = false;
                 }
             } while (restart);
         });
     }
 
-    private async Task<bool> PlayInternal(int generation)
+    private async Task<bool> PlayInternal(int generation, CancellationToken playbackToken)
     {
-        if (!_isEnabled.Value || Scene == null)
+        Scene? scene = Scene;
+        if (playbackToken.IsCancellationRequested || !_isEnabled.Value || scene == null)
         {
-            IsPlaying.Value = false;
+            _sessionGuard.TryApply(generation, () => IsPlaying.Value = false);
             return false;
         }
 
         BufferStatusViewModel bufferStatus = EditViewModel.BufferStatus;
         FrameCacheManager frameCacheManager = EditViewModel.FrameCacheManager.Value;
-        Scene.Edited -= OnSceneEdited;
-        _currentFrameSubscription?.Dispose();
-        _currentFrameSubscription = null;
-
         int rate = GetFrameRate();
 
         TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
         TimeSpan startTime = _editorClock.CurrentTime.Value;
-        TimeSpan durationTime = Scene.Duration;
+        TimeSpan durationTime = scene.Duration;
         int startFrame = (int)startTime.ToFrameNumber(rate);
         int durationFrame = (int)Math.Ceiling(durationTime.ToFrameNumber(rate));
-        int endFrame = (int)Scene.Start.ToFrameNumber(rate) + durationFrame;
-        bufferStatus.StartTime.Value = startTime;
-        bufferStatus.EndTime.Value = startTime;
-        frameCacheManager.Options = frameCacheManager.Options with
+        int endFrame = (int)scene.Start.ToFrameNumber(rate) + durationFrame;
+        if (!_sessionGuard.TryApply(generation, () =>
         {
-            DeletionStrategy = FrameCacheDeletionStrategy.BackwardBlock
-        };
+            scene.Edited -= OnSceneEdited;
+            _currentFrameSubscription?.Dispose();
+            _currentFrameSubscription = null;
+            bufferStatus.StartTime.Value = startTime;
+            bufferStatus.EndTime.Value = startTime;
+            frameCacheManager.Options = frameCacheManager.Options with
+            {
+                DeletionStrategy = FrameCacheDeletionStrategy.BackwardBlock
+            };
+            frameCacheManager.CurrentFrame = startFrame;
+        }))
+        {
+            return false;
+        }
 
-        frameCacheManager.CurrentFrame = startFrame;
         bool reachedNaturalEnd = false;
         try
         {
-            using var playerImpl = new BufferedPlayer(EditViewModel, Scene, IsPlaying, rate);
+            using var playerImpl = new BufferedPlayer(EditViewModel, scene, IsPlaying, rate, playbackToken);
             _logger.LogInformation("Start the playback. ({SceneId}, {Rate}, {Start}, {Duration})",
                 _editViewModel.SceneId, rate, startFrame, durationFrame);
-            playerImpl.Start();
 
             var clock = new AudioPlaybackClock();
-            var audioTask = PlayAudio(Scene, clock, startTime, generation);
+            if (!_sessionGuard.TryApply(generation, playerImpl.Start))
+            {
+                return false;
+            }
+            Task audioTask = PlayAudio(scene, clock, startTime, generation, playbackToken);
 
             // 音声バッファの準備に1フレーム以上かかると、映像だけが先に進んでしまい、
             // その後音声がアンカーされた瞬間に「映像が先行した状態」で止まってしまう。
@@ -578,6 +602,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             var tcs = new TaskCompletionSource<bool>();
             int nextExpectedFrame = startFrame + 1;
             int processing = 0;
+            bool renderFailureHandled = false;
 
             int ComputeExpectFrame()
             {
@@ -586,6 +611,27 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     : DateTime.UtcNow - startDateTime;
                 if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
                 return (int)(elapsed.Ticks / tick.Ticks) + startFrame;
+            }
+
+            bool StopForRenderFailure()
+            {
+                BufferedPlayer.RenderFailure? failure = playerImpl.Failure;
+                if (failure is null)
+                    return false;
+
+                if (renderFailureHandled)
+                    return true;
+
+                renderFailureHandled = true;
+                _sessionGuard.TryApply(generation, () =>
+                {
+                    ApplyPlaybackRenderFailure(
+                        failure,
+                        rate,
+                        () => _sessionGuard.Owns(generation));
+                    tcs.TrySetResult(true);
+                });
+                return true;
             }
 
             await using var timer = new Timer(_ =>
@@ -604,22 +650,33 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         return;
                     }
 
+                    // The producer publishes its terminal render exception before ProducerStopped.
+                    // Stop before consuming any older frames still buffered ahead of the playhead,
+                    // otherwise a pre-failure frame could hide the error that ended playback.
+                    if (StopForRenderFailure())
+                    {
+                        return;
+                    }
+
                     var expectFrame = ComputeExpectFrame();
                     if (_stopRequested || !IsPlaying.Value || expectFrame >= endFrame)
                     {
-                        // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える。
-                        // ただし停止要求中はループの自然終端とみなさず、再開させない。
-                        if (!_stopRequested && IsLoopEnabled.Value && expectFrame >= endFrame)
+                        _sessionGuard.TryApply(generation, () =>
                         {
-                            reachedNaturalEnd = true;
-                            IsPlaying.Value = false;
-                        }
-                        else if (_stopRequested)
-                        {
-                            // A pause that raced the loop re-arm leaves IsPlaying=true; clear it so the
-                            // audio task stops here instead of running to the scene's natural end.
-                            IsPlaying.Value = false;
-                        }
+                            // ループ用に endFrame で打ち切る場合、音声側にも停止を伝える。
+                            // ただし停止要求中はループの自然終端とみなさず、再開させない。
+                            if (!_stopRequested && IsLoopEnabled.Value && expectFrame >= endFrame)
+                            {
+                                reachedNaturalEnd = true;
+                                IsPlaying.Value = false;
+                            }
+                            else if (_stopRequested)
+                            {
+                                // A pause that raced the loop re-arm leaves IsPlaying=true; clear it so the
+                                // audio task stops here instead of running to the scene's natural end.
+                                IsPlaying.Value = false;
+                            }
+                        });
 
                         tcs.TrySetResult(true);
                         return;
@@ -636,12 +693,23 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         dequeued = true;
                         using (frame.Bitmap)
                         {
-                            UpdateImage(frame.Bitmap.Clone());
-
-                            if (Scene != null)
+                            Ref<Bitmap> preview = frame.Bitmap.Clone();
+                            bool applied = _sessionGuard.TryApply(generation, () =>
                             {
-                                _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
-                                EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
+                                UpdateImage(preview);
+                                ClearPreviewRenderError(generation);
+
+                                if (Scene != null)
+                                {
+                                    _editorClock.CurrentTime.Value = frame.Time.ToTimeSpan(rate);
+                                    EditViewModel.FrameCacheManager.Value.CurrentFrame = frame.Time;
+                                }
+                            });
+                            if (!applied)
+                            {
+                                preview.Dispose();
+                                tcs.TrySetResult(true);
+                                return;
                             }
                         }
 
@@ -657,9 +725,24 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         // 期待していたフレームよりも前のフレームが来た場合
                     }
 
+                    // Close the race where the producer faults while this timer callback is
+                    // dequeuing the last successfully rendered frame.
+                    if (StopForRenderFailure())
+                    {
+                        return;
+                    }
+
                     if (!dequeued && playerImpl.ProducerStopped)
                     {
-                        IsPlaying.Value = false;
+                        // ProducerStopped is published after Failure. Re-read Failure only after
+                        // observing the terminal flag so a fault published in the preceding gap
+                        // cannot be mistaken for a normal producer stop.
+                        if (StopForRenderFailure())
+                        {
+                            return;
+                        }
+
+                        _sessionGuard.TryApply(generation, () => IsPlaying.Value = false);
                         tcs.TrySetResult(true);
                         return;
                     }
@@ -677,10 +760,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             // Committing the recorded cache blocks is a shared write, so gate it on ownership like the
             // finally/rewind paths below: a task disowned by a Pause() timeout that unblocks after a
             // newer session started must not stomp that session's frame-cache bookkeeping.
-            if (_sessionGuard.Owns(generation))
-            {
-                frameCacheManager.UpdateBlocks();
-            }
+            _sessionGuard.TryApply(generation, frameCacheManager.UpdateBlocks);
         }
         finally
         {
@@ -688,10 +768,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             // task detached on entry) only while this task still owns the session. If a Pause()
             // timeout disowned it and a newer session took over, restoring here would stomp that
             // session, so the new owner — or Pause()'s timeout path — restores it instead.
-            if (_sessionGuard.Owns(generation))
-            {
-                RestoreStoppedPreviewState();
-            }
+            _sessionGuard.TryApply(generation, RestoreStoppedPreviewState);
 
             _logger.LogInformation("End the playback. ({SceneId})", _editViewModel.SceneId);
         }
@@ -700,10 +777,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         // loopStart は購読で最新化されているため、再生中の In/Out 変更にも追従する。
         // A task disowned by a Pause() timeout must not rewind the playhead of a stopped editor or
         // the session that replaced it, so gate the shared CurrentTime write on ownership too.
-        if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null && _sessionGuard.Owns(generation))
+        if (IsLoopEnabled.Value && reachedNaturalEnd && Scene != null)
         {
-            _editorClock.CurrentTime.Value = Scene.Start;
-            return true;
+            return _sessionGuard.TryApply(generation, () => _editorClock.CurrentTime.Value = Scene.Start);
         }
 
         return false;
@@ -924,13 +1000,16 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void StartShuttle()
     {
-        if (_isShuttling || Scene == null) return;
+        Scene? scene = Scene;
+        if (_isShuttling || scene == null) return;
         // Clear a stop request left by a prior Pause() so the flag's "true until the next
         // playback start" invariant holds across shuttle too, not just Play().
-        _stopRequested = false;
-        _isShuttling = true;
-        IsPlaying.Value = true;
-        int generation = _sessionGuard.Claim();
+        int generation = _sessionGuard.Claim(() =>
+        {
+            _stopRequested = false;
+            _isShuttling = true;
+            IsPlaying.Value = true;
+        });
 
         _playbackTask = Task.Run(async () =>
         {
@@ -939,11 +1018,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 int rate = GetFrameRate();
                 TimeSpan tick = TimeSpan.FromSeconds(1d / rate);
 
-                Scene.Edited -= OnSceneEdited;
+                if (!_sessionGuard.TryApply(generation, () => scene.Edited -= OnSceneEdited))
+                {
+                    return;
+                }
                 // 既存の CurrentFrame 購読は維持して UpdateCurrentFrame 経由でレンダリングを行う
 
                 DateTime lastTime = DateTime.UtcNow;
-                while (_isShuttling && IsPlaying.Value && Scene != null)
+                while (_isShuttling
+                       && IsPlaying.Value
+                       && Scene != null
+                       && _sessionGuard.Owns(generation))
                 {
                     var direction = PlaybackDirection.Value;
                     if (direction == ViewModels.PlaybackDirection.Stopped)
@@ -995,10 +1080,13 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     TimeSpan target = next;
                     Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                     {
-                        if (Scene != null)
+                        _sessionGuard.TryApply(generation, () =>
                         {
-                            _editorClock.CurrentTime.Value = target;
-                        }
+                            if (Scene != null)
+                            {
+                                _editorClock.CurrentTime.Value = target;
+                            }
+                        });
                     });
 
                     await Task.Delay(tick).ConfigureAwait(false);
@@ -1008,7 +1096,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             {
                 // Only restore shared state while this shuttle still owns the session; a Pause()
                 // timeout that disowned it must not let this late finally stomp a newer session.
-                if (_sessionGuard.Owns(generation))
+                _sessionGuard.TryApply(generation, () =>
                 {
                     _isShuttling = false;
                     IsPlaying.Value = false;
@@ -1019,28 +1107,38 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         Scene.Edited -= OnSceneEdited;
                         Scene.Edited += OnSceneEdited;
                     }
-                }
+                });
             }
         });
     }
 
-    private async Task PlayAudio(Scene scene, AudioPlaybackClock clock, TimeSpan startTime, int generation)
+    private async Task PlayAudio(
+        Scene scene,
+        AudioPlaybackClock clock,
+        TimeSpan startTime,
+        int generation,
+        CancellationToken playbackToken)
     {
         try
         {
+            playbackToken.ThrowIfCancellationRequested();
             if (OperatingSystem.IsWindows())
             {
                 using var audioContext = new XAudioContext();
-                await PlayWithXA2(audioContext, scene, clock, startTime).ConfigureAwait(false);
+                await PlayWithXA2(audioContext, scene, clock, startTime, playbackToken).ConfigureAwait(false);
             }
             else
             {
                 await Task.Run(async () =>
                 {
+                    playbackToken.ThrowIfCancellationRequested();
                     using var audioContext = new AudioContext();
-                    await PlayWithOpenAL(audioContext, scene, clock, startTime);
-                });
+                    await PlayWithOpenAL(audioContext, scene, clock, startTime, playbackToken);
+                }, playbackToken);
             }
+        }
+        catch (OperationCanceledException) when (playbackToken.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
@@ -1049,10 +1147,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             _logger.LogError(ex, "An exception occurred during audio playback.");
             // Only stop the session this task owns: a fault from an audio backend abandoned by a
             // Pause() timeout must not clear IsPlaying on the session that replaced it.
-            if (_sessionGuard.Owns(generation))
-            {
-                IsPlaying.Value = false;
-            }
+            _sessionGuard.TryApply(generation, () => IsPlaying.Value = false);
         }
         finally
         {
@@ -1134,8 +1229,10 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     }
 
     private async Task PlayWithXA2(XAudioContext audioContext, Scene scene,
-        AudioPlaybackClock clock, TimeSpan startTime)
+        AudioPlaybackClock clock, TimeSpan startTime, CancellationToken playbackToken)
     {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(playbackToken);
+        cts.Token.ThrowIfCancellationRequested();
         var composer = EditViewModel.Composer.Value;
         int sampleRate = composer.SampleRate;
         TimeSpan cur = startTime;
@@ -1148,9 +1245,11 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
         void PrepareBuffer(XAudioBuffer buffer)
         {
+            cts.Token.ThrowIfCancellationRequested();
             TimeSpan bufferStartTime = cur;
             TimeSpan sceneEndTime = scene.Start + scene.Duration;
-            Pcm<Stereo32BitFloat>? pcm = FillAudioData(cur, sceneEndTime, composer);
+            using Pcm<Stereo32BitFloat>? pcm = FillAudioData(cur, sceneEndTime, composer);
+            cts.Token.ThrowIfCancellationRequested();
             if (pcm != null)
             {
                 if (!hasAudio)
@@ -1173,17 +1272,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             double seconds = (double)source.SamplesPlayed / sampleRate;
             clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
         }
-
-        var cts = new CancellationTokenSource();
-        IDisposable revoker = IsPlaying.Where(v => !v)
-            .Take(1)
-            .Subscribe(_ =>
-            {
-                // ReSharper disable AccessToDisposedClosure
-                source.Stop();
-                cts.Cancel();
-                // ReSharper restore AccessToDisposedClosure
-            });
 
         try
         {
@@ -1243,50 +1331,51 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         }
         finally
         {
-            revoker.Dispose();
             source.Dispose();
-            cts.Dispose();
             primaryBuffer.Dispose();
             secondaryBuffer.Dispose();
         }
     }
 
     private async Task PlayWithOpenAL(AudioContext audioContext, Scene scene,
-        AudioPlaybackClock clock, TimeSpan startTime)
+        AudioPlaybackClock clock, TimeSpan startTime, CancellationToken playbackToken)
     {
-        var cts = new CancellationTokenSource();
-        IDisposable revoker = IsPlaying.Where(v => !v)
-            .Take(1)
-            .Subscribe(_ => cts.Cancel());
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(playbackToken);
+        cts.Token.ThrowIfCancellationRequested();
+        audioContext.MakeCurrent();
+
+        var composer = EditViewModel.Composer.Value;
+        int sampleRate = composer.SampleRate;
+        TimeSpan cur = startTime;
+        uint[] buffers = audioContext.GenBuffers(2);
+        uint source = audioContext.GenSource();
+        long totalProcessedSamples = 0;
+        var queuedBufferSamples = new Queue<int>();
+        bool hasAudio = false;
+        bool audioClockValid = false;
+
+        void AnchorClock()
+        {
+            if (!hasAudio || !audioClockValid) return;
+            audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int sampleOffset);
+            long pos = totalProcessedSamples + sampleOffset;
+            double seconds = (double)pos / sampleRate;
+            clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
+        }
 
         try
         {
-            audioContext.MakeCurrent();
-
-            var composer = EditViewModel.Composer.Value;
-            int sampleRate = composer.SampleRate;
-            TimeSpan cur = startTime;
-            uint[] buffers = audioContext.GenBuffers(2);
-            uint source = audioContext.GenSource();
-            long totalProcessedSamples = 0;
-            var queuedBufferSamples = new Queue<int>();
-            bool hasAudio = false;
-            bool audioClockValid = false;
-
-            void AnchorClock()
-            {
-                if (!hasAudio || !audioClockValid) return;
-                audioContext.GetSource(source, GetSourceInteger.SampleOffset, out int sampleOffset);
-                long pos = totalProcessedSamples + sampleOffset;
-                double seconds = (double)pos / sampleRate;
-                clock.Anchor(startTime + TimeSpan.FromSeconds(seconds));
-            }
-
             foreach (uint buffer in buffers)
             {
+                if (cts.Token.IsCancellationRequested)
+                    break;
+
                 TimeSpan bufferStartTime = cur;
                 TimeSpan sceneEndTime = scene.Start + scene.Duration;
                 using Pcm<Stereo32BitFloat>? pcmf = FillAudioData(cur, sceneEndTime, composer);
+                if (cts.Token.IsCancellationRequested)
+                    break;
+
                 cur += s_second;
                 int fillSamples = 0;
                 if (pcmf != null)
@@ -1308,6 +1397,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 queuedBufferSamples.Enqueue(fillSamples);
             }
 
+            cts.Token.ThrowIfCancellationRequested();
             audioContext.SourcePlay(source);
 
             try
@@ -1340,15 +1430,17 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 // ここで明示的に StartedTask をシグナルする。
                 clock.SignalStarted();
 
-                while (IsPlaying.Value)
+                while (IsPlaying.Value && !cts.Token.IsCancellationRequested)
                 {
                     audioContext.MakeCurrent();
                     audioContext.GetSource(source, GetSourceInteger.BuffersProcessed, out int processed);
                     while (processed > 0)
                     {
+                        cts.Token.ThrowIfCancellationRequested();
                         TimeSpan bufferStartTime = cur;
                         TimeSpan sceneEndTime = scene.Start + scene.Duration;
                         using Pcm<Stereo32BitFloat>? pcmf = FillAudioData(cur, sceneEndTime, composer);
+                        cts.Token.ThrowIfCancellationRequested();
                         cur += s_second;
                         uint buffer = audioContext.SourceUnqueueBuffer(source);
                         int fillSamples = 0;
@@ -1386,7 +1478,9 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         break;
                 }
 
-                while (audioContext.GetSourceState(source) == SourceState.Playing && IsPlaying.Value)
+                while (audioContext.GetSourceState(source) == SourceState.Playing
+                       && IsPlaying.Value
+                       && !cts.Token.IsCancellationRequested)
                 {
                     audioContext.MakeCurrent();
                     audioContext.GetSource(source, GetSourceInteger.BuffersProcessed, out int drainProcessed);
@@ -1403,16 +1497,15 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             catch (OperationCanceledException)
             {
             }
-
+        }
+        finally
+        {
+            audioContext.MakeCurrent();
             audioContext.SourceStop(source);
             // https://hamken100.blogspot.com/2014/04/aldeletebuffersalinvalidoperation.html
             audioContext.Source(source, SourceInteger.Buffer, 0);
             audioContext.DeleteBuffers(buffers);
             audioContext.DeleteSource(source);
-        }
-        finally
-        {
-            revoker.Dispose();
         }
     }
 
@@ -1451,8 +1544,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                     // session, then restore the stopped state here: the task detached the preview
                     // subscriptions on entry and, now disowned, will skip re-attaching them, so
                     // otherwise the editor would stay detached until (if ever) the task unblocks.
-                    _sessionGuard.Disown();
-                    RestoreStoppedPreviewState();
+                    _sessionGuard.Disown(RestoreStoppedPreviewState);
                 }
             }
         }
@@ -1505,6 +1597,79 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
         PreviewInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
+    private void ReportPreviewRenderError(CancellationToken token)
+    {
+        UpdatePreviewRenderError(
+            MessageStrings.FrameDrawingException,
+            () => !token.IsCancellationRequested);
+    }
+
+    private void ClearPreviewRenderError(CancellationToken token)
+    {
+        UpdatePreviewRenderError(null, () => !token.IsCancellationRequested);
+    }
+
+    private void ClearPreviewRenderError(int generation)
+    {
+        UpdatePreviewRenderError(null, () => _sessionGuard.Owns(generation));
+    }
+
+    internal void SetPreviewRenderError(string? message)
+    {
+        UpdatePreviewRenderError(message, static () => true);
+    }
+
+    internal bool ApplyPlaybackRenderFailure(
+        BufferedPlayer.RenderFailure failure,
+        int rate,
+        Func<bool> isCurrent)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        ArgumentNullException.ThrowIfNull(isCurrent);
+        if (Scene is null || !isCurrent())
+            return false;
+
+        _editorClock.CurrentTime.Value = failure.Frame.ToTimeSpan(rate);
+        EditViewModel.FrameCacheManager.Value.CurrentFrame = failure.Frame;
+        UpdatePreviewRenderError(MessageStrings.FrameDrawingException, isCurrent);
+        IsPlaying.Value = false;
+        return true;
+    }
+
+    private void UpdatePreviewRenderError(string? message, Func<bool> isCurrent)
+    {
+        if (!isCurrent())
+            return;
+
+        long version = Interlocked.Increment(ref _previewRenderErrorIssuedVersion);
+
+        void Update()
+        {
+            // A queued update may run after this view model was disposed or its render/playback
+            // request was superseded. Keep the error scoped to the preview that still owns it.
+            // Invalid newer updates do not advance the applied version, so they cannot suppress
+            // an older update that is still valid for the current request.
+            if (Scene is not null
+                && isCurrent()
+                && version > _previewRenderErrorAppliedVersion)
+            {
+                _previewRenderErrorAppliedVersion = version;
+                _previewRenderError.Value = message;
+            }
+        }
+
+        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            Update();
+        }
+        else
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(
+                Update,
+                Avalonia.Threading.DispatcherPriority.Background);
+        }
+    }
+
     private void DrawBoundaries(Renderer renderer, SKCanvas canvas, Size canvasSize, bool recalculate = false)
     {
         int? selected = _editorSelection.SelectedLayerNumber.Value;
@@ -1551,9 +1716,6 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     private void QueueRender()
     {
-        if (EditViewModel.Renderer.Value.IsGraphicsRendering)
-            return;
-
         void RenderOnRenderThread(CancellationToken token)
         {
             if (token.IsCancellationRequested)
@@ -1746,11 +1908,20 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                         }
                     }
 
+                    if (token.IsCancellationRequested)
+                    {
+                        bitmapRef.Dispose();
+                        return;
+                    }
+
                     UpdateImage(bitmapRef);
 
                     // Dispose と並走した場合に AfterRendered が破棄されている可能性があるためトークンを確認する
                     if (!token.IsCancellationRequested)
+                    {
                         AfterRendered.OnNext(Unit.Default);
+                        ClearPreviewRenderError(token);
+                    }
                 }
                 catch (ObjectDisposedException) when (token.IsCancellationRequested)
                 {
@@ -1759,22 +1930,45 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 }
                 catch (Exception ex)
                 {
-                    NotificationService.ShowError(MessageStrings.UnexpectedError,
-                        MessageStrings.FrameDrawingException);
                     _logger.LogError(ex,
                         "An exception occurred while drawing the frame. onionSkin={UseOnionSkin}, sampleCount={Count}, frame={Frame}.",
                         useOnionSkin, onionSampleCount, frame);
+                    ReportPreviewRenderError(token);
                 }
             }, ct: token);
         }
 
-        _cts?.Cancel();
-        _cts = new CancellationTokenSource();
+        CancellationTokenSource cts;
+        CancellationTokenSource? previousCts;
+        CancellationToken token;
+        lock (_renderRequestLock)
+        {
+            if (_isDisposing)
+                return;
 
-        Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
-            () => RenderOnRenderThread(_cts.Token),
-            Avalonia.Threading.DispatcherPriority.Background,
-            _cts.Token);
+            cts = new CancellationTokenSource();
+            token = cts.Token;
+            previousCts = _cts;
+            _cts = cts;
+
+            // Serialize the UI-side handoff with DisposeAsync. Once disposal claims this lock,
+            // no callback can enqueue more render-thread work behind its teardown barrier.
+            Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () =>
+                {
+                    lock (_renderRequestLock)
+                    {
+                        if (!_isDisposing && !token.IsCancellationRequested)
+                        {
+                            RenderOnRenderThread(token);
+                        }
+                    }
+                },
+                Avalonia.Threading.DispatcherPriority.Background,
+                token);
+        }
+
+        previousCts?.Cancel();
     }
 
     private void UpdateCurrentFrame(TimeSpan timeSpan)
@@ -1804,12 +1998,25 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing PlayerViewModel. ({SceneId})", _editViewModel.SceneId);
+        CancellationTokenSource? renderCts;
+        lock (_renderRequestLock)
+        {
+            _isDisposing = true;
+            renderCts = _cts;
+            _cts = null;
+        }
+
+        // Stop accepting and cancel preview renders before Pause() can yield. QueueRender and
+        // teardown share the same lock, so a newly created source can never be disposed out from
+        // under the request that captured its token.
+        renderCts?.Cancel();
         await Pause();
+        // All preview callbacks dispatched before _isDisposing was set are ahead of this barrier.
+        // Wait for them to finish before disposing their token source and the subjects they use.
+        await RenderThread.Dispatcher.InvokeAsync(static () => { });
         // 進行中の QueueRender をキャンセルしてから Subject を破棄し、レンダースレッドが
         // 破棄済みの AfterRendered/_audioFramePushed に OnNext しないようにする
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = null;
+        renderCts?.Dispose();
         Scene!.Edited -= OnSceneEdited;
         _disposables.Dispose();
         _currentFrameSubscription?.Dispose();

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -138,21 +138,56 @@
             </Button>
         </Player.InnerRightContent>
         <Player.Content>
-            <Panel Name="framePanel"
-                   Margin="0"
-                   Background="Transparent">
-                <Border Name="imageBackground"
-                        Background="Black"
-                        ClipToBounds="True" />
+            <Grid>
+                <Panel Name="framePanel"
+                       Margin="0"
+                       Background="Transparent">
+                    <Border Name="imageBackground"
+                            Background="Black"
+                            ClipToBounds="True" />
 
-                <!-- BitmapView or HdrBitmapView is created dynamically in code-behind -->
+                    <!-- BitmapView or HdrBitmapView is created dynamically in code-behind -->
 
-                <pathEditor:PathEditorView Name="pathEditorView"
-                                           DataContext="{Binding PathEditor}" />
+                    <pathEditor:PathEditorView Name="pathEditorView"
+                                               DataContext="{Binding PathEditor}" />
 
-                <local:TransformHandlesOverlay Name="transformHandlesOverlay"
-                                               IsVisible="False" />
-            </Panel>
+                    <local:TransformHandlesOverlay Name="transformHandlesOverlay"
+                                                   IsVisible="False" />
+                </Panel>
+
+                <!-- Keep the error outside framePanel so preview pan/zoom does not transform it. -->
+                <Border Name="previewRenderErrorOverlay"
+                        Padding="24"
+                        Background="{DynamicResource SmokeFillColorDefaultBrush}"
+                        IsHitTestVisible="False"
+                        IsVisible="{Binding PreviewRenderError.Value,
+                                            Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                    <Border MaxWidth="480"
+                            Padding="16"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="{DynamicResource SystemFillColorCriticalBackgroundBrush}"
+                            BorderBrush="{DynamicResource SystemFillColorCriticalBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4">
+                        <StackPanel Spacing="8">
+                            <TextBlock HorizontalAlignment="Center"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                                       Text="{x:Static lang:MessageStrings.UnexpectedError}" />
+                            <TextBlock Name="previewRenderErrorMessage"
+                                       HorizontalAlignment="Center"
+                                       AutomationProperties.LiveSetting="Assertive"
+                                       AutomationProperties.Name="{Binding PreviewRenderError.Value}"
+                                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                       Text="{Binding PreviewRenderError.Value}"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
+                </Border>
+            </Grid>
         </Player.Content>
     </Player>
 </UserControl>

--- a/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
@@ -101,7 +101,11 @@ public class PlaybackSessionGuardTests
         Task<bool> updateTask = Task.Run(() => guard.TryApply(first, () =>
         {
             updateEntered.Set();
-            releaseUpdate.Wait();
+            if (!releaseUpdate.Wait(TimeSpan.FromSeconds(5)))
+            {
+                throw new TimeoutException("The guarded update was not released within the test timeout.");
+            }
+
             state = 1;
         }));
         Assert.That(updateEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);

--- a/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs
@@ -52,4 +52,84 @@ public class PlaybackSessionGuardTests
             Assert.That(guard.Owns(sessionB), Is.True, "the new session owns the shared playback state");
         });
     }
+
+    [Test]
+    public void TryApply_only_updates_state_for_the_current_session()
+    {
+        var guard = new PlaybackSessionGuard();
+        int first = guard.Claim();
+        int second = guard.Claim();
+        int state = 0;
+
+        bool staleApplied = guard.TryApply(first, () => state = 1);
+        bool currentApplied = guard.TryApply(second, () => state = 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(staleApplied, Is.False, "a superseded timer cannot mutate shared playback state");
+            Assert.That(currentApplied, Is.True, "the current playback session can update shared state");
+            Assert.That(state, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Claim_and_Disown_apply_their_state_changes_with_the_generation_change()
+    {
+        var guard = new PlaybackSessionGuard();
+        int state = 0;
+
+        int token = guard.Claim(() => state = 1);
+        guard.Disown(() => state = 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.Owns(token), Is.False);
+            Assert.That(state, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task A_new_claim_waits_for_the_current_guarded_update_before_initializing()
+    {
+        var guard = new PlaybackSessionGuard();
+        int first = guard.Claim();
+        int state = 0;
+        using var updateEntered = new ManualResetEventSlim();
+        using var releaseUpdate = new ManualResetEventSlim();
+        using var claimStarted = new ManualResetEventSlim();
+
+        Task<bool> updateTask = Task.Run(() => guard.TryApply(first, () =>
+        {
+            updateEntered.Set();
+            releaseUpdate.Wait();
+            state = 1;
+        }));
+        Assert.That(updateEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+        Task<int> claimTask = Task.Run(() =>
+        {
+            claimStarted.Set();
+            return guard.Claim(() => state = 2);
+        });
+
+        try
+        {
+            Assert.That(claimStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            await Task.Delay(20);
+            Assert.That(claimTask.IsCompleted, Is.False,
+                "a new session cannot initialize while the old session is applying a final update");
+        }
+        finally
+        {
+            releaseUpdate.Set();
+        }
+
+        Assert.That(await updateTask, Is.True);
+        int second = await claimTask;
+        Assert.Multiple(() =>
+        {
+            Assert.That(state, Is.EqualTo(2), "the newer session initialization must be the last write");
+            Assert.That(guard.Owns(second), Is.True);
+        });
+    }
 }

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelPauseTimeoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelPauseTimeoutTests.cs
@@ -49,6 +49,44 @@ public class PlayerViewModelPauseTimeoutTests
             await PlayerViewModel.WaitForPlaybackStopAsync(faulted, TimeSpan.FromSeconds(5), logger, "scene-1"));
     }
 
+    [Test]
+    public async Task RunAudioPlaybackWithImmediateStopAsync_stops_audio_while_playback_is_blocked()
+    {
+        using var playbackCts = new CancellationTokenSource();
+        using var playbackEntered = new ManualResetEventSlim();
+        using var releasePlayback = new ManualResetEventSlim();
+        var stopped = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task playback = Task.Run(() => PlayerViewModel.RunAudioPlaybackWithImmediateStopAsync(
+            playbackCts.Token,
+            () => stopped.TrySetResult(true),
+            () =>
+            {
+                playbackEntered.Set();
+                if (!releasePlayback.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("The simulated synchronous buffer composition was not released.");
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        try
+        {
+            Assert.That(playbackEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            playbackCts.Cancel();
+
+            await stopped.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(playback.IsCompleted, Is.False,
+                "audio must stop without waiting for synchronous buffer composition to return");
+        }
+        finally
+        {
+            releasePlayback.Set();
+        }
+
+        await playback.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed class CapturingLogger : ILogger
     {
         public List<string> Errors { get; } = [];

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -189,7 +189,94 @@ public class PreviewRenderErrorTests
     }
 
     [AvaloniaTest]
-    public async Task Play_WhenRenderingFails_ShowsPreviewErrorAndStopsWithoutNotification()
+    public async Task BufferedPlayer_WhenPlaybackIsCanceledDuringRendering_DoesNotStoreFailure()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("canceled-rendering-buffered-player");
+        var drawable = new ArmablePreviewFaultDrawable();
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => drawable));
+        HeadlessTestHelpers.Settle();
+        RenderThread.Dispatcher.Invoke(static () => { });
+        editor.FrameCacheManager.Value.Clear();
+        drawable.Arm();
+
+        using var isPlaying = new ReactivePropertySlim<bool>(true);
+        using var playbackCts = new CancellationTokenSource();
+        using var player = new BufferedPlayer(
+            editor,
+            editor.Scene,
+            isPlaying,
+            editor.Player.GetFrameRate(),
+            playbackCts.Token);
+
+        try
+        {
+            player.Start();
+            await drawable.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            playbackCts.Cancel();
+            drawable.ReleaseRender();
+
+            await WaitUntilAsync(() => player.ProducerStopped, TimeSpan.FromSeconds(5));
+            Assert.That(player.Failure, Is.Null);
+        }
+        finally
+        {
+            drawable.ReleaseRender();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task BufferedPlayer_WhenDisposedDuringRendering_DoesNotStoreFailure()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("disposed-rendering-buffered-player");
+        var drawable = new ArmablePreviewFaultDrawable();
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => drawable));
+        HeadlessTestHelpers.Settle();
+        RenderThread.Dispatcher.Invoke(static () => { });
+        editor.FrameCacheManager.Value.Clear();
+        drawable.Arm();
+
+        using var isPlaying = new ReactivePropertySlim<bool>(true);
+        using var player = new BufferedPlayer(
+            editor,
+            editor.Scene,
+            isPlaying,
+            editor.Player.GetFrameRate(),
+            CancellationToken.None);
+
+        try
+        {
+            player.Start();
+            await drawable.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            player.Dispose();
+            drawable.ReleaseRender();
+
+            await WaitUntilAsync(() => player.ProducerStopped, TimeSpan.FromSeconds(5));
+            Assert.That(player.Failure, Is.Null);
+        }
+        finally
+        {
+            drawable.ReleaseRender();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Play_WhenRenderingFails_ShowsPreviewErrorAndStopsWithoutRenderNotification()
     {
         GpuTestGate.EnsureAvailable();
         await ResetProjectAsync();
@@ -217,7 +304,9 @@ public class PreviewRenderErrorTests
                 Assert.That(message, Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
                 Assert.That(editor.Player.IsPlaying.Value, Is.False);
                 Assert.That(editor.FrameCacheManager.Value.CurrentFrame, Is.EqualTo(0));
-                Assert.That(notifications.Notifications, Is.Empty);
+                Assert.That(
+                    notifications.Notifications.Select(static notification => notification.Message),
+                    Does.Not.Contain(Beutl.Language.MessageStrings.FrameDrawingException));
             });
         }
         finally
@@ -414,6 +503,41 @@ internal sealed partial class SupersededPreviewFaultDrawable : Drawable
             _releaseFirstRender.Task.GetAwaiter().GetResult();
             throw new InvalidOperationException(PreviewFaultDrawable.ErrorMessage);
         }
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(16, 16);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed partial class ArmablePreviewFaultDrawable : Drawable
+{
+    private readonly TaskCompletionSource<bool> _renderEntered =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _releaseRender =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private volatile bool _armed;
+
+    public TaskCompletionSource<bool> RenderEntered => _renderEntered;
+
+    public void Arm()
+    {
+        _armed = true;
+        Opacity.CurrentValue = 99f;
+    }
+
+    public void ReleaseRender() => _releaseRender.TrySetResult(true);
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        if (!_armed)
+            return;
+
+        _renderEntered.TrySetResult(true);
+        _releaseRender.Task.GetAwaiter().GetResult();
+        throw new InvalidOperationException(PreviewFaultDrawable.ErrorMessage);
     }
 
     protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(16, 16);

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -1,0 +1,436 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reactive.Linq;
+
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics;
+using Beutl.Graphics.Rendering;
+using Beutl.Models;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.Views;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[NonParallelizable]
+[TestFixture]
+public class PreviewRenderErrorTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            320, 240, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    private static void AddFaultingDrawable(EditViewModel editor)
+    {
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => new PreviewFaultDrawable()));
+        editor.FrameCacheManager.Value.Clear();
+    }
+
+    [AvaloniaTest]
+    public async Task QueuePreviewRender_WhenRenderingFails_ShowsPreviewErrorUntilRecoveryWithoutNotification()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preview-error");
+        INotificationServiceHandler previousHandler = NotificationService.Handler;
+        var notifications = new CaptureNotificationHandler();
+
+        try
+        {
+            NotificationService.Handler = notifications;
+            var errorReported = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = editor.Player.PreviewRenderError
+                .Where(static message => !string.IsNullOrEmpty(message))
+                .Take(1)
+                .Subscribe(message => errorReported.TrySetResult(message!));
+
+            AddFaultingDrawable(editor);
+            editor.Player.QueuePreviewRender();
+
+            string message = await errorReported.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(message, Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+            Assert.That(notifications.Notifications, Is.Empty);
+
+            var errorCleared = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable recoverySubscription = editor.Player.PreviewRenderError
+                .Where(static current => string.IsNullOrEmpty(current))
+                .Take(1)
+                .Subscribe(_ => errorCleared.TrySetResult(true));
+            var structure = editor.GetRequiredService<IElementStructureService>();
+            structure.Delete(editor.Scene, editor.Scene.Children.ToArray());
+            editor.FrameCacheManager.Value.Clear();
+            editor.Player.QueuePreviewRender();
+
+            await errorCleared.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(editor.Player.PreviewRenderError.Value, Is.Null);
+            Assert.That(notifications.Notifications, Is.Empty);
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task BufferedPlayer_WhenRenderingFails_StoresFailureWithoutNotification()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("buffered-preview-error");
+        INotificationServiceHandler previousHandler = NotificationService.Handler;
+        var notifications = new CaptureNotificationHandler();
+
+        try
+        {
+            NotificationService.Handler = notifications;
+            AddFaultingDrawable(editor);
+            using var isPlaying = new ReactivePropertySlim<bool>(true);
+            using var player = new BufferedPlayer(
+                editor, editor.Scene, isPlaying, editor.Player.GetFrameRate(), CancellationToken.None);
+
+            player.Start();
+            await WaitUntilAsync(() => player.ProducerStopped, TimeSpan.FromSeconds(5));
+
+            Assert.That(player.Failure, Is.Not.Null);
+            Assert.That(player.Failure!.Exception, Is.TypeOf<InvalidOperationException>());
+            Assert.That(player.Failure.Exception.Message, Is.EqualTo(PreviewFaultDrawable.ErrorMessage));
+            Assert.That(player.Failure.Frame, Is.EqualTo(0));
+            Assert.That(notifications.Notifications, Is.Empty);
+        }
+        finally
+        {
+            NotificationService.Handler = previousHandler;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task BufferedPlayer_WhenDrawableThrowsObjectDisposed_StoresFailure()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("buffered-object-disposed-error");
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => new PreviewObjectDisposedFaultDrawable()));
+        editor.FrameCacheManager.Value.Clear();
+        using var isPlaying = new ReactivePropertySlim<bool>(true);
+        using var player = new BufferedPlayer(
+            editor, editor.Scene, isPlaying, editor.Player.GetFrameRate(), CancellationToken.None);
+
+        player.Start();
+        await WaitUntilAsync(() => player.ProducerStopped, TimeSpan.FromSeconds(5));
+
+        Assert.That(player.Failure, Is.Not.Null);
+        Assert.That(player.Failure!.Exception, Is.TypeOf<ObjectDisposedException>());
+        Assert.That(player.Failure.Frame, Is.EqualTo(0));
+    }
+
+    [AvaloniaTest]
+    public async Task BufferedPlayer_DoesNotStartForACanceledPlaybackSession()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("canceled-buffered-player");
+        using var isPlaying = new ReactivePropertySlim<bool>(true);
+        using var playbackCts = new CancellationTokenSource();
+        playbackCts.Cancel();
+        using var player = new BufferedPlayer(
+            editor,
+            editor.Scene,
+            isPlaying,
+            editor.Player.GetFrameRate(),
+            playbackCts.Token);
+
+        player.Start();
+        await WaitUntilAsync(() => player.ProducerStopped, TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(player.Failure, Is.Null);
+            Assert.That(player.TryDequeue(out _), Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task Play_WhenRenderingFails_ShowsPreviewErrorAndStopsWithoutNotification()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("playing-preview-error");
+        INotificationServiceHandler previousHandler = NotificationService.Handler;
+        var notifications = new CaptureNotificationHandler();
+
+        try
+        {
+            NotificationService.Handler = notifications;
+            AddFaultingDrawable(editor);
+            var errorReported = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = editor.Player.PreviewRenderError
+                .Where(static message => !string.IsNullOrEmpty(message))
+                .Take(1)
+                .Subscribe(message => errorReported.TrySetResult(message!));
+
+            editor.Player.Play();
+
+            string message = await errorReported.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await WaitUntilAsync(() => !editor.Player.IsPlaying.Value, TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(message, Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+                Assert.That(editor.Player.IsPlaying.Value, Is.False);
+                Assert.That(editor.FrameCacheManager.Value.CurrentFrame, Is.EqualTo(0));
+                Assert.That(notifications.Notifications, Is.Empty);
+            });
+        }
+        finally
+        {
+            await editor.Player.Pause();
+            NotificationService.Handler = previousHandler;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PlaybackRenderFailure_UpdatesPreviewStateAndStopsPlayback()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("playback-preview-error");
+        IEditorClock clock = editor.GetRequiredService<IEditorClock>();
+        const int frame = 7;
+        const int rate = 30;
+        editor.Player.IsPlaying.Value = true;
+
+        bool applied = editor.Player.ApplyPlaybackRenderFailure(
+            new BufferedPlayer.RenderFailure(new InvalidOperationException(PreviewFaultDrawable.ErrorMessage), frame),
+            rate,
+            static () => true);
+        HeadlessTestHelpers.Settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.True);
+            Assert.That(editor.Player.IsPlaying.Value, Is.False);
+            Assert.That(clock.CurrentTime.Value, Is.EqualTo(TimeSpan.FromSeconds((double)frame / rate)));
+            Assert.That(editor.FrameCacheManager.Value.CurrentFrame, Is.EqualTo(frame));
+            Assert.That(
+                editor.Player.PreviewRenderError.Value,
+                Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task SupersededRenderFailure_DoesNotReplaceTheNewerSuccessfulPreview()
+    {
+        GpuTestGate.EnsureAvailable();
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("superseded-preview-error");
+        var drawable = new SupersededPreviewFaultDrawable();
+        var adder = (IElementAdder)editor.GetRequiredService<IElementAdder>();
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => drawable));
+        editor.FrameCacheManager.Value.Clear();
+
+        try
+        {
+            editor.Player.QueuePreviewRender();
+            await drawable.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var rendered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = editor.Player.AfterRendered
+                .Take(1)
+                .Subscribe(_ => rendered.TrySetResult(true));
+            editor.Player.QueuePreviewRender();
+            drawable.ReleaseFirstRender();
+
+            await rendered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            HeadlessTestHelpers.Settle();
+
+            Assert.That(editor.Player.PreviewRenderError.Value, Is.Null);
+        }
+        finally
+        {
+            drawable.ReleaseFirstRender();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PlayerView_TracksPreviewRenderErrorVisibility()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preview-error-overlay");
+        var view = new PlayerView { DataContext = editor.Player };
+        var window = new Window { Content = view, Width = 640, Height = 480 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Panel framePanel = view.FindControl<Panel>("framePanel")!;
+            Border overlay = view.FindControl<Border>("previewRenderErrorOverlay")!;
+            TextBlock message = view.FindControl<TextBlock>("previewRenderErrorMessage")!;
+            Assert.That(framePanel, Is.Not.Null);
+            Assert.That(overlay, Is.Not.Null);
+            Assert.That(message, Is.Not.Null);
+            Assert.That(overlay.Parent, Is.SameAs(framePanel.Parent),
+                "The error overlay must remain a sibling of the transformed preview panel.");
+            Assert.That(
+                AutomationProperties.GetLiveSetting(message),
+                Is.EqualTo(AutomationLiveSetting.Assertive));
+            Assert.That(overlay.IsVisible, Is.False);
+
+            editor.Player.SetPreviewRenderError(Beutl.Language.MessageStrings.FrameDrawingException);
+            HeadlessTestHelpers.Render();
+
+            Assert.That(overlay.IsVisible, Is.True);
+            Assert.That(message.Text, Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+            Assert.That(
+                AutomationProperties.GetName(message),
+                Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+
+            editor.Player.SetPreviewRenderError(null);
+            HeadlessTestHelpers.Render();
+
+            Assert.That(overlay.IsVisible, Is.False);
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PreviewRenderError_LatestQueuedUpdateWins()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preview-error-order");
+
+        await Task.Run(() =>
+        {
+            editor.Player.SetPreviewRenderError("superseded");
+            editor.Player.SetPreviewRenderError(Beutl.Language.MessageStrings.FrameDrawingException);
+        });
+        HeadlessTestHelpers.Settle();
+
+        Assert.That(
+            editor.Player.PreviewRenderError.Value,
+            Is.EqualTo(Beutl.Language.MessageStrings.FrameDrawingException));
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.Elapsed >= timeout)
+            {
+                Assert.Fail($"Condition was not met within {timeout}.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        public ConcurrentQueue<Notification> Notifications { get; } = new();
+
+        public void Show(Notification notification) => Notifications.Enqueue(notification);
+    }
+}
+
+internal sealed partial class PreviewFaultDrawable : Drawable
+{
+    public const string ErrorMessage = "preview render failed";
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+        => throw new InvalidOperationException(ErrorMessage);
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(16, 16);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed partial class SupersededPreviewFaultDrawable : Drawable
+{
+    private readonly TaskCompletionSource<bool> _renderEntered =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _releaseFirstRender =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _renderCount;
+
+    public TaskCompletionSource<bool> RenderEntered => _renderEntered;
+
+    public void ReleaseFirstRender() => _releaseFirstRender.TrySetResult(true);
+
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+    {
+        if (Interlocked.Increment(ref _renderCount) == 1)
+        {
+            _renderEntered.TrySetResult(true);
+            _releaseFirstRender.Task.GetAwaiter().GetResult();
+            throw new InvalidOperationException(PreviewFaultDrawable.ErrorMessage);
+        }
+    }
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(16, 16);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}
+
+internal sealed partial class PreviewObjectDisposedFaultDrawable : Drawable
+{
+    public override void Render(GraphicsContext2D context, Drawable.Resource resource)
+        => throw new ObjectDisposedException(nameof(PreviewObjectDisposedFaultDrawable));
+
+    protected override Size MeasureCore(Size availableSize, Drawable.Resource resource) => new(16, 16);
+
+    protected override void OnDraw(GraphicsContext2D context, Drawable.Resource resource)
+    {
+    }
+}


### PR DESCRIPTION
## Description

- Display preview rendering failures directly over the preview instead of sending global error notifications, keeping the failure associated with the affected surface.
- Propagate buffered playback failures to the preview, stop playback at the failed frame, and prevent stale playback sessions or superseded render requests from overwriting newer state.
- Clear the error after a successful render and expose the overlay as an assertive accessible live region.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- Added `tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs` covering paused and active playback failures, notification suppression, recovery, cancellation, stale render supersession, failure ordering, and accessible overlay behavior.
- Updated `tests/Beutl.HeadlessUITests/PlaybackSessionGuardTests.cs` to cover atomic session claims, disowning, and guarded state updates.
- Ran the focused Headless UI test suite: 18 passed, 0 failed, 0 skipped.
- Built `src/Beutl/Beutl.csproj` for `net10.0-windows`: succeeded with 0 errors.
- Ran `dotnet format --verify-no-changes` and `git diff --check`: passed.
- Manual recording: None; overlay visibility and accessibility behavior are covered by headless UI assertions.

## Fixed issues / References

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a player overlay to display preview rendering errors (“UnexpectedError” with the detailed message).
  - Exposed a `PreviewRenderError` reactive property to drive the new UI.

- **Bug Fixes**
  - Rendering failures are now handled more reliably: playback stops, previews recover after successful renders, and failures are prevented from being superseded incorrectly.
  - Improved cancellation/disposal behavior for rendering and audio playback, including safer resource cleanup.

- **Tests**
  - Expanded coverage for preview error behavior, cancellation/disposal paths, and generation-safe concurrent playback session updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->