### PR TITLE
fix: Resolve relative file-source URIs in AgentToolkit document apply

### DIFF
--- a/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
+++ b/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
@@ -17,12 +17,17 @@ namespace Beutl.AgentToolkit.Documents;
 
 internal sealed class DeclarativeDocumentApplier
 {
+    // Fallback base for objects not attached to the hierarchy yet (newly created identity-list members),
+    // whose own ancestry cannot supply the Uri their relative file sources were written against.
+    private Uri? _documentBaseUri;
+
     public void Apply(CoreObject root, JsonObject document)
     {
+        _documentBaseUri = ResolveBaseUri(root);
         ApplyCoreObject(root, document);
     }
 
-    private static void ApplyCoreObject(CoreObject target, JsonObject desired)
+    private void ApplyCoreObject(CoreObject target, JsonObject desired)
     {
         switch (target)
         {
@@ -49,7 +54,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyScene(Scene scene, JsonObject desired)
+    private void ApplyScene(Scene scene, JsonObject desired)
     {
         ApplyRegisteredProperties(
             scene,
@@ -97,7 +102,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyElement(Element element, JsonObject desired)
+    private void ApplyElement(Element element, JsonObject desired)
     {
         JsonObject payload = (JsonObject)desired.DeepClone();
         payload.Remove(nameof(Element.Objects));
@@ -119,7 +124,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyEngineObject(EngineObject target, JsonObject desired)
+    private void ApplyEngineObject(EngineObject target, JsonObject desired)
     {
         JsonObject payload = (JsonObject)desired.DeepClone();
         payload.Remove("Animations");
@@ -141,7 +146,7 @@ internal sealed class DeclarativeDocumentApplier
         ApplyExpressions(target, desired);
     }
 
-    private static void ApplyKeyFrameAnimation(KeyFrameAnimation animation, JsonObject desired)
+    private void ApplyKeyFrameAnimation(KeyFrameAnimation animation, JsonObject desired)
     {
         JsonObject payload = (JsonObject)desired.DeepClone();
         payload.Remove(nameof(KeyFrameAnimation.KeyFrames));
@@ -152,7 +157,7 @@ internal sealed class DeclarativeDocumentApplier
 
         if (desired.TryGetPropertyValue(nameof(KeyFrameAnimation.KeyFrames), out JsonNode? keyframesNode))
         {
-            ApplyKeyFrameList(animation.KeyFrames, RequireArrayMember(keyframesNode, nameof(KeyFrameAnimation.KeyFrames)));
+            ApplyKeyFrameList(animation.KeyFrames, RequireArrayMember(keyframesNode, nameof(KeyFrameAnimation.KeyFrames)), animation);
         }
         else
         {
@@ -160,7 +165,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyKeyFrame(IKeyFrame keyFrame, JsonObject desired)
+    private void ApplyKeyFrame(IKeyFrame keyFrame, JsonObject desired)
     {
         if (keyFrame is CoreObject coreObject)
         {
@@ -189,11 +194,11 @@ internal sealed class DeclarativeDocumentApplier
             keyFrame.KeyTime = (TimeSpan)CoreSerializer.DeserializeFromJsonNode(
                 keyTimeNode.DeepClone(),
                 typeof(TimeSpan),
-                keyFrame is CoreObject keyFrameCore ? CreateOptions(keyFrameCore) : CreateOptions(null))!;
+                CreateOptions(keyFrame as CoreObject))!;
         }
     }
 
-    private static void ApplyRegisteredProperties(CoreObject target, JsonObject desired, IReadOnlySet<string> excluded)
+    private void ApplyRegisteredProperties(CoreObject target, JsonObject desired, IReadOnlySet<string> excluded)
     {
         foreach (CoreProperty property in PropertyRegistry.GetRegistered(target.GetType()))
         {
@@ -277,7 +282,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyListProperties(EngineObject target, JsonObject desired)
+    private void ApplyListProperties(EngineObject target, JsonObject desired)
     {
         foreach (IListProperty listProperty in target.Properties.OfType<IListProperty>())
         {
@@ -292,7 +297,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyAnimations(EngineObject target, JsonObject desired)
+    private void ApplyAnimations(EngineObject target, JsonObject desired)
     {
         JsonObject? animations = desired.TryGetPropertyValue("Animations", out JsonNode? animationsNode)
             ? RequireObjectMember(animationsNode, "Animations")
@@ -334,7 +339,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyAnimation(IProperty property, JsonObject animationJson)
+    private void ApplyAnimation(IProperty property, JsonObject animationJson)
     {
         IAnimation? current = property.Animation;
         if (current is CoreObject currentObject
@@ -409,11 +414,11 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyIdentityList(IList list, Type elementBaseType, string fieldName, JsonArray desired, CoreObject? owner)
+    private void ApplyIdentityList(IList list, Type elementBaseType, string fieldName, JsonArray desired, CoreObject? owner)
     {
         if (!IsIdentityArray(desired))
         {
-            ReplaceList(list, elementBaseType, fieldName, desired);
+            ReplaceList(list, elementBaseType, fieldName, desired, owner);
             return;
         }
 
@@ -443,12 +448,17 @@ internal sealed class DeclarativeDocumentApplier
                 }
                 else
                 {
-                    item = CreateIdentityListItem(itemJson, elementBaseType);
+                    item = CreateIdentityListItem(itemJson, elementBaseType, owner);
                     if (owner is Scene scene && item is Element element)
                     {
                         JsonObject elementJson = (JsonObject)itemJson.DeepClone();
                         elementJson.Remove("Uri");
-                        ApplyCoreObject(element, elementJson);
+                        // The subtree's relative media URIs were written against the incoming
+                        // element's own .belm, which may sit in a subdirectory of the scene. That
+                        // path only survives in the JSON: the element is still detached here, and
+                        // AssignNewElementUri later rehomes it directly under the scene.
+                        Uri? incomingBaseUri = ResolveIncomingElementBaseUri(scene, itemJson);
+                        ApplyDetached(element, elementJson, incomingBaseUri);
                         AssignNewElementUri(scene, element);
                     }
                     else
@@ -519,7 +529,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ApplyKeyFrameList(KeyFrames list, JsonArray desired)
+    private void ApplyKeyFrameList(KeyFrames list, JsonArray desired, CoreObject? owner)
     {
         var desiredIds = new HashSet<Guid>();
         for (int index = 0; index < desired.Count; index++)
@@ -546,7 +556,7 @@ internal sealed class DeclarativeDocumentApplier
                 item = (CoreObject)CoreSerializer.DeserializeFromJsonObject(
                     NormalizeCoreSerializableJson(itemJson, typeof(IKeyFrame)),
                     typeof(IKeyFrame),
-                    CreateOptions(null));
+                    CreateOptions(owner));
                 list.Add((IKeyFrame)item, out _);
             }
 
@@ -579,7 +589,7 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static void ReplaceList(IList list, Type elementBaseType, string fieldName, JsonArray desired)
+    private void ReplaceList(IList list, Type elementBaseType, string fieldName, JsonArray desired, CoreObject? owner)
     {
         bool typedObjectList = typeof(ICoreSerializable).IsAssignableFrom(elementBaseType);
         // Validate and deserialize every entry before mutating the target: DocumentAdapter.Write can run
@@ -611,8 +621,8 @@ internal sealed class DeclarativeDocumentApplier
                 ? CoreSerializer.DeserializeFromJsonObject(
                     NormalizeCoreSerializableJson(obj, elementBaseType),
                     elementBaseType,
-                    CreateOptions(null))
-                : EnumJsonValueNormalizer.Deserialize(node, elementBaseType, CreateOptions(null)));
+                    CreateOptions(owner))
+                : EnumJsonValueNormalizer.Deserialize(node, elementBaseType, CreateOptions(owner)));
         }
 
         list.Clear();
@@ -657,7 +667,7 @@ internal sealed class DeclarativeDocumentApplier
             $"Provide '{fieldName}' as an object keyed by property name, or omit it entirely to clear it."));
     }
 
-    private static CoreObject CreateIdentityListItem(JsonObject itemJson, Type elementBaseType)
+    private CoreObject CreateIdentityListItem(JsonObject itemJson, Type elementBaseType, CoreObject? owner)
     {
         var shell = new JsonObject();
         CopyIfPresent(itemJson, shell, "$type");
@@ -666,7 +676,7 @@ internal sealed class DeclarativeDocumentApplier
         return (CoreObject)CoreSerializer.DeserializeFromJsonObject(
             NormalizeCoreSerializableJson(shell, elementBaseType),
             elementBaseType,
-            CreateOptions(null));
+            CreateOptions(owner));
     }
 
     private static void CopyIfPresent(JsonObject source, JsonObject destination, string propertyName)
@@ -865,12 +875,64 @@ internal sealed class DeclarativeDocumentApplier
         list.Insert(Math.Clamp(newIndex, 0, list.Count), item);
     }
 
-    internal static CoreSerializerOptions CreateOptions(CoreObject? root)
+    // Applies a subtree whose relative file sources were written against a base other than the
+    // document root's, for objects that cannot reach that base through HierarchicalParent.
+    private void ApplyDetached(CoreObject target, JsonObject desired, Uri? baseUri)
+    {
+        Uri? previous = _documentBaseUri;
+        _documentBaseUri = baseUri ?? previous;
+        try
+        {
+            ApplyCoreObject(target, desired);
+        }
+        finally
+        {
+            _documentBaseUri = previous;
+        }
+    }
+
+    private static Uri? ResolveIncomingElementBaseUri(Scene scene, JsonObject itemJson)
+    {
+        return itemJson["Uri"] is JsonValue value
+               && value.TryGetValue(out string? relative)
+               && Uri.TryCreate(scene.Uri, Uri.UnescapeDataString(relative), out Uri? uri)
+            ? uri
+            : null;
+    }
+
+    private CoreSerializerOptions CreateOptions(CoreObject? target)
+    {
+        return CreateOptions(ResolveBaseUri(target) ?? _documentBaseUri);
+    }
+
+    internal static CoreSerializerOptions CreateOptions(Uri? baseUri)
     {
         return new CoreSerializerOptions
         {
-            BaseUri = root?.Uri,
+            BaseUri = baseUri,
             Mode = CoreSerializationMode.Read | CoreSerializationMode.EmbedReferencedObjects
         };
+    }
+
+    // Mirrors the serializer's context chain: a nested object inherits the BaseUri of the nearest
+    // ancestor that owns a Uri, which is what its relative file-source URIs were written against.
+    internal static Uri? ResolveBaseUri(CoreObject? target)
+    {
+        if (target?.Uri is { } own)
+        {
+            return own;
+        }
+
+        for (IHierarchical? parent = (target as IHierarchical)?.HierarchicalParent;
+             parent is not null;
+             parent = parent.HierarchicalParent)
+        {
+            if (parent is CoreObject { Uri: not null } owner)
+            {
+                return owner.Uri;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
+++ b/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
@@ -457,7 +457,7 @@ internal sealed class DeclarativeDocumentApplier
                         // element's own .belm, which may sit in a subdirectory of the scene. That
                         // path only survives in the JSON: the element is still detached here, and
                         // AssignNewElementUri later rehomes it directly under the scene.
-                        Uri? incomingBaseUri = ResolveIncomingElementBaseUri(scene, itemJson);
+                        Uri? incomingBaseUri = ResolveIncomingBaseUri(scene.Uri, itemJson);
                         ApplyDetached(element, elementJson, incomingBaseUri);
                         AssignNewElementUri(scene, element);
                     }
@@ -620,10 +620,7 @@ internal sealed class DeclarativeDocumentApplier
             }
 
             items.Add(node is JsonObject obj && typedObjectList
-                ? CoreSerializer.DeserializeFromJsonObject(
-                    NormalizeCoreSerializableJson(obj, elementBaseType),
-                    elementBaseType,
-                    CreateOptions(owner))
+                ? DeserializeListItem(obj, elementBaseType, ResolveBaseUri(owner) ?? _documentBaseUri)
                 : EnumJsonValueNormalizer.Deserialize(node, elementBaseType, CreateOptions(owner)));
         }
 
@@ -893,11 +890,27 @@ internal sealed class DeclarativeDocumentApplier
         }
     }
 
-    private static Uri? ResolveIncomingElementBaseUri(Scene scene, JsonObject itemJson)
+    // An embedded object that carries its own "Uri" is the base for its own subtree. CoreSerializer
+    // resolves that field but leaves BaseUri alone when options are already non-null (ReflectUri's
+    // `options ??=`), so the object's Uri is absolutized here and the resolved value passed as the
+    // base — absolutizing keeps ReflectUri from re-resolving it against itself.
+    private object DeserializeListItem(JsonObject itemJson, Type elementBaseType, Uri? ownerBaseUri)
+    {
+        JsonObject normalized = NormalizeCoreSerializableJson(itemJson, elementBaseType);
+        if (ResolveIncomingBaseUri(ownerBaseUri, itemJson) is { } ownUri)
+        {
+            normalized["Uri"] = ownUri.ToString();
+            return CoreSerializer.DeserializeFromJsonObject(normalized, elementBaseType, CreateOptions(ownUri));
+        }
+
+        return CoreSerializer.DeserializeFromJsonObject(normalized, elementBaseType, CreateOptions(ownerBaseUri));
+    }
+
+    private static Uri? ResolveIncomingBaseUri(Uri? parentBaseUri, JsonObject itemJson)
     {
         return itemJson["Uri"] is JsonValue value
                && value.TryGetValue(out string? relative)
-               && Uri.TryCreate(scene.Uri, Uri.UnescapeDataString(relative), out Uri? uri)
+               && Uri.TryCreate(parentBaseUri, Uri.UnescapeDataString(relative), out Uri? uri)
             ? uri
             : null;
     }

--- a/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
+++ b/src/Beutl.AgentToolkit/Documents/DeclarativeDocumentApplier.cs
@@ -463,7 +463,9 @@ internal sealed class DeclarativeDocumentApplier
                     }
                     else
                     {
-                        ApplyCoreObject(item, itemJson);
+                        // Same detachment as above: the item is populated before insertion, so it
+                        // cannot reach the owner through HierarchicalParent.
+                        ApplyDetached(item, itemJson, ResolveBaseUri(owner));
                     }
                 }
             }

--- a/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
@@ -1034,7 +1034,8 @@ public sealed class Reconciler
                 return;
             }
 
-            CoreSerializerOptions options = DeclarativeDocumentApplier.CreateOptions(target);
+            CoreSerializerOptions options = DeclarativeDocumentApplier.CreateOptions(
+                DeclarativeDocumentApplier.ResolveBaseUri(target) ?? root.Uri);
 
             if (PropertyRegistry.FindRegistered(target, propertyName) is { } coreProperty)
             {

--- a/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
@@ -13,6 +13,7 @@ namespace Beutl.AgentToolkit.Tests.Documents;
 // detectable difference rather than the same answer by coincidence.
 // KeyFrame values are not covered: every in-tree media property is a non-animatable
 // SimpleProperty, so only a plugin could produce a media-valued keyframe.
+[TestFixture]
 public class RelativeFileSourceApplyTests
 {
     [Test]
@@ -62,6 +63,27 @@ public class RelativeFileSourceApplyTests
 
         Assert.That(target.Children, Has.Count.EqualTo(1));
         Assert.That(SourceUriOf(target.Children[0])?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    [Test]
+    public void Write_resolves_a_relative_file_source_uri_on_an_object_added_to_an_existing_element()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        var scene = new Scene(1920, 1080, "Scene") { Uri = new Uri(Path.Combine(dir, "Scene.scene")) };
+        Element element = CreateElement(Path.Combine(subDir, "media.belm"), imagePath);
+        scene.Children.Add(element);
+        var adapter = new DocumentAdapter();
+        JsonObject document = adapter.Read(scene);
+
+        // The element stays Id-matched so only the object is new: it is populated before insertion
+        // and cannot reach the element's .belm through HierarchicalParent, while the ambient
+        // document root is the scene, whose directory differs from the element's.
+        element.Objects.Clear();
+        adapter.Write(scene, document);
+
+        Assert.That(SourceUriOf(element)?.LocalPath, Is.EqualTo(imagePath));
     }
 
     [Test]

--- a/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
@@ -87,6 +87,30 @@ public class RelativeFileSourceApplyTests
     }
 
     [Test]
+    public void Write_resolves_a_relative_file_source_uri_on_a_wholesale_replaced_element_list()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        var sceneUri = new Uri(Path.Combine(dir, "Scene.scene"));
+        var source = new Scene(1920, 1080, "Scene") { Uri = sceneUri };
+        source.Children.Add(CreateElement(Path.Combine(subDir, "media.belm"), imagePath));
+        var adapter = new DocumentAdapter();
+
+        JsonObject document = adapter.Read(source);
+        foreach (JsonObject item in RequireArray(document, "Elements").OfType<JsonObject>())
+        {
+            item.Remove(nameof(CoreObject.Id));
+        }
+
+        var target = new Scene(1920, 1080, "Scene") { Uri = sceneUri };
+        adapter.Write(target, document);
+
+        Assert.That(target.Children, Has.Count.EqualTo(1));
+        Assert.That(SourceUriOf(target.Children[0])?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    [Test]
     public void Write_resolves_a_relative_file_source_uri_on_a_wholesale_replaced_object_list()
     {
         string dir = CreateWorkspace();

--- a/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs
@@ -1,0 +1,128 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.AgentToolkit.Documents;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+
+namespace Beutl.AgentToolkit.Tests.Documents;
+
+// Media URIs are written relative to the owning element's .belm, which Scene stores as a path
+// relative to the scene file and may therefore sit in a subdirectory. Every case below keeps the
+// .belm in a subdirectory so that resolving against the scene instead of the element is a
+// detectable difference rather than the same answer by coincidence.
+// KeyFrame values are not covered: every in-tree media property is a non-animatable
+// SimpleProperty, so only a plugin could produce a media-valued keyframe.
+public class RelativeFileSourceApplyTests
+{
+    [Test]
+    public void Write_resolves_a_relative_file_source_uri_nested_under_an_element()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        var scene = new Scene(1920, 1080, "Scene") { Uri = new Uri(Path.Combine(dir, "Scene.scene")) };
+        Element element = CreateElement(Path.Combine(subDir, "media.belm"), imagePath);
+        scene.Children.Add(element);
+        var adapter = new DocumentAdapter();
+
+        JsonObject document = adapter.Read(scene);
+        adapter.Write(scene, document);
+
+        Assert.That(SourceUriOf(element)?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    [Test]
+    public void Write_resolves_a_relative_file_source_uri_on_an_element_subtree()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        Element element = CreateElement(Path.Combine(subDir, "media.belm"), imagePath);
+        var adapter = new DocumentAdapter();
+
+        JsonObject document = adapter.Read(element);
+        adapter.Write(element, document);
+
+        Assert.That(SourceUriOf(element)?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    [Test]
+    public void Write_resolves_a_relative_file_source_uri_on_a_newly_inserted_element()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        JsonObject document = ReadSceneDocument(dir, subDir, imagePath);
+
+        // The element does not exist on the target scene yet, so it is created detached from the
+        // hierarchy and cannot reach its own .belm through HierarchicalParent.
+        var target = new Scene(1920, 1080, "Scene") { Uri = new Uri(Path.Combine(dir, "Scene.scene")) };
+        new DocumentAdapter().Write(target, document);
+
+        Assert.That(target.Children, Has.Count.EqualTo(1));
+        Assert.That(SourceUriOf(target.Children[0])?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    [Test]
+    public void Write_resolves_a_relative_file_source_uri_on_a_wholesale_replaced_object_list()
+    {
+        string dir = CreateWorkspace();
+        string subDir = CreateSubDirectory(dir);
+        string imagePath = CreateImage(subDir);
+        Element element = CreateElement(Path.Combine(subDir, "media.belm"), imagePath);
+        var adapter = new DocumentAdapter();
+
+        JsonObject document = adapter.Read(element);
+        // Dropping every Id makes Objects a non-identity array, which routes the apply through the
+        // wholesale ReplaceList path instead of the per-item identity path.
+        foreach (JsonObject item in RequireArray(document, nameof(Element.Objects)).OfType<JsonObject>())
+        {
+            item.Remove(nameof(CoreObject.Id));
+        }
+
+        adapter.Write(element, document);
+
+        Assert.That(SourceUriOf(element)?.LocalPath, Is.EqualTo(imagePath));
+    }
+
+    private static JsonObject ReadSceneDocument(string dir, string subDir, string imagePath)
+    {
+        var source = new Scene(1920, 1080, "Scene") { Uri = new Uri(Path.Combine(dir, "Scene.scene")) };
+        source.Children.Add(CreateElement(Path.Combine(subDir, "media.belm"), imagePath));
+        return new DocumentAdapter().Read(source);
+    }
+
+    private static Element CreateElement(string belmPath, string imagePath)
+    {
+        var source = new ImageSource();
+        source.ReadFrom(new Uri(imagePath));
+        var element = new Element { Length = TimeSpan.FromSeconds(1), Uri = new Uri(belmPath) };
+        element.Objects.Add(new SourceImage { Source = { CurrentValue = source } });
+        return element;
+    }
+
+    private static Uri? SourceUriOf(Element element)
+        => element.Objects.OfType<SourceImage>().Single().Source.CurrentValue?.Uri;
+
+    private static JsonArray RequireArray(JsonObject document, string name)
+        => document[name] as JsonArray ?? throw new InvalidOperationException($"'{name}' is not an array.");
+
+    private static string CreateImage(string dir)
+    {
+        string path = Path.Combine(dir, "source.png");
+        using var bitmap = new Bitmap(8, 8);
+        Assert.That(bitmap.Save(path, EncodedImageFormat.Png), Is.True);
+        return path;
+    }
+
+    private static string CreateSubDirectory(string dir)
+        => Directory.CreateDirectory(Path.Combine(dir, "sub")).FullName;
+
+    private static string CreateWorkspace()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
## Description
- Agent Editing Toolkit (MCP) sessions broke permanently once an element referenced media: `DeclarativeDocumentApplier.CreateOptions` was handed the object being populated instead of the document root, so a nested `EngineObject` (whose `Uri` is always null) produced a null `BaseUri` and `FileSourceJsonConverter` threw `Invalid relative URI` for every subsequent `apply_edit`.
- Resolve the base URI the way the serializer's own context chain builds it — the nearest ancestor that owns a `Uri`, which is exactly what the relative URIs were written against.
- Newly created identity-list members are still detached from the hierarchy when they are populated. A new element under a scene therefore takes its base from the incoming JSON `Uri` (its own `.belm`, which may sit in a scene subdirectory); everything else falls back to the document root.

## Affected areas
- [ ] `Beutl.Engine` / `Beutl.ProjectSystem` / UI / `Beutl.Extensibility` / `Beutl.NodeGraph` / FFmpeg / `Beutl.Api` / Build-CI-docs

`Beutl.AgentToolkit` only — not covered by the checklist above. No other module is touched.

## Breaking changes
None. The change is confined to `internal` members of `Beutl.AgentToolkit`.

## Test plan
`tests/Beutl.AgentToolkit.Tests/Documents/RelativeFileSourceApplyTests.cs` (new, 4 tests) — all red before the fix, green after:
- media nested under an attached element
- an element subtree applied on its own
- a newly inserted element (detached-object path)
- a wholesale `ReplaceList` replacement (non-identity array)

Every case keeps the `.belm` in a scene subdirectory so that resolving against the scene instead of the element is a detectable difference. Without that, both bases give the same answer and the detached-object path silently resolves to a wrong path with no exception — `ImageSource.ReadFrom` does not check existence, so the failure would only surface at render time.

KeyFrame values are not covered: every in-tree media property is a non-animatable `SimpleProperty`, so only a plugin could produce a media-valued keyframe.

`dotnet test tests/Beutl.AgentToolkit.Tests` — 486 passed. `dotnet format` applied.

## Fixed issues / References
- Closes #2108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolution of relative media/image “source” URIs when opening or writing documents, including nested elements, detached subtrees, newly inserted elements, element/object list replacements, and object-added cases.
  * Improved base-URI inheritance so deserialization (including keyframe-related data) consistently resolves relative references to the correct owning context.
  * Validation now resolves property values using the correct base URI derived from the target document.

* **Tests**
  * Added NUnit coverage for relative file-source URI resolution across element-in-scene, subtree writes, insertions, object additions, and wholesale replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->