### PR TITLE
fix!: Serialize AgentToolkit validation payloads instead of live engine objects

### DIFF
--- a/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
@@ -1033,7 +1033,7 @@ public sealed class Reconciler
             {
                 string? easingError = DeclarativeDocumentApplier.ValidateEasingNode(valueNode);
                 validation.Add(easingError is null
-                    ? ValidationOutcome.Ok(valueNode?.DeepClone(), options: null)
+                    ? ValidationOutcome.Ok(valueNode, options: null)
                     : ValidationOutcome.Rejected(null, $"{propertyName}: {easingError}", options: null));
                 return;
             }

--- a/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
@@ -228,7 +228,7 @@ public sealed class Reconciler
             string lengthText = elementLength.ToString("c");
             string message = $"UseGlobalClock=false keyframe at '{keyFramePath}' has KeyTime '{keyTime:c}' outside Element '{elementName}' local range '00:00:00'..'{lengthText}' (Element Start '{elementStart}', Length '{lengthText}').";
             string hint = "For UseGlobalClock=false, KeyTime is local to the owning timeline element. Use 00:00:00..Element.Length, or set UseGlobalClock=true when the KeyTime values are scene timeline times.";
-            validation.Add(ValidationOutcome.Warning(keyTime.ToString("c"), message, hint));
+            validation.Add(ValidationOutcome.Warning(keyTime.ToString("c"), message, options: null, hint));
         }
     }
 
@@ -598,6 +598,7 @@ public sealed class Reconciler
             validation.Add(ValidationOutcome.Rejected(
                 element.Start.ToString("c"),
                 $"Element {identity} Start '{element.Start:c}' must be non-negative.",
+                options: null,
                 $"Set a non-negative Start on element {element.Id}."));
         }
 
@@ -606,6 +607,7 @@ public sealed class Reconciler
             validation.Add(ValidationOutcome.Rejected(
                 element.Length.ToString("c"),
                 $"Element {identity} Length '{element.Length:c}' must be positive.",
+                options: null,
                 $"Set a positive Length on element {element.Id}."));
         }
     }
@@ -625,6 +627,7 @@ public sealed class Reconciler
             validation.Add(ValidationOutcome.Rejected(
                 $"{scene.FrameSize.Width}x{scene.FrameSize.Height}",
                 $"Scene frame size '{scene.FrameSize.Width}x{scene.FrameSize.Height}' must be positive.",
+                options: null,
                 "Set Width and Height to positive pixel values before applying."));
         }
 
@@ -633,6 +636,7 @@ public sealed class Reconciler
             validation.Add(ValidationOutcome.Rejected(
                 scene.Duration.ToString("c"),
                 $"Scene duration '{scene.Duration:c}' must be positive.",
+                options: null,
                 "Set a positive Duration before applying."));
         }
     }
@@ -1029,8 +1033,8 @@ public sealed class Reconciler
             {
                 string? easingError = DeclarativeDocumentApplier.ValidateEasingNode(valueNode);
                 validation.Add(easingError is null
-                    ? ValidationOutcome.Ok(valueNode?.DeepClone())
-                    : ValidationOutcome.Rejected(null, $"{propertyName}: {easingError}", null));
+                    ? ValidationOutcome.Ok(valueNode?.DeepClone(), options: null)
+                    : ValidationOutcome.Rejected(null, $"{propertyName}: {easingError}", options: null));
                 return;
             }
 
@@ -1061,6 +1065,7 @@ public sealed class Reconciler
             validation.Add(ValidationOutcome.Rejected(
                 null,
                 $"{propertyName}: {ex.Message}",
+                options: null,
                 targetType is null ? null : ValidationEvaluator.CreateValueHint(targetType)));
         }
     }

--- a/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/Reconciler.cs
@@ -1042,7 +1042,7 @@ public sealed class Reconciler
                 object? value = valueNode is null
                     ? null
                     : EnumJsonValueNormalizer.Deserialize(valueNode, coreProperty.PropertyType, options);
-                validation.Add(ValidationEvaluator.Evaluate(target, coreProperty, value));
+                validation.Add(ValidationEvaluator.Evaluate(target, coreProperty, value, options));
                 return;
             }
 
@@ -1052,7 +1052,7 @@ public sealed class Reconciler
                 object? value = valueNode is null
                     ? null
                     : EnumJsonValueNormalizer.Deserialize(valueNode, engineProperty.ValueType, options);
-                validation.Add(ValidationEvaluator.Evaluate(engineProperty, value));
+                validation.Add(ValidationEvaluator.Evaluate(engineProperty, value, options));
             }
         }
         catch (Exception ex)

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
@@ -2,10 +2,14 @@
 using System.Text.Json.Serialization;
 using Beutl.Engine;
 using Beutl.Media;
+using Beutl.Serialization;
 using Beutl.Validation;
 
 namespace Beutl.AgentToolkit.Reconciliation;
 
+// Written by name so the payload matches ReconcilePlan.ValidationStatuses, which keys off
+// Status.ToString(); the Web serializer defaults would otherwise emit a bare ordinal.
+[JsonConverter(typeof(JsonStringEnumConverter<ValidationStatus>))]
 public enum ValidationStatus
 {
     Ok,
@@ -22,37 +26,40 @@ public sealed record ValidationOutcome(
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? Hint = null)
 {
-    public static ValidationOutcome Ok(object? value)
+    public static ValidationOutcome Ok(object? value, CoreSerializerOptions? options = null)
     {
-        JsonNode? node = ValidationValueNode.From(value);
+        JsonNode? node = ValidationValueNode.From(value, options);
         return new ValidationOutcome(ValidationStatus.Ok, node, node?.DeepClone(), null);
     }
 
-    public static ValidationOutcome Coerced(object? original, object? coerced)
+    public static ValidationOutcome Coerced(object? original, object? coerced, CoreSerializerOptions? options = null)
     {
         return new ValidationOutcome(
             ValidationStatus.Coerced,
-            ValidationValueNode.From(original),
-            ValidationValueNode.From(coerced),
+            ValidationValueNode.From(original, options),
+            ValidationValueNode.From(coerced, options),
             null);
     }
 
-    public static ValidationOutcome Warning(object? value, string message, string? hint = null)
+    public static ValidationOutcome Warning(
+        object? value, string message, string? hint = null, CoreSerializerOptions? options = null)
     {
-        JsonNode? node = ValidationValueNode.From(value);
+        JsonNode? node = ValidationValueNode.From(value, options);
         return new ValidationOutcome(ValidationStatus.Warning, node, node?.DeepClone(), message, hint);
     }
 
-    public static ValidationOutcome Rejected(object? original, string message, string? hint = null)
+    public static ValidationOutcome Rejected(
+        object? original, string message, string? hint = null, CoreSerializerOptions? options = null)
     {
-        JsonNode? node = ValidationValueNode.From(original);
+        JsonNode? node = ValidationValueNode.From(original, options);
         return new ValidationOutcome(ValidationStatus.Rejected, node, node?.DeepClone(), message, hint);
     }
 }
 
 public static class ValidationEvaluator
 {
-    public static ValidationOutcome Evaluate(ICoreObject target, CoreProperty property, object? value)
+    public static ValidationOutcome Evaluate(
+        ICoreObject target, CoreProperty property, object? value, CoreSerializerOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(property);
@@ -62,14 +69,16 @@ public static class ValidationEvaluator
             return ValidationOutcome.Rejected(
                 value,
                 $"Value is not assignable to {property.PropertyType.FullName}.",
-                CreateValueHint(property.PropertyType));
+                CreateValueHint(property.PropertyType),
+                options);
         }
 
         IValidator? validator = property.GetMetadata<ICorePropertyMetadata>(target.GetType()).GetValidator();
-        return EvaluateValidator(validator, new ValidationContext(target, property), value);
+        return EvaluateValidator(validator, new ValidationContext(target, property), value, options);
     }
 
-    public static ValidationOutcome Evaluate(IProperty property, object? value)
+    public static ValidationOutcome Evaluate(
+        IProperty property, object? value, CoreSerializerOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(property);
 
@@ -78,32 +87,34 @@ public static class ValidationEvaluator
             return ValidationOutcome.Rejected(
                 value,
                 $"Value is not assignable to {property.ValueType.FullName}.",
-                CreateValueHint(property.ValueType));
+                CreateValueHint(property.ValueType),
+                options);
         }
 
         IValidator validator = property.CreateValidator(property.GetAttributes() ?? []);
-        return EvaluateValidator(validator, new ValidationContext(property, null), value);
+        return EvaluateValidator(validator, new ValidationContext(property, null), value, options);
     }
 
-    private static ValidationOutcome EvaluateValidator(IValidator? validator, ValidationContext context, object? value)
+    private static ValidationOutcome EvaluateValidator(
+        IValidator? validator, ValidationContext context, object? value, CoreSerializerOptions? options)
     {
         if (validator is null)
         {
-            return ValidationOutcome.Ok(value);
+            return ValidationOutcome.Ok(value, options);
         }
 
         object? coerced = value;
         if (validator.TryCoerce(context, ref coerced))
         {
             return Equals(value, coerced)
-                ? ValidationOutcome.Ok(value)
-                : ValidationOutcome.Coerced(value, coerced);
+                ? ValidationOutcome.Ok(value, options)
+                : ValidationOutcome.Coerced(value, coerced, options);
         }
 
         string? message = validator.Validate(context, value);
         return message is null
-            ? ValidationOutcome.Ok(value)
-            : ValidationOutcome.Rejected(value, message);
+            ? ValidationOutcome.Ok(value, options)
+            : ValidationOutcome.Rejected(value, message, null, options);
     }
 
     private static bool IsAssignableValue(Type targetType, object? value)

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
@@ -26,13 +26,13 @@ public sealed record ValidationOutcome(
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? Hint = null)
 {
-    public static ValidationOutcome Ok(object? value, CoreSerializerOptions? options = null)
+    public static ValidationOutcome Ok(object? value, CoreSerializerOptions? options)
     {
         JsonNode? node = ValidationValueNode.From(value, options);
         return new ValidationOutcome(ValidationStatus.Ok, node, node?.DeepClone(), null);
     }
 
-    public static ValidationOutcome Coerced(object? original, object? coerced, CoreSerializerOptions? options = null)
+    public static ValidationOutcome Coerced(object? original, object? coerced, CoreSerializerOptions? options)
     {
         return new ValidationOutcome(
             ValidationStatus.Coerced,
@@ -42,14 +42,14 @@ public sealed record ValidationOutcome(
     }
 
     public static ValidationOutcome Warning(
-        object? value, string message, string? hint = null, CoreSerializerOptions? options = null)
+        object? value, string message, CoreSerializerOptions? options, string? hint = null)
     {
         JsonNode? node = ValidationValueNode.From(value, options);
         return new ValidationOutcome(ValidationStatus.Warning, node, node?.DeepClone(), message, hint);
     }
 
     public static ValidationOutcome Rejected(
-        object? original, string message, string? hint = null, CoreSerializerOptions? options = null)
+        object? original, string message, CoreSerializerOptions? options, string? hint = null)
     {
         JsonNode? node = ValidationValueNode.From(original, options);
         return new ValidationOutcome(ValidationStatus.Rejected, node, node?.DeepClone(), message, hint);
@@ -59,7 +59,7 @@ public sealed record ValidationOutcome(
 public static class ValidationEvaluator
 {
     public static ValidationOutcome Evaluate(
-        ICoreObject target, CoreProperty property, object? value, CoreSerializerOptions? options = null)
+        ICoreObject target, CoreProperty property, object? value, CoreSerializerOptions? options)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(property);
@@ -69,8 +69,8 @@ public static class ValidationEvaluator
             return ValidationOutcome.Rejected(
                 value,
                 $"Value is not assignable to {property.PropertyType.FullName}.",
-                CreateValueHint(property.PropertyType),
-                options);
+                options,
+                CreateValueHint(property.PropertyType));
         }
 
         IValidator? validator = property.GetMetadata<ICorePropertyMetadata>(target.GetType()).GetValidator();
@@ -78,7 +78,7 @@ public static class ValidationEvaluator
     }
 
     public static ValidationOutcome Evaluate(
-        IProperty property, object? value, CoreSerializerOptions? options = null)
+        IProperty property, object? value, CoreSerializerOptions? options)
     {
         ArgumentNullException.ThrowIfNull(property);
 
@@ -87,8 +87,8 @@ public static class ValidationEvaluator
             return ValidationOutcome.Rejected(
                 value,
                 $"Value is not assignable to {property.ValueType.FullName}.",
-                CreateValueHint(property.ValueType),
-                options);
+                options,
+                CreateValueHint(property.ValueType));
         }
 
         IValidator validator = property.CreateValidator(property.GetAttributes() ?? []);
@@ -114,7 +114,7 @@ public static class ValidationEvaluator
         string? message = validator.Validate(context, value);
         return message is null
             ? ValidationOutcome.Ok(value, options)
-            : ValidationOutcome.Rejected(value, message, null, options);
+            : ValidationOutcome.Rejected(value, message, options);
     }
 
     private static bool IsAssignableValue(Type targetType, object? value)

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationEvaluator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Beutl.Engine;
 using Beutl.Media;
 using Beutl.Validation;
@@ -15,30 +16,37 @@ public enum ValidationStatus
 
 public sealed record ValidationOutcome(
     ValidationStatus Status,
-    object? OriginalValue,
-    object? CoercedValue,
+    JsonNode? OriginalValue,
+    JsonNode? CoercedValue,
     string? Message,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? Hint = null)
 {
     public static ValidationOutcome Ok(object? value)
     {
-        return new ValidationOutcome(ValidationStatus.Ok, value, value, null);
+        JsonNode? node = ValidationValueNode.From(value);
+        return new ValidationOutcome(ValidationStatus.Ok, node, node?.DeepClone(), null);
     }
 
     public static ValidationOutcome Coerced(object? original, object? coerced)
     {
-        return new ValidationOutcome(ValidationStatus.Coerced, original, coerced, null);
+        return new ValidationOutcome(
+            ValidationStatus.Coerced,
+            ValidationValueNode.From(original),
+            ValidationValueNode.From(coerced),
+            null);
     }
 
     public static ValidationOutcome Warning(object? value, string message, string? hint = null)
     {
-        return new ValidationOutcome(ValidationStatus.Warning, value, value, message, hint);
+        JsonNode? node = ValidationValueNode.From(value);
+        return new ValidationOutcome(ValidationStatus.Warning, node, node?.DeepClone(), message, hint);
     }
 
     public static ValidationOutcome Rejected(object? original, string message, string? hint = null)
     {
-        return new ValidationOutcome(ValidationStatus.Rejected, original, original, message, hint);
+        JsonNode? node = ValidationValueNode.From(original);
+        return new ValidationOutcome(ValidationStatus.Rejected, node, node?.DeepClone(), message, hint);
     }
 }
 

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
@@ -1,10 +1,14 @@
 ﻿using System.Text.Json.Nodes;
+using Beutl.Logging;
 using Beutl.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Beutl.AgentToolkit.Reconciliation;
 
 internal static class ValidationValueNode
 {
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(ValidationValueNode));
+
     // System.Text.Json cannot write a live engine object: IProperty.ValueType is a System.Type, and
     // IFileSource needs a serialization context that is gone by the time the response is written.
     // options carries the document's BaseUri, without which a media reference is reported as an
@@ -25,9 +29,11 @@ internal static class ValidationValueNode
         {
             return CoreSerializer.SerializeToJsonNode(value, options);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return JsonValue.Create(value.ToString());
+            // Throwing would restore the false failure this type exists to prevent, so degrade instead.
+            s_logger.LogWarning(ex, "Failed to serialize a validation payload of type {Type}.", value.GetType());
+            return JsonValue.Create(value.ToString()) ?? JsonValue.Create(value.GetType().FullName);
         }
     }
 }

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
@@ -7,7 +7,9 @@ internal static class ValidationValueNode
 {
     // System.Text.Json cannot write a live engine object: IProperty.ValueType is a System.Type, and
     // IFileSource needs a serialization context that is gone by the time the response is written.
-    public static JsonNode? From(object? value)
+    // options carries the document's BaseUri, without which a media reference is reported as an
+    // absolute host path while the document itself reports it relative.
+    public static JsonNode? From(object? value, CoreSerializerOptions? options)
     {
         switch (value)
         {
@@ -21,7 +23,7 @@ internal static class ValidationValueNode
 
         try
         {
-            return CoreSerializer.SerializeToJsonNode(value);
+            return CoreSerializer.SerializeToJsonNode(value, options);
         }
         catch (Exception)
         {

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Serialization;
+
+namespace Beutl.AgentToolkit.Reconciliation;
+
+internal static class ValidationValueNode
+{
+    // System.Text.Json cannot write a live engine object: IProperty.ValueType is a System.Type, and
+    // IFileSource needs a serialization context that is gone by the time the response is written.
+    public static JsonNode? From(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return null;
+            case JsonNode node:
+                return node.DeepClone();
+            case string text:
+                return JsonValue.Create(text);
+        }
+
+        try
+        {
+            return CoreSerializer.SerializeToJsonNode(value);
+        }
+        catch (Exception)
+        {
+            return JsonValue.Create(value.ToString());
+        }
+    }
+}

--- a/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
+++ b/src/Beutl.AgentToolkit/Reconciliation/ValidationValueNode.cs
@@ -2,12 +2,35 @@
 using Beutl.Logging;
 using Beutl.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Beutl.AgentToolkit.Reconciliation;
 
 internal static class ValidationValueNode
 {
-    private static readonly ILogger s_logger = Log.CreateLogger(typeof(ValidationValueNode));
+    private static ILogger? s_logger;
+
+    // Log.LoggerFactory is assign-once and hands out a NullLoggerFactory until the host configures it,
+    // so caching eagerly would let type-load order decide whether the warning below ever reaches a log.
+    // Log.IsLoggerFactoryConfigured is internal to Beutl.Core and not visible here; the public getter
+    // returns exactly NullLoggerFactory.Instance while unconfigured, which is the same signal.
+    private static ILogger Logger
+    {
+        get
+        {
+            if (s_logger is not null) return s_logger;
+            if (ReferenceEquals(Log.LoggerFactory, NullLoggerFactory.Instance)) return NullLogger.Instance;
+
+            try
+            {
+                return s_logger = Log.CreateLogger(typeof(ValidationValueNode));
+            }
+            catch (Exception)
+            {
+                return NullLogger.Instance;
+            }
+        }
+    }
 
     // System.Text.Json cannot write a live engine object: IProperty.ValueType is a System.Type, and
     // IFileSource needs a serialization context that is gone by the time the response is written.
@@ -32,7 +55,7 @@ internal static class ValidationValueNode
         catch (Exception ex)
         {
             // Throwing would restore the false failure this type exists to prevent, so degrade instead.
-            s_logger.LogWarning(ex, "Failed to serialize a validation payload of type {Type}.", value.GetType());
+            Logger.LogWarning(ex, "Failed to serialize a validation payload of type {Type}.", value.GetType());
             return JsonValue.Create(value.ToString()) ?? JsonValue.Create(value.GetType().FullName);
         }
     }

--- a/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
+++ b/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
@@ -134,16 +134,16 @@ public static class McpToolErrorFilters
     private static CallToolResult CreateValidationRejectedResult(string? toolName, string? detail = null)
     {
         string target = string.IsNullOrWhiteSpace(toolName) ? "tool" : toolName;
-        // This filter wraps the whole pipeline, so the failure may also come from serializing an
-        // already-applied tool result — the caller's arguments are not necessarily at fault.
+        // This filter wraps the whole downstream pipeline, so it cannot tell argument binding, the
+        // tool body, and result serialization apart. Do not name a cause the caller cannot trust.
         string message = detail is null
-            ? $"Call to '{target}' failed while binding arguments or serializing the result. Check required parameters and parameter types."
-            : $"Call to '{target}' failed while binding arguments or serializing the result: {detail}";
+            ? $"Call to '{target}' failed. Check required parameters and parameter types."
+            : $"Call to '{target}' failed: {detail}";
         ToolResult<object?> result = ToolResult<object?>.Failure(
             ErrorCode.ValidationRejected,
             message,
             target,
-            "If the message names a missing or mistyped argument, call tools/list for the current schema and pass the documented JSON shapes. Otherwise the failure happened after the tool ran, so read back the current state before retrying to avoid applying the same edit twice.");
+            "If the message names a missing or mistyped argument, call tools/list for the current schema and pass the documented JSON shapes. Otherwise the tool may have already applied its changes, so read back the current state before retrying to avoid applying the same edit twice.");
 
         return new CallToolResult
         {

--- a/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
+++ b/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
@@ -137,7 +137,7 @@ public static class McpToolErrorFilters
         // This filter wraps the whole downstream pipeline, so it cannot tell argument binding, the
         // tool body, and result serialization apart. Do not name a cause the caller cannot trust.
         string message = detail is null
-            ? $"Call to '{target}' failed. Check required parameters and parameter types."
+            ? $"Call to '{target}' failed."
             : $"Call to '{target}' failed: {detail}";
         ToolResult<object?> result = ToolResult<object?>.Failure(
             ErrorCode.ValidationRejected,

--- a/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
+++ b/src/Beutl.AgentToolkit/Tools/McpToolErrorFilters.cs
@@ -134,14 +134,16 @@ public static class McpToolErrorFilters
     private static CallToolResult CreateValidationRejectedResult(string? toolName, string? detail = null)
     {
         string target = string.IsNullOrWhiteSpace(toolName) ? "tool" : toolName;
+        // This filter wraps the whole pipeline, so the failure may also come from serializing an
+        // already-applied tool result — the caller's arguments are not necessarily at fault.
         string message = detail is null
-            ? $"Tool arguments could not be bound for '{target}'. Check required parameters and parameter types."
-            : $"Tool arguments could not be bound for '{target}': {detail}";
+            ? $"Call to '{target}' failed while binding arguments or serializing the result. Check required parameters and parameter types."
+            : $"Call to '{target}' failed while binding arguments or serializing the result: {detail}";
         ToolResult<object?> result = ToolResult<object?>.Failure(
             ErrorCode.ValidationRejected,
             message,
             target,
-            "Call tools/list for the current schema and pass the required arguments with the documented JSON shapes.");
+            "If the message names a missing or mistyped argument, call tools/list for the current schema and pass the documented JSON shapes. Otherwise the failure happened after the tool ran, so read back the current state before retrying to avoid applying the same edit twice.");
 
         return new CallToolResult
         {

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationEvaluatorTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationEvaluatorTests.cs
@@ -12,8 +12,8 @@ public class ValidationEvaluatorTests
     {
         var target = new RangedCoreObject();
 
-        ValidationOutcome coerced = ValidationEvaluator.Evaluate(target, RangedCoreObject.AmountProperty, 50);
-        ValidationOutcome rejected = ValidationEvaluator.Evaluate(target, RangedCoreObject.AmountProperty, "bad");
+        ValidationOutcome coerced = ValidationEvaluator.Evaluate(target, RangedCoreObject.AmountProperty, 50, options: null);
+        ValidationOutcome rejected = ValidationEvaluator.Evaluate(target, RangedCoreObject.AmountProperty, "bad", options: null);
 
         Assert.Multiple(() =>
         {
@@ -29,8 +29,8 @@ public class ValidationEvaluatorTests
     {
         var target = new RangedEngineObject();
 
-        ValidationOutcome coerced = ValidationEvaluator.Evaluate(target.Amount, 50);
-        ValidationOutcome rejected = ValidationEvaluator.Evaluate(target.Amount, "bad");
+        ValidationOutcome coerced = ValidationEvaluator.Evaluate(target.Amount, 50, options: null);
+        ValidationOutcome rejected = ValidationEvaluator.Evaluate(target.Amount, "bad", options: null);
 
         Assert.Multiple(() =>
         {
@@ -45,8 +45,8 @@ public class ValidationEvaluatorTests
     {
         var target = new TypedEngineObject();
 
-        ValidationOutcome color = ValidationEvaluator.Evaluate(target.Color, "Amber");
-        ValidationOutcome pen = ValidationEvaluator.Evaluate(target.Pen, new object());
+        ValidationOutcome color = ValidationEvaluator.Evaluate(target.Color, "Amber", options: null);
+        ValidationOutcome pen = ValidationEvaluator.Evaluate(target.Pen, new object(), options: null);
 
         Assert.Multiple(() =>
         {

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationEvaluatorTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationEvaluatorTests.cs
@@ -18,7 +18,8 @@ public class ValidationEvaluatorTests
         Assert.Multiple(() =>
         {
             Assert.That(coerced.Status, Is.EqualTo(ValidationStatus.Coerced));
-            Assert.That(coerced.CoercedValue, Is.EqualTo(10));
+            Assert.That(coerced.CoercedValue!.GetValue<int>(), Is.EqualTo(10));
+            Assert.That(coerced.OriginalValue!.GetValue<int>(), Is.EqualTo(50));
             Assert.That(rejected.Status, Is.EqualTo(ValidationStatus.Rejected));
         });
     }
@@ -34,7 +35,7 @@ public class ValidationEvaluatorTests
         Assert.Multiple(() =>
         {
             Assert.That(coerced.Status, Is.EqualTo(ValidationStatus.Coerced));
-            Assert.That(coerced.CoercedValue, Is.EqualTo(10));
+            Assert.That(coerced.CoercedValue!.GetValue<int>(), Is.EqualTo(10));
             Assert.That(rejected.Status, Is.EqualTo(ValidationStatus.Rejected));
         });
     }

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using Beutl.AgentToolkit.Common;
 using Beutl.AgentToolkit.Schema;
@@ -57,12 +57,12 @@ public sealed class ValidationPayloadSerializationTests
         Assert.Multiple(() =>
         {
             Assert.That(apply.IsSuccess, Is.True, apply.Error?.Message);
+            Assert.That(apply.Value!.Valid, Is.True);
             Assert.That(rect.FilterEffect.CurrentValue, Is.InstanceOf<Blur>());
-            Assert.That(apply.Value!.Validation, Is.Not.Null.And.Not.Empty);
+            Assert.That(apply.Value.Validation, Is.Not.Null.And.Not.Empty);
             Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
-            Assert.That(
-                SerializeValidation(apply.Value),
-                Does.Contain("\"Sigma\":\"9, 9\""));
+            Assert.That(SerializeValidation(apply.Value), Does.Contain("\"Sigma\":\"9, 9\""));
+            Assert.That(SerializeValidation(apply.Value), Does.Contain("\"status\":\"Ok\""));
         });
     }
 
@@ -98,10 +98,14 @@ public sealed class ValidationPayloadSerializationTests
         Assert.Multiple(() =>
         {
             Assert.That(apply.IsSuccess, Is.True, apply.Error?.Message);
+            Assert.That(apply.Value!.Valid, Is.True);
             Assert.That(scene.Children, Has.Count.EqualTo(2));
-            Assert.That(apply.Value!.Validation, Is.Not.Null.And.Not.Empty);
+            Assert.That(apply.Value.Validation, Is.Not.Null.And.Not.Empty);
             Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
             Assert.That(SerializeValidation(apply.Value), Does.Contain("image.png"));
+            // The document reports media relative to the scene, so the validation payload must not
+            // leak the host path alongside it.
+            Assert.That(SerializeValidation(apply.Value), Does.Not.Contain("file:///"));
         });
     }
 

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Beutl.AgentToolkit.Common;
+using Beutl.AgentToolkit.Schema;
+using Beutl.AgentToolkit.Sessions;
+using Beutl.AgentToolkit.Tests.Helpers;
+using Beutl.AgentToolkit.Tools;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
+
+namespace Beutl.AgentToolkit.Tests.Reconciliation;
+
+public sealed class ValidationPayloadSerializationTests
+{
+    private static readonly JsonSerializerOptions s_toolResultOptions = new(JsonSerializerDefaults.Web);
+
+    [Test]
+    public void Validation_payload_for_a_replaced_effect_is_serializable()
+    {
+        Scene scene = CreateSceneWithElement(out Element element);
+        var rect = new RectShape
+        {
+            Name = "Filtered rect",
+            Width = { CurrentValue = 200 },
+            Height = { CurrentValue = 100 },
+            // Only a null FilterEffect makes the patch replace the whole property, so validation sees
+            // a live Blur instead of a leaf value.
+            FilterEffect = { CurrentValue = null }
+        };
+        element.AddObject(rect);
+        using var session = new AgentToolkitTestSession(scene);
+        var manager = new AgentSessionManager();
+        manager.UseSource(new AgentToolkitTestSessionSource(session));
+        var tools = new EditTools(manager);
+
+        ToolResult<ApplyEditResponse> apply = tools.ApplyEdit(
+            patch: new JsonObject
+            {
+                ["Elements"] = new JsonArray(new JsonObject
+                {
+                    [nameof(CoreObject.Id)] = element.Id.ToString(),
+                    [nameof(Element.Objects)] = new JsonArray(new JsonObject
+                    {
+                        [nameof(CoreObject.Id)] = rect.Id.ToString(),
+                        [nameof(Drawable.FilterEffect)] = new JsonObject
+                        {
+                            ["$type"] = IdentityHelper.WriteDiscriminator(typeof(Blur)),
+                            [nameof(Blur.Sigma)] = "9, 9"
+                        }
+                    })
+                })
+            },
+            schemaVersion: SchemaVersion.Current);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(apply.IsSuccess, Is.True, apply.Error?.Message);
+            Assert.That(rect.FilterEffect.CurrentValue, Is.InstanceOf<Blur>());
+            Assert.That(apply.Value!.Validation, Is.Not.Null.And.Not.Empty);
+            Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
+            Assert.That(
+                SerializeValidation(apply.Value),
+                Does.Contain("\"Sigma\":\"9, 9\""));
+        });
+    }
+
+    [Test]
+    public void Validation_payload_for_an_inserted_media_reference_is_serializable()
+    {
+        Scene scene = CreateSceneWithElement(out _);
+        string mediaPath = Path.Combine(Path.GetDirectoryName(scene.Uri!.LocalPath)!, "image.png");
+        File.WriteAllBytes(mediaPath, []);
+        using var session = new AgentToolkitTestSession(scene);
+        var manager = new AgentSessionManager();
+        manager.UseSource(new AgentToolkitTestSessionSource(session));
+        var tools = new EditTools(manager);
+
+        ToolResult<ApplyEditResponse> apply = tools.ApplyEdit(
+            patch: new JsonObject
+            {
+                ["Elements"] = new JsonArray(new JsonObject
+                {
+                    ["$type"] = "[Beutl.ProjectSystem]:Element",
+                    [nameof(CoreObject.Name)] = "photo",
+                    [nameof(Element.Start)] = TimeSpan.Zero.ToString("c"),
+                    [nameof(Element.Length)] = TimeSpan.FromSeconds(5).ToString("c"),
+                    [nameof(Element.Objects)] = new JsonArray(new JsonObject
+                    {
+                        ["$type"] = IdentityHelper.WriteDiscriminator(typeof(SourceImage)),
+                        [nameof(SourceImage.Source)] = new Uri(mediaPath).ToString()
+                    })
+                })
+            },
+            schemaVersion: SchemaVersion.Current);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(apply.IsSuccess, Is.True, apply.Error?.Message);
+            Assert.That(scene.Children, Has.Count.EqualTo(2));
+            Assert.That(apply.Value!.Validation, Is.Not.Null.And.Not.Empty);
+            Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
+            Assert.That(SerializeValidation(apply.Value), Does.Contain("image.png"));
+        });
+    }
+
+    private static string SerializeValidation(ApplyEditResponse response)
+    {
+        return JsonSerializer.Serialize(response.Validation, s_toolResultOptions);
+    }
+
+    private static Scene CreateSceneWithElement(out Element element)
+    {
+        string dir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var scene = new Scene(1920, 1080, "Scene")
+        {
+            Uri = new Uri(Path.Combine(dir, "Scene.scene"))
+        };
+        element = new Element
+        {
+            Start = TimeSpan.FromSeconds(1),
+            Length = TimeSpan.FromSeconds(2),
+            Uri = new Uri(Path.Combine(dir, "element.belm"))
+        };
+        scene.Children.Add(element);
+        return scene;
+    }
+}

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs
@@ -60,7 +60,7 @@ public sealed class ValidationPayloadSerializationTests
             Assert.That(apply.Value!.Valid, Is.True);
             Assert.That(rect.FilterEffect.CurrentValue, Is.InstanceOf<Blur>());
             Assert.That(apply.Value.Validation, Is.Not.Null.And.Not.Empty);
-            Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
+            Assert.That(() => JsonSerializer.Serialize(apply, s_toolResultOptions), Throws.Nothing);
             Assert.That(SerializeValidation(apply.Value), Does.Contain("\"Sigma\":\"9, 9\""));
             Assert.That(SerializeValidation(apply.Value), Does.Contain("\"status\":\"Ok\""));
         });
@@ -101,11 +101,11 @@ public sealed class ValidationPayloadSerializationTests
             Assert.That(apply.Value!.Valid, Is.True);
             Assert.That(scene.Children, Has.Count.EqualTo(2));
             Assert.That(apply.Value.Validation, Is.Not.Null.And.Not.Empty);
-            Assert.DoesNotThrow(() => JsonSerializer.Serialize(apply, s_toolResultOptions));
+            Assert.That(() => JsonSerializer.Serialize(apply, s_toolResultOptions), Throws.Nothing);
             Assert.That(SerializeValidation(apply.Value), Does.Contain("image.png"));
             // The document reports media relative to the scene, so the validation payload must not
             // leak the host path alongside it.
-            Assert.That(SerializeValidation(apply.Value), Does.Not.Contain("file:///"));
+            Assert.That(SerializeValidation(apply.Value), Does.Not.Contain("file://"));
         });
     }
 

--- a/tests/Beutl.AgentToolkit.Tests/Schema/SafeFeedbackTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Schema/SafeFeedbackTests.cs
@@ -15,7 +15,7 @@ public sealed class SafeFeedbackTests
     public void Out_of_range_values_are_reported_before_apply()
     {
         var text = new TextBlock();
-        ValidationOutcome outcome = ValidationEvaluator.Evaluate(text.Size, -10f);
+        ValidationOutcome outcome = ValidationEvaluator.Evaluate(text.Size, -10f, options: null);
 
         Assert.That(outcome.Status, Is.AnyOf(ValidationStatus.Coerced, ValidationStatus.Rejected));
     }


### PR DESCRIPTION
## Description

`apply_edit` returned `validation_rejected` for edits it had **already applied**. The edit itself succeeded; only the response payload failed to serialize, so agents that retried the "failed" call risked applying the same edit twice.

- `ValidationOutcome.OriginalValue` / `CoercedValue` were declared `object?` and held live engine objects. System.Text.Json then walked their reflected surface and hit types it cannot write:
  - `IProperty.ValueType` is a `System.Type` → `Serialization and deserialization of 'System.Type' instances is not supported. Path: $.Value.Validation.OriginalValue.Sigma.ValueType.` (reported trigger, `Blur.Sigma`)
  - `FileSourceJsonConverter.Write` requires a `ThreadLocalSerializationContext` that is gone by the time the response is written → `Cannot serialize IFileSource without a parent context.` (second trigger from the issue comment, a new `SourceImage.Source`)
- Both payloads are now `JsonNode?`, converted through `CoreSerializer` in the `ValidationOutcome` factories. Fixing it at the type level covers every construction site, so neither offending member type — nor a future one — can reach the response serializer.
- The conversion receives the document's `CoreSerializerOptions`, the same ones `Reconciler.AddValidation` already builds. Without them a media reference would be reported as an absolute host path (`file:///Users/...`) while the document reports it relative — a leak of the user's paths and a second, conflicting representation of the same value in one response.
- Those options are a **required** parameter on `ValidationEvaluator.Evaluate` and the `ValidationOutcome` factories. Left optional, omitting them — the exact mistake above — would have stayed the language-level default with nothing to flag it; the existing tests still bound the old overload, so a future call site that forgot them would not have failed anything. Call sites whose payload is already JSON-safe pass `options: null` explicitly.
- `ValidationStatus` is now written by name. The Web serializer defaults emitted a bare ordinal (`"status":0`), which disagreed with `ReconcilePlan.ValidationStatuses` in the same response (`{"Ok":3}`) and would have shifted silently if a member were ever inserted.
- `McpToolErrorFilters` wraps the whole downstream pipeline — argument binding, the tool body, and result serialization alike — so it no longer names a cause it cannot distinguish. Its hint now says the tool *may* have already applied its changes and tells the agent to read back the current state before retrying, so a false failure does not become a double apply.

`quiet: true` was the only workaround before this change; it is no longer needed.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only
- [x] `Beutl.AgentToolkit`

## Breaking changes

1. `ValidationOutcome.OriginalValue` / `CoercedValue` are `System.Text.Json.Nodes.JsonNode?` instead of `object?`. Consumers that read them must now consume a `JsonNode` — e.g. `CoercedValue!.GetValue<int>()` instead of unboxing to `int`.
2. `ValidationEvaluator.Evaluate` and the `ValidationOutcome` `Ok` / `Coerced` / `Warning` / `Rejected` factories require a trailing `CoreSerializerOptions?` argument, and on `Warning` / `Rejected` it precedes `hint`. Pass the options that produced the value, or `null` when the payload is already a string, a `JsonNode`, or `null`.
3. `ValidationStatus` serializes as its name (`"Ok"`) rather than its ordinal (`0`) in MCP tool responses. This now matches `ReconcilePlan.ValidationStatuses`, which already keyed off the name.

## Test plan

- New `tests/Beutl.AgentToolkit.Tests/Reconciliation/ValidationPayloadSerializationTests.cs` reproduces both triggers end-to-end through `EditTools.ApplyEdit` and asserts the whole `ToolResult<ApplyEditResponse>` serializes. Verified red against the unmodified code with the exact reported exceptions (`System.Type` at `$.Value.Validation.OriginalValue.Sigma.ValueType`, and `Cannot serialize IFileSource without a parent context.`), green after the fix.
- The same tests pin the payload's actual content rather than just "it stopped throwing": the serialized shape (`"Sigma":"9, 9"`), the status name (`"status":"Ok"`), the absence of a `file:///` host path, and `Valid == true` on the response — the last being the exact symptom the issue reported.
- `ValidationEvaluatorTests` and `SafeFeedbackTests` updated for the new signatures; `ValidationEvaluatorTests` now also pins `OriginalValue` (previously unasserted).
- `dotnet build Beutl.slnx` → 0 errors. `dotnet test Beutl.slnx -f net10.0` → green (490 AgentToolkit, 4756 unit, 150 headless UI, 63 E2E, plus the rest). `dotnet format --verify-no-changes` clean on both touched projects.
- One full run showed 2 failures in `Beutl.HeadlessUITests` with `PlatformNotSupportedException` at `Avalonia.Threading.Dispatcher.PushFrame`, inside the Avalonia headless session rather than any code this PR touches. The suite passes 150/150 on re-run and the named test passes 3/3 in isolation, so it reads as infrastructure flakiness, not a regression here.

## Fixed issues / References
- Closes #2111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation outcomes now store original and coerced values in JSON-compatible form to improve downstream serialization.
  * Validation and reconciliation now forward optional serializer settings through the evaluation/coercion flow.
  * Tool “validation rejected” errors now use clearer call-failure messaging and more actionable retry guidance.
* **Tests**
  * Expanded validation payload serialization checks for replaced effects and inserted media references.
  * Updated evaluator assertions to verify strongly-typed values derived from JSON-backed outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->