### PR TITLE
feat: round the timeline clip and inset its name label

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
@@ -55,11 +55,9 @@
     <ControlTheme x:Key="ElementNameTextBoxTheme"
                   TargetType="TextBox"
                   BasedOn="{StaticResource {x:Type TextBox}}">
-        <ControlTheme.Resources>
-            <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
-        </ControlTheme.Resources>
         <!-- Padding.Left must equal the display label's margin, or renaming shifts the name.
-             The border is dropped so padding is the only inset in that sum. -->
+             The base theme's focus ring is left alone: it draws inside PART_BorderElement and so
+             does not move the content. -->
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="6,0,6,0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
@@ -52,6 +52,19 @@
         </Style>
     </ControlTheme>
 
+    <ControlTheme x:Key="ElementNameTextBoxTheme"
+                  TargetType="TextBox"
+                  BasedOn="{StaticResource {x:Type TextBox}}">
+        <ControlTheme.Resources>
+            <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
+        </ControlTheme.Resources>
+        <!-- Padding.Left must equal the display label's margin, or renaming shifts the name.
+             The border is dropped so padding is the only inset in that sum. -->
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="6,0,6,0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </ControlTheme>
+
     <ControlTheme x:Key="LayerHeaderButtonTheme"
                   TargetType="Button"
                   BasedOn="{StaticResource TransparentButton}">

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -112,7 +112,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             .ToReactiveProperty()
             .AddTo(_disposables);
 
-        RestBorderColor = Color.Select(v => (Avalonia.Media.Color)((Color2)v).LightenPercent(-0.15f))
+        RestBorderColor = Color.Select(v => (Avalonia.Media.Color)((Color2)v).LightenPercent(-0.3f))
             .ToReadOnlyReactivePropertySlim();
 
         TextColor = Color.Select(ColorGenerator.GetTextColor)

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -29,6 +29,7 @@
             HorizontalAlignment="Left"
             Background="{Binding Color.Value, Converter={StaticResource ColorToBrushConverter}}"
             BorderThickness="1"
+            CornerRadius="4"
             Classes.elm-disabled="{Binding !IsEnabled.Value}"
             Classes.elm-locked="{Binding !IsEditable.Value}"
             Classes.selected="{Binding IsSelected.Value}">
@@ -196,36 +197,49 @@
             </ui:FAMenuFlyout>
         </Border.ContextFlyout>
         <Panel>
-            <v:ThumbnailStripControl x:Name="thumbnailStrip"
-                                     HorizontalAlignment="Stretch"
-                                     VerticalAlignment="Stretch"
-                                     IsVisible="{Binding IsThumbnailsKindVideo.Value}"
-                                     ThumbnailCount="{Binding VideoThumbnailCount.Value}" />
+            <Border x:Name="mediaClip"
+                    ClipToBounds="True"
+                    CornerRadius="3">
+                <Panel>
+                    <v:ThumbnailStripControl x:Name="thumbnailStrip"
+                                             HorizontalAlignment="Stretch"
+                                             VerticalAlignment="Stretch"
+                                             IsVisible="{Binding IsThumbnailsKindVideo.Value}"
+                                             ThumbnailCount="{Binding VideoThumbnailCount.Value}" />
 
-            <v:WaveformControl x:Name="waveformControl"
-                               HorizontalAlignment="Stretch"
-                               VerticalAlignment="Stretch"
-                               ChunkCount="{Binding WaveformChunkCount.Value}"
-                               IsVisible="{Binding IsThumbnailsKindAudio.Value}"
-                               WaveformBrush="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}" />
-
-            <TextBlock x:Name="textBlock"
-                       VerticalAlignment="Center"
-                       ClipToBounds="True"
-                       Foreground="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}"
-                       Text="{Binding Name.Value}" />
+                    <v:WaveformControl x:Name="waveformControl"
+                                       HorizontalAlignment="Stretch"
+                                       VerticalAlignment="Stretch"
+                                       ChunkCount="{Binding WaveformChunkCount.Value}"
+                                       IsVisible="{Binding IsThumbnailsKindAudio.Value}"
+                                       WaveformBrush="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}" />
+                </Panel>
+            </Border>
+            <!-- The lock glyph owns a column, so the label clears it by layout instead of by a
+                 reserved margin; a hidden glyph measures to zero and the label keeps its own inset. -->
+            <Grid ColumnDefinitions="Auto,*">
+                <icons:FluentIcon x:Name="lockIcon"
+                                  Grid.Column="0"
+                                  Margin="6,0,0,0"
+                                  VerticalAlignment="Center"
+                                  FontSize="12"
+                                  Foreground="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}"
+                                  IsVisible="{Binding !IsEditable.Value}"
+                                  Icon="LockClosed" />
+                <TextBlock x:Name="textBlock"
+                           Grid.Column="1"
+                           Margin="6,0,0,1"
+                           VerticalAlignment="Center"
+                           ClipToBounds="True"
+                           Foreground="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}"
+                           Text="{Binding Name.Value}" />
+            </Grid>
             <TextBox x:Name="textBox"
                      HorizontalAlignment="Stretch"
                      IsEnabled="{Binding IsEditable.Value}"
                      IsVisible="False"
-                     Text="{Binding Name.Value}" />
-            <icons:FluentIcon Margin="4,0"
-                              HorizontalAlignment="Left"
-                              VerticalAlignment="Center"
-                              FontSize="12"
-                              Foreground="{Binding TextColor.Value, Converter={StaticResource ColorToBrushConverter}}"
-                              IsVisible="{Binding !IsEditable.Value}"
-                              Icon="LockClosed" />
+                     Text="{Binding Name.Value}"
+                     Theme="{StaticResource ElementNameTextBoxTheme}" />
 
             <Border x:Name="proxyIndicator"
                     Width="8"

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -29,6 +29,7 @@
             HorizontalAlignment="Left"
             Background="{Binding Color.Value, Converter={StaticResource ColorToBrushConverter}}"
             BorderThickness="1"
+            ClipToBounds="True"
             CornerRadius="4"
             Classes.elm-disabled="{Binding !IsEnabled.Value}"
             Classes.elm-locked="{Binding !IsEditable.Value}"

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -133,10 +133,17 @@ public class ElementViewLayoutTests
             Control label = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBlock");
             var textBox = (TextBox)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBox");
 
-            textBox.IsVisible = true;
-            HeadlessTestHelpers.Render(5);
-
+            // Read the label first: entering rename hides it, and an unarranged control has no
+            // position to compare against.
             double labelInset = label.TranslatePoint(new Point(0, 0), border)!.Value.X;
+
+            // Focus-time styling changes the editor's border, so an unfocused probe would miss a
+            // shift that renaming actually shows.
+            ((ElementViewModel)element.DataContext!).RenameRequested();
+            HeadlessTestHelpers.Render(5);
+            Assert.That(textBox.IsVisible && textBox.IsFocused, Is.True,
+                "Rename did not put the focused editor on screen, so this comparison would prove nothing.");
+
             TextPresenter presenter = textBox.GetVisualDescendants().OfType<TextPresenter>().First();
             double editInset = presenter.TranslatePoint(new Point(0, 0), border)!.Value.X;
 

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -1,0 +1,186 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.NUnit;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Components.TimelineTab.Views;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Graphics.Shapes;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.Views;
+
+namespace Beutl.HeadlessUITests;
+
+// Locks the rounded timeline-clip layout: the name label is inset clear of the corner arc and of
+// the lock glyph, renaming does not move it, and the thumbnail strip + waveform are wrapped in a
+// rounded, clipped media host so their corners no longer poke past the clip's border.
+[TestFixture]
+public class ElementViewLayoutTests
+{
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    private static void AddRectangle(EditViewModel editor)
+    {
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        adder.AddElement(new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            EngineObjectFactory: () => new RectShape()));
+        HeadlessTestHelpers.Settle();
+    }
+
+    private static async Task<(Window Window, ElementView Element)> InflateFirstElementView(string name)
+    {
+        await TestReset.ResetShellAsync();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        EditViewModel editor = await OpenEditorForNewScene(name);
+        AddRectangle(editor);
+
+        var window = new Window { Content = new EditView { DataContext = editor }, Width = 1200, Height = 800 };
+        window.Show();
+        HeadlessTestHelpers.Render(5);
+
+        ElementView? element = window.GetVisualDescendants().OfType<ElementView>().FirstOrDefault();
+        Assert.That(element, Is.Not.Null, "The timeline should inflate an ElementView for the added clip.");
+        return (window, element!);
+    }
+
+    [AvaloniaTest]
+    public async Task Label_is_inset_clear_of_the_rounded_corner()
+    {
+        (Window window, ElementView element) = await InflateFirstElementView("elementview-inset");
+        try
+        {
+            Control border = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "border");
+            Control label = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBlock");
+            double labelLeftInset = label.TranslatePoint(new Point(0, 0), border)!.Value.X;
+
+            // The 4px corner arc eats a flush-left label, which is where it sat before (1px, the border
+            // stroke alone). A 6px margin on top of that stroke clears the arc.
+            Assert.That(labelLeftInset, Is.EqualTo(7).Within(0.5),
+                $"Label left inset was {labelLeftInset}; expected 7 (1px border stroke + 6px margin).");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Locked_clip_keeps_the_label_clear_of_the_lock_glyph()
+    {
+        (Window window, ElementView element) = await InflateFirstElementView("elementview-locked");
+        try
+        {
+            var viewModel = (ElementViewModel)element.DataContext!;
+            viewModel.Model.IsLocked = true;
+            HeadlessTestHelpers.Render(5);
+            Assert.That(viewModel.IsEditable.Value, Is.False, "Locking the element must make it non-editable.");
+
+            Control lockIcon = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "lockIcon");
+            Control label = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBlock");
+            Assert.That(lockIcon.IsVisible, Is.True, "A locked clip must show the lock glyph.");
+
+            double glyphRight = lockIcon.TranslatePoint(new Point(lockIcon.Bounds.Width, 0), element)!.Value.X;
+            double labelLeft = label.TranslatePoint(new Point(0, 0), element)!.Value.X;
+
+            // Asserted against the glyph's measured width rather than a reserved constant, so growing
+            // the glyph's FontSize fails here instead of silently overlapping the name.
+            Assert.That(labelLeft, Is.GreaterThanOrEqualTo(glyphRight),
+                $"The name overlaps the lock glyph: glyph ends at {glyphRight}, label starts at {labelLeft}.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Rename_textbox_text_starts_where_the_label_does()
+    {
+        (Window window, ElementView element) = await InflateFirstElementView("elementview-rename");
+        try
+        {
+            Control border = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "border");
+            Control label = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBlock");
+            var textBox = (TextBox)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBox");
+
+            textBox.IsVisible = true;
+            HeadlessTestHelpers.Render(5);
+
+            double labelInset = label.TranslatePoint(new Point(0, 0), border)!.Value.X;
+            TextPresenter presenter = textBox.GetVisualDescendants().OfType<TextPresenter>().First();
+            double editInset = presenter.TranslatePoint(new Point(0, 0), border)!.Value.X;
+
+            Assert.That(editInset, Is.EqualTo(labelInset).Within(0.5),
+                $"Renaming must not shift the name horizontally: label at {labelInset}px, edit text at "
+                + $"{editInset}px (off by {editInset - labelInset}px). Check ElementNameTextBoxTheme's "
+                + "Padding against the label's Margin.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Media_host_rounds_and_clips_the_thumbnail_and_waveform()
+    {
+        (Window window, ElementView element) = await InflateFirstElementView("elementview-rounded");
+        try
+        {
+            // A real filmstrip/waveform never renders in this headless layout pass (both need async
+            // media decode), so the rounding is asserted structurally: the wrapper Border rounds to
+            // the clip's inner radius (3px = 4px outer - 1px stroke) and clips its children.
+            var mediaClip = (Border)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "mediaClip");
+            Assert.Multiple(() =>
+            {
+                Assert.That(mediaClip.CornerRadius, Is.EqualTo(new CornerRadius(3)),
+                    "Media host must round to the clip's inner radius.");
+                Assert.That(mediaClip.ClipToBounds, Is.True,
+                    "Media host must clip its children to the rounded rect.");
+            });
+
+            Control thumbnailStrip = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "thumbnailStrip");
+            Control waveform = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "waveformControl");
+            Assert.Multiple(() =>
+            {
+                Assert.That(thumbnailStrip.GetVisualAncestors(), Does.Contain(mediaClip),
+                    "The thumbnail strip must sit inside the rounded media host.");
+                Assert.That(waveform.GetVisualAncestors(), Does.Contain(mediaClip),
+                    "The waveform must sit inside the rounded media host.");
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -1,7 +1,10 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
+using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using Beutl.Editor.Components.TimelineTab.ViewModels;
@@ -147,6 +150,64 @@ public class ElementViewLayoutTests
             window.Close();
             HeadlessTestHelpers.Settle();
         }
+    }
+
+    [AvaloniaTest]
+    public async Task Renaming_does_not_paint_into_the_rounded_corner()
+    {
+        (Window window, ElementView element) = await InflateFirstElementView("elementview-corner");
+        try
+        {
+            Control border = element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "border");
+            var textBox = (TextBox)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBox");
+            Point origin = border.TranslatePoint(new Point(0, 0), window)!.Value;
+
+            // (+1,+0) lies outside the 4px corner arc: at y=0.5 the rounded edge only starts at
+            // x≈2.06. The rename editor overhangs the clip vertically, so without a rounded clip on
+            // the border it repaints this pixel.
+            var probe = new PixelPoint((int)origin.X + 1, (int)origin.Y);
+            uint atRest = SamplePixel(window, probe);
+
+            textBox.IsVisible = true;
+            textBox.Focus();
+            HeadlessTestHelpers.Render(5);
+            uint whileRenaming = SamplePixel(window, probe);
+
+            // Measured: 39 with the border clipped, 133 without it (the editor's fill bleeding into
+            // the corner). The threshold sits between, so it tolerates antialiasing but not the bleed.
+            int drift = MaxChannelDelta(atRest, whileRenaming);
+            Assert.That(drift, Is.LessThan(64),
+                $"Renaming repainted the rounded corner: #{atRest:X8} became #{whileRenaming:X8} "
+                + $"(max channel drift {drift}). The clip's Border needs ClipToBounds to round its children.");
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static uint SamplePixel(Window window, PixelPoint point)
+    {
+        using WriteableBitmap frame = window.CaptureRenderedFrame()!;
+        using ILockedFramebuffer buffer = frame.Lock();
+        unsafe
+        {
+            byte* row = (byte*)buffer.Address + (point.Y * buffer.RowBytes);
+            return ((uint*)row)[point.X];
+        }
+    }
+
+    private static int MaxChannelDelta(uint left, uint right)
+    {
+        int max = 0;
+        for (int shift = 0; shift < 32; shift += 8)
+        {
+            int delta = Math.Abs((int)((left >> shift) & 0xFF) - (int)((right >> shift) & 0xFF));
+            max = Math.Max(max, delta);
+        }
+
+        return max;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -162,22 +162,24 @@ public class ElementViewLayoutTests
             var textBox = (TextBox)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "textBox");
             Point origin = border.TranslatePoint(new Point(0, 0), window)!.Value;
 
-            // (+1,+0) lies outside the 4px corner arc: at y=0.5 the rounded edge only starts at
-            // x≈2.06. The rename editor overhangs the clip vertically, so without a rounded clip on
-            // the border it repaints this pixel.
-            var probe = new PixelPoint((int)origin.X + 1, (int)origin.Y);
+            // The probe pixel straddles the clip's corner arc, so a correctly clipped repaint still
+            // shifts it by antialiasing alone. An unclipped one fills it with the editor's focus
+            // accent instead. Measured drift: 39 clipped, 133 unclipped.
+            PixelPoint probe = ToPixel(window, origin + new Point(1, 0));
             uint atRest = SamplePixel(window, probe);
 
-            textBox.IsVisible = true;
-            textBox.Focus();
+            // Drive the real rename entry point: a probe taken without focus would sample the
+            // unfocused editor and pass even with the clip removed.
+            ((ElementViewModel)element.DataContext!).RenameRequested();
             HeadlessTestHelpers.Render(5);
+            Assert.That(textBox.IsVisible && textBox.IsFocused, Is.True,
+                "Rename did not put the focused editor on screen, so this probe would prove nothing.");
+
             uint whileRenaming = SamplePixel(window, probe);
 
-            // Measured: 39 with the border clipped, 133 without it (the editor's fill bleeding into
-            // the corner). The threshold sits between, so it tolerates antialiasing but not the bleed.
             int drift = MaxChannelDelta(atRest, whileRenaming);
             Assert.That(drift, Is.LessThan(64),
-                $"Renaming repainted the rounded corner: #{atRest:X8} became #{whileRenaming:X8} "
+                $"Renaming repainted the rounded corner: {Rgba(atRest)} became {Rgba(whileRenaming)} "
                 + $"(max channel drift {drift}). The clip's Border needs ClipToBounds to round its children.");
         }
         finally
@@ -187,16 +189,35 @@ public class ElementViewLayoutTests
         }
     }
 
+    private static PixelPoint ToPixel(Window window, Point dip)
+    {
+        double scale = window.RenderScaling;
+        return new PixelPoint((int)Math.Round(dip.X * scale), (int)Math.Round(dip.Y * scale));
+    }
+
+    // Reads raw framebuffer memory, so every assumption it makes has to fail loudly: an
+    // out-of-range index would read unrelated memory instead of throwing.
     private static uint SamplePixel(Window window, PixelPoint point)
     {
-        using WriteableBitmap frame = window.CaptureRenderedFrame()!;
+        using WriteableBitmap frame = window.CaptureRenderedFrame()
+            ?? throw new InvalidOperationException("CaptureRenderedFrame returned null; the window never rendered.");
         using ILockedFramebuffer buffer = frame.Lock();
+        Assert.That(buffer.Format, Is.EqualTo(PixelFormat.Rgba8888).Or.EqualTo(PixelFormat.Bgra8888),
+            $"SamplePixel assumes a 32bpp framebuffer but the frame is {buffer.Format}.");
+        Assert.That(point.X, Is.InRange(0, buffer.Size.Width - 1), "Probe X is outside the captured frame.");
+        Assert.That(point.Y, Is.InRange(0, buffer.Size.Height - 1), "Probe Y is outside the captured frame.");
+
         unsafe
         {
             byte* row = (byte*)buffer.Address + (point.Y * buffer.RowBytes);
             return ((uint*)row)[point.X];
         }
     }
+
+    // The framebuffer is Rgba8888, so a little-endian uint reads back as 0xAABBGGRR — printing it
+    // as hex would name the channels in the wrong order.
+    private static string Rgba(uint pixel)
+        => $"rgba({pixel & 0xFF},{(pixel >> 8) & 0xFF},{(pixel >> 16) & 0xFF},{pixel >> 24})";
 
     private static int MaxChannelDelta(uint left, uint right)
     {

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -203,26 +203,33 @@ public class ElementViewLayoutTests
     }
 
     // Reads raw framebuffer memory, so every assumption it makes has to fail loudly: an
-    // out-of-range index would read unrelated memory instead of throwing.
+    // out-of-range index would read unrelated memory instead of throwing. The result is normalized
+    // to RGBA byte order so callers never have to re-check which layout the backend handed back.
     private static uint SamplePixel(Window window, PixelPoint point)
     {
         using WriteableBitmap frame = window.CaptureRenderedFrame()
             ?? throw new InvalidOperationException("CaptureRenderedFrame returned null; the window never rendered.");
         using ILockedFramebuffer buffer = frame.Lock();
         Assert.That(buffer.Format, Is.EqualTo(PixelFormat.Rgba8888).Or.EqualTo(PixelFormat.Bgra8888),
-            $"SamplePixel assumes a 32bpp framebuffer but the frame is {buffer.Format}.");
+            $"SamplePixel assumes a 32bpp RGBA or BGRA framebuffer but the frame is {buffer.Format}.");
         Assert.That(point.X, Is.InRange(0, buffer.Size.Width - 1), "Probe X is outside the captured frame.");
         Assert.That(point.Y, Is.InRange(0, buffer.Size.Height - 1), "Probe Y is outside the captured frame.");
 
+        uint pixel;
         unsafe
         {
             byte* row = (byte*)buffer.Address + (point.Y * buffer.RowBytes);
-            return ((uint*)row)[point.X];
+            pixel = ((uint*)row)[point.X];
         }
+
+        return buffer.Format == PixelFormat.Bgra8888 ? SwapRedAndBlue(pixel) : pixel;
     }
 
-    // The framebuffer is Rgba8888, so a little-endian uint reads back as 0xAABBGGRR — printing it
-    // as hex would name the channels in the wrong order.
+    private static uint SwapRedAndBlue(uint pixel)
+        => (pixel & 0xFF00FF00) | ((pixel & 0x000000FF) << 16) | ((pixel & 0x00FF0000) >> 16);
+
+    // A little-endian uint over an RGBA frame reads back as 0xAABBGGRR, so printing it as hex would
+    // name the channels in reverse.
     private static string Rgba(uint pixel)
         => $"rgba({pixel & 0xFF},{(pixel >> 8) & 0xFF},{(pixel >> 16) & 0xFF},{pixel >> 24})";
 


### PR DESCRIPTION
## Description
Reshapes the timeline clip so its outline and name read cleanly. Clip colors are untouched.

- The clip border gets a 4px corner radius, and the thumbnail strip and waveform are wrapped in a matching rounded, clipped media host so their corners no longer poke past the outline.
- The name label is inset 6px from the border stroke (7px from the clip edge) so the corner arc no longer eats it — it previously sat flush at 1px.
- **Bug fix:** the lock glyph now occupies its own layout column instead of being overlaid on the label. On a locked clip the glyph was drawn on top of the first characters of the name; the column makes the clearance structural rather than a reserved margin, so growing the glyph cannot reintroduce the overlap.
- Renaming no longer shifts the name: the rename TextBox takes a timeline-local `ElementNameTextBoxTheme` whose left padding carries the label's margin, following the existing `LayerHeaderNameTextBoxTheme` pattern. Previously the label sat at 1px and the edit text at 12px.
- The rest-state border is derived at -30% lightness instead of -15% for a clearer edge against the clip fill.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None.

## Test plan
`tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs` pins four properties, each characterized against the unpatched code so none of them is a tautology:

- `Label_is_inset_clear_of_the_rounded_corner` — 7px inset (1px stroke + 6px margin), tolerance `Within(0.5)`.
- `Locked_clip_keeps_the_label_clear_of_the_lock_glyph` — asserts the label starts at or after the glyph's *measured* right edge, not a reserved constant. Reverting to the overlay layout fails it with "glyph ends at 19, label starts at 7".
- `Rename_textbox_text_starts_where_the_label_does` — compares the edit `TextPresenter` inset to the label's. Reverting the theme padding fails it with "label at 7, edit text at 12".
- `Media_host_rounds_and_clips_the_thumbnail_and_waveform` — structural check on the rounded clip host.

`dotnet build Beutl.slnx` is clean and the headless UI suite passes locally (154 tests). Note: that suite has a pre-existing intermittent `Dispatcher.PushFrame` / `PlatformNotSupportedException` flake that hits a different unrelated test each run — it also fails on `main`'s own CI (`OpenProject_round_trips_frame_size` on c2ddfd54) and is not introduced here.

## Fixed issues / References
Split out of the in-progress `design` branch so the timeline clip layout can be reviewed and merged on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Adjusted the timeline clip’s “rest” border tint to be softer.
  - Refined the clip layout with updated rounded corners and spacing, including the locked-state alignment for the label and lock glyph.
  - Improved media rendering by wrapping the thumbnail strip and waveform in a rounded, clipped container.
  - Added a dedicated `TextBox` theme for timeline element name editing.
- **Tests**
  - Added headless UI layout regression coverage for label inset, locked-state non-overlap, rename alignment, and rounded/clipped media hosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->