### PR TITLE
feat: log surviving objects and stacks via ClrMD when an extension's AssemblyLoadContext fails to unload

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="4.0.732401" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.10" />

--- a/src/Beutl.Api/Beutl.Api.csproj
+++ b/src/Beutl.Api/Beutl.Api.csproj
@@ -5,7 +5,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" />
+    <!-- Development-only: the ClrMD unload diagnostics are compiled and wired under DEBUG only, so keep the heavy
+         Microsoft.Diagnostics.Runtime dependency (and its transitive diagnostics packages) out of Release. -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Nito.AsyncEx" />
     <PackageReference Include="OpenTelemetry" />
@@ -17,6 +19,12 @@
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.Resolver" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <!-- Excluded from Release together with the Microsoft.Diagnostics.Runtime reference above; this is the only
+         type that depends on ClrMD, and it is instantiated exclusively under #if DEBUG (BeutlApiApplication). -->
+    <Compile Remove="Services\ClrmdLoadContextUnloadDiagnostics.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Beutl.Api/Beutl.Api.csproj
+++ b/src/Beutl.Api/Beutl.Api.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Nito.AsyncEx" />
     <PackageReference Include="OpenTelemetry" />

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -153,9 +153,18 @@ public class BeutlApiApplication
         Register(() => new PackageChangesQueue());
         Register(() => new LibraryService(this));
         Register(() => new PackageInstaller(new HttpClient(), GetResource<InstalledPackageRepository>(), this));
-        Register(() => new PackageManager(
-            GetResource<InstalledPackageRepository>(), GetResource<ExtensionProvider>(),
-            GetResource<ContextCommandManager>(), this, new ClrmdLoadContextUnloadDiagnostics()));
+        Register(() =>
+        {
+            // Unload diagnostics take a heavy ClrMD self-snapshot and write a dump; they are a development-only aid,
+            // so Release builds wire null and neither snapshot, dump, nor log on an unload failure.
+            ILoadContextUnloadDiagnostics? unloadDiagnostics = null;
+#if DEBUG
+            unloadDiagnostics = new ClrmdLoadContextUnloadDiagnostics();
+#endif
+            return new PackageManager(
+                GetResource<InstalledPackageRepository>(), GetResource<ExtensionProvider>(),
+                GetResource<ContextCommandManager>(), this, unloadDiagnostics);
+        });
     }
 
     private void Register<T>(Func<T> factory)

--- a/src/Beutl.Api/BeutlApiApplication.cs
+++ b/src/Beutl.Api/BeutlApiApplication.cs
@@ -155,7 +155,7 @@ public class BeutlApiApplication
         Register(() => new PackageInstaller(new HttpClient(), GetResource<InstalledPackageRepository>(), this));
         Register(() => new PackageManager(
             GetResource<InstalledPackageRepository>(), GetResource<ExtensionProvider>(),
-            GetResource<ContextCommandManager>(), this));
+            GetResource<ContextCommandManager>(), this, new ClrmdLoadContextUnloadDiagnostics()));
     }
 
     private void Register<T>(Func<T> factory)

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -153,6 +153,13 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
         foreach (ClrRoot root in heap.EnumerateRoots())
         {
+            // A root-heavy process can blow the object/time bound during seeding alone, before the walk below runs.
+            if (parent.Count >= MaxVisitedObjects || stopwatch.Elapsed > s_budget)
+            {
+                truncated = true;
+                break;
+            }
+
             ClrObject obj = root.Object;
             if (!obj.IsValid || obj.Address == 0 || parent.ContainsKey(obj.Address))
             {
@@ -210,14 +217,16 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
         return (results, truncated);
     }
 
-    private static UnloadDiagnosticsRootPath BuildPath(
+    internal static UnloadDiagnosticsRootPath BuildPath(
         ulong targetAddress, Dictionary<ulong, (ulong Parent, string Edge, string Type)> parent)
     {
+        const int MaxHops = 128;
         var reversed = new List<string>();
         string targetType = "<unknown>";
         ulong address = targetAddress;
+        bool reachedRoot = false;
 
-        for (int guard = 0; guard < 128 && parent.TryGetValue(address, out (ulong Parent, string Edge, string Type) node); guard++)
+        for (int guard = 0; guard < MaxHops && parent.TryGetValue(address, out (ulong Parent, string Edge, string Type) node); guard++)
         {
             if (address == targetAddress)
             {
@@ -227,10 +236,17 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             reversed.Add($"{node.Edge} -> {node.Type} (0x{address:x})");
             if (node.Parent == 0)
             {
+                reachedRoot = true;
                 break;
             }
 
             address = node.Parent;
+        }
+
+        if (!reachedRoot)
+        {
+            // Hit the hop cap before a GC root; mark it so a cut chain isn't read as reaching the root.
+            reversed.Add($"... (path truncated after {MaxHops} hops; GC root not reached)");
         }
 
         reversed.Reverse();
@@ -278,6 +294,13 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             var frames = new List<string>();
             foreach (ClrStackFrame frame in thread.EnumerateStackTrace(includeContext: false))
             {
+                // A single deep stack can exceed the shared budget on its own, so check per frame, not just per thread.
+                if (stopwatch.Elapsed > s_budget)
+                {
+                    truncated = true;
+                    break;
+                }
+
                 if (frames.Count >= MaxFramesPerThread)
                 {
                     break;
@@ -289,6 +312,11 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             // Keep alive threads with no managed frames too: a native-only stack is itself a signal, and the report
             // renders it as "(no managed frames)".
             results.Add(new UnloadDiagnosticsThreadStack(thread.ManagedThreadId, thread.OSThreadId, frames));
+
+            if (truncated)
+            {
+                break;
+            }
         }
 
         return (results, truncated);

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -307,17 +307,20 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             }
 
             var frames = new List<string>();
+            bool budgetExpired = false;
             foreach (ClrStackFrame frame in thread.EnumerateStackTrace(includeContext: false))
             {
                 // A single deep stack can exceed the shared budget on its own, so check per frame, not just per thread.
                 if (stopwatch.Elapsed > s_budget)
                 {
                     truncated = true;
+                    budgetExpired = true;
                     break;
                 }
 
                 if (frames.Count >= MaxFramesPerThread)
                 {
+                    // A per-thread cap only makes this thread partial; keep capturing the remaining threads.
                     truncated = true;
                     break;
                 }
@@ -329,7 +332,9 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             // renders it as "(no managed frames)".
             results.Add(new UnloadDiagnosticsThreadStack(thread.ManagedThreadId, thread.OSThreadId, frames));
 
-            if (truncated)
+            // Only the shared time budget stops the whole walk; the per-thread frame cap must not skip later threads
+            // (one of which may be the one holding the plugin alive).
+            if (budgetExpired)
             {
                 break;
             }
@@ -393,13 +398,19 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
                 return;
             }
 
+            int retain = Math.Max(0, maxRetained);
             FileInfo[] dumps = dir.GetFiles("unload-dump-*.txt");
-            if (dumps.Length <= maxRetained)
+            if (dumps.Length <= retain)
             {
                 return;
             }
 
-            foreach (FileInfo old in dumps.OrderByDescending(f => f.LastWriteTimeUtc).Skip(maxRetained))
+            // Name is the tie-breaker (it embeds the timestamp + GUID), so which files survive is deterministic even
+            // when several dumps share a LastWriteTimeUtc.
+            foreach (FileInfo old in dumps
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ThenByDescending(f => f.Name, StringComparer.Ordinal)
+                .Skip(retain))
             {
                 try
                 {

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -21,6 +21,9 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
     private const int MaxVisitedObjects = 300_000;
     private const int MaxFramesPerThread = 200;
 
+    // The shared log-dir housekeeping only runs in the desktop host, so self-prune to stay bounded in headless hosts.
+    private const int MaxRetainedDumps = 5;
+
     private readonly ILogger _logger = Log.CreateLogger<ClrmdLoadContextUnloadDiagnostics>();
 
     public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
@@ -289,12 +292,49 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             string fileName = $"unload-dump-{safeName}-{DateTime.Now:yyyyMMddHHmmss}.txt";
             string path = Path.Combine(logDir, fileName);
             File.WriteAllText(path, report.BuildReport());
+            PruneOldDumps(logDir, MaxRetainedDumps);
             return path;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to write unload diagnostics dump for {PackageName}.", packageName);
             return null;
+        }
+    }
+
+    // Best-effort retention: keep the newest dumps by write time and drop the rest. Never throws, so a failed prune
+    // cannot mask the dump that was just written.
+    internal static void PruneOldDumps(string logDir, int maxRetained)
+    {
+        try
+        {
+            var dir = new DirectoryInfo(logDir);
+            if (!dir.Exists)
+            {
+                return;
+            }
+
+            FileInfo[] dumps = dir.GetFiles("unload-dump-*.txt");
+            if (dumps.Length <= maxRetained)
+            {
+                return;
+            }
+
+            foreach (FileInfo old in dumps.OrderByDescending(f => f.LastWriteTimeUtc).Skip(maxRetained))
+            {
+                try
+                {
+                    old.Delete();
+                }
+                catch
+                {
+                    // A racing host may have removed it already; skip and continue.
+                }
+            }
+        }
+        catch
+        {
+            // Retention must never disturb the uninstall flow.
         }
     }
 }

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -189,15 +189,16 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
             if (remaining.Remove(current.Address))
             {
+                // Record the path but keep walking this object's children: a selected survivor can be the only route
+                // to another selected survivor, which would otherwise get no root path.
                 results.Add(BuildPath(current.Address, parent));
-                continue;
             }
 
             foreach (ClrReference reference in current.EnumerateReferencesWithFields(carefully: true, considerDependantHandles: true))
             {
-                // Children are enqueued faster than they are dequeued, so bound the map here too; the dequeue-side
-                // visit cap alone would let it outgrow MaxVisitedObjects on a large heap.
-                if (parent.Count >= MaxVisitedObjects)
+                // Children are enqueued faster than they are dequeued, and a huge reference array can add no new
+                // parent entries at all, so bound by both the map size and the time budget here.
+                if (parent.Count >= MaxVisitedObjects || stopwatch.Elapsed > s_budget)
                 {
                     truncated = true;
                     break;
@@ -303,6 +304,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
                 if (frames.Count >= MaxFramesPerThread)
                 {
+                    truncated = true;
                     break;
                 }
 

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -25,10 +25,20 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
     // retention bound. Unload failures are rare, so keeping a few is plenty of history.
     private const int MaxRetainedDumps = 5;
 
+    // Skip a capture while one is already running: concurrent unload failures would otherwise fire several heavy
+    // self-snapshots at once. Internal so a test can hold it to exercise the skip path.
+    internal static readonly SemaphoreSlim s_captureGate = new(1, 1);
+
     private readonly ILogger _logger = Log.CreateLogger<ClrmdLoadContextUnloadDiagnostics>();
 
     public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
     {
+        if (!s_captureGate.Wait(0))
+        {
+            _logger.LogWarning("Skipping unload diagnostics for {PackageName}: a capture is already in progress.", packageName);
+            return;
+        }
+
         try
         {
             var pluginAssemblies = new HashSet<string>(assemblySimpleNames, StringComparer.OrdinalIgnoreCase);
@@ -74,6 +84,10 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
         {
             // Diagnostics must never disturb the uninstall flow; swallow everything after logging.
             _logger.LogError(ex, "Failed to capture unload diagnostics for {PackageName}.", packageName);
+        }
+        finally
+        {
+            s_captureGate.Release();
         }
     }
 

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -21,7 +21,8 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
     private const int MaxVisitedObjects = 300_000;
     private const int MaxFramesPerThread = 200;
 
-    // The shared log-dir housekeeping only runs in the desktop host, so self-prune to stay bounded in headless hosts.
+    // Dumps get their own directory that the app-side log housekeeping never scans, so PruneOldDumps is their only
+    // retention bound. Unload failures are rare, so keeping a few is plenty of history.
     private const int MaxRetainedDumps = 5;
 
     private readonly ILogger _logger = Log.CreateLogger<ClrmdLoadContextUnloadDiagnostics>();
@@ -282,17 +283,20 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
         return signature;
     }
 
+    internal static string GetDumpDirectory() =>
+        Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "log", "unload-dumps");
+
     private string? TryWriteReport(string packageName, UnloadDiagnosticsReport report)
     {
         try
         {
-            string logDir = Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "log");
-            Directory.CreateDirectory(logDir);
+            string dumpDir = GetDumpDirectory();
+            Directory.CreateDirectory(dumpDir);
             string safeName = string.Concat(packageName.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
             string fileName = $"unload-dump-{safeName}-{DateTime.Now:yyyyMMddHHmmss}.txt";
-            string path = Path.Combine(logDir, fileName);
+            string path = Path.Combine(dumpDir, fileName);
             File.WriteAllText(path, report.BuildReport());
-            PruneOldDumps(logDir, MaxRetainedDumps);
+            PruneOldDumps(dumpDir, MaxRetainedDumps);
             return path;
         }
         catch (Exception ex)

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -31,12 +31,12 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
     private readonly ILogger _logger = Log.CreateLogger<ClrmdLoadContextUnloadDiagnostics>();
 
-    public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
+    public string? CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
     {
         if (!s_captureGate.Wait(0))
         {
             _logger.LogWarning("Skipping unload diagnostics for {PackageName}: a capture is already in progress.", packageName);
-            return;
+            return null;
         }
 
         try
@@ -44,7 +44,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             var pluginAssemblies = new HashSet<string>(assemblySimpleNames, StringComparer.OrdinalIgnoreCase);
             if (pluginAssemblies.Count == 0)
             {
-                return;
+                return null;
             }
 
             var stopwatch = Stopwatch.StartNew();
@@ -52,7 +52,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             if (dataTarget.ClrVersions.IsDefaultOrEmpty)
             {
                 _logger.LogWarning("No CLR found in snapshot; cannot capture unload diagnostics for {PackageName}.", packageName);
-                return;
+                return null;
             }
 
             using ClrRuntime runtime = dataTarget.ClrVersions[0].CreateRuntime();
@@ -60,7 +60,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             if (!heap.CanWalkHeap)
             {
                 _logger.LogWarning("Snapshot heap is not walkable; cannot capture unload diagnostics for {PackageName}.", packageName);
-                return;
+                return null;
             }
 
             (List<UnloadDiagnosticsObjectGroup> groups, int total, HashSet<ulong> targets, bool censusTruncated) =
@@ -79,11 +79,13 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             string? dumpPath = TryWriteReport(packageName, report);
             _logger.LogWarning(
                 "{Summary} Dump file: {DumpPath}", report.BuildSummary(), dumpPath ?? "(not written)");
+            return dumpPath;
         }
         catch (Exception ex)
         {
             // Diagnostics must never disturb the uninstall flow; swallow everything after logging.
             _logger.LogError(ex, "Failed to capture unload diagnostics for {PackageName}.", packageName);
+            return null;
         }
         finally
         {

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -15,7 +15,9 @@ namespace Beutl.Api.Services;
 /// </summary>
 internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiagnostics
 {
-    // The whole capture runs only on the rare unload-failure path; these caps keep a large heap from hanging it.
+    // These caps keep a large heap from hanging the rare unload-failure capture. s_budget bounds only the heap, root,
+    // and thread walks below; DataTarget.CreateSnapshotAndAttach is a synchronous ClrMD call with no cancellation
+    // hook, so snapshot creation itself is outside this budget and can run longer on a huge or stalled process.
     private static readonly TimeSpan s_budget = TimeSpan.FromSeconds(30);
     private const int MaxRootPaths = 15;
     private const int MaxVisitedObjects = 300_000;
@@ -63,8 +65,10 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
                 return null;
             }
 
+            HashSet<ulong> loadContextTargets = FindLoadContextTargets(runtime, pluginAssemblies);
+
             (List<UnloadDiagnosticsObjectGroup> groups, int total, HashSet<ulong> targets, bool censusTruncated) =
-                CensusSurvivingObjects(heap, pluginAssemblies, stopwatch);
+                CensusSurvivingObjects(heap, pluginAssemblies, loadContextTargets, stopwatch);
 
             (List<UnloadDiagnosticsRootPath> rootPaths, bool rootTruncated) =
                 FindRootPaths(heap, targets, stopwatch);
@@ -94,12 +98,25 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
     }
 
     private (List<UnloadDiagnosticsObjectGroup> Groups, int Total, HashSet<ulong> Targets, bool Truncated) CensusSurvivingObjects(
-        ClrHeap heap, HashSet<string> pluginAssemblies, Stopwatch stopwatch)
+        ClrHeap heap, HashSet<string> pluginAssemblies, HashSet<ulong> loadContextTargets, Stopwatch stopwatch)
     {
         var counts = new Dictionary<(string Assembly, string TypeName), int>();
         var targets = new HashSet<ulong>();
         int total = 0;
         bool truncated = false;
+
+        // The plugin-module filter below only catches heap objects whose own type lives in a plugin assembly, so it
+        // misses the failure mode where no plugin instance survives and only the collectible AssemblyLoadContext (a
+        // Beutl.Api type) still roots the context. Seed those load-context objects first so the leak still has an anchor.
+        foreach (ulong address in loadContextTargets)
+        {
+            if (targets.Count >= MaxRootPaths)
+            {
+                break;
+            }
+
+            targets.Add(address);
+        }
 
         foreach (ClrObject obj in heap.EnumerateObjects())
         {
@@ -132,6 +149,51 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
         }
 
         return (ToObjectGroups(counts), total, targets, truncated);
+    }
+
+    // Resolve the AssemblyLoadContext object for each plugin assembly straight from its module metadata, which the
+    // runtime keeps alive as long as the context is loaded. This finds the leaked context even when no plugin-typed
+    // instance survives — the case the heap census cannot see, because the context object is a Beutl.Api type.
+    internal static HashSet<ulong> FindLoadContextTargets(ClrRuntime runtime, HashSet<string> pluginAssemblies)
+    {
+        var addresses = new HashSet<ulong>();
+        foreach (ClrModule module in runtime.EnumerateModules())
+        {
+            if (module.Name is not { } moduleName
+                || !pluginAssemblies.Contains(Path.GetFileNameWithoutExtension(moduleName)))
+            {
+                continue;
+            }
+
+            ulong loadContext = ResolveLoadContextAddress(runtime, module);
+            if (loadContext != 0)
+            {
+                addresses.Add(loadContext);
+            }
+        }
+
+        return addresses;
+    }
+
+    // AssemblyLoadContextAddress lives on ClrType, not ClrModule, so read it off any constructed type the module
+    // defines; every type loaded into a context reports that context's address, so the first non-zero hit suffices.
+    private static ulong ResolveLoadContextAddress(ClrRuntime runtime, ClrModule module)
+    {
+        foreach ((ulong methodTable, _) in module.EnumerateTypeDefToMethodTableMap())
+        {
+            if (methodTable == 0)
+            {
+                continue;
+            }
+
+            ClrType? type = runtime.GetTypeByMethodTable(methodTable);
+            if (type is not null && type.AssemblyLoadContextAddress != 0)
+            {
+                return type.AssemblyLoadContextAddress;
+            }
+        }
+
+        return 0;
     }
 
     // Keyed by (assembly, type) so identical type names from different plugin assemblies stay distinct; keying by

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -1,0 +1,300 @@
+﻿using System.Diagnostics;
+
+using Beutl.Logging;
+
+using Microsoft.Diagnostics.Runtime;
+
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Api.Services;
+
+/// <summary>
+/// ClrMD-backed <see cref="ILoadContextUnloadDiagnostics"/>. It snapshots the current process (an out-of-band copy,
+/// so walking it adds no GC roots to the live heap) and records the surviving plugin objects, the reference chains
+/// from GC roots that keep them alive, and the managed thread stacks.
+/// </summary>
+internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiagnostics
+{
+    // The whole capture runs only on the rare unload-failure path; these caps keep a large heap from hanging it.
+    private static readonly TimeSpan s_budget = TimeSpan.FromSeconds(30);
+    private const int MaxRootPaths = 15;
+    private const int MaxVisitedObjects = 300_000;
+    private const int MaxFramesPerThread = 200;
+
+    private readonly ILogger _logger = Log.CreateLogger<ClrmdLoadContextUnloadDiagnostics>();
+
+    public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
+    {
+        try
+        {
+            var pluginAssemblies = new HashSet<string>(assemblySimpleNames, StringComparer.OrdinalIgnoreCase);
+            if (pluginAssemblies.Count == 0)
+            {
+                return;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            using DataTarget dataTarget = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
+            if (dataTarget.ClrVersions.IsDefaultOrEmpty)
+            {
+                _logger.LogWarning("No CLR found in snapshot; cannot capture unload diagnostics for {PackageName}.", packageName);
+                return;
+            }
+
+            using ClrRuntime runtime = dataTarget.ClrVersions[0].CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+            if (!heap.CanWalkHeap)
+            {
+                _logger.LogWarning("Snapshot heap is not walkable; cannot capture unload diagnostics for {PackageName}.", packageName);
+                return;
+            }
+
+            (List<UnloadDiagnosticsObjectGroup> groups, int total, HashSet<ulong> targets, bool censusTruncated) =
+                CensusSurvivingObjects(heap, pluginAssemblies, stopwatch);
+
+            (List<UnloadDiagnosticsRootPath> rootPaths, bool rootTruncated) =
+                FindRootPaths(heap, targets, stopwatch);
+
+            List<UnloadDiagnosticsThreadStack> threads = CaptureThreadStacks(runtime, pluginAssemblies);
+
+            var report = new UnloadDiagnosticsReport(
+                packageName, assemblySimpleNames, total, groups, rootPaths, threads, censusTruncated || rootTruncated);
+
+            string? dumpPath = TryWriteReport(packageName, report);
+            _logger.LogWarning(
+                "{Summary} Dump file: {DumpPath}", report.BuildSummary(), dumpPath ?? "(not written)");
+        }
+        catch (Exception ex)
+        {
+            // Diagnostics must never disturb the uninstall flow; swallow everything after logging.
+            _logger.LogError(ex, "Failed to capture unload diagnostics for {PackageName}.", packageName);
+        }
+    }
+
+    private (List<UnloadDiagnosticsObjectGroup> Groups, int Total, HashSet<ulong> Targets, bool Truncated) CensusSurvivingObjects(
+        ClrHeap heap, HashSet<string> pluginAssemblies, Stopwatch stopwatch)
+    {
+        var counts = new Dictionary<string, (string Assembly, int Count)>(StringComparer.Ordinal);
+        var targets = new HashSet<ulong>();
+        int total = 0;
+        bool truncated = false;
+
+        foreach (ClrObject obj in heap.EnumerateObjects())
+        {
+            if (stopwatch.Elapsed > s_budget)
+            {
+                truncated = true;
+                break;
+            }
+
+            ClrType? type = obj.Type;
+            if (type?.Module?.Name is not { } moduleName)
+            {
+                continue;
+            }
+
+            string assembly = Path.GetFileNameWithoutExtension(moduleName);
+            if (!pluginAssemblies.Contains(assembly))
+            {
+                continue;
+            }
+
+            total++;
+            string typeName = type.Name ?? "<unknown>";
+            counts.TryGetValue(typeName, out (string Assembly, int Count) entry);
+            counts[typeName] = (assembly, entry.Count + 1);
+
+            if (targets.Count < MaxRootPaths && obj.Address != 0)
+            {
+                targets.Add(obj.Address);
+            }
+        }
+
+        var groups = counts
+            .Select(kv => new UnloadDiagnosticsObjectGroup(kv.Key, kv.Value.Assembly, kv.Value.Count))
+            .ToList();
+        return (groups, total, targets, truncated);
+    }
+
+    private static (List<UnloadDiagnosticsRootPath> Paths, bool Truncated) FindRootPaths(
+        ClrHeap heap, HashSet<ulong> targets, Stopwatch stopwatch)
+    {
+        var results = new List<UnloadDiagnosticsRootPath>();
+        if (targets.Count == 0)
+        {
+            return (results, false);
+        }
+
+        var remaining = new HashSet<ulong>(targets);
+        // Forward BFS from every GC root. parent maps each visited object to the edge that first reached it,
+        // so a path back to its root can be reconstructed without a full reverse reference graph. (ClrMD 4.x has
+        // no GCRoot helper.)
+        var parent = new Dictionary<ulong, (ulong Parent, string Edge, string Type)>();
+        var queue = new Queue<ClrObject>();
+        bool truncated = false;
+
+        foreach (ClrRoot root in heap.EnumerateRoots())
+        {
+            ClrObject obj = root.Object;
+            if (!obj.IsValid || obj.Address == 0 || parent.ContainsKey(obj.Address))
+            {
+                continue;
+            }
+
+            parent[obj.Address] = (0, root.RootKind.ToString(), obj.Type?.Name ?? "<unknown>");
+            queue.Enqueue(obj);
+        }
+
+        int visited = 0;
+        while (queue.Count > 0)
+        {
+            if (remaining.Count == 0 || results.Count >= MaxRootPaths)
+            {
+                break;
+            }
+
+            if (visited >= MaxVisitedObjects || stopwatch.Elapsed > s_budget)
+            {
+                truncated = true;
+                break;
+            }
+
+            ClrObject current = queue.Dequeue();
+            visited++;
+
+            if (remaining.Remove(current.Address))
+            {
+                results.Add(BuildPath(current.Address, parent));
+                continue;
+            }
+
+            foreach (ClrReference reference in current.EnumerateReferencesWithFields(carefully: true, considerDependantHandles: true))
+            {
+                ClrObject child = reference.Object;
+                if (!child.IsValid || child.Address == 0 || parent.ContainsKey(child.Address))
+                {
+                    continue;
+                }
+
+                parent[child.Address] = (current.Address, DescribeEdge(reference), child.Type?.Name ?? "<unknown>");
+                queue.Enqueue(child);
+            }
+        }
+
+        return (results, truncated);
+    }
+
+    private static UnloadDiagnosticsRootPath BuildPath(
+        ulong targetAddress, Dictionary<ulong, (ulong Parent, string Edge, string Type)> parent)
+    {
+        var reversed = new List<string>();
+        string targetType = "<unknown>";
+        ulong address = targetAddress;
+
+        for (int guard = 0; guard < 128 && parent.TryGetValue(address, out (ulong Parent, string Edge, string Type) node); guard++)
+        {
+            if (address == targetAddress)
+            {
+                targetType = node.Type;
+            }
+
+            reversed.Add($"{node.Edge} -> {node.Type} (0x{address:x})");
+            if (node.Parent == 0)
+            {
+                break;
+            }
+
+            address = node.Parent;
+        }
+
+        reversed.Reverse();
+        return new UnloadDiagnosticsRootPath(targetType, reversed);
+    }
+
+    private static string DescribeEdge(ClrReference reference)
+    {
+        if (reference.IsDependentHandle)
+        {
+            return "[dependent handle]";
+        }
+
+        if (reference.IsField && reference.Field?.Name is { } fieldName)
+        {
+            return $"field {fieldName}";
+        }
+
+        if (reference.IsArrayElement)
+        {
+            return "[array element]";
+        }
+
+        return "references";
+    }
+
+    private static List<UnloadDiagnosticsThreadStack> CaptureThreadStacks(ClrRuntime runtime, HashSet<string> pluginAssemblies)
+    {
+        var results = new List<UnloadDiagnosticsThreadStack>();
+        foreach (ClrThread thread in runtime.Threads)
+        {
+            if (!thread.IsAlive)
+            {
+                continue;
+            }
+
+            var frames = new List<string>();
+            foreach (ClrStackFrame frame in thread.EnumerateStackTrace(includeContext: false))
+            {
+                if (frames.Count >= MaxFramesPerThread)
+                {
+                    break;
+                }
+
+                frames.Add(DescribeFrame(frame, pluginAssemblies));
+            }
+
+            if (frames.Count > 0)
+            {
+                results.Add(new UnloadDiagnosticsThreadStack(thread.ManagedThreadId, thread.OSThreadId, frames));
+            }
+        }
+
+        return results;
+    }
+
+    private static string DescribeFrame(ClrStackFrame frame, HashSet<string> pluginAssemblies)
+    {
+        ClrMethod? method = frame.Method;
+        if (method is null)
+        {
+            return string.IsNullOrEmpty(frame.FrameName) ? "[unknown frame]" : $"[{frame.FrameName}]";
+        }
+
+        string signature = method.Signature ?? method.Name ?? "<unknown method>";
+        if (method.Type?.Module?.Name is { } moduleName
+            && pluginAssemblies.Contains(Path.GetFileNameWithoutExtension(moduleName)))
+        {
+            return $"{signature}  <-- plugin";
+        }
+
+        return signature;
+    }
+
+    private string? TryWriteReport(string packageName, UnloadDiagnosticsReport report)
+    {
+        try
+        {
+            string logDir = Path.Combine(BeutlEnvironment.GetHomeDirectoryPath(), "log");
+            Directory.CreateDirectory(logDir);
+            string safeName = string.Concat(packageName.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
+            string fileName = $"unload-dump-{safeName}-{DateTime.Now:yyyyMMddHHmmss}.txt";
+            string path = Path.Combine(logDir, fileName);
+            File.WriteAllText(path, report.BuildReport());
+            return path;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write unload diagnostics dump for {PackageName}.", packageName);
+            return null;
+        }
+    }
+}

--- a/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ClrmdLoadContextUnloadDiagnostics.cs
@@ -59,10 +59,12 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             (List<UnloadDiagnosticsRootPath> rootPaths, bool rootTruncated) =
                 FindRootPaths(heap, targets, stopwatch);
 
-            List<UnloadDiagnosticsThreadStack> threads = CaptureThreadStacks(runtime, pluginAssemblies);
+            (List<UnloadDiagnosticsThreadStack> threads, bool threadTruncated) =
+                CaptureThreadStacks(runtime, pluginAssemblies, stopwatch);
 
             var report = new UnloadDiagnosticsReport(
-                packageName, assemblySimpleNames, total, groups, rootPaths, threads, censusTruncated || rootTruncated);
+                packageName, assemblySimpleNames, total, groups, rootPaths, threads,
+                censusTruncated || rootTruncated || threadTruncated);
 
             string? dumpPath = TryWriteReport(packageName, report);
             _logger.LogWarning(
@@ -78,7 +80,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
     private (List<UnloadDiagnosticsObjectGroup> Groups, int Total, HashSet<ulong> Targets, bool Truncated) CensusSurvivingObjects(
         ClrHeap heap, HashSet<string> pluginAssemblies, Stopwatch stopwatch)
     {
-        var counts = new Dictionary<string, (string Assembly, int Count)>(StringComparer.Ordinal);
+        var counts = new Dictionary<(string Assembly, string TypeName), int>();
         var targets = new HashSet<ulong>();
         int total = 0;
         bool truncated = false;
@@ -105,8 +107,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
             total++;
             string typeName = type.Name ?? "<unknown>";
-            counts.TryGetValue(typeName, out (string Assembly, int Count) entry);
-            counts[typeName] = (assembly, entry.Count + 1);
+            CountSurvivor(counts, assembly, typeName);
 
             if (targets.Count < MaxRootPaths && obj.Address != 0)
             {
@@ -114,11 +115,24 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             }
         }
 
-        var groups = counts
-            .Select(kv => new UnloadDiagnosticsObjectGroup(kv.Key, kv.Value.Assembly, kv.Value.Count))
-            .ToList();
-        return (groups, total, targets, truncated);
+        return (ToObjectGroups(counts), total, targets, truncated);
     }
+
+    // Keyed by (assembly, type) so identical type names from different plugin assemblies stay distinct; keying by
+    // type name alone would merge their counts and mislabel the assembly.
+    internal static void CountSurvivor(
+        Dictionary<(string Assembly, string TypeName), int> counts, string assembly, string typeName)
+    {
+        (string Assembly, string TypeName) key = (assembly, typeName);
+        counts.TryGetValue(key, out int count);
+        counts[key] = count + 1;
+    }
+
+    internal static List<UnloadDiagnosticsObjectGroup> ToObjectGroups(
+        Dictionary<(string Assembly, string TypeName), int> counts) =>
+        counts
+            .Select(kv => new UnloadDiagnosticsObjectGroup(kv.Key.TypeName, kv.Key.Assembly, kv.Value))
+            .ToList();
 
     private static (List<UnloadDiagnosticsRootPath> Paths, bool Truncated) FindRootPaths(
         ClrHeap heap, HashSet<ulong> targets, Stopwatch stopwatch)
@@ -157,7 +171,7 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
                 break;
             }
 
-            if (visited >= MaxVisitedObjects || stopwatch.Elapsed > s_budget)
+            if (visited >= MaxVisitedObjects || parent.Count >= MaxVisitedObjects || stopwatch.Elapsed > s_budget)
             {
                 truncated = true;
                 break;
@@ -174,6 +188,14 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
 
             foreach (ClrReference reference in current.EnumerateReferencesWithFields(carefully: true, considerDependantHandles: true))
             {
+                // Children are enqueued faster than they are dequeued, so bound the map here too; the dequeue-side
+                // visit cap alone would let it outgrow MaxVisitedObjects on a large heap.
+                if (parent.Count >= MaxVisitedObjects)
+                {
+                    truncated = true;
+                    break;
+                }
+
                 ClrObject child = reference.Object;
                 if (!child.IsValid || child.Address == 0 || parent.ContainsKey(child.Address))
                 {
@@ -235,11 +257,19 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
         return "references";
     }
 
-    private static List<UnloadDiagnosticsThreadStack> CaptureThreadStacks(ClrRuntime runtime, HashSet<string> pluginAssemblies)
+    private static (List<UnloadDiagnosticsThreadStack> Threads, bool Truncated) CaptureThreadStacks(
+        ClrRuntime runtime, HashSet<string> pluginAssemblies, Stopwatch stopwatch)
     {
         var results = new List<UnloadDiagnosticsThreadStack>();
+        bool truncated = false;
         foreach (ClrThread thread in runtime.Threads)
         {
+            if (stopwatch.Elapsed > s_budget)
+            {
+                truncated = true;
+                break;
+            }
+
             if (!thread.IsAlive)
             {
                 continue;
@@ -256,13 +286,12 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
                 frames.Add(DescribeFrame(frame, pluginAssemblies));
             }
 
-            if (frames.Count > 0)
-            {
-                results.Add(new UnloadDiagnosticsThreadStack(thread.ManagedThreadId, thread.OSThreadId, frames));
-            }
+            // Keep alive threads with no managed frames too: a native-only stack is itself a signal, and the report
+            // renders it as "(no managed frames)".
+            results.Add(new UnloadDiagnosticsThreadStack(thread.ManagedThreadId, thread.OSThreadId, frames));
         }
 
-        return results;
+        return (results, truncated);
     }
 
     private static string DescribeFrame(ClrStackFrame frame, HashSet<string> pluginAssemblies)
@@ -293,7 +322,9 @@ internal sealed class ClrmdLoadContextUnloadDiagnostics : ILoadContextUnloadDiag
             string dumpDir = GetDumpDirectory();
             Directory.CreateDirectory(dumpDir);
             string safeName = string.Concat(packageName.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
-            string fileName = $"unload-dump-{safeName}-{DateTime.Now:yyyyMMddHHmmss}.txt";
+            // UTC (matching the LastWriteTimeUtc retention sort) with milliseconds and a GUID: concurrent captures
+            // for the same package would otherwise share a second-resolution name and overwrite each other.
+            string fileName = $"unload-dump-{safeName}-{DateTime.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}.txt";
             string path = Path.Combine(dumpDir, fileName);
             File.WriteAllText(path, report.BuildReport());
             PruneOldDumps(dumpDir, MaxRetainedDumps);

--- a/src/Beutl.Api/Services/ILoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ILoadContextUnloadDiagnostics.cs
@@ -1,0 +1,23 @@
+﻿namespace Beutl.Api.Services;
+
+/// <summary>
+/// Captures diagnostics when an extension's collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+/// fails to unload at runtime, so the surviving objects, their GC roots, and the running thread stacks can be logged.
+/// </summary>
+/// <remarks>
+/// Implementations MUST NOT create any managed reference to the extension's assemblies, types, or load context —
+/// doing so would itself pin the context and defeat the unload being diagnosed. Only the assembly simple names
+/// (plain strings) are passed in; a heap/thread walk must be performed out-of-band (e.g. against a process snapshot).
+/// </remarks>
+public interface ILoadContextUnloadDiagnostics
+{
+    /// <summary>
+    /// Inspects the current process and records why the extension's load context is still alive.
+    /// This is best-effort diagnostics: it must never throw and never alter the uninstall flow.
+    /// </summary>
+    /// <param name="packageName">The extension package name, used for log context and the dump file name.</param>
+    /// <param name="assemblySimpleNames">
+    /// The simple names (e.g. <c>MyPlugin</c>) of the assemblies loaded into the leaked context, captured as strings.
+    /// </param>
+    void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames);
+}

--- a/src/Beutl.Api/Services/ILoadContextUnloadDiagnostics.cs
+++ b/src/Beutl.Api/Services/ILoadContextUnloadDiagnostics.cs
@@ -19,5 +19,10 @@ public interface ILoadContextUnloadDiagnostics
     /// <param name="assemblySimpleNames">
     /// The simple names (e.g. <c>MyPlugin</c>) of the assemblies loaded into the leaked context, captured as strings.
     /// </param>
-    void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames);
+    /// <returns>
+    /// The full path of the diagnostics dump that was written, or <see langword="null"/> when none was produced
+    /// (e.g. snapshotting is unsupported, no plugin objects survived, or the write failed). Callers may surface this
+    /// path so a developer can open the dump; it is a plain string and must never be used to root the leaked context.
+    /// </returns>
+    string? CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames);
 }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -8,6 +8,7 @@ using Beutl.Api.Objects;
 using Beutl.Engine;
 using Beutl.Extensibility;
 using Beutl.Logging;
+using Beutl.Services;
 using Microsoft.Extensions.Logging;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -262,7 +263,8 @@ public sealed class PackageManager(
                 {
                     try
                     {
-                        diagnostics.CaptureUnloadFailure(package.Name, assemblyNames);
+                        string? dumpPath = diagnostics.CaptureUnloadFailure(package.Name, assemblyNames);
+                        NotifyUnloadFailure(package.Name, dumpPath);
                     }
                     catch (Exception ex)
                     {
@@ -339,6 +341,48 @@ public sealed class PackageManager(
         // https://learn.microsoft.com/ja-jp/dotnet/standard/assembly/unloadability#use-a-custom-collectible-assemblyloadcontext
         weakReference = new WeakReference(info.LoadContext, trackResurrection: true);
         return true;
+    }
+
+    private Action<string>? _dumpOpener;
+
+    // Test seam: a unit test substitutes this to assert the "Open dump" action targets the captured dump path
+    // without launching a real process. Production leaves it as OpenDumpFile.
+    internal Action<string> DumpOpener
+    {
+        get => _dumpOpener ??= OpenDumpFile;
+        set => _dumpOpener = value;
+    }
+
+    // Diagnostics are wired only in Debug builds (BeutlApiApplication injects null in Release), so the dump and its
+    // log line are Debug-only already; [Conditional] strips this toast the same way, keeping the prompt in step.
+    [Conditional("DEBUG")]
+    internal void NotifyUnloadFailure(string packageName, string? dumpPath)
+    {
+        // No dump was produced (snapshot unsupported / census empty / write failed): nothing to open, so stay silent.
+        if (string.IsNullOrEmpty(dumpPath))
+        {
+            return;
+        }
+
+        NotificationService.ShowWarning(
+            $"Failed to unload '{packageName}'",
+            "The extension's load context is still alive. A diagnostics dump was written; "
+            + "open it to see what is keeping the assemblies loaded.",
+            expiration: TimeSpan.FromSeconds(30),
+            actions: [new NotificationAction("Open dump", () => DumpOpener(dumpPath))]);
+    }
+
+    private void OpenDumpFile(string dumpPath)
+    {
+        try
+        {
+            // UseShellExecute routes to the OS handler (ShellExecute / open / xdg-open) to open the .txt on any platform.
+            Process.Start(new ProcessStartInfo(dumpPath) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open unload diagnostics dump at {DumpPath}.", dumpPath);
+        }
     }
 
     public LocalPackage[] FindLoadedPackage(string name)

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -318,12 +318,20 @@ public sealed class PackageManager(
 
         if (info.LoadContext is { } loadContext)
         {
-            // Capture only the assembly names as strings; never retain the assemblies/types, or the diagnostics
-            // pass below would itself root the context it is meant to diagnose.
-            assemblyNames = [.. loadContext.Assemblies
-                .Select(a => a.GetName().Name)
-                .OfType<string>()
-                .Distinct(StringComparer.OrdinalIgnoreCase)];
+            try
+            {
+                // Capture only the assembly names as strings; never retain the assemblies/types, or the diagnostics
+                // pass below would itself root the context it is meant to diagnose.
+                assemblyNames = [.. loadContext.Assemblies
+                    .Select(a => a.GetName().Name)
+                    .OfType<string>()
+                    .Distinct(StringComparer.OrdinalIgnoreCase)];
+            }
+            catch (Exception ex)
+            {
+                // Best-effort like TryUnloadLoadContext: a reflection failure here must not break the unload flow.
+                _logger.LogWarning(ex, "Failed to capture assembly names for unload diagnostics of {PackageName}.", package.Name);
+            }
 
             TryUnloadLoadContext(package, loadContext);
         }

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -256,8 +256,19 @@ public sealed class PackageManager(
             {
                 activity?.AddEvent(new ActivityEvent("Capturing unload diagnostics"));
                 // Fire-and-forget: the snapshot is heavy and the contract forbids delaying the uninstall flow.
-                // The implementation self-guards and never throws, so the task cannot fault.
-                _ = Task.Run(() => diagnostics.CaptureUnloadFailure(package.Name, assemblyNames));
+                // The interface is public, so contain exceptions here too — a throwing third-party implementation
+                // would otherwise fault an unobserved task.
+                _ = Task.Run(() =>
+                {
+                    try
+                    {
+                        diagnostics.CaptureUnloadFailure(package.Name, assemblyNames);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Unload diagnostics capture threw for {PackageName}.", package.Name);
+                    }
+                });
             }
 
             return unloaded;

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -255,22 +255,9 @@ public sealed class PackageManager(
             bool unloaded = !weakReference.IsAlive;
             if (!unloaded && unloadDiagnostics is { } diagnostics && assemblyNames.Length > 0)
             {
-                activity?.AddEvent(new ActivityEvent("Capturing unload diagnostics"));
-                // Fire-and-forget: the snapshot is heavy and the contract forbids delaying the uninstall flow.
-                // The interface is public, so contain exceptions here too — a throwing third-party implementation
-                // would otherwise fault an unobserved task.
-                _ = Task.Run(() =>
-                {
-                    try
-                    {
-                        string? dumpPath = diagnostics.CaptureUnloadFailure(package.Name, assemblyNames);
-                        NotifyUnloadFailure(package.Name, dumpPath);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Unload diagnostics capture threw for {PackageName}.", package.Name);
-                    }
-                });
+                activity?.AddEvent(new ActivityEvent("Prompting for unload diagnostics"));
+                // Ask before snapshotting: the ClrMD self-snapshot is heavy, so the developer decides whether it runs.
+                PromptCaptureUnloadDiagnostics(diagnostics, package.Name, assemblyNames);
             }
 
             return unloaded;
@@ -345,31 +332,65 @@ public sealed class PackageManager(
 
     private Action<string>? _dumpOpener;
 
-    // Test seam: a unit test substitutes this to assert the "Open dump" action targets the captured dump path
-    // without launching a real process. Production leaves it as OpenDumpFile.
+    // Test seam: a unit test substitutes this to assert the capture opens the written dump path without launching a
+    // real process. Production leaves it as OpenDumpFile.
     internal Action<string> DumpOpener
     {
         get => _dumpOpener ??= OpenDumpFile;
         set => _dumpOpener = value;
     }
 
-    // Diagnostics are wired only in Debug builds (BeutlApiApplication injects null in Release), so the dump and its
-    // log line are Debug-only already; [Conditional] strips this toast the same way, keeping the prompt in step.
+    // Diagnostics are wired only in Debug builds (BeutlApiApplication injects null in Release), so [Conditional]
+    // strips this prompt the same way, keeping the offer in step with the capture it would trigger.
     [Conditional("DEBUG")]
-    internal void NotifyUnloadFailure(string packageName, string? dumpPath)
+    internal void PromptCaptureUnloadDiagnostics(
+        ILoadContextUnloadDiagnostics diagnostics, string packageName, string[] assemblyNames)
     {
-        // No dump was produced (snapshot unsupported / census empty / write failed): nothing to open, so stay silent.
-        if (string.IsNullOrEmpty(dumpPath))
-        {
-            return;
-        }
-
         NotificationService.ShowWarning(
             $"Failed to unload '{packageName}'",
-            "The extension's load context is still alive. A diagnostics dump was written; "
-            + "open it to see what is keeping the assemblies loaded.",
+            "The extension's load context is still alive. Capture a diagnostics dump to find what is keeping the "
+            + "assemblies loaded?",
             expiration: TimeSpan.FromSeconds(30),
-            actions: [new NotificationAction("Open dump", () => DumpOpener(dumpPath))]);
+            actions:
+            [
+                // Offload: the ClrMD self-snapshot is heavy and must not block the UI thread the click runs on.
+                new NotificationAction(
+                    "Capture dump",
+                    () => { _ = Task.Run(() => CaptureAndOpenUnloadDump(diagnostics, packageName, assemblyNames)); })
+            ]);
+    }
+
+    // Synchronous so a test can drive it directly; production reaches it from the prompt action's Task.Run. Contained
+    // because CaptureUnloadFailure is a public interface a third-party implementation could throw from.
+    internal void CaptureAndOpenUnloadDump(
+        ILoadContextUnloadDiagnostics diagnostics, string packageName, string[] assemblyNames)
+    {
+        try
+        {
+            string? dumpPath = diagnostics.CaptureUnloadFailure(packageName, assemblyNames);
+            if (!string.IsNullOrEmpty(dumpPath))
+            {
+                DumpOpener(dumpPath);
+            }
+            else
+            {
+                // The capture ran but produced nothing (context already collected / another capture holds the gate /
+                // snapshotting unsupported). The click already dismissed the prompt, so acknowledge it or it looks dead.
+                NotifyDiagnosticsUnavailable(packageName);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unload diagnostics capture threw for {PackageName}.", packageName);
+        }
+    }
+
+    private static void NotifyDiagnosticsUnavailable(string packageName)
+    {
+        NotificationService.ShowInformation(
+            $"No dump captured for '{packageName}'",
+            "The load context was already collected, another capture is in progress, or snapshotting is "
+            + "unavailable. See the log for details.");
     }
 
     private void OpenDumpFile(string dumpPath)

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -22,7 +22,8 @@ public sealed class PackageManager(
     InstalledPackageRepository installedPackageRepository,
     ExtensionProvider extensionProvider,
     ContextCommandManager commandManager,
-    BeutlApiApplication apiApplication) : PackageLoader
+    BeutlApiApplication apiApplication,
+    ILoadContextUnloadDiagnostics? unloadDiagnostics = null) : PackageLoader
 {
     private readonly ILogger _logger = Log.CreateLogger<PackageManager>();
     private readonly ConcurrentDictionary<int, LoadedPackageInfo> _loadedPackages = new();
@@ -236,7 +237,7 @@ public sealed class PackageManager(
     {
         using (Activity? activity = Telemetry.ActivitySource.StartActivity("Unload"))
         {
-            var result = UnloadCore(activity, package, out WeakReference? weakReference);
+            var result = UnloadCore(activity, package, out WeakReference? weakReference, out string[] assemblyNames);
             if (!result || weakReference == null)
             {
                 return false;
@@ -250,13 +251,25 @@ public sealed class PackageManager(
                 await Task.Delay(100).ConfigureAwait(false);
             }
 
-            return !weakReference.IsAlive;
+            bool unloaded = !weakReference.IsAlive;
+            if (!unloaded && unloadDiagnostics is { } diagnostics && assemblyNames.Length > 0)
+            {
+                activity?.AddEvent(new ActivityEvent("Capturing unload diagnostics"));
+                // Fire-and-forget: the snapshot is heavy and the contract forbids delaying the uninstall flow.
+                // The implementation self-guards and never throws, so the task cannot fault.
+                _ = Task.Run(() => diagnostics.CaptureUnloadFailure(package.Name, assemblyNames));
+            }
+
+            return unloaded;
         }
     }
 
-    private bool UnloadCore(Activity? activity, LocalPackage package, [NotNullWhen(true)] out WeakReference? weakReference)
+    private bool UnloadCore(
+        Activity? activity, LocalPackage package,
+        [NotNullWhen(true)] out WeakReference? weakReference, out string[] assemblyNames)
     {
         weakReference = null;
+        assemblyNames = [];
         activity?.SetTag("PackageName", package.Name);
 
         if (package.LocalId == LocalPackage.Reserved0)
@@ -294,6 +307,13 @@ public sealed class PackageManager(
 
         if (info.LoadContext is { } loadContext)
         {
+            // Capture only the assembly names as strings; never retain the assemblies/types, or the diagnostics
+            // pass below would itself root the context it is meant to diagnose.
+            assemblyNames = [.. loadContext.Assemblies
+                .Select(a => a.GetName().Name)
+                .OfType<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)];
+
             TryUnloadLoadContext(package, loadContext);
         }
 

--- a/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
+++ b/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
@@ -66,8 +66,12 @@ internal sealed class UnloadDiagnosticsReport
             ? "(none)"
             : string.Join(", ", SurvivingTypes.Take(TopTypesInSummary).Select(x => $"{x.TypeName} [{x.AssemblyName}] x{x.Count}"));
 
-        return $"Package '{PackageName}' failed to unload: {SurvivingObjectCount} live object(s) across [{assemblies}]. " +
+        string summary =
+            $"Package '{PackageName}' failed to unload: {SurvivingObjectCount} live object(s) across [{assemblies}]. " +
             $"Top types: {topTypes}. {RootPaths.Count} root path(s), {ThreadStacks.Count} thread(s) captured.";
+
+        // The warning log line uses this summary, so it must flag partial results without opening the full dump.
+        return CaptureTruncated ? summary + " Capture truncated; results may be partial." : summary;
     }
 
     public string BuildReport()

--- a/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
+++ b/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
@@ -33,8 +33,12 @@ internal sealed class UnloadDiagnosticsReport
         PackageName = packageName;
         AssemblyNames = assemblyNames;
         SurvivingObjectCount = survivingObjectCount;
-        // Sort here so callers may pass groups in any order and both outputs stay deterministic.
-        SurvivingTypes = [.. survivingTypes.OrderByDescending(x => x.Count).ThenBy(x => x.TypeName, StringComparer.Ordinal)];
+        // Sort here so callers may pass groups in any order and both outputs stay deterministic. AssemblyName is the
+        // final tie-breaker because the same type name can appear in two assemblies with an equal count.
+        SurvivingTypes = [.. survivingTypes
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.TypeName, StringComparer.Ordinal)
+            .ThenBy(x => x.AssemblyName, StringComparer.Ordinal)];
         RootPaths = rootPaths;
         ThreadStacks = threadStacks;
         CaptureTruncated = captureTruncated;

--- a/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
+++ b/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
@@ -1,0 +1,144 @@
+﻿using System.Text;
+
+namespace Beutl.Api.Services;
+
+/// <summary>A group of surviving heap objects of one type, with the assembly it belongs to.</summary>
+internal sealed record UnloadDiagnosticsObjectGroup(string TypeName, string AssemblyName, int Count);
+
+/// <summary>A reference chain from a GC root down to a surviving plugin object.</summary>
+/// <param name="TargetType">The type name of the surviving plugin object at the end of the chain.</param>
+/// <param name="Hops">Human-readable hops ordered from the GC root to the target object.</param>
+internal sealed record UnloadDiagnosticsRootPath(string TargetType, IReadOnlyList<string> Hops);
+
+/// <summary>A managed thread and its captured stack frames.</summary>
+internal sealed record UnloadDiagnosticsThreadStack(int ManagedThreadId, uint OsThreadId, IReadOnlyList<string> Frames);
+
+/// <summary>
+/// Formats the data collected for a failed load-context unload into a full text report and a one-line summary.
+/// This type is intentionally free of any process-inspection dependency so it can be unit-tested with synthetic data.
+/// </summary>
+internal sealed class UnloadDiagnosticsReport
+{
+    private const int TopTypesInSummary = 5;
+
+    public UnloadDiagnosticsReport(
+        string packageName,
+        IReadOnlyList<string> assemblyNames,
+        int survivingObjectCount,
+        IReadOnlyList<UnloadDiagnosticsObjectGroup> survivingTypes,
+        IReadOnlyList<UnloadDiagnosticsRootPath> rootPaths,
+        IReadOnlyList<UnloadDiagnosticsThreadStack> threadStacks,
+        bool rootSearchTruncated)
+    {
+        PackageName = packageName;
+        AssemblyNames = assemblyNames;
+        SurvivingObjectCount = survivingObjectCount;
+        // Sort here so callers may pass groups in any order and both outputs stay deterministic.
+        SurvivingTypes = [.. survivingTypes.OrderByDescending(x => x.Count).ThenBy(x => x.TypeName, StringComparer.Ordinal)];
+        RootPaths = rootPaths;
+        ThreadStacks = threadStacks;
+        RootSearchTruncated = rootSearchTruncated;
+    }
+
+    public string PackageName { get; }
+
+    public IReadOnlyList<string> AssemblyNames { get; }
+
+    public int SurvivingObjectCount { get; }
+
+    public IReadOnlyList<UnloadDiagnosticsObjectGroup> SurvivingTypes { get; }
+
+    public IReadOnlyList<UnloadDiagnosticsRootPath> RootPaths { get; }
+
+    public IReadOnlyList<UnloadDiagnosticsThreadStack> ThreadStacks { get; }
+
+    public bool RootSearchTruncated { get; }
+
+    public string BuildSummary()
+    {
+        string assemblies = AssemblyNames.Count == 0 ? "(none)" : string.Join(", ", AssemblyNames);
+        string topTypes = SurvivingTypes.Count == 0
+            ? "(none)"
+            : string.Join(", ", SurvivingTypes.Take(TopTypesInSummary).Select(x => $"{x.TypeName} x{x.Count}"));
+
+        return $"Package '{PackageName}' failed to unload: {SurvivingObjectCount} live object(s) across [{assemblies}]. " +
+            $"Top types: {topTypes}. {RootPaths.Count} root path(s), {ThreadStacks.Count} thread(s) captured.";
+    }
+
+    public string BuildReport()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("=== Extension unload failure diagnostics ===");
+        sb.Append("Package: ").AppendLine(PackageName);
+        sb.Append("Assemblies: ").AppendLine(AssemblyNames.Count == 0 ? "(none)" : string.Join(", ", AssemblyNames));
+        sb.Append("Surviving objects: ").Append(SurvivingObjectCount)
+            .Append(" (across ").Append(SurvivingTypes.Count).AppendLine(" type(s))");
+        sb.AppendLine();
+
+        sb.AppendLine("--- Surviving objects by type ---");
+        if (SurvivingTypes.Count == 0)
+        {
+            sb.AppendLine("(none)");
+        }
+        else
+        {
+            foreach (UnloadDiagnosticsObjectGroup group in SurvivingTypes)
+            {
+                sb.Append("  ").Append(group.Count).Append("  ").Append(group.TypeName)
+                    .Append("  [").Append(group.AssemblyName).AppendLine("]");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("--- GC root paths (why the objects are still alive) ---");
+        if (RootPaths.Count == 0)
+        {
+            sb.AppendLine("(no root path captured)");
+        }
+        else
+        {
+            for (int i = 0; i < RootPaths.Count; i++)
+            {
+                UnloadDiagnosticsRootPath path = RootPaths[i];
+                sb.Append('#').Append(i + 1).Append(" -> ").AppendLine(path.TargetType);
+                foreach (string hop in path.Hops)
+                {
+                    sb.Append("    ").AppendLine(hop);
+                }
+            }
+        }
+
+        if (RootSearchTruncated)
+        {
+            sb.AppendLine("(root path search stopped early: object or time budget exceeded)");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("--- Managed thread stacks ---");
+        if (ThreadStacks.Count == 0)
+        {
+            sb.AppendLine("(none)");
+        }
+        else
+        {
+            foreach (UnloadDiagnosticsThreadStack thread in ThreadStacks)
+            {
+                sb.Append("Thread managed=").Append(thread.ManagedThreadId)
+                    .Append(" os=").Append(thread.OsThreadId).AppendLine();
+                if (thread.Frames.Count == 0)
+                {
+                    sb.AppendLine("    (no managed frames)");
+                }
+                else
+                {
+                    foreach (string frame in thread.Frames)
+                    {
+                        sb.Append("    at ").AppendLine(frame);
+                    }
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
+++ b/src/Beutl.Api/Services/UnloadDiagnosticsReport.cs
@@ -28,7 +28,7 @@ internal sealed class UnloadDiagnosticsReport
         IReadOnlyList<UnloadDiagnosticsObjectGroup> survivingTypes,
         IReadOnlyList<UnloadDiagnosticsRootPath> rootPaths,
         IReadOnlyList<UnloadDiagnosticsThreadStack> threadStacks,
-        bool rootSearchTruncated)
+        bool captureTruncated)
     {
         PackageName = packageName;
         AssemblyNames = assemblyNames;
@@ -37,7 +37,7 @@ internal sealed class UnloadDiagnosticsReport
         SurvivingTypes = [.. survivingTypes.OrderByDescending(x => x.Count).ThenBy(x => x.TypeName, StringComparer.Ordinal)];
         RootPaths = rootPaths;
         ThreadStacks = threadStacks;
-        RootSearchTruncated = rootSearchTruncated;
+        CaptureTruncated = captureTruncated;
     }
 
     public string PackageName { get; }
@@ -52,14 +52,15 @@ internal sealed class UnloadDiagnosticsReport
 
     public IReadOnlyList<UnloadDiagnosticsThreadStack> ThreadStacks { get; }
 
-    public bool RootSearchTruncated { get; }
+    // Set when any capture phase (heap census, root search, or thread walk) stopped early on an object/time/frame bound.
+    public bool CaptureTruncated { get; }
 
     public string BuildSummary()
     {
         string assemblies = AssemblyNames.Count == 0 ? "(none)" : string.Join(", ", AssemblyNames);
         string topTypes = SurvivingTypes.Count == 0
             ? "(none)"
-            : string.Join(", ", SurvivingTypes.Take(TopTypesInSummary).Select(x => $"{x.TypeName} x{x.Count}"));
+            : string.Join(", ", SurvivingTypes.Take(TopTypesInSummary).Select(x => $"{x.TypeName} [{x.AssemblyName}] x{x.Count}"));
 
         return $"Package '{PackageName}' failed to unload: {SurvivingObjectCount} live object(s) across [{assemblies}]. " +
             $"Top types: {topTypes}. {RootPaths.Count} root path(s), {ThreadStacks.Count} thread(s) captured.";
@@ -108,11 +109,6 @@ internal sealed class UnloadDiagnosticsReport
             }
         }
 
-        if (RootSearchTruncated)
-        {
-            sb.AppendLine("(root path search stopped early: object or time budget exceeded)");
-        }
-
         sb.AppendLine();
         sb.AppendLine("--- Managed thread stacks ---");
         if (ThreadStacks.Count == 0)
@@ -137,6 +133,12 @@ internal sealed class UnloadDiagnosticsReport
                     }
                 }
             }
+        }
+
+        if (CaptureTruncated)
+        {
+            sb.AppendLine();
+            sb.AppendLine("(capture stopped early: an object, time, or frame budget exceeded; results may be partial)");
         }
 
         return sb.ToString();

--- a/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
+++ b/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Runtime.CompilerServices;
+
+using Beutl.Api.Services;
+
+using Microsoft.Diagnostics.Runtime;
+
+namespace Beutl.UnitTests.Api;
+
+// Explicit: it snapshots the whole test-host process (slow, and CreateSnapshotAndAttach needs `createdump`,
+// which is unavailable in some sandboxes). Run it manually to verify the ClrMD path end to end; it self-skips
+// when snapshotting is not supported. This is the manual-verification companion to UnloadDiagnosticsReportTests.
+[TestFixture]
+[Explicit]
+[NonParallelizable]
+public class ClrmdUnloadDiagnosticsTests
+{
+    private sealed class LeakyProbe
+    {
+        public byte[] Payload { get; } = new byte[64];
+    }
+
+    // Static so the probes are GC-rooted and therefore guaranteed to survive into the snapshot.
+    private static readonly List<LeakyProbe> s_rooted = [];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateRootedProbes()
+    {
+        for (int i = 0; i < 32; i++)
+        {
+            s_rooted.Add(new LeakyProbe());
+        }
+    }
+
+    [Test]
+    public void CaptureUnloadFailure_WritesDump_NamingSurvivingProbeType()
+    {
+        if (!CanSnapshotSelf())
+        {
+            Assert.Ignore("CreateSnapshotAndAttach is not supported in this environment.");
+        }
+
+        string home = Path.Combine(Path.GetTempPath(), "beutl-clrmd-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(home);
+        string? previousHome = Environment.GetEnvironmentVariable("BEUTL_HOME");
+        try
+        {
+            Environment.SetEnvironmentVariable("BEUTL_HOME", home);
+            AllocateRootedProbes();
+
+            var diagnostics = new ClrmdLoadContextUnloadDiagnostics();
+            diagnostics.CaptureUnloadFailure("ClrmdProbe", ["Beutl.UnitTests"]);
+
+            string[] dumps = Directory.GetFiles(Path.Combine(home, "log"), "unload-dump-ClrmdProbe-*.txt");
+            Assert.That(dumps, Is.Not.Empty, "a dump file should have been written");
+
+            string content = File.ReadAllText(dumps[0]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(content, Does.Contain("LeakyProbe"), "the surviving probe type should be listed");
+                Assert.That(content, Does.Contain("Managed thread stacks"));
+            });
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("BEUTL_HOME", previousHome);
+            s_rooted.Clear();
+            try
+            {
+                Directory.Delete(home, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static bool CanSnapshotSelf()
+    {
+        try
+        {
+            using DataTarget dataTarget = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
+            return !dataTarget.ClrVersions.IsDefaultOrEmpty;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
+++ b/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
@@ -50,8 +50,15 @@ public class ClrmdUnloadDiagnosticsTests
             var diagnostics = new ClrmdLoadContextUnloadDiagnostics();
             diagnostics.CaptureUnloadFailure("ClrmdProbe", ["Beutl.UnitTests"]);
 
-            string[] dumps = Directory.GetFiles(Path.Combine(home, "log"), "unload-dump-ClrmdProbe-*.txt");
-            Assert.That(dumps, Is.Not.Empty, "a dump file should have been written");
+            string[] dumps = Directory.GetFiles(
+                ClrmdLoadContextUnloadDiagnostics.GetDumpDirectory(), "unload-dump-ClrmdProbe-*.txt");
+            Assert.Multiple(() =>
+            {
+                Assert.That(dumps, Is.Not.Empty, "a dump file should have been written");
+                Assert.That(
+                    Directory.Exists(Path.Combine(home, "log", "unload-dumps")),
+                    "dumps should live in the dedicated log/unload-dumps subdirectory");
+            });
 
             string content = File.ReadAllText(dumps[0]);
             Assert.Multiple(() =>

--- a/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
+++ b/tests/Beutl.UnitTests/Api/ClrmdUnloadDiagnosticsTests.cs
@@ -81,6 +81,78 @@ public class ClrmdUnloadDiagnosticsTests
         }
     }
 
+    // Rooted so the collectible context survives into the snapshot; no plugin instance is kept, which is the "only the
+    // load context is retained" path the heap census cannot explain on its own. A plain collectible AssemblyLoadContext
+    // stands in for PluginLoadContext here: re-hosting this framework-dependent test assembly in PluginLoadContext's
+    // custom resolver fails to bind the runtime facades, and FindLoadContextTargets reads AssemblyLoadContextAddress the
+    // same way for any load-context subtype.
+    private static System.Runtime.Loader.AssemblyLoadContext? s_leakedContext;
+
+    // Verifies the load-context anchoring in isolation: an assembly loaded into a live collectible context must resolve
+    // to that context object even with no surviving instance of its types. Scoped to FindLoadContextTargets (module
+    // metadata only) rather than a full CaptureUnloadFailure so it does not depend on the whole-heap walk, which can
+    // exceed the capture budget on a large test host.
+    [Test]
+    public void FindLoadContextTargets_ResolvesTheCollectibleContext_WithNoSurvivingInstance()
+    {
+        if (!CanSnapshotSelf())
+        {
+            Assert.Ignore("CreateSnapshotAndAttach is not supported in this environment.");
+        }
+
+        string location = typeof(ClrmdUnloadDiagnosticsTests).Assembly.Location;
+        var context = new System.Runtime.Loader.AssemblyLoadContext("unload-diag-probe", isCollectible: true);
+        var collectible = context.LoadFromAssemblyPath(location);
+        // Construct a type so its MethodTable exists (ResolveLoadContextAddress reads the ALC off a type), but keep no
+        // instance; then collect any transient garbage so only the context roots the collectible module.
+        Assert.That(collectible.CreateInstance(typeof(ContextProbe).FullName!), Is.Not.Null);
+        s_leakedContext = context;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        try
+        {
+            using DataTarget dataTarget = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
+            using ClrRuntime runtime = dataTarget.ClrVersions[0].CreateRuntime();
+
+            HashSet<ulong> targets = ClrmdLoadContextUnloadDiagnostics.FindLoadContextTargets(
+                runtime, new HashSet<string>(["Beutl.UnitTests"], StringComparer.OrdinalIgnoreCase));
+
+            var resolved = targets
+                .Select(address => runtime.Heap.GetObject(address))
+                .Where(o => o.IsValid)
+                .ToList();
+
+            // Every resolved anchor must be a real AssemblyLoadContext object, and the collectible context this test
+            // added (a base AssemblyLoadContext, not the runtime's DefaultAssemblyLoadContext) must be among them.
+            Assert.That(resolved, Is.Not.Empty, "the loaded plugin module should resolve to at least one load context");
+            Assert.That(
+                resolved.All(o => DerivesFromAssemblyLoadContext(o.Type)), Is.True,
+                "every resolved anchor should be an AssemblyLoadContext object");
+            Assert.That(
+                resolved.Any(o => o.Type?.Name == "System.Runtime.Loader.AssemblyLoadContext"), Is.True,
+                "the collectible context that loaded the assembly should be among the resolved anchors");
+        }
+        finally
+        {
+            s_leakedContext = null;
+        }
+    }
+
+    private static bool DerivesFromAssemblyLoadContext(ClrType? type)
+    {
+        for (ClrType? t = type; t is not null; t = t.BaseType)
+        {
+            if (t.Name == "System.Runtime.Loader.AssemblyLoadContext")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool CanSnapshotSelf()
     {
         try
@@ -94,3 +166,7 @@ public class ClrmdUnloadDiagnosticsTests
         }
     }
 }
+
+// Top-level and dependency-free so a collectible context can construct its MethodTable by loading only this assembly;
+// nesting it in the fixture would drag in the test's NUnit / ClrMD references and fail to resolve in that context.
+internal sealed class ContextProbe;

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -157,9 +157,10 @@ public class PackageManagerExtensionLifecycleTests
     {
         public int InvokeCount { get; private set; }
 
-        public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
+        public string? CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
         {
             InvokeCount++;
+            return null;
         }
     }
 

--- a/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerExtensionLifecycleTests.cs
@@ -109,7 +109,34 @@ public class PackageManagerExtensionLifecycleTests
         Assert.That(commandManager.GetDefinitions(typeof(SuccessfulViewExtension)), Is.Empty);
     }
 
+    [Test]
+    public async Task Unload_DoesNotCaptureDiagnostics_WhenPackageUnloadsCleanly()
+    {
+        var diagnostics = new RecordingUnloadDiagnostics();
+        PackageManager manager = CreatePackageManager(diagnostics, out _, out _);
+        var package = new LocalPackage { Name = "CleanUnload" };
+        manager.LoadExtensionsAndRegister(
+            activity: null, package, assemblies: [], loadContext: null, [typeof(SuccessfulViewExtension)]);
+
+        bool unloaded = await manager.Unload(package);
+
+        Assert.Multiple(() =>
+        {
+            // No load context means nothing pins the package, so the unload succeeds and diagnostics stay idle.
+            Assert.That(unloaded, Is.True);
+            Assert.That(diagnostics.InvokeCount, Is.EqualTo(0));
+        });
+    }
+
     private static PackageManager CreatePackageManager(
+        out ContextCommandManager commandManager,
+        out ExtensionProvider extensionProvider)
+    {
+        return CreatePackageManager(diagnostics: null, out commandManager, out extensionProvider);
+    }
+
+    private static PackageManager CreatePackageManager(
+        ILoadContextUnloadDiagnostics? diagnostics,
         out ContextCommandManager commandManager,
         out ExtensionProvider extensionProvider)
     {
@@ -122,7 +149,18 @@ public class PackageManagerExtensionLifecycleTests
             new InstalledPackageRepository(),
             extensionProvider,
             commandManager,
-            apiApplication: null!);
+            apiApplication: null!,
+            diagnostics);
+    }
+
+    private sealed class RecordingUnloadDiagnostics : ILoadContextUnloadDiagnostics
+    {
+        public int InvokeCount { get; private set; }
+
+        public void CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
+        {
+            InvokeCount++;
+        }
     }
 
     // Nested + private so the app's exported-type scan never picks these up; [Export] stays because

--- a/tests/Beutl.UnitTests/Api/PackageManagerUnloadNotificationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerUnloadNotificationTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Concurrent;
+
+using Beutl.Api.Services;
+using Beutl.Services;
+
+namespace Beutl.UnitTests.Api;
+
+// NotificationService.Handler is a process-global facade; [NonParallelizable] keeps this fixture from racing the
+// other handler-swapping fixtures (SceneSettings / NotificationService).
+[TestFixture]
+[NonParallelizable]
+public class PackageManagerUnloadNotificationTests
+{
+    private CaptureNotificationHandler _handler = null!;
+    private INotificationServiceHandler? _previousHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _previousHandler = NotificationService.Handler;
+        _handler = new CaptureNotificationHandler();
+        NotificationService.Handler = _handler;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // The setter rejects null, so only restore a real prior handler; each SetUp installs a fresh capture anyway.
+        if (_previousHandler is not null)
+        {
+            NotificationService.Handler = _previousHandler;
+        }
+    }
+
+    [Test]
+    public void NotifyUnloadFailure_ShowsWarningWithOpenDumpAction_WhenDumpWritten()
+    {
+        const string DumpPath = "/tmp/unload-dump-MyPlugin.txt";
+        PackageManager manager = CreatePackageManager();
+        string? openedPath = null;
+        manager.DumpOpener = path => openedPath = path;
+
+        manager.NotifyUnloadFailure("MyPlugin", DumpPath);
+
+#if DEBUG
+        Beutl.Services.Notification notification = _handler.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(notification.Type, Is.EqualTo(NotificationType.Warning));
+            Assert.That(notification.Title, Does.Contain("MyPlugin"));
+            Assert.That(notification.Actions, Is.Not.Null.With.Count.EqualTo(1));
+            Assert.That(notification.Actions![0].Text, Is.EqualTo("Open dump"));
+        });
+
+        // Invoking the action must open the exact dump path captured when the notification was built.
+        notification.Actions![0].Callback();
+        Assert.That(openedPath, Is.EqualTo(DumpPath));
+#else
+        // NotifyUnloadFailure is [Conditional("DEBUG")]: in Release builds the call is stripped, so nothing is shown.
+        Assert.That(_handler.Notifications, Is.Empty);
+#endif
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void NotifyUnloadFailure_ShowsNothing_WhenNoDumpWritten(string? dumpPath)
+    {
+        PackageManager manager = CreatePackageManager();
+
+        manager.NotifyUnloadFailure("MyPlugin", dumpPath);
+
+        Assert.That(_handler.Notifications, Is.Empty);
+    }
+
+    private static PackageManager CreatePackageManager()
+    {
+        return new PackageManager(
+            new InstalledPackageRepository(),
+            new ExtensionProvider(),
+            new ContextCommandManager(new ContextCommandSettingsStore(), new ContextCommandHandlerRegistry()),
+            apiApplication: null!,
+            unloadDiagnostics: null);
+    }
+
+    private sealed class CaptureNotificationHandler : INotificationServiceHandler
+    {
+        // Fully qualified: System.Reactive also defines a Notification type, so the bare name is ambiguous.
+        private readonly ConcurrentQueue<Beutl.Services.Notification> _notifications = new();
+
+        public IReadOnlyCollection<Beutl.Services.Notification> Notifications => _notifications;
+
+        public void Show(Beutl.Services.Notification notification) => _notifications.Enqueue(notification);
+
+        public Beutl.Services.Notification Single()
+        {
+            Assert.That(_notifications, Has.Count.EqualTo(1));
+            return _notifications.First();
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PackageManagerUnloadNotificationTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageManagerUnloadNotificationTests.cs
@@ -33,14 +33,12 @@ public class PackageManagerUnloadNotificationTests
     }
 
     [Test]
-    public void NotifyUnloadFailure_ShowsWarningWithOpenDumpAction_WhenDumpWritten()
+    public void PromptCaptureUnloadDiagnostics_ShowsWarningOfferingCapture_WithoutCapturingYet()
     {
-        const string DumpPath = "/tmp/unload-dump-MyPlugin.txt";
-        PackageManager manager = CreatePackageManager();
-        string? openedPath = null;
-        manager.DumpOpener = path => openedPath = path;
+        var diagnostics = new StubUnloadDiagnostics();
+        PackageManager manager = CreatePackageManager(diagnostics);
 
-        manager.NotifyUnloadFailure("MyPlugin", DumpPath);
+        manager.PromptCaptureUnloadDiagnostics(diagnostics, "MyPlugin", ["MyPlugin.dll"]);
 
 #if DEBUG
         Beutl.Services.Notification notification = _handler.Single();
@@ -49,37 +47,86 @@ public class PackageManagerUnloadNotificationTests
             Assert.That(notification.Type, Is.EqualTo(NotificationType.Warning));
             Assert.That(notification.Title, Does.Contain("MyPlugin"));
             Assert.That(notification.Actions, Is.Not.Null.With.Count.EqualTo(1));
-            Assert.That(notification.Actions![0].Text, Is.EqualTo("Open dump"));
+            Assert.That(notification.Actions![0].Text, Is.EqualTo("Capture dump"));
+            // The snapshot must not run just from showing the prompt; it waits for the action.
+            Assert.That(diagnostics.InvokeCount, Is.EqualTo(0));
         });
-
-        // Invoking the action must open the exact dump path captured when the notification was built.
-        notification.Actions![0].Callback();
-        Assert.That(openedPath, Is.EqualTo(DumpPath));
 #else
-        // NotifyUnloadFailure is [Conditional("DEBUG")]: in Release builds the call is stripped, so nothing is shown.
+        // PromptCaptureUnloadDiagnostics is [Conditional("DEBUG")]: in Release builds the call is stripped.
         Assert.That(_handler.Notifications, Is.Empty);
 #endif
     }
 
-    [TestCase(null)]
-    [TestCase("")]
-    public void NotifyUnloadFailure_ShowsNothing_WhenNoDumpWritten(string? dumpPath)
+    [Test]
+    public void CaptureAndOpenUnloadDump_CapturesThenOpensTheWrittenDump()
     {
-        PackageManager manager = CreatePackageManager();
+        const string DumpPath = "/tmp/unload-dump-MyPlugin.txt";
+        var diagnostics = new StubUnloadDiagnostics { DumpPath = DumpPath };
+        PackageManager manager = CreatePackageManager(diagnostics);
+        string? openedPath = null;
+        manager.DumpOpener = path => openedPath = path;
 
-        manager.NotifyUnloadFailure("MyPlugin", dumpPath);
+        manager.CaptureAndOpenUnloadDump(diagnostics, "MyPlugin", ["MyPlugin.dll"]);
 
-        Assert.That(_handler.Notifications, Is.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.CapturedPackage, Is.EqualTo("MyPlugin"));
+            Assert.That(diagnostics.CapturedAssemblies, Is.EqualTo(new[] { "MyPlugin.dll" }));
+            // The action must open exactly the path the capture returned, proving the value is threaded end to end.
+            Assert.That(openedPath, Is.EqualTo(DumpPath));
+        });
     }
 
-    private static PackageManager CreatePackageManager()
+    [TestCase(null)]
+    [TestCase("")]
+    public void CaptureAndOpenUnloadDump_AcknowledgesWithoutOpening_WhenNoDumpWritten(string? dumpPath)
+    {
+        var diagnostics = new StubUnloadDiagnostics { DumpPath = dumpPath };
+        PackageManager manager = CreatePackageManager(diagnostics);
+        string? openedPath = null;
+        manager.DumpOpener = path => openedPath = path;
+
+        manager.CaptureAndOpenUnloadDump(diagnostics, "MyPlugin", ["MyPlugin.dll"]);
+
+        // A capture that yields no dump must still tell the user something happened; the click already dismissed the
+        // prompt, so a silent no-op would look broken.
+        Beutl.Services.Notification notification = _handler.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics.InvokeCount, Is.EqualTo(1));
+            Assert.That(openedPath, Is.Null);
+            Assert.That(notification.Type, Is.EqualTo(NotificationType.Information));
+            Assert.That(notification.Title, Does.Contain("MyPlugin"));
+        });
+    }
+
+    private static PackageManager CreatePackageManager(ILoadContextUnloadDiagnostics diagnostics)
     {
         return new PackageManager(
             new InstalledPackageRepository(),
             new ExtensionProvider(),
             new ContextCommandManager(new ContextCommandSettingsStore(), new ContextCommandHandlerRegistry()),
             apiApplication: null!,
-            unloadDiagnostics: null);
+            unloadDiagnostics: diagnostics);
+    }
+
+    private sealed class StubUnloadDiagnostics : ILoadContextUnloadDiagnostics
+    {
+        public string? DumpPath { get; init; }
+
+        public int InvokeCount { get; private set; }
+
+        public string? CapturedPackage { get; private set; }
+
+        public IReadOnlyList<string>? CapturedAssemblies { get; private set; }
+
+        public string? CaptureUnloadFailure(string packageName, IReadOnlyList<string> assemblySimpleNames)
+        {
+            InvokeCount++;
+            CapturedPackage = packageName;
+            CapturedAssemblies = assemblySimpleNames;
+            return DumpPath;
+        }
     }
 
     private sealed class CaptureNotificationHandler : INotificationServiceHandler

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
@@ -72,6 +72,6 @@ public class UnloadDiagnosticsDumpRetentionTests
     {
         string missing = Path.Combine(_logDir, "does-not-exist");
 
-        Assert.DoesNotThrow(() => ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(missing, maxRetained: 5));
+        Assert.That(() => ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(missing, maxRetained: 5), Throws.Nothing);
     }
 }

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
@@ -68,6 +68,31 @@ public class UnloadDiagnosticsDumpRetentionTests
     }
 
     [Test]
+    public void PruneOldDumps_BreaksWriteTimeTies_ByNameDeterministically()
+    {
+        var sameTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (char c = 'a'; c <= 'f'; c++)
+        {
+            string path = Path.Combine(_logDir, $"unload-dump-Pkg-20260101000000-{c}.txt");
+            File.WriteAllText(path, "dump");
+            File.SetLastWriteTimeUtc(path, sameTime);
+        }
+
+        ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(_logDir, maxRetained: 2);
+
+        string[] remaining = Directory.GetFiles(_logDir, "unload-dump-*.txt")
+            .Select(Path.GetFileName)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray()!;
+        // With write times tied, the highest names win, so the two kept files are deterministic.
+        Assert.That(remaining, Is.EqualTo(new[]
+        {
+            "unload-dump-Pkg-20260101000000-e.txt",
+            "unload-dump-Pkg-20260101000000-f.txt",
+        }));
+    }
+
+    [Test]
     public void PruneOldDumps_DoesNotThrow_WhenDirectoryMissing()
     {
         string missing = Path.Combine(_logDir, "does-not-exist");

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsDumpRetentionTests.cs
@@ -1,0 +1,77 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public class UnloadDiagnosticsDumpRetentionTests
+{
+    private string _logDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logDir = Path.Combine(Path.GetTempPath(), "beutl-unload-dump-" + TestContext.CurrentContext.Test.ID);
+        Directory.CreateDirectory(_logDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_logDir))
+        {
+            Directory.Delete(_logDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PruneOldDumps_KeepsNewestByWriteTime_AndLeavesUnrelatedFiles()
+    {
+        var baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        // Package name is deliberately the inverse of the age, so a filename sort would retain the opposite set from
+        // the write-time sort the pruner must use.
+        for (int i = 0; i < 8; i++)
+        {
+            string path = Path.Combine(_logDir, $"unload-dump-Pkg{7 - i}-2026010100000{i}.txt");
+            File.WriteAllText(path, "dump");
+            File.SetLastWriteTimeUtc(path, baseTime.AddMinutes(i));
+        }
+
+        string unrelated = Path.Combine(_logDir, "log20260101000000-4321.txt");
+        File.WriteAllText(unrelated, "keep");
+
+        ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(_logDir, maxRetained: 5);
+
+        string[] remaining = Directory.GetFiles(_logDir, "unload-dump-*.txt")
+            .Select(Path.GetFileName)
+            .ToArray()!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(remaining, Has.Length.EqualTo(5));
+            // The newest by write time (index 7) survives and the oldest (index 0) is gone, regardless of package name.
+            Assert.That(remaining, Does.Contain("unload-dump-Pkg0-20260101000007.txt"));
+            Assert.That(remaining, Does.Not.Contain("unload-dump-Pkg7-20260101000000.txt"));
+            Assert.That(File.Exists(unrelated), Is.True);
+        });
+    }
+
+    [Test]
+    public void PruneOldDumps_DoesNothing_WhenAtOrBelowLimit()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            File.WriteAllText(Path.Combine(_logDir, $"unload-dump-Pkg-2026010100000{i}.txt"), "dump");
+        }
+
+        ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(_logDir, maxRetained: 5);
+
+        Assert.That(Directory.GetFiles(_logDir, "unload-dump-*.txt"), Has.Length.EqualTo(3));
+    }
+
+    [Test]
+    public void PruneOldDumps_DoesNotThrow_WhenDirectoryMissing()
+    {
+        string missing = Path.Combine(_logDir, "does-not-exist");
+
+        Assert.DoesNotThrow(() => ClrmdLoadContextUnloadDiagnostics.PruneOldDumps(missing, maxRetained: 5));
+    }
+}

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
@@ -57,6 +57,39 @@ public class UnloadDiagnosticsReportTests
     }
 
     [Test]
+    public void BuildPath_MarksTruncation_WhenChainExceedsHopCap()
+    {
+        // A linear chain longer than the 128-hop cap where no node has Parent == 0, so a GC root is never reached.
+        var parent = new Dictionary<ulong, (ulong Parent, string Edge, string Type)>();
+        for (ulong i = 1; i <= 200; i++)
+        {
+            parent[i] = (i + 1, $"field f{i}", $"Type{i}");
+        }
+
+        UnloadDiagnosticsRootPath path = ClrmdLoadContextUnloadDiagnostics.BuildPath(1, parent);
+
+        Assert.That(path.Hops, Has.Some.Contains("truncated after 128 hops"));
+    }
+
+    [Test]
+    public void BuildPath_DoesNotMarkTruncation_WhenChainReachesRoot()
+    {
+        var parent = new Dictionary<ulong, (ulong Parent, string Edge, string Type)>
+        {
+            [1] = (2, "field child", "Leaf"),
+            [2] = (0, "StaticVar", "Root"),
+        };
+
+        UnloadDiagnosticsRootPath path = ClrmdLoadContextUnloadDiagnostics.BuildPath(1, parent);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(path.Hops, Has.None.Contains("truncated"));
+            Assert.That(path.TargetType, Is.EqualTo("Leaf"));
+        });
+    }
+
+    [Test]
     public void BuildSummary_ListsTopFiveTypesAndCounts()
     {
         UnloadDiagnosticsObjectGroup[] groups =
@@ -76,10 +109,11 @@ public class UnloadDiagnosticsReportTests
         {
             Assert.That(summary, Does.Contain("MyPlugin"));
             Assert.That(summary, Does.Contain("21 live object(s)"));
-            Assert.That(summary, Does.Contain("T1 x6"));
-            Assert.That(summary, Does.Contain("T5 x2"));
+            // Each top type carries its assembly so colliding type names stay disambiguated.
+            Assert.That(summary, Does.Contain("T1 [MyPlugin] x6"));
+            Assert.That(summary, Does.Contain("T5 [MyPlugin] x2"));
             // Only the top five appear in the one-line summary.
-            Assert.That(summary, Does.Not.Contain("T6 x1"));
+            Assert.That(summary, Does.Not.Contain("T6 [MyPlugin] x1"));
         });
     }
 

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
@@ -187,4 +187,31 @@ public class UnloadDiagnosticsReportTests
             Assert.That(report.BuildSummary(), Does.Contain("Top types: (none)"));
         });
     }
+
+    [Test]
+    public void BuildSummary_NotesTruncation_WhenCaptureTruncated()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(CreateReport(truncated: true).BuildSummary(), Does.Contain("Capture truncated"));
+            Assert.That(CreateReport(truncated: false).BuildSummary(), Does.Not.Contain("Capture truncated"));
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void CaptureUnloadFailure_SkipsWithoutThrowing_WhenACaptureIsAlreadyRunning()
+    {
+        // Hold the gate to simulate an in-flight capture; the call must take the skip path and return without work.
+        Assert.That(ClrmdLoadContextUnloadDiagnostics.s_captureGate.Wait(0), Is.True);
+        try
+        {
+            var diagnostics = new ClrmdLoadContextUnloadDiagnostics();
+            Assert.That(() => diagnostics.CaptureUnloadFailure("Pkg", ["Asm"]), Throws.Nothing);
+        }
+        finally
+        {
+            ClrmdLoadContextUnloadDiagnostics.s_captureGate.Release();
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
@@ -36,6 +36,23 @@ public class UnloadDiagnosticsReportTests
     }
 
     [Test]
+    public void SurvivingTypes_BreakTiesByAssemblyName_ForStableOrderAcrossInputOrders()
+    {
+        // Same type name and count in two assemblies: order must not depend on the input sequence.
+        UnloadDiagnosticsObjectGroup a = new("Ns.Same", "Plugin.A", 5);
+        UnloadDiagnosticsObjectGroup b = new("Ns.Same", "Plugin.B", 5);
+
+        string[] fromAb = CreateReport([a, b]).SurvivingTypes.Select(x => x.AssemblyName).ToArray();
+        string[] fromBa = CreateReport([b, a]).SurvivingTypes.Select(x => x.AssemblyName).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fromAb, Is.EqualTo(new[] { "Plugin.A", "Plugin.B" }));
+            Assert.That(fromBa, Is.EqualTo(new[] { "Plugin.A", "Plugin.B" }));
+        });
+    }
+
+    [Test]
     public void ObjectGroups_KeepSameTypeNameFromDifferentAssembliesDistinct()
     {
         var counts = new Dictionary<(string Assembly, string TypeName), int>();

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
@@ -36,6 +36,27 @@ public class UnloadDiagnosticsReportTests
     }
 
     [Test]
+    public void ObjectGroups_KeepSameTypeNameFromDifferentAssembliesDistinct()
+    {
+        var counts = new Dictionary<(string Assembly, string TypeName), int>();
+        ClrmdLoadContextUnloadDiagnostics.CountSurvivor(counts, "Plugin.A", "Shared.Ns.Foo");
+        ClrmdLoadContextUnloadDiagnostics.CountSurvivor(counts, "Plugin.B", "Shared.Ns.Foo");
+        ClrmdLoadContextUnloadDiagnostics.CountSurvivor(counts, "Plugin.A", "Shared.Ns.Foo");
+
+        List<UnloadDiagnosticsObjectGroup> groups = ClrmdLoadContextUnloadDiagnostics.ToObjectGroups(counts);
+
+        Assert.Multiple(() =>
+        {
+            // The same type name from two assemblies must not be merged into one group with a single assembly label.
+            Assert.That(groups, Has.Count.EqualTo(2));
+            Assert.That(groups, Has.One.Matches<UnloadDiagnosticsObjectGroup>(
+                g => g.AssemblyName == "Plugin.A" && g.TypeName == "Shared.Ns.Foo" && g.Count == 2));
+            Assert.That(groups, Has.One.Matches<UnloadDiagnosticsObjectGroup>(
+                g => g.AssemblyName == "Plugin.B" && g.TypeName == "Shared.Ns.Foo" && g.Count == 1));
+        });
+    }
+
+    [Test]
     public void BuildSummary_ListsTopFiveTypesAndCounts()
     {
         UnloadDiagnosticsObjectGroup[] groups =

--- a/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
+++ b/tests/Beutl.UnitTests/Api/UnloadDiagnosticsReportTests.cs
@@ -1,0 +1,118 @@
+﻿using Beutl.Api.Services;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+public class UnloadDiagnosticsReportTests
+{
+    private static UnloadDiagnosticsReport CreateReport(
+        IReadOnlyList<UnloadDiagnosticsObjectGroup>? groups = null,
+        int total = 0,
+        IReadOnlyList<UnloadDiagnosticsRootPath>? rootPaths = null,
+        IReadOnlyList<UnloadDiagnosticsThreadStack>? threads = null,
+        bool truncated = false)
+    {
+        return new UnloadDiagnosticsReport(
+            "MyPlugin",
+            ["MyPlugin", "MyPlugin.Extra"],
+            total,
+            groups ?? [],
+            rootPaths ?? [],
+            threads ?? [],
+            truncated);
+    }
+
+    [Test]
+    public void SurvivingTypes_AreSortedByCountDescending_RegardlessOfInputOrder()
+    {
+        UnloadDiagnosticsReport report = CreateReport(
+        [
+            new UnloadDiagnosticsObjectGroup("A.Small", "MyPlugin", 1),
+            new UnloadDiagnosticsObjectGroup("B.Large", "MyPlugin", 50),
+            new UnloadDiagnosticsObjectGroup("C.Medium", "MyPlugin", 10),
+        ]);
+
+        Assert.That(report.SurvivingTypes.Select(x => x.TypeName), Is.EqualTo(new[] { "B.Large", "C.Medium", "A.Small" }));
+    }
+
+    [Test]
+    public void BuildSummary_ListsTopFiveTypesAndCounts()
+    {
+        UnloadDiagnosticsObjectGroup[] groups =
+        [
+            new("T1", "MyPlugin", 6),
+            new("T2", "MyPlugin", 5),
+            new("T3", "MyPlugin", 4),
+            new("T4", "MyPlugin", 3),
+            new("T5", "MyPlugin", 2),
+            new("T6", "MyPlugin", 1),
+        ];
+        UnloadDiagnosticsReport report = CreateReport(groups, total: 21);
+
+        string summary = report.BuildSummary();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(summary, Does.Contain("MyPlugin"));
+            Assert.That(summary, Does.Contain("21 live object(s)"));
+            Assert.That(summary, Does.Contain("T1 x6"));
+            Assert.That(summary, Does.Contain("T5 x2"));
+            // Only the top five appear in the one-line summary.
+            Assert.That(summary, Does.Not.Contain("T6 x1"));
+        });
+    }
+
+    [Test]
+    public void BuildReport_IncludesAllSections_WithRootPathAndStack()
+    {
+        UnloadDiagnosticsReport report = CreateReport(
+            groups: [new UnloadDiagnosticsObjectGroup("MyPlugin.Leaky", "MyPlugin", 3)],
+            total: 3,
+            rootPaths:
+            [
+                new UnloadDiagnosticsRootPath("MyPlugin.Leaky",
+                    ["StaticVar -> Core.Registry (0x1)", "field _handler -> MyPlugin.Leaky (0x2)"]),
+            ],
+            threads:
+            [
+                new UnloadDiagnosticsThreadStack(1, 4242, ["MyPlugin.Leaky.Run()", "System.Threading.Thread.Loop()"]),
+            ]);
+
+        string text = report.BuildReport();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Contain("Package: MyPlugin"));
+            Assert.That(text, Does.Contain("Surviving objects by type"));
+            Assert.That(text, Does.Contain("MyPlugin.Leaky"));
+            Assert.That(text, Does.Contain("GC root paths"));
+            Assert.That(text, Does.Contain("field _handler -> MyPlugin.Leaky (0x2)"));
+            Assert.That(text, Does.Contain("Managed thread stacks"));
+            Assert.That(text, Does.Contain("os=4242"));
+            Assert.That(text, Does.Contain("at MyPlugin.Leaky.Run()"));
+        });
+    }
+
+    [Test]
+    public void BuildReport_ReportsTruncation_WhenBudgetExceeded()
+    {
+        UnloadDiagnosticsReport report = CreateReport(truncated: true);
+
+        Assert.That(report.BuildReport(), Does.Contain("budget exceeded"));
+    }
+
+    [Test]
+    public void BuildReport_HandlesEmptyData_WithoutThrowing()
+    {
+        UnloadDiagnosticsReport report = CreateReport();
+
+        string text = report.BuildReport();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Contain("Surviving objects: 0"));
+            Assert.That(text, Does.Contain("(no root path captured)"));
+            Assert.That(report.BuildSummary(), Does.Contain("Top types: (none)"));
+        });
+    }
+}

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -55,4 +55,12 @@
     <EmbeddedResource Include="Assets\**\*.*" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <!-- These exercise the ClrMD unload diagnostics in Beutl.Api, which are Debug-only; drop them from Release so a
+         Release solution build stays green after ClrmdLoadContextUnloadDiagnostics is excluded there. -->
+    <Compile Remove="Api\ClrmdUnloadDiagnosticsTests.cs" />
+    <Compile Remove="Api\UnloadDiagnosticsDumpRetentionTests.cs" />
+    <Compile Remove="Api\UnloadDiagnosticsReportTests.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
When a runtime extension uninstall fails because the collectible
PluginLoadContext cannot be collected, PackageManager.Unload now uses ClrMD
(Microsoft.Diagnostics.Runtime) to snapshot the current process and record
what is keeping the context alive: the surviving heap objects that belong to
the extension's assemblies, the GC-root reference chains pinning them, and
the managed thread stacks. A full report is written to
$BEUTL_HOME/log/unload-dump-<package>-<timestamp>.txt and a concise summary
is logged.

Design notes:
- Only assembly simple names (strings) cross into the diagnostic; the load
  context, its assemblies, and its types are never retained, so the capture
  cannot re-root the very context it is diagnosing. ClrMD reads an
  out-of-band process snapshot, adding no GC roots to the live heap.
- The capture is best-effort and fire-and-forget: it never throws into the
  uninstall path and never delays it.
- The public PackageManager constructor gains an optional
  ILoadContextUnloadDiagnostics parameter (source-compatible). The ClrMD
  implementation and the report model are internal; the interface is the
  only new public surface.
- ClrMD (MIT) is referenced only by the MIT Beutl.Api project, so the
  GPL/MIT boundary is unaffected.

Tests: deterministic report-builder tests plus a wiring test asserting the
diagnostic stays idle on a clean unload; an [Explicit] integration test
exercises the real self-snapshot end to end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KRkXMAz9i2LVmUnonFC1WZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort unload-failure diagnostics for collectible assemblies, including surviving object counts, GC reference-path evidence, and managed thread stack context.
  * When available, generates local diagnostics dump files with consistent naming and automatic retention pruning.
  * In debug builds, shows a warning notification offering a “Capture dump” action and opens the resulting dump when written.

* **Bug Fixes**
  * Improved unload flow resilience so diagnostics capture never blocks or disrupts unload/uninstall.

* **Tests**
  * Expanded coverage for dump generation, report sorting/rendering, retention pruning, clean-unload behavior, and skipping when capture is already in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->