### PR TITLE
feat: Add tool tab menu to dock headers

### DIFF
--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -179,6 +179,24 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
         }
     }
 
+    internal IEnumerable<ToolTabExtension> EnumerateToolTabExtensions()
+    {
+        return editViewModel.ExtensionProvider.AllExtensions
+            .OfType<ToolTabExtension>()
+            .Where(extension => extension.Header is not null)
+            .OrderBy(extension => extension.Name);
+    }
+
+    internal bool IsToolTabOpen(ToolTabExtension extension)
+    {
+        return EnumerateTools().Any(tool => tool.ToolContext.Extension == extension);
+    }
+
+    internal bool OpenToolTab(ToolTabExtension extension, IToolDock target)
+    {
+        return editViewModel.DockHost.OpenToolTabFromExtension(extension, target);
+    }
+
     internal void SetRootDock(IRootDock rootDock)
     {
         _rootDock = rootDock;

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -145,10 +145,20 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
             rightDock.ActiveDockable = rightDock.VisibleDockables?.FirstOrDefault();
     }
 
-    private void OpenToolTabFromExtension(ToolTabExtension ext, IToolDock? target)
+    internal bool OpenToolTabFromExtension(ToolTabExtension ext, IToolDock? target)
     {
-        if (ext.TryCreateContext(_editViewModel, out IToolContext? tab))
-            OpenToolTab(tab, target);
+        if (!ext.TryCreateContext(_editViewModel, out IToolContext? tab))
+        {
+            return false;
+        }
+
+        if (OpenToolTab(tab, target))
+        {
+            return true;
+        }
+
+        tab.Dispose();
+        return false;
     }
 
     private void EnsureDefaultLayout()

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -147,7 +147,8 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
 
     internal bool OpenToolTabFromExtension(ToolTabExtension ext, IToolDock? target)
     {
-        if (!ext.TryCreateContext(_editViewModel, out IToolContext? tab))
+        if (!ext.TryCreateContext(_editViewModel, out IToolContext? tab)
+            || tab is null)
         {
             return false;
         }

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -65,20 +65,22 @@
                                           ItemsSource="{Binding VisibleDockables}"
                                           ModifiedTemplate="{TemplateBinding ModifiedTemplate}"
                                           SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" />
-                            <local:ToolTabAddButton x:Name="PART_AddButton"
-                                                    Grid.Column="1"
-                                                    Width="28"
-                                                    Height="28"
-                                                    Padding="0"
-                                                    AutomationProperties.Name="{x:Static lang:Strings.Add}"
-                                                    Background="Transparent"
-                                                    BorderThickness="0"
-                                                    IsHitTestVisible="False"
-                                                    IsTabStop="False"
-                                                    Opacity="0"
-                                                    ToolTip.Tip="{x:Static lang:Strings.Add}">
-                                <icons:FluentIcon Icon="Add" />
-                            </local:ToolTabAddButton>
+                            <Border x:Name="PART_AddButtonBorder"
+                                    Grid.Column="1"
+                                    BorderBrush="{DynamicResource DockThemeBorderLowBrush}"
+                                    BorderThickness="0,0,0,1">
+                                <local:ToolTabAddButton x:Name="PART_AddButton"
+                                                        Width="28"
+                                                        Height="28"
+                                                        Padding="0"
+                                                        AutomationProperties.Name="{x:Static lang:Strings.Add}"
+                                                        IsHitTestVisible="False"
+                                                        IsTabStop="True"
+                                                        Opacity="0"
+                                                        ToolTip.Tip="{x:Static lang:Strings.Add}">
+                                    <icons:FluentIcon Icon="Add" />
+                                </local:ToolTabAddButton>
+                            </Border>
                         </Grid>
                         <Border x:Name="PART_Border">
                             <DockableControl DataContext="{Binding ActiveDockable}" TrackingMode="Visible">
@@ -109,7 +111,25 @@
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
 
+            <Style Selector="^/template/ local|ToolTabAddButton#PART_AddButton">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+            </Style>
+
             <Style Selector="^/template/ Grid#PART_TabHeader:pointerover local|ToolTabAddButton#PART_AddButton">
+                <Setter Property="IsHitTestVisible" Value="True" />
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+
+            <Style Selector="^/template/ local|ToolTabAddButton#PART_AddButton:pointerover">
+                <Setter Property="Background" Value="{DynamicResource DockChromeButtonHoverBackgroundBrush}" />
+            </Style>
+
+            <Style Selector="^/template/ local|ToolTabAddButton#PART_AddButton:pressed">
+                <Setter Property="Background" Value="{DynamicResource DockChromeButtonPressedBackgroundBrush}" />
+            </Style>
+
+            <Style Selector="^/template/ local|ToolTabAddButton#PART_AddButton:focus-visible">
                 <Setter Property="IsHitTestVisible" Value="True" />
                 <Setter Property="Opacity" Value="1" />
             </Style>

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -2,7 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:acr="using:Avalonia.Controls.Recycling"
         xmlns:core="using:Dock.Model.Core"
-        xmlns:dmc="using:Dock.Model.Controls">
+        xmlns:dmc="using:Dock.Model.Controls"
+        xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+        xmlns:lang="using:Beutl.Language"
+        xmlns:local="using:Beutl.Views.Dock">
     <Styles.Resources>
         <!--  The default Fluent theme hides PART_ItemsPresenter on :singleitem; keep the lone tab visible so it can be dragged to another zone.  -->
         <ControlTheme x:Key="{x:Type ToolTabStrip}"
@@ -49,16 +52,34 @@
                     <DockPanel x:Name="PART_DockPanel"
                                DockProperties.IsDockTarget="True"
                                DockProperties.IsDropArea="True">
-                        <ToolTabStrip x:Name="PART_TabStrip"
-                                      MinHeight="28"
-                                      DockPanel.Dock="Top"
-                                      DockProperties.DockAdornerHost="{Binding #PART_DockPanel}"
-                                      DockProperties.IsDropArea="True"
-                                      HeaderTemplate="{TemplateBinding HeaderTemplate}"
-                                      IconTemplate="{TemplateBinding IconTemplate}"
-                                      ItemsSource="{Binding VisibleDockables}"
-                                      ModifiedTemplate="{TemplateBinding ModifiedTemplate}"
-                                      SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" />
+                        <Grid x:Name="PART_TabHeader"
+                              MinHeight="28"
+                              Background="Transparent"
+                              ColumnDefinitions="*,Auto"
+                              DockPanel.Dock="Top">
+                            <ToolTabStrip x:Name="PART_TabStrip"
+                                          DockProperties.DockAdornerHost="{Binding #PART_DockPanel}"
+                                          DockProperties.IsDropArea="True"
+                                          HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                                          IconTemplate="{TemplateBinding IconTemplate}"
+                                          ItemsSource="{Binding VisibleDockables}"
+                                          ModifiedTemplate="{TemplateBinding ModifiedTemplate}"
+                                          SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" />
+                            <local:ToolTabAddButton x:Name="PART_AddButton"
+                                                    Grid.Column="1"
+                                                    Width="28"
+                                                    Height="28"
+                                                    Padding="0"
+                                                    AutomationProperties.Name="{x:Static lang:Strings.Add}"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    IsHitTestVisible="False"
+                                                    IsTabStop="False"
+                                                    Opacity="0"
+                                                    ToolTip.Tip="{x:Static lang:Strings.Add}">
+                                <icons:FluentIcon Icon="Add" />
+                            </local:ToolTabAddButton>
+                        </Grid>
                         <Border x:Name="PART_Border">
                             <DockableControl DataContext="{Binding ActiveDockable}" TrackingMode="Visible">
                                 <ContentControl x:Name="PART_ContentPresenter"
@@ -86,6 +107,11 @@
                 <Setter Property="Margin" Value="0" />
                 <Setter Property="BorderBrush" Value="Transparent" />
                 <Setter Property="BorderThickness" Value="0" />
+            </Style>
+
+            <Style Selector="^/template/ Grid#PART_TabHeader:pointerover local|ToolTabAddButton#PART_AddButton">
+                <Setter Property="IsHitTestVisible" Value="True" />
+                <Setter Property="Opacity" Value="1" />
             </Style>
         </ControlTheme>
     </Styles.Resources>

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -74,7 +74,6 @@
                                                         Height="28"
                                                         Padding="0"
                                                         AutomationProperties.Name="{x:Static lang:Strings.Add}"
-                                                        IsHitTestVisible="False"
                                                         IsTabStop="True"
                                                         Opacity="0"
                                                         ToolTip.Tip="{x:Static lang:Strings.Add}">
@@ -117,7 +116,6 @@
             </Style>
 
             <Style Selector="^/template/ Grid#PART_TabHeader:pointerover local|ToolTabAddButton#PART_AddButton">
-                <Setter Property="IsHitTestVisible" Value="True" />
                 <Setter Property="Opacity" Value="1" />
             </Style>
 
@@ -130,7 +128,6 @@
             </Style>
 
             <Style Selector="^/template/ local|ToolTabAddButton#PART_AddButton:focus-visible">
-                <Setter Property="IsHitTestVisible" Value="True" />
                 <Setter Property="Opacity" Value="1" />
             </Style>
         </ControlTheme>

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Beutl.ViewModels.Dock;
 using Dock.Model.Controls;
 

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -23,14 +23,14 @@ public sealed class ToolTabAddButton : Button
             return null;
         }
 
-        var items = factory.EnumerateToolTabExtensions()
-            .Select(extension => CreateMenuItem(factory, target, extension))
-            .ToArray();
-
-        return new ContextMenu
+        var menu = new ContextMenu();
+        menu.Opening += (_, _) =>
         {
-            ItemsSource = items,
+            menu.ItemsSource = factory.EnumerateToolTabExtensions()
+                .Select(extension => CreateMenuItem(factory, target, extension))
+                .ToArray();
         };
+        return menu;
     }
 
     private static MenuItem CreateMenuItem(

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -1,0 +1,51 @@
+using Avalonia.Controls;
+using Beutl.ViewModels.Dock;
+using Dock.Model.Controls;
+
+namespace Beutl.Views.Dock;
+
+public sealed class ToolTabAddButton : Button
+{
+    protected override void OnClick()
+    {
+        base.OnClick();
+
+        ContextMenu?.Close();
+        ContextMenu = CreateContextMenu();
+        ContextMenu?.Open();
+    }
+
+    internal ContextMenu? CreateContextMenu()
+    {
+        if (DataContext is not IToolDock target
+            || target.Factory is not BeutlDockFactory factory)
+        {
+            return null;
+        }
+
+        var items = factory.EnumerateToolTabExtensions()
+            .Select(extension => CreateMenuItem(factory, target, extension))
+            .ToArray();
+
+        return new ContextMenu
+        {
+            ItemsSource = items,
+        };
+    }
+
+    private static MenuItem CreateMenuItem(
+        BeutlDockFactory factory,
+        IToolDock target,
+        ToolTabExtension extension)
+    {
+        var item = new MenuItem
+        {
+            DataContext = extension,
+            Header = extension.Header,
+            IsEnabled = extension.CanMultiple || !factory.IsToolTabOpen(extension),
+        };
+
+        item.Click += (_, _) => factory.OpenToolTab(extension, target);
+        return item;
+    }
+}

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -23,13 +23,18 @@ public sealed class ToolTabAddButton : Button
             return null;
         }
 
-        var menu = new ContextMenu();
-        menu.Opening += (_, _) =>
+        MenuItem[] CreateItems()
         {
-            menu.ItemsSource = factory.EnumerateToolTabExtensions()
+            return factory.EnumerateToolTabExtensions()
                 .Select(extension => CreateMenuItem(factory, target, extension))
                 .ToArray();
+        }
+
+        var menu = new ContextMenu
+        {
+            ItemsSource = CreateItems(),
         };
+        menu.Opening += (_, _) => menu.ItemsSource = CreateItems();
         return menu;
     }
 

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -82,7 +82,7 @@ public class DockTabAddButtonTests
                 Assert.That(addButtonBorder.BorderBrush, Is.Not.Null);
                 Assert.That(addButtonBorder.BorderThickness.Bottom, Is.EqualTo(1));
                 Assert.That(button.Opacity, Is.EqualTo(0));
-                Assert.That(button.IsHitTestVisible, Is.False);
+                Assert.That(button.IsHitTestVisible, Is.True);
                 Assert.That(button.IsTabStop, Is.True);
             });
 
@@ -108,7 +108,7 @@ public class DockTabAddButtonTests
             Assert.Multiple(() =>
             {
                 Assert.That(button.Opacity, Is.EqualTo(0));
-                Assert.That(button.IsHitTestVisible, Is.False);
+                Assert.That(button.IsHitTestVisible, Is.True);
             });
 
             Assert.That(button.Focus(NavigationMethod.Tab), Is.True);
@@ -147,7 +147,6 @@ public class DockTabAddButtonTests
                 .Single(control => ReferenceEquals(control.DataContext, target));
             ToolTabAddButton button = FindAddButton(targetControl)!;
             Point buttonCenter = Center(button, window);
-            window.MouseMove(buttonCenter);
             window.MouseDown(buttonCenter, MouseButton.Left);
             window.MouseUp(buttonCenter, MouseButton.Left);
             HeadlessTestHelpers.Settle();
@@ -180,6 +179,14 @@ public class DockTabAddButtonTests
                 Assert.That(added, Is.Not.Null);
                 Assert.That(target.ActiveDockable, Is.SameAs(added));
             });
+
+            menu.Open();
+            HeadlessTestHelpers.Settle();
+
+            MenuItem refreshedColorScopesItem = menu.ItemsSource!
+                .Cast<MenuItem>()
+                .Single(item => ReferenceEquals(item.DataContext, ColorScopesTabExtension.Instance));
+            Assert.That(refreshedColorScopesItem.IsEnabled, Is.False);
         }
         finally
         {

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -1,7 +1,9 @@
+﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Beutl.Editor.Components.ColorScopesTab;
@@ -71,11 +73,17 @@ public class DockTabAddButtonTests
             Grid header = playerControl.GetVisualDescendants()
                 .OfType<Grid>()
                 .Single(control => control.Name == "PART_TabHeader");
+            Border addButtonBorder = playerControl.GetVisualDescendants()
+                .OfType<Border>()
+                .Single(control => control.Name == "PART_AddButtonBorder");
 
             Assert.Multiple(() =>
             {
+                Assert.That(addButtonBorder.BorderBrush, Is.Not.Null);
+                Assert.That(addButtonBorder.BorderThickness.Bottom, Is.EqualTo(1));
                 Assert.That(button.Opacity, Is.EqualTo(0));
                 Assert.That(button.IsHitTestVisible, Is.False);
+                Assert.That(button.IsTabStop, Is.True);
             });
 
             window.MouseMove(Center(header, window));
@@ -87,6 +95,13 @@ public class DockTabAddButtonTests
                 Assert.That(button.IsHitTestVisible, Is.True);
             });
 
+            window.MouseMove(Center(button, window));
+            HeadlessTestHelpers.Settle();
+
+            Assert.That(
+                button.Background,
+                Is.SameAs(button.FindResource("DockChromeButtonHoverBackgroundBrush")));
+
             window.MouseMove(new Point(1, window.Bounds.Height - 1));
             HeadlessTestHelpers.Settle();
 
@@ -94,6 +109,15 @@ public class DockTabAddButtonTests
             {
                 Assert.That(button.Opacity, Is.EqualTo(0));
                 Assert.That(button.IsHitTestVisible, Is.False);
+            });
+
+            Assert.That(button.Focus(NavigationMethod.Tab), Is.True);
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(button.Opacity, Is.EqualTo(1));
+                Assert.That(button.IsHitTestVisible, Is.True);
             });
         }
         finally
@@ -122,7 +146,15 @@ public class DockTabAddButtonTests
                 .OfType<ToolControl>()
                 .Single(control => ReferenceEquals(control.DataContext, target));
             ToolTabAddButton button = FindAddButton(targetControl)!;
-            ContextMenu menu = button.CreateContextMenu()!;
+            Point buttonCenter = Center(button, window);
+            window.MouseMove(buttonCenter);
+            window.MouseDown(buttonCenter, MouseButton.Left);
+            window.MouseUp(buttonCenter, MouseButton.Left);
+            HeadlessTestHelpers.Settle();
+
+            ContextMenu? menu = button.ContextMenu;
+            Assert.That(menu, Is.Not.Null);
+            Assert.That(menu!.IsOpen, Is.True);
             MenuItem[] items = menu.ItemsSource!.Cast<MenuItem>().ToArray();
 
             MenuItem timelineItem = items.Single(
@@ -156,6 +188,18 @@ public class DockTabAddButtonTests
         }
     }
 
+    [AvaloniaTest]
+    public async Task Extension_returning_success_with_a_null_context_is_rejected()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-add-null-context");
+        IToolDock target = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+
+        bool opened = editor.DockHost.OpenToolTabFromExtension(new NullContextToolTabExtension(), target);
+
+        Assert.That(opened, Is.False);
+    }
+
     private static ToolTabAddButton? FindAddButton(Visual root)
     {
         return root.GetVisualDescendants().OfType<ToolTabAddButton>().SingleOrDefault();
@@ -168,5 +212,26 @@ public class DockTabAddButtonTests
             relativeTo);
         Assert.That(point, Is.Not.Null);
         return point!.Value;
+    }
+
+    private sealed class NullContextToolTabExtension : ToolTabExtension
+    {
+        public override bool CanMultiple => true;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = null;
+            return false;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = null!;
+            return true;
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -6,7 +6,6 @@ using Avalonia.Headless.NUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
-using Beutl.Editor.Components.ColorScopesTab;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Services.PrimitiveImpls;
@@ -158,21 +157,21 @@ public class DockTabAddButtonTests
 
             MenuItem timelineItem = items.Single(
                 item => ReferenceEquals(item.DataContext, TimelineTabExtension.Instance));
-            MenuItem colorScopesItem = items.Single(
-                item => ReferenceEquals(item.DataContext, ColorScopesTabExtension.Instance));
+            MenuItem historyItem = items.Single(
+                item => ReferenceEquals(item.DataContext, HistoryTabExtension.Instance));
 
             Assert.Multiple(() =>
             {
                 Assert.That(timelineItem.IsEnabled, Is.False);
-                Assert.That(colorScopesItem.IsEnabled, Is.True);
+                Assert.That(historyItem.IsEnabled, Is.True);
             });
 
-            colorScopesItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            historyItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
             HeadlessTestHelpers.Settle();
 
             BeutlToolDockable? added = target.VisibleDockables?
                 .OfType<BeutlToolDockable>()
-                .SingleOrDefault(dockable => dockable.ToolContext.Extension == ColorScopesTabExtension.Instance);
+                .SingleOrDefault(dockable => dockable.ToolContext.Extension == HistoryTabExtension.Instance);
 
             Assert.Multiple(() =>
             {
@@ -180,13 +179,16 @@ public class DockTabAddButtonTests
                 Assert.That(target.ActiveDockable, Is.SameAs(added));
             });
 
-            menu.Open();
+            menu.Close();
+            HeadlessTestHelpers.Settle();
+            window.MouseDown(buttonCenter, MouseButton.Right);
+            window.MouseUp(buttonCenter, MouseButton.Right);
             HeadlessTestHelpers.Settle();
 
-            MenuItem refreshedColorScopesItem = menu.ItemsSource!
+            MenuItem refreshedHistoryItem = menu.ItemsSource!
                 .Cast<MenuItem>()
-                .Single(item => ReferenceEquals(item.DataContext, ColorScopesTabExtension.Instance));
-            Assert.That(refreshedColorScopesItem.IsEnabled, Is.False);
+                .Single(item => ReferenceEquals(item.DataContext, HistoryTabExtension.Instance));
+            Assert.That(refreshedHistoryItem.IsEnabled, Is.False);
         }
         finally
         {

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -1,0 +1,172 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Beutl.Editor.Components.ColorScopesTab;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.Views;
+using Beutl.Views.Dock;
+using Dock.Avalonia.Controls;
+using Dock.Model.Controls;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DockTabAddButtonTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task Add_button_is_available_on_every_dock_and_only_visible_while_its_header_is_hovered()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-add-hover");
+
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            ToolControl[] controls = view.GetVisualDescendants()
+                .OfType<ToolControl>()
+                .ToArray();
+            Assert.That(controls, Is.Not.Empty);
+            Assert.That(
+                controls.All(control => FindAddButton(control) is not null),
+                Is.True,
+                "Every rendered dock tab strip should expose an add button.");
+
+            IToolDock playerDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Player)!;
+            ToolControl playerControl = controls.Single(control => ReferenceEquals(control.DataContext, playerDock));
+            ToolTabAddButton button = FindAddButton(playerControl)!;
+            Grid header = playerControl.GetVisualDescendants()
+                .OfType<Grid>()
+                .Single(control => control.Name == "PART_TabHeader");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(button.Opacity, Is.EqualTo(0));
+                Assert.That(button.IsHitTestVisible, Is.False);
+            });
+
+            window.MouseMove(Center(header, window));
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(button.Opacity, Is.EqualTo(1));
+                Assert.That(button.IsHitTestVisible, Is.True);
+            });
+
+            window.MouseMove(new Point(1, window.Bounds.Height - 1));
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(button.Opacity, Is.EqualTo(0));
+                Assert.That(button.IsHitTestVisible, Is.False);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Add_menu_disables_open_singletons_and_opens_the_selected_tool_in_its_dock()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-add-menu");
+
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            IToolDock target = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+            ToolControl targetControl = view.GetVisualDescendants()
+                .OfType<ToolControl>()
+                .Single(control => ReferenceEquals(control.DataContext, target));
+            ToolTabAddButton button = FindAddButton(targetControl)!;
+            ContextMenu menu = button.CreateContextMenu()!;
+            MenuItem[] items = menu.ItemsSource!.Cast<MenuItem>().ToArray();
+
+            MenuItem timelineItem = items.Single(
+                item => ReferenceEquals(item.DataContext, TimelineTabExtension.Instance));
+            MenuItem colorScopesItem = items.Single(
+                item => ReferenceEquals(item.DataContext, ColorScopesTabExtension.Instance));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(timelineItem.IsEnabled, Is.False);
+                Assert.That(colorScopesItem.IsEnabled, Is.True);
+            });
+
+            colorScopesItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            BeutlToolDockable? added = target.VisibleDockables?
+                .OfType<BeutlToolDockable>()
+                .SingleOrDefault(dockable => dockable.ToolContext.Extension == ColorScopesTabExtension.Instance);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(added, Is.Not.Null);
+                Assert.That(target.ActiveDockable, Is.SameAs(added));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static ToolTabAddButton? FindAddButton(Visual root)
+    {
+        return root.GetVisualDescendants().OfType<ToolTabAddButton>().SingleOrDefault();
+    }
+
+    private static Point Center(Control control, Visual relativeTo)
+    {
+        Point? point = control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
+            relativeTo);
+        Assert.That(point, Is.Not.Null);
+        return point!.Value;
+    }
+}


### PR DESCRIPTION
## Description

- Make tool tabs easier to discover by showing an add button when a dock header is hovered.
- Allow users to open a tool directly in the dock whose add button was clicked.
- Keep already-open singleton tools visible in the menu while disabling duplicate creation.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- Added `tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs` to verify hover visibility, singleton disabling, and insertion into the selected dock.
- `dotnet build src/Beutl/Beutl.csproj -c Debug --no-restore`
- `dotnet test tests/Beutl.HeadlessUITests/Beutl.HeadlessUITests.csproj -f net10.0 --settings coverlet.runsettings`
- Manual screenshots were not captured; the interaction is covered by headless UI tests.

## Fixed issues / References

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dock tab “add” button in the tab header with a divider; it becomes visible on header hover and shows a localized tooltip.
  * The button opens an updated context menu of available tool tabs (ordered), enabling only options valid for the selected dock.
* **Bug Fixes**
  * Tool-tab opening now provides clearer success/failure behavior and safely cleans up if opening cannot proceed (including null-context cases).
* **Tests**
  * Added headless UI tests covering add-button visibility/styling, context menu enablement, opening/activation behavior, and rejecting invalid open attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->