### PR TITLE
fix: stop the LayerHeader height feedback loop overflowing the stack

### DIFF
--- a/src/Beutl.Editor.Components/Helpers/FrameNumberHelper.cs
+++ b/src/Beutl.Editor.Components/Helpers/FrameNumberHelper.cs
@@ -10,8 +10,20 @@ public static class FrameNumberHelper
 
     static FrameNumberHelper()
     {
-        SecondWidth = (double)(Application.Current?.FindResource("SecondWidth") ?? 150);
-        LayerHeight = (double)(Application.Current?.FindResource("LayerHeight") ?? 25);
+        SecondWidth = ResolveDouble("SecondWidth", 150d);
+        LayerHeight = ResolveDouble("LayerHeight", 25d);
+    }
+
+    // FindResource boxes the resource as its declared type, so an int-typed resource (or a
+    // boxed int fallback) would make a direct (double) unbox throw.
+    private static double ResolveDouble(string key, double fallback)
+    {
+        return Application.Current?.FindResource(key) switch
+        {
+            double d => d,
+            int i => i,
+            _ => fallback,
+        };
     }
 
     public static int GetFrameRate(this Project? project)

--- a/src/Beutl.Editor.Components/Helpers/FrameNumberHelper.cs
+++ b/src/Beutl.Editor.Components/Helpers/FrameNumberHelper.cs
@@ -14,16 +14,26 @@ public static class FrameNumberHelper
         LayerHeight = ResolveDouble("LayerHeight", 25d);
     }
 
-    // FindResource boxes the resource as its declared type, so an int-typed resource (or a
-    // boxed int fallback) would make a direct (double) unbox throw.
+    // FindResource boxes the resource as its declared type, so a direct (double) unbox throws for
+    // anything but x:Double. A theme extension may supply any numeric type, and silently falling
+    // back would desync these values from the DynamicResource the same key drives in XAML.
     private static double ResolveDouble(string key, double fallback)
+        => ToDouble(Application.Current?.FindResource(key), fallback);
+
+    internal static double ToDouble(object? resource, double fallback)
     {
-        return Application.Current?.FindResource(key) switch
+        if (resource is double d) return d;
+
+        try
         {
-            double d => d,
-            int i => i,
-            _ => fallback,
-        };
+            return resource is IConvertible convertible and not string and not bool and not char
+                ? convertible.ToDouble(CultureInfo.InvariantCulture)
+                : fallback;
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        {
+            return fallback;
+        }
     }
 
     public static int GetFrameRate(this Project? project)

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -34,6 +34,8 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private readonly Dictionary<int, TrackedLayerTopObservable> _trackerCache = [];
     private bool _isDisposed;
     private bool _updatingToolMode;
+    private bool _addingLayerHeaders;
+    private int _pendingLayerHeaderCount;
 
     public TimelineTabViewModel(IEditorContext editorContext)
     {
@@ -579,23 +581,42 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     private void AddLayerHeaders(int count)
     {
         _logger.LogDebug("Adding layer headers up to count {Count}.", count);
-        if (LayerHeaders.Count != 0)
+
+        // A new header's Height emits synchronously, reaching CalculateLayerTop and re-entering
+        // here; fold that request into the running loop's bound rather than recursing.
+        if (_addingLayerHeaders)
         {
-            LayerHeaderViewModel last = LayerHeaders[LayerHeaders.Count - 1];
+            _pendingLayerHeaderCount = Math.Max(_pendingLayerHeaderCount, count);
+            return;
+        }
 
-            for (int i = last.Number.Value + 1; i < count; i++)
+        _addingLayerHeaders = true;
+        try
+        {
+            _pendingLayerHeaderCount = count;
+            for (int next = NextLayerNumber(); next < _pendingLayerHeaderCount; next = NextLayerNumber())
             {
-                LayerHeaders.Add(new LayerHeaderViewModel(i, this));
-            }
-
-            if (Options.Value.MaxLayerCount != LayerHeaders.Count)
-            {
-                Options.Value = Options.Value with { MaxLayerCount = LayerHeaders.Count };
-
-                _logger.LogDebug("The number of layers has been changed. ({Count})", count);
+                LayerHeaders.Add(new LayerHeaderViewModel(next, this));
             }
         }
+        finally
+        {
+            _addingLayerHeaders = false;
+            _pendingLayerHeaderCount = 0;
+        }
+
+        if (Options.Value.MaxLayerCount != LayerHeaders.Count)
+        {
+            Options.Value = Options.Value with { MaxLayerCount = LayerHeaders.Count };
+
+            _logger.LogDebug("The number of layers has been changed. ({Count})", count);
+        }
     }
+
+    // Headers can be renumbered by a layer move, so the next row follows the last header's
+    // Number rather than the list index.
+    private int NextLayerNumber()
+        => LayerHeaders.Count == 0 ? 0 : LayerHeaders[^1].Number.Value + 1;
 
     private void TryApplyLayerCount(int count)
     {
@@ -871,8 +892,11 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
     {
         AddLayerHeaders(layer + 1);
 
+        // Reentrant calls from AddLayerHeaders see a partially grown list, so clamp rather than
+        // index past the end.
         double sum = 0;
-        for (int i = 0; i < layer; i++)
+        int count = Math.Min(layer, LayerHeaders.Count);
+        for (int i = 0; i < count; i++)
         {
             sum += LayerHeaders[i].Height.Value;
         }

--- a/tests/Beutl.UnitTests/Editor/FrameNumberHelperTests.cs
+++ b/tests/Beutl.UnitTests/Editor/FrameNumberHelperTests.cs
@@ -1,0 +1,41 @@
+﻿using Beutl.Editor.Components.Helpers;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class FrameNumberHelperTests
+{
+    // A theme extension may declare these resources with any numeric type, and FindResource boxes
+    // the value as declared — so every numeric representation must resolve, not fall back.
+    [TestCase(25d, 25d)]
+    [TestCase(25, 25d)]
+    [TestCase(25f, 25d)]
+    [TestCase(25L, 25d)]
+    [TestCase((short)25, 25d)]
+    [TestCase((byte)25, 25d)]
+    public void ToDouble_NumericResource_ResolvesInsteadOfFallingBack(object resource, double expected)
+    {
+        Assert.That(FrameNumberHelper.ToDouble(resource, fallback: -1d), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ToDouble_DecimalResource_Resolves()
+    {
+        Assert.That(FrameNumberHelper.ToDouble(25m, fallback: -1d), Is.EqualTo(25d));
+    }
+
+    [TestCaseSource(nameof(NonNumericResources))]
+    public void ToDouble_NonNumericResource_UsesFallback(object? resource)
+    {
+        Assert.That(FrameNumberHelper.ToDouble(resource, fallback: 42d), Is.EqualTo(42d));
+    }
+
+    private static IEnumerable<object?> NonNumericResources()
+    {
+        yield return null;
+        yield return "25";
+        yield return true;
+        yield return 'x';
+        yield return new object();
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -89,12 +89,13 @@ public class TimelineTabViewModelTests
         });
     }
 
-    // A new header's Height emits synchronously into CalculateLayerTop, which re-enters
-    // AddLayerHeaders — without the reentrancy guard this recursed once per layer.
+    // A live tracked-layer-top subscription is what closes the loop — without a subscriber the
+    // synchronous Height emits reach nothing and no re-entry happens at all.
     [Test]
-    public void CalculateLayerTop_DeepLayer_GrowsHeadersWithoutRecursing()
+    public void CalculateLayerTop_DeepLayer_WithTrackedSubscriber_GrowsWithoutRecursing()
     {
         using TimelineTabViewModel viewModel = CreateViewModel();
+        using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(1).Subscribe(_ => { });
 
         double top = viewModel.CalculateLayerTop(2000);
 
@@ -107,10 +108,26 @@ public class TimelineTabViewModelTests
         });
     }
 
+    // The subscriber's own layer is above the growth, so every new header's height feeds it and
+    // it must still end holding the completed sum, not a partial one.
     [Test]
-    public void ToLayerNumber_FarBelowLastHeader_GrowsHeadersWithoutRecursing()
+    public void TrackedLayerTop_DeepSubscriber_EndsWithCompletedSum()
     {
         using TimelineTabViewModel viewModel = CreateViewModel();
+        double observed = double.NaN;
+        using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(2000)
+            .Subscribe(v => observed = v);
+
+        viewModel.CalculateLayerTop(2000);
+
+        Assert.That(observed, Is.EqualTo(viewModel.LayerHeaders.Take(2000).Sum(h => h.Height.Value)));
+    }
+
+    [Test]
+    public void ToLayerNumber_FarBelowLastHeader_WithTrackedSubscriber_GrowsWithoutRecursing()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+        using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(1).Subscribe(_ => { });
         double deepOffset = viewModel.CalculateLayerTop(1) * 2000;
 
         int layer = viewModel.ToLayerNumber(deepOffset);

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -89,6 +89,39 @@ public class TimelineTabViewModelTests
         });
     }
 
+    // A new header's Height emits synchronously into CalculateLayerTop, which re-enters
+    // AddLayerHeaders — without the reentrancy guard this recursed once per layer.
+    [Test]
+    public void CalculateLayerTop_DeepLayer_GrowsHeadersWithoutRecursing()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+
+        double top = viewModel.CalculateLayerTop(2000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.LayerHeaders, Has.Count.GreaterThanOrEqualTo(2001));
+            Assert.That(
+                top,
+                Is.EqualTo(viewModel.LayerHeaders.Take(2000).Sum(h => h.Height.Value)));
+        });
+    }
+
+    [Test]
+    public void ToLayerNumber_FarBelowLastHeader_GrowsHeadersWithoutRecursing()
+    {
+        using TimelineTabViewModel viewModel = CreateViewModel();
+        double deepOffset = viewModel.CalculateLayerTop(1) * 2000;
+
+        int layer = viewModel.ToLayerNumber(deepOffset);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(layer, Is.GreaterThanOrEqualTo(2000));
+            Assert.That(viewModel.LayerHeaders, Has.Count.GreaterThan(layer));
+        });
+    }
+
     private static TimelineTabViewModel CreateViewModel()
     {
         var scene = new Scene();


### PR DESCRIPTION
## Description
- `CalculateLayerTop` called `AddLayerHeaders`, and each newly constructed
  `LayerHeaderViewModel` emits its `Height` synchronously. That reached
  `RaiseLayerHeightChanged` -> `TrackedLayerTopObservable.OnLayerHeightChanged`
  -> `CalculateLayerTop`, adding one stack frame per layer until a deep ZIndex
  overflowed the stack. Reported from the Agent Toolkit path, where applying a
  document subscribes `ElementScopeViewModel`'s tracked-layer-top observable.
- `AddLayerHeaders` now guards against reentrancy and folds a reentrant request
  into the running loop's bound, so growth is one iteration at depth 1.
- Two defects on the same path are fixed with it, both reachable from the same
  repro: `AddLayerHeaders` returned early on an empty `LayerHeaders` list, so a
  scene with `MaxLayerCount = 0` never got a header at all; and
  `FrameNumberHelper` boxed its `int` fallbacks before an unconditional
  `(double)` unbox, so an unresolved resource always threw InvalidCastException.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Added `CalculateLayerTop_DeepLayer_GrowsHeadersWithoutRecursing` and
  `ToLayerNumber_FarBelowLastHeader_GrowsHeadersWithoutRecursing` in
  `tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs`, covering the
  direct call and the `ToLayerNumber` entry into the same recursion.
- Both were confirmed red against the unmodified code (the recursion dies on an
  out-of-range `LayerHeaders` read) and green after the fix.
- Full suites pass: Beutl.UnitTests 4,893, Beutl.E2ETests 78,
  Beutl.HeadlessUITests 182.

## Fixed issues / References
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric theme/resource resolution for display settings, correctly handling boxed numeric types without failing conversions.
  * Made timeline layer/header expansion more robust for deep positions by preventing re-entrancy issues during header growth.
  * Hardened layer position calculations to avoid invalid range behavior during dynamic expansion.
* **Tests**
  * Added regression tests covering deep layer/header expansion and tracked “layer top” emission behavior.
  * Added unit tests for numeric conversion behavior in the frame number helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->