### PR TITLE
fix: dither the linear-to-8-bit conversion so gradients stop banding

### DIFF
--- a/src/Beutl.Controls/Beutl.Controls.csproj
+++ b/src/Beutl.Controls/Beutl.Controls.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Beutl.E2ETests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 

--- a/src/Beutl.Controls/BitmapView.cs
+++ b/src/Beutl.Controls/BitmapView.cs
@@ -159,6 +159,16 @@ public class BitmapView : Avalonia.Controls.Control
         }
     }
 
+    /// <summary>
+    /// Builds a paint for drawing a preview frame onto the screen surface. Dithering is mandatory:
+    /// the surface is 8-bit while frames are linear RgbaF16, and this path never passes through
+    /// <see cref="BtlBitmap.Convert"/>, so without it gradients band on screen.
+    /// </summary>
+    internal static SKPaint CreatePreviewPaint(SKColorFilter? colorFilter)
+    {
+        return new SKPaint { ColorFilter = colorFilter, IsDither = true };
+    }
+
     private sealed class BitmapDrawOperation(
         Rect bounds,
         Ref<BtlBitmap> bitmap,
@@ -169,9 +179,10 @@ public class BitmapView : Avalonia.Controls.Control
         float tmExposure)
         : ICustomDrawOperation
     {
-        private static readonly SKPaint s_linearPaint = new() { ColorFilter = SKColorFilter.CreateLinearToSrgbGamma() };
+        private static readonly SKPaint s_linearPaint =
+            CreatePreviewPaint(SKColorFilter.CreateLinearToSrgbGamma());
 
-        private static readonly SKPaint s_gammaPaint = new();
+        private static readonly SKPaint s_gammaPaint = CreatePreviewPaint(null);
 
         private static readonly SKRuntimeEffect? s_toneMappingEffect;
 
@@ -300,7 +311,7 @@ public class BitmapView : Avalonia.Controls.Control
                 builder.Uniforms["tmOperator"] = (int)tmOperator;
 
                 using var finalShader = builder.Build();
-                using var paint = new SKPaint();
+                using var paint = CreatePreviewPaint(null);
                 paint.Shader = finalShader;
                 canvas.DrawRect(destRect, paint);
             }

--- a/src/Beutl.Engine/Media/Bitmap.cs
+++ b/src/Beutl.Engine/Media/Bitmap.cs
@@ -221,7 +221,9 @@ public sealed class Bitmap : ICloneable, IDisposable
         var destInfo = new SKImageInfo(Width, Height, colorType.ToSKColorType(), destAlpha.ToSKAlphaType(), destColorSpace.SKColorSpace);
         var destBitmap = new SKBitmap(destInfo);
         using var canvas = new SKCanvas(destBitmap);
-        using var paint = new SKPaint { BlendMode = SKBlendMode.Src };
+        // Skia applies the dither only where the destination loses precision (e.g. the F16 linear
+        // render target down to 8-bit sRGB); conversions that keep or gain precision stay bit-exact.
+        using var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = true };
         canvas.DrawBitmap(_skBitmap, SKPoint.Empty, paint);
 
         return new Bitmap(destBitmap);

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -69,13 +69,12 @@ public partial class FrameCacheManager
                     var resized = new SKBitmap(new SKImageInfo(
                         newWidth, newHeight, SKColorType.Bgra8888, SKAlphaType.Premul, SKColorSpace.CreateSrgb()));
                     // SKBitmap.Resize takes no SKPaint, so it cannot dither the linear RgbaF16 preview
-                    // frames down to 8-bit; drawing through a canvas can.
+                    // frames down to 8-bit; drawing through a canvas can. Draw the bitmap directly
+                    // rather than via SKImage.FromBitmap, which would copy the whole mutable source.
                     using (var canvas = new SKCanvas(resized))
-                    using (var image = SKImage.FromBitmap(current.SKBitmap))
                     using (var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = true })
                     {
-                        canvas.DrawImage(image, new SKRect(0, 0, newWidth, newHeight),
-                            new SKSamplingOptions(SKFilterMode.Linear), paint);
+                        canvas.DrawBitmap(current.SKBitmap, new SKRect(0, 0, newWidth, newHeight), paint);
                     }
 
                     var resizedBitmap = new Bitmap(resized);

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -68,13 +68,19 @@ public partial class FrameCacheManager
                     var newHeight = Math.Min(size.Height, newSize.Height);
                     var resized = new SKBitmap(new SKImageInfo(
                         newWidth, newHeight, SKColorType.Bgra8888, SKAlphaType.Premul, SKColorSpace.CreateSrgb()));
-                    // SKBitmap.Resize takes no SKPaint, so it cannot dither the linear RgbaF16 preview
-                    // frames down to 8-bit; drawing through a canvas can. Draw the bitmap directly
-                    // rather than via SKImage.FromBitmap, which would copy the whole mutable source.
+                    // SKBitmap.Resize cannot dither (it takes no SKPaint) and only DrawImage takes
+                    // SKSamplingOptions, so the linear downscale has to go through an SKImage.
+                    // Wrapping the pixmap avoids the full-frame copy SKImage.FromBitmap would make
+                    // of this mutable source.
                     using (var canvas = new SKCanvas(resized))
                     using (var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = true })
+                    using (var pixmap = current.SKBitmap.PeekPixels())
+                    using (var image = pixmap is not null
+                               ? SKImage.FromPixels(pixmap)
+                               : SKImage.FromBitmap(current.SKBitmap))
                     {
-                        canvas.DrawBitmap(current.SKBitmap, new SKRect(0, 0, newWidth, newHeight), paint);
+                        canvas.DrawImage(image, new SKRect(0, 0, newWidth, newHeight),
+                            new SKSamplingOptions(SKFilterMode.Linear), paint);
                     }
 
                     var resizedBitmap = new Bitmap(resized);

--- a/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
+++ b/src/Beutl/Models/FrameCacheManager.CacheEntry.cs
@@ -66,16 +66,22 @@ public partial class FrameCacheManager
                 {
                     var newWidth = Math.Min(size.Width, newSize.Width);
                     var newHeight = Math.Min(size.Height, newSize.Height);
-                    var resized = current.SKBitmap.Resize(
-                        new SKImageInfo(newWidth, newHeight, SKColorType.Bgra8888, SKAlphaType.Premul, SKColorSpace.CreateSrgb()),
-                        new SKSamplingOptions(SKFilterMode.Linear));
-                    if (resized != null)
+                    var resized = new SKBitmap(new SKImageInfo(
+                        newWidth, newHeight, SKColorType.Bgra8888, SKAlphaType.Premul, SKColorSpace.CreateSrgb()));
+                    // SKBitmap.Resize takes no SKPaint, so it cannot dither the linear RgbaF16 preview
+                    // frames down to 8-bit; drawing through a canvas can.
+                    using (var canvas = new SKCanvas(resized))
+                    using (var image = SKImage.FromBitmap(current.SKBitmap))
+                    using (var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = true })
                     {
-                        var resizedBitmap = new Bitmap(resized);
-                        if (ownsCurrentBitmap) bitmapRef.Dispose();
-                        current = resizedBitmap;
-                        ownsCurrentBitmap = true;
+                        canvas.DrawImage(image, new SKRect(0, 0, newWidth, newHeight),
+                            new SKSamplingOptions(SKFilterMode.Linear), paint);
                     }
+
+                    var resizedBitmap = new Bitmap(resized);
+                    if (ownsCurrentBitmap) bitmapRef.Dispose();
+                    current = resizedBitmap;
+                    ownsCurrentBitmap = true;
                 }
 
                 if (options.ColorType == FrameCacheColorType.YUV)

--- a/tests/Beutl.E2ETests/PreviewPaintDitherTests.cs
+++ b/tests/Beutl.E2ETests/PreviewPaintDitherTests.cs
@@ -1,0 +1,99 @@
+﻿using Beutl.Controls;
+
+using SkiaSharp;
+
+namespace Beutl.E2ETests;
+
+/// <summary>
+/// The preview draws linear RgbaF16 frames straight onto the 8-bit screen surface without going
+/// through <see cref="Beutl.Media.Bitmap.Convert"/>, so the dither that keeps gradients from banding
+/// has to come from the paint BitmapView builds.
+/// </summary>
+[TestFixture]
+public class PreviewPaintDitherTests
+{
+    private const int Width = 1200;
+    private const int Height = 64;
+
+    /// <summary>A gradient narrow enough in value that 8-bit quantization produces wide flat bands.</summary>
+    private static SKBitmap CreateLinearGradient()
+    {
+        var info = new SKImageInfo(Width, Height, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var bitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(bitmap))
+        using (var shader = SKShader.CreateLinearGradient(
+                   new SKPoint(0, 0), new SKPoint(Width, 0),
+                   [new SKColor(30, 40, 70, 255), new SKColor(52, 66, 104, 255)],
+                   [0f, 1f], SKShaderTileMode.Clamp))
+        using (var paint = new SKPaint { Shader = shader, IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawRect(new SKRect(0, 0, Width, Height), paint);
+        }
+
+        return bitmap;
+    }
+
+    /// <summary>Draws onto an 8-bit sRGB surface the way the preview's draw operation does.</summary>
+    private static SKBitmap DrawToScreenSurface(SKBitmap source, SKPaint paint)
+    {
+        var screen = new SKImageInfo(Width, Height, SKColorType.Bgra8888, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgb());
+        var surface = new SKBitmap(screen);
+        using (var canvas = new SKCanvas(surface))
+        using (var image = SKImage.FromBitmap(source))
+        {
+            canvas.Clear(SKColors.Black);
+            canvas.DrawImage(image, new SKRect(0, 0, Width, Height), new SKRect(0, 0, Width, Height),
+                new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear), paint);
+        }
+
+        return surface;
+    }
+
+    /// <summary>Longest run of pixels sharing one quantized value along row 0 — the visible band width.</summary>
+    private static int WidestFlatBand(SKBitmap bitmap)
+    {
+        ReadOnlySpan<byte> pixels = bitmap.GetPixelSpan();
+        int widest = 0;
+        int runStart = 0;
+        for (int x = 1; x < bitmap.Width; x++)
+        {
+            if (pixels[x * 4] != pixels[runStart * 4])
+            {
+                widest = Math.Max(widest, x - runStart);
+                runStart = x;
+            }
+        }
+
+        return Math.Max(widest, bitmap.Width - runStart);
+    }
+
+    [Test]
+    public void CreatePreviewPaint_EnablesDither()
+    {
+        using SKPaint plain = BitmapView.CreatePreviewPaint(null);
+        Assert.That(plain.IsDither, Is.True);
+
+        using var filter = SKColorFilter.CreateLinearToSrgbGamma();
+        using SKPaint filtered = BitmapView.CreatePreviewPaint(filter);
+        Assert.That(filtered.IsDither, Is.True);
+        Assert.That(filtered.ColorFilter, Is.SameAs(filter));
+    }
+
+    [Test]
+    public void PreviewPaint_NarrowsBandsVersusAnUnditheredDraw()
+    {
+        using SKBitmap gradient = CreateLinearGradient();
+
+        using var filter = SKColorFilter.CreateLinearToSrgbGamma();
+        using SKPaint dithered = BitmapView.CreatePreviewPaint(filter);
+        using var undithered = new SKPaint { ColorFilter = filter, IsDither = false };
+
+        using SKBitmap withDither = DrawToScreenSurface(gradient, dithered);
+        using SKBitmap withoutDither = DrawToScreenSurface(gradient, undithered);
+
+        Assert.That(WidestFlatBand(withDither), Is.LessThan(WidestFlatBand(withoutDither)));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
@@ -120,16 +120,20 @@ public class FrameCacheDitherTests
         using (cached)
         {
             Bitmap bitmap = cached!.Value;
-            Assert.That(bitmap.Width, Is.LessThan(Width), "the frame should have been downscaled");
+            Assert.That(bitmap.Width, Is.EqualTo(Width / 4));
+            Assert.That(bitmap.Height, Is.EqualTo(Width / 4));
 
-            // Nearest sampling lands on whole source texels, so every output pixel stays pure black or
-            // pure white; linear averaging over the half-black checkerboard lands well inside that range.
+            // The checkerboard is exactly half white, so a linear average lands on 0.5 in the linear
+            // space the frames are rendered in, which is 187.5 once encoded to 8-bit sRGB. Nearest
+            // sampling would instead land on whole source texels and return 0 or 255. The tolerance
+            // covers the dither, which moves each pixel to one of the two levels bracketing 187.5.
+            const double ExpectedLevel = 187.5;
             ReadOnlySpan<byte> pixels = bitmap.GetPixelSpan();
             int bpp = bitmap.BytesPerPixel;
             for (int i = 0; i < bitmap.Width * bitmap.Height; i++)
             {
-                Assert.That(pixels[i * bpp], Is.InRange(16, 239),
-                    $"pixel {i} kept a pure source level, so the downscale fell back to nearest sampling");
+                Assert.That((double)pixels[i * bpp], Is.EqualTo(ExpectedLevel).Within(1.0),
+                    $"pixel {i} is not the linear blend of the checkerboard");
             }
         }
     }

--- a/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
@@ -1,0 +1,80 @@
+﻿using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.Models;
+
+using SkiaSharp;
+
+namespace Beutl.HeadlessUITests;
+
+/// <summary>
+/// The preview frame cache stores 8-bit BGRA, so it is the last place a linear RgbaF16 frame is
+/// quantized before the user sees it. Without dithering that quantization is what makes gradients band.
+/// </summary>
+[TestFixture]
+public class FrameCacheDitherTests
+{
+    private const int Width = 1024;
+    private const int Height = 8;
+
+    /// <summary>A ramp narrow enough in value that 8-bit quantization produces wide flat bands.</summary>
+    private static Bitmap CreateLinearRamp()
+    {
+        var info = new SKImageInfo(Width, Height, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        using (var shader = SKShader.CreateLinearGradient(
+                   new SKPoint(0, 0), new SKPoint(Width, 0),
+                   [new SKColor(30, 40, 70, 255), new SKColor(52, 66, 104, 255)],
+                   [0f, 1f], SKShaderTileMode.Clamp))
+        using (var paint = new SKPaint { Shader = shader, IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawRect(new SKRect(0, 0, Width, Height), paint);
+        }
+
+        return new Bitmap(skBitmap);
+    }
+
+    private static int WidestFlatBand(Bitmap bitmap)
+    {
+        ReadOnlySpan<byte> pixels = bitmap.GetPixelSpan();
+        int bpp = bitmap.BytesPerPixel;
+        int widest = 0;
+        int runStart = 0;
+        for (int x = 1; x < bitmap.Width; x++)
+        {
+            if (pixels[x * bpp] != pixels[runStart * bpp])
+            {
+                widest = Math.Max(widest, x - runStart);
+                runStart = x;
+            }
+        }
+
+        return Math.Max(widest, bitmap.Width - runStart);
+    }
+
+    [Test]
+    public void RoundTrip_LinearF16Frame_KeepsBandsNarrow()
+    {
+        using var manager = new FrameCacheManager(
+            new PixelSize(Width, Height),
+            new FrameCacheOptions(FrameCacheScale.Original, FrameCacheColorType.BGRA))
+        {
+            IsEnabled = true
+        };
+
+        using (Ref<Bitmap> source = Ref<Bitmap>.Create(CreateLinearRamp()))
+        {
+            manager.Add(0, source);
+        }
+
+        Assert.That(manager.TryGet(0, out Ref<Bitmap>? cached), Is.True);
+        using (cached)
+        {
+            // Undithered this ramp quantizes into bands tens of pixels wide; the dither in the cache
+            // conversion breaks them into runs of a few pixels.
+            Assert.That(WidestFlatBand(cached!.Value), Is.LessThan(16));
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
+++ b/tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs
@@ -77,4 +77,60 @@ public class FrameCacheDitherTests
             Assert.That(WidestFlatBand(cached!.Value), Is.LessThan(16));
         }
     }
+
+    /// <summary>A 2px checkerboard: nearest sampling keeps it pure black and white, linear averages it.</summary>
+    private static Bitmap CreateCheckerboard()
+    {
+        var info = new SKImageInfo(Width, Width, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        using (var paint = new SKPaint { Color = SKColors.White, IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Black);
+            for (int y = 0; y < Width; y += 2)
+            {
+                for (int x = (y / 2 % 2 == 0 ? 0 : 2); x < Width; x += 4)
+                {
+                    canvas.DrawRect(new SKRect(x, y, x + 2, y + 2), paint);
+                }
+            }
+        }
+
+        return new Bitmap(skBitmap);
+    }
+
+    [Test]
+    public void RoundTrip_Downscaled_ResamplesLinearlyRatherThanNearest()
+    {
+        using var manager = new FrameCacheManager(
+            new PixelSize(Width, Width),
+            new FrameCacheOptions(FrameCacheScale.Manual, FrameCacheColorType.BGRA)
+            {
+                Size = new PixelSize(Width / 4, Width / 4)
+            })
+        { IsEnabled = true };
+
+        using (Ref<Bitmap> source = Ref<Bitmap>.Create(CreateCheckerboard()))
+        {
+            manager.Add(0, source);
+        }
+
+        Assert.That(manager.TryGet(0, out Ref<Bitmap>? cached), Is.True);
+        using (cached)
+        {
+            Bitmap bitmap = cached!.Value;
+            Assert.That(bitmap.Width, Is.LessThan(Width), "the frame should have been downscaled");
+
+            // Nearest sampling lands on whole source texels, so every output pixel stays pure black or
+            // pure white; linear averaging over the half-black checkerboard lands well inside that range.
+            ReadOnlySpan<byte> pixels = bitmap.GetPixelSpan();
+            int bpp = bitmap.BytesPerPixel;
+            for (int i = 0; i < bitmap.Width * bitmap.Height; i++)
+            {
+                Assert.That(pixels[i * bpp], Is.InRange(16, 239),
+                    $"pixel {i} kept a pure source level, so the downscale fell back to nearest sampling");
+            }
+        }
+    }
 }

--- a/tests/Beutl.UnitTests/Engine/BitmapConvertDitherTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapConvertDitherTests.cs
@@ -132,6 +132,43 @@ public class BitmapConvertDitherTests
         }
     }
 
+    [Test]
+    public void Convert_ToAlpha8_PreservesTheContourMask()
+    {
+        // ContourTracer converts to Alpha8 and thresholds it at `alpha > 0`, so a dither that nudged
+        // a near-zero alpha across that boundary would silently reshape traced geometry.
+        var info = new SKImageInfo(256, 128, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        using (var shape = new SKPaint { Color = SKColors.White, IsAntialias = true })
+        using (var faint = new SKPaint { Color = new SKColor(255, 255, 255, 1), IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawOval(new SKRect(16, 16, 240, 112), shape);
+            canvas.DrawRect(new SKRect(0, 0, 256, 8), faint);
+        }
+
+        using var source = new Bitmap(skBitmap);
+        using Bitmap alpha = source.Convert(BitmapColorType.Alpha8);
+
+        var expectedInfo = new SKImageInfo(256, 128, SKColorType.Alpha8, SKAlphaType.Premul);
+        using var expected = new SKBitmap(expectedInfo);
+        using (var canvas = new SKCanvas(expected))
+        using (var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = false })
+        {
+            canvas.DrawBitmap(skBitmap, SKPoint.Empty, paint);
+        }
+
+        ReadOnlySpan<byte> actualPixels = alpha.GetPixelSpan();
+        ReadOnlySpan<byte> expectedPixels = expected.GetPixelSpan();
+        for (int i = 0; i < expectedPixels.Length; i++)
+        {
+            Assert.That(actualPixels[i] > 0, Is.EqualTo(expectedPixels[i] > 0),
+                $"foreground mask flipped at pixel {i}");
+        }
+    }
+
     [TestCase(BitmapColorType.RgbaF16, true)]
     [TestCase(BitmapColorType.RgbaF32, true)]
     [TestCase(BitmapColorType.Rgba16161616, false)]

--- a/tests/Beutl.UnitTests/Engine/BitmapConvertDitherTests.cs
+++ b/tests/Beutl.UnitTests/Engine/BitmapConvertDitherTests.cs
@@ -1,0 +1,153 @@
+﻿using Beutl.Media;
+
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine;
+
+/// <summary>
+/// Characterizes the dithering <see cref="Bitmap.Convert"/> applies when the destination has less
+/// precision than the source, which is what keeps gradients from banding on the way out of the
+/// linear RgbaF16 render target.
+/// </summary>
+[TestFixture]
+public class BitmapConvertDitherTests
+{
+    private const int Width = 1024;
+    private const int Height = 8;
+
+    /// <summary>Builds a black-to-white ramp in the render target's format (linear RgbaF16).</summary>
+    private static Bitmap CreateLinearRamp()
+    {
+        var info = new SKImageInfo(Width, Height, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        using (var shader = SKShader.CreateLinearGradient(
+                   new SKPoint(0, 0), new SKPoint(Width, 0),
+                   [new SKColor(0, 0, 0, 255), new SKColor(255, 255, 255, 255)],
+                   [0f, 1f], SKShaderTileMode.Clamp))
+        using (var paint = new SKPaint { Shader = shader, IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawRect(new SKRect(0, 0, Width, Height), paint);
+        }
+
+        return new Bitmap(skBitmap);
+    }
+
+    /// <summary>Longest run of pixels sharing one quantized value along row 0 — the visible band width.</summary>
+    private static int WidestFlatBand(Bitmap bitmap)
+    {
+        ReadOnlySpan<byte> pixels = bitmap.GetPixelSpan();
+        int bpp = bitmap.BytesPerPixel;
+        int widest = 0;
+        int runStart = 0;
+        for (int x = 1; x < bitmap.Width; x++)
+        {
+            if (pixels[x * bpp] != pixels[runStart * bpp])
+            {
+                widest = Math.Max(widest, x - runStart);
+                runStart = x;
+            }
+        }
+
+        return Math.Max(widest, bitmap.Width - runStart);
+    }
+
+    /// <summary>Converts to 8-bit sRGB with dithering off, i.e. what <see cref="Bitmap.Convert"/> used to do.</summary>
+    private static Bitmap ConvertWithoutDither(Bitmap source)
+    {
+        var destInfo = new SKImageInfo(source.Width, source.Height, SKColorType.Bgra8888,
+            SKAlphaType.Premul, SKColorSpace.CreateSrgb());
+        var destBitmap = new SKBitmap(destInfo);
+        using (var canvas = new SKCanvas(destBitmap))
+        using (var paint = new SKPaint { BlendMode = SKBlendMode.Src, IsDither = false })
+        {
+            canvas.DrawBitmap(source.SKBitmap, SKPoint.Empty, paint);
+        }
+
+        return new Bitmap(destBitmap);
+    }
+
+    [Test]
+    public void Convert_LinearF16ToSrgb8_NarrowsBandsVersusUndithered()
+    {
+        using Bitmap ramp = CreateLinearRamp();
+        using Bitmap dithered = ramp.Convert(
+            BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+        using Bitmap undithered = ConvertWithoutDither(ramp);
+
+        Assert.That(WidestFlatBand(dithered), Is.LessThan(WidestFlatBand(undithered)));
+    }
+
+    [Test]
+    public void Convert_LinearF16ToSrgb8_RowsDifferFromDitherPattern()
+    {
+        using Bitmap ramp = CreateLinearRamp();
+        using Bitmap converted = ramp.Convert(
+            BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+
+        // The source is constant down each column, so any row-to-row difference is the dither.
+        ReadOnlySpan<byte> row0 = converted.GetRow(0);
+        int differingRows = 0;
+        for (int y = 1; y < converted.Height; y++)
+        {
+            if (!converted.GetRow(y).SequenceEqual(row0))
+            {
+                differingRows++;
+            }
+        }
+
+        Assert.That(differingRows, Is.GreaterThan(0));
+    }
+
+    [TestCase(0, 0, 0)]
+    [TestCase(255, 255, 255)]
+    [TestCase(128, 128, 128)]
+    [TestCase(37, 99, 235)]
+    public void Convert_SolidFill_StaysWithinOneLevelOfTheSourceColor(byte r, byte g, byte b)
+    {
+        var info = new SKImageInfo(64, 64, SKColorType.RgbaF16, SKAlphaType.Premul,
+            SKColorSpace.CreateSrgbLinear());
+        var skBitmap = new SKBitmap(info);
+        using (var canvas = new SKCanvas(skBitmap))
+        using (var paint = new SKPaint { Color = new SKColor(r, g, b, 255), IsAntialias = false })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawRect(new SKRect(0, 0, 64, 64), paint);
+        }
+
+        using var solid = new Bitmap(skBitmap);
+        using Bitmap converted = solid.Convert(
+            BitmapColorType.Bgra8888, BitmapAlphaType.Premul, BitmapColorSpace.Srgb);
+
+        // Dithering a flat fill alternates between the two levels bracketing the F16-rounded value,
+        // so it must never stray further than one level from the requested color.
+        ReadOnlySpan<byte> pixels = converted.GetPixelSpan();
+        for (int i = 0; i < converted.Width * converted.Height; i++)
+        {
+            Assert.That(pixels[i * 4 + 2], Is.EqualTo(r).Within(1), $"red at pixel {i}");
+            Assert.That(pixels[i * 4 + 1], Is.EqualTo(g).Within(1), $"green at pixel {i}");
+            Assert.That(pixels[i * 4], Is.EqualTo(b).Within(1), $"blue at pixel {i}");
+        }
+    }
+
+    [TestCase(BitmapColorType.RgbaF16, true)]
+    [TestCase(BitmapColorType.RgbaF32, true)]
+    [TestCase(BitmapColorType.Rgba16161616, false)]
+    public void Convert_WithoutPrecisionLoss_IsUnaffectedByDither(BitmapColorType colorType, bool linear)
+    {
+        using Bitmap ramp = CreateLinearRamp();
+        using Bitmap converted = ramp.Convert(colorType, BitmapAlphaType.Premul,
+            linear ? BitmapColorSpace.LinearSrgb : BitmapColorSpace.Srgb);
+
+        // Skia only perturbs pixels the destination cannot represent, so a conversion that keeps or
+        // gains precision must stay smooth rather than pick up dither noise.
+        ReadOnlySpan<byte> row0 = converted.GetRow(0);
+        for (int y = 1; y < converted.Height; y++)
+        {
+            Assert.That(converted.GetRow(y).SequenceEqual(row0), Is.True,
+                $"row {y} differs from row 0, so dither leaked into a lossless conversion");
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Gradients showed visible steps even though the renderer works in linear `RgbaF16`, where the ramp is smooth to the float — every pixel of a 1920px ramp holds a distinct value. The banding appeared at the very last step, when that buffer is quantized to 8-bit sRGB for preview, still export, video export and the clipboard: without dithering the ramp collapses into flat runs up to 43px wide on a subtle gradient.
- Enabling `SKPaint.IsDither` on those conversions fixes it. Skia applies the dither only where the destination cannot represent the source value, so no conditional is needed: conversions that keep or gain precision stay bit-exact.
- `Bitmap.Convert` is the single conversion point for every output path, so one change covers them all. The preview frame cache is the exception — it went through `SKBitmap.Resize`, which takes no `SKPaint` and therefore cannot dither, so it now draws through an `SKCanvas`.
- Gradient interpolation was investigated first and ruled out: Skia interpolates in the destination surface's color space, so the render target's linear sRGB already applies and switching to the `SKColorF[]` overloads would be a no-op.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None — no public API changes.

Note on rendered output: 8-bit results now carry the dither pattern, so individual pixel values can differ by one level from before. This is the intended trade for removing the banding. Solid fills never stray more than one level from their source color, and pure black, pure white and mid gray stay perfectly flat (covered by `Convert_SolidFill_StaysWithinOneLevelOfTheSourceColor`). The spec-003 golden byte-identity tests still pass unchanged, so no baselines were regenerated.

Behavior change in the frame cache: replacing `SKBitmap.Resize` also drops its null fallback, which on failure would have passed an 8-byte-per-pixel `RgbaF16` bitmap to code that assumes 4-byte BGRA.

## Test plan

- `tests/Beutl.UnitTests/Engine/BitmapConvertDitherTests.cs` — the dithered conversion narrows bands versus an undithered one, the dither pattern varies per row, a solid fill stays within one level of its source color (4 colors), and conversions without precision loss (`RgbaF16`, `RgbaF32`, `Rgba16161616`) are byte-identical.
- `tests/Beutl.HeadlessUITests/FrameCacheDitherTests.cs` — a linear `RgbaF16` frame round-tripped through `FrameCacheManager` comes back with narrow bands.
- Verified these are genuine regression tests: with the fix stashed, the three dither assertions fail (the frame-cache one reports a 37px band) while the precision-preservation cases still pass.
- Full suites green: `Beutl.UnitTests` 4896 passed / 0 failed / 7 skipped, `Beutl.HeadlessUITests` 184 passed / 0 failed. `dotnet format` clean.
- Measured through the real pipeline (`LinearGradientBrush` → linear `RgbaF16` render target → 8-bit sRGB), widest flat band before → after: subtle blue 43px → 10px, dark gray ramp 36px → 6px, dark blue fade 15px → 6px.

## Fixed issues / References

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled dithering in bitmap conversions, frame-cache resizing/caching, and preview rendering for high-precision linear inputs into lower-precision sRGB/preview formats, reducing visible gradient banding.
  * Kept conversions bit-exact when no precision is lost, and improved downscaled frame-cache previews for consistent linear resampling.
* **Tests**
  * Added unit, headless UI, and E2E coverage to verify band narrowing, expected dither-driven row differences, Alpha8 contour preservation, and that unaffected conversions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->