### PR TITLE
fix: preserve terminal session across tab switches

### DIFF
--- a/src/Beutl.Editor.Components/TerminalTab/TerminalTabExtension.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/TerminalTabExtension.cs
@@ -20,6 +20,8 @@ public sealed class TerminalTabExtension : ToolTabExtension
 
     public override bool CanMultiple => true;
 
+    public override bool ReuseContentAcrossActivation => true;
+
     public override DockAnchor DefaultAnchor => DockAnchor.Bottom;
 
     public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)

--- a/src/Beutl.Extensibility/SceneEditorTabExtension.cs
+++ b/src/Beutl.Extensibility/SceneEditorTabExtension.cs
@@ -18,6 +18,17 @@ public abstract class ToolTabExtension : ViewExtension
 {
     public abstract bool CanMultiple { get; }
 
+    /// <summary>
+    /// Gets whether the host reuses the same content control when this tool is deactivated and
+    /// activated again.
+    /// </summary>
+    /// <remarks>
+    /// Reused controls can still be unloaded from and loaded into the visual tree. State and
+    /// resources that must survive those transitions and require deterministic cleanup should be
+    /// owned by the <see cref="IToolContext"/>, which is disposed when its dockable closes.
+    /// </remarks>
+    public virtual bool ReuseContentAcrossActivation => false;
+
     public virtual string? Header => null;
 
     public virtual DockAnchor DefaultAnchor => DockAnchor.None;

--- a/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Avalonia.Controls;
 using Dock.Model.Inpc.Controls;
 using FluentAvalonia.UI.Controls;
 
@@ -39,6 +40,8 @@ public class BeutlToolDockable : Tool, IDisposable
 
     public EditViewModel EditViewModel { get; }
 
+    internal Control? ToolContent { get; set; }
+
     private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (_isDisposed) return;
@@ -55,6 +58,7 @@ public class BeutlToolDockable : Tool, IDisposable
         PropertyChanged -= OnPropertyChanged;
         _isSelectedSubscription.Dispose();
         ToolContext.Dispose();
+        ToolContent = null;
     }
 
     private static string CreateId(IToolContext context)

--- a/src/Beutl/Views/ToolTabContent.cs
+++ b/src/Beutl/Views/ToolTabContent.cs
@@ -19,24 +19,44 @@ public sealed class ToolTabContent : ContentControl
             return;
         }
 
-        if (DataContext is not BeutlToolDockable dockable ||
-            !dockable.ToolContext.Extension.TryCreateContent(dockable.EditViewModel, out Control? control))
+        if (DataContext is not BeutlToolDockable dockable)
         {
-            control = new TextBlock
-            {
-                Text = $"""
-                        Error:
-                            {MessageStrings.CannotDisplayContext}
-                        """
-            };
+            Content = CreateErrorContent();
+            return;
         }
-        else
+
+        if (dockable.ToolContent is not { } control)
         {
+            if (!dockable.ToolContext.Extension.TryCreateContent(dockable.EditViewModel, out control))
+            {
+                Content = CreateErrorContent();
+                return;
+            }
+
             var cm = AppHelper.GetContextCommandManager?.Invoke();
             cm?.Attach(control, dockable.ToolContext.Extension);
             control.DataContext = dockable.ToolContext;
+            dockable.ToolContent = control;
+        }
+
+        if (control.Parent is ContentControl previousOwner
+            && !ReferenceEquals(previousOwner, this)
+            && ReferenceEquals(previousOwner.Content, control))
+        {
+            previousOwner.Content = null;
         }
 
         Content = control;
+    }
+
+    private static TextBlock CreateErrorContent()
+    {
+        return new TextBlock
+        {
+            Text = $"""
+                    Error:
+                        {MessageStrings.CannotDisplayContext}
+                    """
+        };
     }
 }

--- a/src/Beutl/Views/ToolTabContent.cs
+++ b/src/Beutl/Views/ToolTabContent.cs
@@ -25,7 +25,11 @@ public sealed class ToolTabContent : ContentControl
             return;
         }
 
-        if (dockable.ToolContent is not { } control)
+        Control? control = dockable.ToolContext.Extension.ReuseContentAcrossActivation
+            ? dockable.ToolContent
+            : null;
+
+        if (control is null)
         {
             if (!dockable.ToolContext.Extension.TryCreateContent(dockable.EditViewModel, out control))
             {
@@ -36,7 +40,10 @@ public sealed class ToolTabContent : ContentControl
             var cm = AppHelper.GetContextCommandManager?.Invoke();
             cm?.Attach(control, dockable.ToolContext.Extension);
             control.DataContext = dockable.ToolContext;
-            dockable.ToolContent = control;
+            if (dockable.ToolContext.Extension.ReuseContentAcrossActivation)
+            {
+                dockable.ToolContent = control;
+            }
         }
 
         if (control.Parent is ContentControl previousOwner

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -1,11 +1,16 @@
-﻿using Avalonia.Controls;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+
+using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
 using Avalonia.VisualTree;
 
 using Beutl.Editor.Components.TerminalTab.ViewModels;
 using Beutl.Editor.Components.TerminalTab.Views;
+using Beutl.Editor.Components.TimelineTab.Views;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dock;
@@ -14,6 +19,8 @@ using Beutl.Views;
 using Dock.Model.Controls;
 
 using Iciclecreek.Terminal;
+
+using Reactive.Bindings;
 
 namespace Beutl.HeadlessUITests;
 
@@ -44,12 +51,13 @@ public class TerminalTabLifecycleTests
     [AvaloniaTest]
     public async Task SwitchingToolTabs_ReusesTerminalViewAndShell()
     {
+        await ResetProjectAsync();
+
         if (OperatingSystem.IsWindows())
         {
             Assert.Ignore("The Windows ConPTY path is not exercised by this headless test.");
         }
 
-        await ResetProjectAsync();
         EditViewModel editor = await OpenEditorForNewScene("terminal-tab-lifecycle");
         IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
         var terminalContext = new TerminalTabViewModel(editor);
@@ -103,6 +111,48 @@ public class TerminalTabLifecycleTests
         }
     }
 
+    [AvaloniaTest]
+    public async Task SwitchingToolTabs_RecreatesNonPersistentToolContent()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tool-tab-content-lifecycle");
+        IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
+        var transientContext = new TransientToolContext();
+        Assert.That(editor.DockHost.OpenToolTab(transientContext, bottomDock), Is.True);
+        BeutlToolDockable timelineDockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => ReferenceEquals(item.ToolContext.Extension, TimelineTabExtension.Instance));
+        BeutlToolDockable transientDockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => ReferenceEquals(item.ToolContext, transientContext));
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            editor.DockHost.Factory.SetActiveDockable(timelineDockable);
+            HeadlessTestHelpers.Render();
+            TimelineTabView firstTimeline = view.GetVisualDescendants()
+                .OfType<TimelineTabView>()
+                .Single();
+
+            editor.DockHost.Factory.SetActiveDockable(transientDockable);
+            HeadlessTestHelpers.Render();
+            editor.DockHost.Factory.SetActiveDockable(timelineDockable);
+            HeadlessTestHelpers.Render();
+
+            TimelineTabView secondTimeline = view.GetVisualDescendants()
+                .OfType<TimelineTabView>()
+                .Single();
+            Assert.That(secondTimeline, Is.Not.SameAs(firstTimeline));
+        }
+        finally
+        {
+            editor.CloseToolTab(transientContext);
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
     private static TerminalControl FindTerminal(EditView view)
     {
         return view.GetVisualDescendants()
@@ -125,5 +175,52 @@ public class TerminalTabLifecycleTests
         }
 
         Assert.Fail(failureMessage);
+    }
+
+    private sealed class TransientToolContext : IToolContext
+    {
+        public ToolTabExtension Extension => TransientToolExtension.Instance;
+
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+
+        public string Header => "Transient";
+
+        public void Dispose()
+        {
+            IsSelected.Dispose();
+        }
+
+        public object? GetService(Type serviceType) => null;
+
+        public void ReadFromJson(JsonObject json)
+        {
+        }
+
+        public void WriteToJson(JsonObject json)
+        {
+        }
+    }
+
+    private sealed class TransientToolExtension : ToolTabExtension
+    {
+        public static readonly TransientToolExtension Instance = new();
+
+        public override bool CanMultiple => false;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = new TransientToolContext();
+            return true;
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -1,0 +1,129 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+using Beutl.Editor.Components.TerminalTab.Views;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.Views;
+
+using Dock.Model.Controls;
+
+using Iciclecreek.Terminal;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class TerminalTabLifecycleTests
+{
+    private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task SwitchingToolTabs_ReusesTerminalViewAndShell()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The Windows ConPTY path is not exercised by this headless test.");
+        }
+
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("terminal-tab-lifecycle");
+        IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
+        var terminalContext = new TerminalTabViewModel(editor);
+        Assert.That(editor.DockHost.OpenToolTab(terminalContext, bottomDock), Is.True);
+
+        var terminalDockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => ReferenceEquals(item.ToolContext, terminalContext));
+        BeutlToolDockable otherDockable = bottomDock.VisibleDockables!
+            .OfType<BeutlToolDockable>()
+            .First(item => !ReferenceEquals(item, terminalDockable));
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            editor.DockHost.Factory.SetActiveDockable(terminalDockable);
+            HeadlessTestHelpers.Render();
+
+            TerminalControl firstTerminal = FindTerminal(view);
+            WaitUntil(() => firstTerminal.HasPtyConnection, "the terminal shell did not start");
+            int pid = firstTerminal.Pid;
+
+            editor.DockHost.Factory.SetActiveDockable(otherDockable);
+            HeadlessTestHelpers.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstTerminal.HasPtyConnection, Is.True);
+                Assert.That(firstTerminal.Pid, Is.EqualTo(pid));
+                Assert.That(terminalContext.IsProcessExited.Value, Is.False);
+            });
+
+            editor.DockHost.Factory.SetActiveDockable(terminalDockable);
+            HeadlessTestHelpers.Render();
+
+            TerminalControl secondTerminal = FindTerminal(view);
+            Assert.Multiple(() =>
+            {
+                Assert.That(secondTerminal, Is.SameAs(firstTerminal));
+                Assert.That(secondTerminal.HasPtyConnection, Is.True);
+                Assert.That(secondTerminal.Pid, Is.EqualTo(pid));
+                Assert.That(terminalContext.IsProcessExited.Value, Is.False);
+            });
+        }
+        finally
+        {
+            editor.CloseToolTab(terminalContext);
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static TerminalControl FindTerminal(EditView view)
+    {
+        return view.GetVisualDescendants()
+            .OfType<TerminalTabView>()
+            .Single()
+            .FindControl<TerminalControl>("Terminal")!;
+    }
+
+    private static void WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 5000)
+    {
+        for (int elapsed = 0; elapsed < timeoutMs; elapsed += 50)
+        {
+            HeadlessTestHelpers.Settle();
+            if (condition())
+            {
+                return;
+            }
+
+            Thread.Sleep(50);
+        }
+
+        Assert.Fail(failureMessage);
+    }
+}


### PR DESCRIPTION
## Description

- Keep each tool tab control associated with its dockable so transient data-template recreation does not reset stateful views.
- Reparent cached controls between tool-tab hosts, preserving the terminal PTY and process ID while the tab is hidden.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- Added `tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs` to verify that switching tool tabs preserves the terminal control, PTY connection, and process ID.
- `Beutl.HeadlessUITests`: 4 targeted dock and terminal tests passed.
- `Beutl.UnitTests`: 20 terminal view-model tests passed.
- `Beutl.E2ETests`: 1 terminal input test passed.
- `dotnet format Beutl.slnx --no-restore --verify-no-changes --verbosity minimal` passed.

## Fixed issues / References

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-tab content lifecycle when switching between tabs, including proper detachment/cleanup.
  * Added a clearer in-UI error view when tool context content can’t be created.
  * Terminal tool tabs now reliably reuse the existing terminal session on reactivation; transient tool tabs are recreated as expected.

* **Tests**
  * Added headless UI coverage verifying terminal reuse (connection + process state) and recreation for non-persistent tool content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->