### PR TITLE
fix: Isolate unit tests from user settings

### DIFF
--- a/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
+++ b/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
@@ -22,7 +22,14 @@ public class InstalledPackageRepositoryTests
     }
 
     [TearDown]
-    public void TearDown() => File.Delete(InstalledPackagesFile);
+    public void TearDown()
+    {
+        Assert.That(
+            Helper.AppRoot,
+            Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        File.Delete(InstalledPackagesFile);
+    }
 
     [Test]
     public void GetPackageObservable_EmitsNull_WhenNotInstalled()

--- a/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
+++ b/tests/Beutl.UnitTests/Api/InstalledPackageRepositoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Api.Services;
+using Beutl.Testing.Headless;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
@@ -8,50 +9,24 @@ namespace Beutl.UnitTests.Api;
 [NonParallelizable]
 public class InstalledPackageRepositoryTests
 {
-    private string? _previousHome;
-    private string? _tempHome;
+    private static string InstalledPackagesFile => Path.Combine(Helper.AppRoot, "installedPackages.json");
 
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
+    [SetUp]
+    public void SetUp()
     {
-        _previousHome = Environment.GetEnvironmentVariable("BEUTL_HOME");
-        _tempHome = Path.Combine(Path.GetTempPath(), $"beutl-repo-tests-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempHome);
-        Environment.SetEnvironmentVariable("BEUTL_HOME", _tempHome);
+        Assert.That(
+            Helper.AppRoot,
+            Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        File.Delete(InstalledPackagesFile);
     }
 
-    [OneTimeTearDown]
-    public void OneTimeTearDown()
-    {
-        Environment.SetEnvironmentVariable("BEUTL_HOME", _previousHome);
-        try
-        {
-            if (_tempHome is not null && Directory.Exists(_tempHome))
-            {
-                Directory.Delete(_tempHome, recursive: true);
-            }
-        }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
-    }
-
-    // Helper.AppRoot is pinned by its static ctor at first use; skip I/O tests when isolation
-    // took effect too late, so they never write to the developer's real ~/.beutl.
-    private bool IsHomeIsolated => _tempHome is not null
-        && Helper.AppRoot.StartsWith(_tempHome, StringComparison.OrdinalIgnoreCase);
+    [TearDown]
+    public void TearDown() => File.Delete(InstalledPackagesFile);
 
     [Test]
     public void GetPackageObservable_EmitsNull_WhenNotInstalled()
     {
-        if (!IsHomeIsolated)
-        {
-            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
-        }
-
         const string name = "Beutl.Package.UpdateTest.None";
         var repo = new InstalledPackageRepository();
 
@@ -64,11 +39,6 @@ public class InstalledPackageRepositoryTests
     [Test]
     public void GetPackageObservable_EmitsInstalledIdentity_AfterUpgrade()
     {
-        if (!IsHomeIsolated)
-        {
-            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
-        }
-
         const string name = "Beutl.Package.UpdateTest.Upgrade";
         var repo = new InstalledPackageRepository();
 
@@ -85,11 +55,6 @@ public class InstalledPackageRepositoryTests
     [Test]
     public void GetObservable_Bool_DoesNotFlashFalse_DuringUpgrade()
     {
-        if (!IsHomeIsolated)
-        {
-            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
-        }
-
         const string name = "Beutl.Package.UpdateTest.Flash";
         var repo = new InstalledPackageRepository();
         repo.UpgradePackages(new PackageIdentity(name, NuGetVersion.Parse("1.0.0")));
@@ -105,11 +70,6 @@ public class InstalledPackageRepositoryTests
     [Test]
     public void GetObservable_ForVersion_TracksEquivalentIdentityInstances()
     {
-        if (!IsHomeIsolated)
-        {
-            Assert.Ignore("BEUTL_HOME isolation took effect after Helper.AppRoot was pinned; skipping I/O test.");
-        }
-
         const string name = "Beutl.Package.UpdateTest.Version";
         const string version = "1.0.0";
         var repo = new InstalledPackageRepository();

--- a/tests/Beutl.UnitTests/AssemblySetUp.cs
+++ b/tests/Beutl.UnitTests/AssemblySetUp.cs
@@ -1,0 +1,21 @@
+using Beutl.Configuration;
+using Beutl.Testing.Headless;
+
+namespace Beutl.UnitTests;
+
+[SetUpFixture]
+public sealed class AssemblySetUp
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        string home = BeutlHomeIsolation.Begin("beutl-unit");
+
+        Assert.That(
+            GlobalConfiguration.DefaultFilePath,
+            Is.EqualTo(Path.Combine(home, "settings.json")));
+    }
+
+    [OneTimeTearDown]
+    public void TearDown() => BeutlHomeIsolation.End();
+}

--- a/tests/Beutl.UnitTests/AssemblySetUp.cs
+++ b/tests/Beutl.UnitTests/AssemblySetUp.cs
@@ -1,4 +1,4 @@
-using Beutl.Configuration;
+﻿using Beutl.Configuration;
 using Beutl.Testing.Headless;
 
 namespace Beutl.UnitTests;

--- a/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
+++ b/tests/Beutl.UnitTests/Beutl.UnitTests.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Beutl.Testing.Headless\Beutl.Testing.Headless.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Threading\Beutl.Threading.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Engine\Beutl.Engine.csproj" />
     <ProjectReference Include="..\..\src\Beutl.NodeGraph\Beutl.NodeGraph.csproj" />


### PR DESCRIPTION
## Description

- Redirect `Beutl.UnitTests` to a per-assembly temporary `BEUTL_HOME` before accessing `GlobalConfiguration`, preventing test auto-save from overwriting developer settings.
- Reuse the assembly-wide isolation in `InstalledPackageRepositoryTests` and clean generated state per test so the tests run without safety skips.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes

None.

## Test plan

- Ran `Beutl.UnitTests`: 4,924 total, 4,921 passed, 3 environment-dependent skips, 0 failures.
- Ran the focused `InstalledPackageRepositoryTests`: 4/4 passed.
- Confirmed that `~/.beutl/settings.json` retained the same SHA-256, modification time, and size across the test runs.

## Fixed issues / References

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved reliability by clearing the installed-packages data before and after each test, ensuring consistent outcomes.
  - Added assembly-level setup/teardown to run the unit suite in a consistent isolated environment.
  - Enabled headless testing support by connecting the unit tests to the headless utilities project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->