### PR TITLE
fix: match dock add button border color

### DIFF
--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -67,7 +67,7 @@
                                           SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" />
                             <Border x:Name="PART_AddButtonBorder"
                                     Grid.Column="1"
-                                    BorderBrush="{DynamicResource DockThemeBorderLowBrush}"
+                                    BorderBrush="{DynamicResource DockBorderSubtleBrush}"
                                     BorderThickness="0,0,0,1">
                                 <local:ToolTabAddButton x:Name="PART_AddButton"
                                                         Width="28"

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -78,7 +78,9 @@ public class DockTabAddButtonTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(addButtonBorder.BorderBrush, Is.Not.Null);
+                Assert.That(
+                    addButtonBorder.BorderBrush,
+                    Is.SameAs(addButtonBorder.FindResource("DockBorderSubtleBrush")));
                 Assert.That(addButtonBorder.BorderThickness.Bottom, Is.EqualTo(1));
                 Assert.That(button.Opacity, Is.EqualTo(0));
                 Assert.That(button.IsHitTestVisible, Is.True);


### PR DESCRIPTION
## Description

- Match the dock tab add-button bottom border with the adjacent tab-strip border.
- Use the existing subtle dock border brush consistently across Light and Dark themes.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- Updated `DockTabAddButtonTests` to verify the add-button border uses `DockBorderSubtleBrush`.
- Ran the three `DockTabAddButtonTests` successfully.
- Manually verified the border color in Dark, Dark (Classic), and Light themes.

## Fixed issues / References

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the dock tab add button border to use the appropriate subtle theme styling for improved visual consistency.

* **Tests**
  * Strengthened UI coverage to verify that the add button uses the expected theme border resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->