### PR TITLE
fix!: clear all build warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,6 +60,7 @@
     <PackageVersion Include="NAudio.Core" Version="2.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
     <PackageVersion Include="NuGet.ProjectModel" Version="7.6.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="NuGet.Resolver" Version="7.6.0" />
@@ -85,6 +86,7 @@
     <PackageVersion Include="System.Interactive" Version="7.0.1" />
     <PackageVersion Include="System.Management" Version="10.0.10" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Vortice.MediaFoundation" Version="3.8.3" />
     <PackageVersion Include="Vortice.XAudio2" Version="3.8.3" />
   </ItemGroup>

--- a/external/.editorconfig
+++ b/external/.editorconfig
@@ -6,3 +6,10 @@ root = true
 
 [*]
 generated_code = true
+
+# generated_code = true also makes the compiler treat every submodule file as auto-generated, and
+# auto-generated code needs an explicit `#nullable` directive before it may use nullable annotations
+# — otherwise every `?` raises CS8669. These are upstream sources we deliberately do not edit, so
+# silence that warning here rather than patching the vendored files.
+[*.cs]
+dotnet_diagnostic.CS8669.severity = none

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -14,7 +14,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Nuke.Common" />
+    <!-- Nuke.Common pulls NuGet.Packaging 6.12.1, which carries a known advisory (NU1901). Pin the
+         same 7.6.0 the app projects use. -->
+    <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="Serilog.Sinks.File" />
+    <!-- Nuke.Common -> Microsoft.Build.Tasks.Core pulls System.Security.Cryptography.Xml 9.0.0,
+         which has known high-severity advisories (NU1903). Lift it to a patched 10.x. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Beutl.Api/Services/Helper.cs
+++ b/src/Beutl.Api/Services/Helper.cs
@@ -109,8 +109,8 @@ internal static class Helper
         foreach (var dependency in package.Dependencies)
         {
             var dependentPackage = new PackageIdentity(dependency.Id, dependency.VersionRange.MinVersion);
-            var path = PackagePathResolver.GetInstalledPath(dependentPackage);
-            if (path != null)
+            string path = ResolveInstalledDirectory(dependentPackage);
+            if (Directory.Exists(path))
             {
                 var reader = new PackageFolderReader(path);
 

--- a/src/Beutl.Api/Services/Helper.cs
+++ b/src/Beutl.Api/Services/Helper.cs
@@ -139,6 +139,15 @@ internal static class Helper
         return Path.Combine(InstallPath, $"{packageId}.{version}", $"{packageId}.{version}.nuspec");
     }
 
+    // GetInstalledPath keys off the package's .nupkg file, so a directory whose .nupkg was deleted
+    // resolves to null even though its extracted files remain. Fall back to the deterministic install
+    // path so cleanup still reaches them; callers use Directory.Exists to tell gone from still-there.
+    public static string ResolveInstalledDirectory(PackageIdentity package)
+    {
+        return PackagePathResolver.GetInstalledPath(package)
+               ?? PackagePathResolver.GetInstallPath(package);
+    }
+
     public static T? TryGetOrDefault<T>(Func<T> func)
     {
         try

--- a/src/Beutl.Api/Services/InstalledPackageRepository.cs
+++ b/src/Beutl.Api/Services/InstalledPackageRepository.cs
@@ -61,7 +61,7 @@ public class InstalledPackageRepository : IBeutlApiResource
     {
         _logger.LogInformation("Adding package: {PackageName} with version: {PackageVersion}", name, version);
         var package = new PackageIdentity(name, new NuGetVersion(version));
-        string installedPath = Helper.PackagePathResolver.GetInstalledPath(package);
+        string? installedPath = Helper.PackagePathResolver.GetInstalledPath(package);
         if (!Directory.Exists(installedPath))
         {
             _logger.LogError("Directory not found for package: {PackageName} with version: {PackageVersion}", name, version);
@@ -81,7 +81,7 @@ public class InstalledPackageRepository : IBeutlApiResource
     public void AddPackage(PackageIdentity package)
     {
         _logger.LogInformation("Adding package: {PackageId} with version: {PackageVersion}", package.Id, package.Version);
-        string installedPath = Helper.PackagePathResolver.GetInstalledPath(package);
+        string? installedPath = Helper.PackagePathResolver.GetInstalledPath(package);
         if (!Directory.Exists(installedPath))
         {
             _logger.LogError("Directory not found for package: {PackageId} with version: {PackageVersion}", package.Id, package.Version);

--- a/src/Beutl.Api/Services/PackageInstaller.Clean.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Clean.cs
@@ -61,8 +61,8 @@ public partial class PackageInstaller
         long size = 0;
         foreach (PackageIdentity package in unnecessaryPackages)
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
-            if (directory is null)
+            string directory = Helper.ResolveInstalledDirectory(package);
+            if (!Directory.Exists(directory))
             {
                 _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
                 continue;
@@ -90,9 +90,10 @@ public partial class PackageInstaller
         long totalSize = 0;
         foreach (PackageIdentity package in context.UnnecessaryPackages)
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
-            if (directory is null)
+            string directory = Helper.ResolveInstalledDirectory(package);
+            if (!Directory.Exists(directory))
             {
+                // The files are already gone, so the repository entry would outlive them.
                 _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
                 _installedPackageRepository.RemovePackage(package);
                 continue;

--- a/src/Beutl.Api/Services/PackageInstaller.Clean.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Clean.cs
@@ -24,7 +24,7 @@ public partial class PackageInstaller
 
         foreach (PackageIdentity packageId in installedPackages)
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
             if (directory != null)
             {
                 var reader = new PackageFolderReader(directory);
@@ -61,7 +61,13 @@ public partial class PackageInstaller
         long size = 0;
         foreach (PackageIdentity package in unnecessaryPackages)
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            if (directory is null)
+            {
+                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                continue;
+            }
+
             foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
             {
                 size += new FileInfo(file).Length;
@@ -84,7 +90,14 @@ public partial class PackageInstaller
         long totalSize = 0;
         foreach (PackageIdentity package in context.UnnecessaryPackages)
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            if (directory is null)
+            {
+                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                _installedPackageRepository.RemovePackage(package);
+                continue;
+            }
+
             bool hasAnyFailures = false;
             foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
             {

--- a/src/Beutl.Api/Services/PackageInstaller.Clean.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Clean.cs
@@ -24,8 +24,11 @@ public partial class PackageInstaller
 
         foreach (PackageIdentity packageId in installedPackages)
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
-            if (directory != null)
+            // Must resolve like the deletion pass below: a package whose .nupkg is gone would
+            // otherwise contribute no dependency metadata yet still be deletable, which would
+            // classify a live dependency as unnecessary.
+            string directory = Helper.ResolveInstalledDirectory(packageId);
+            if (Directory.Exists(directory))
             {
                 var reader = new PackageFolderReader(directory);
 

--- a/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
@@ -33,7 +33,13 @@ public partial class PackageInstaller
         long size = 0;
         foreach (PackageIdentity package in unnecessaryPackages)
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            if (directory is null)
+            {
+                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                continue;
+            }
+
             foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
             {
                 size += new FileInfo(file).Length;
@@ -60,7 +66,14 @@ public partial class PackageInstaller
         long totalSize = 0;
         foreach (PackageIdentity package in context.UnnecessaryPackages)
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
+            if (directory is null)
+            {
+                _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
+                _installedPackageRepository.RemovePackage(package);
+                continue;
+            }
+
             bool hasAnyFailures = false;
             foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
             {

--- a/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.Uninstall.cs
@@ -33,8 +33,8 @@ public partial class PackageInstaller
         long size = 0;
         foreach (PackageIdentity package in unnecessaryPackages)
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
-            if (directory is null)
+            string directory = Helper.ResolveInstalledDirectory(package);
+            if (!Directory.Exists(directory))
             {
                 _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
                 continue;
@@ -66,9 +66,10 @@ public partial class PackageInstaller
         long totalSize = 0;
         foreach (PackageIdentity package in context.UnnecessaryPackages)
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
-            if (directory is null)
+            string directory = Helper.ResolveInstalledDirectory(package);
+            if (!Directory.Exists(directory))
             {
+                // The files are already gone, so the repository entry would outlive them.
                 _logger.LogWarning("Installed directory not found for package: {PackageId}", package.Id);
                 _installedPackageRepository.RemovePackage(package);
                 continue;

--- a/src/Beutl.Api/Services/PackageInstaller.cs
+++ b/src/Beutl.Api/Services/PackageInstaller.cs
@@ -345,7 +345,7 @@ public partial class PackageInstaller : IBeutlApiResource
                         continue;
                     }
 
-                    string installedPath = Helper.PackagePathResolver.GetInstalledPath(packageToInstall);
+                    string? installedPath = Helper.PackagePathResolver.GetInstalledPath(packageToInstall);
                     if (installedPath != null)
                     {
                         installedPaths.Add(installedPath);

--- a/src/Beutl.Api/Services/PackageManager.cs
+++ b/src/Beutl.Api/Services/PackageManager.cs
@@ -162,7 +162,7 @@ public sealed class PackageManager(
 
             foreach (PackageIdentity packageId in packages)
             {
-                string directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
+                string? directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
                 if (Directory.Exists(directory))
                 {
                     var reader = new PackageFolderReader(directory);

--- a/src/Beutl.Api/Services/PackageUninstallContext.cs
+++ b/src/Beutl.Api/Services/PackageUninstallContext.cs
@@ -10,7 +10,10 @@ public class PackageUninstallContext
         Id = packageIdentity;
         PackageId = Id.Id;
         Version = Id.Version.ToString();
-        InstalledPath = installedPath ?? Helper.PackagePathResolver.GetInstalledPath(packageIdentity);
+        InstalledPath = installedPath
+                        ?? Helper.PackagePathResolver.GetInstalledPath(packageIdentity)
+                        ?? throw new ArgumentException(
+                            $"Package '{packageIdentity}' is not installed.", nameof(packageIdentity));
     }
 
     public PackageIdentity Id { get; }

--- a/src/Beutl.Api/Services/PackageUninstallContext.cs
+++ b/src/Beutl.Api/Services/PackageUninstallContext.cs
@@ -10,10 +10,21 @@ public class PackageUninstallContext
         Id = packageIdentity;
         PackageId = Id.Id;
         Version = Id.Version.ToString();
-        InstalledPath = installedPath
-                        ?? Helper.PackagePathResolver.GetInstalledPath(packageIdentity)
-                        ?? throw new ArgumentException(
-                            $"Package '{packageIdentity}' is not installed.", nameof(packageIdentity));
+        InstalledPath = installedPath ?? ResolveInstalledPath(packageIdentity);
+    }
+
+    // Must recognise the same installations Clean / Uninstall do, which reach a package whose .nupkg
+    // is gone but whose extracted files remain.
+    private static string ResolveInstalledPath(PackageIdentity packageIdentity)
+    {
+        string directory = Helper.ResolveInstalledDirectory(packageIdentity);
+        if (!Directory.Exists(directory))
+        {
+            throw new ArgumentException(
+                $"Package '{packageIdentity}' is not installed.", nameof(packageIdentity));
+        }
+
+        return directory;
     }
 
     public PackageIdentity Id { get; }

--- a/src/Beutl.Api/Services/PluginDependencyResolver.cs
+++ b/src/Beutl.Api/Services/PluginDependencyResolver.cs
@@ -127,14 +127,12 @@ internal sealed class PluginDependencyResolver
             .SelectMany(x => x.Packages))
         {
             var dependentPackage = new PackageIdentity(dependency.Id, dependency.VersionRange.MinVersion);
-            path = Helper.PackagePathResolver.GetInstalledPath(dependentPackage);
-            if (path != null)
+            string? dependentPath = Helper.PackagePathResolver.GetInstalledPath(dependentPackage);
+            if (dependentPath != null)
             {
-                reader = new PackageFolderReader(path);
-
                 GetPackageDependencies(
-                    path,
-                    reader,
+                    dependentPath,
+                    new PackageFolderReader(dependentPath),
                     dependentPackage,
                     framework, logger, availablePackages);
             }

--- a/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
@@ -120,19 +120,16 @@ public sealed class ProxiesTabViewModel : IDisposable, IToolContext
         // Media can be added, removed, or replaced while the tab is open; Scene.Edited fires for
         // both structural child changes and forwarded element edits, so Generate All / Delete never
         // act on a stale clip list. ScheduleRefresh coalesces an edit burst into one rebuild.
-        if (_scene != null)
-        {
-            _sceneEditedSubscriptions.DisposeWith(_disposables);
-            RefreshSceneSubscriptions();
+        _sceneEditedSubscriptions.DisposeWith(_disposables);
+        RefreshSceneSubscriptions();
 
-            // Project-wide totals / Generate All / Delete scan every project scene, so a media edit
-            // in another open scene must also refresh; watch the project's scene set for add/remove.
-            if (_scene.FindHierarchicalParent<Project>() is { } project)
-            {
-                project.Items.CollectionChanged += OnProjectItemsChanged;
-                Disposable.Create(() => project.Items.CollectionChanged -= OnProjectItemsChanged)
-                    .DisposeWith(_disposables);
-            }
+        // Project-wide totals / Generate All / Delete scan every project scene, so a media edit
+        // in another open scene must also refresh; watch the project's scene set for add/remove.
+        if (_scene.FindHierarchicalParent<Project>() is { } project)
+        {
+            project.Items.CollectionChanged += OnProjectItemsChanged;
+            Disposable.Create(() => project.Items.CollectionChanged -= OnProjectItemsChanged)
+                .DisposeWith(_disposables);
         }
 
         _config.PropertyChanged += OnProxyConfigPropertyChanged;

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -78,16 +78,6 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         Name = element.GetObservable(CoreObject.NameProperty)
             .ToReactiveProperty()
             .AddTo(_disposables)!;
-        // Skip(1) drops the initial sync emit (IsEditable is assigned later in this ctor). While
-        // locked, a rename must not persist and the display must not diverge from the persisted
-        // name, so snap Name.Value back to Model.Name instead of writing it.
-        Name.Skip(1)
-            .Subscribe(v =>
-            {
-                if (IsEditable.Value) Model.Name = v;
-                else if (v != Model.Name) Name.Value = Model.Name;
-            })
-            .AddTo(_disposables);
 
         IObservable<int> zIndexSubject = element.GetObservable(Element.ZIndexProperty);
         Margin = Timeline.GetTrackedLayerTopObservable(zIndexSubject)
@@ -176,6 +166,16 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
             .ToReadOnlyReactivePropertySlim()
             .AddTo(_disposables);
 
+        // Must stay after IsEditable is assigned — the handler reads it. Skip(1) drops the initial
+        // sync emit; while locked a rename must not persist, so snap Name.Value back to Model.Name.
+        Name.Skip(1)
+            .Subscribe(v =>
+            {
+                if (IsEditable.Value) Model.Name = v;
+                else if (v != Model.Name) Name.Value = Model.Name;
+            })
+            .AddTo(_disposables);
+
         Scope = new ElementScopeViewModel(Model, this);
 
         // プレビュー関連の初期化
@@ -193,11 +193,11 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         ProxyIndicatorBrush = ProxyIndicatorState
             .Select(GetProxyStateBrush)
             .ToReadOnlyReactivePropertySlim()
-            .AddTo(_disposables);
+            .AddTo(_disposables)!;
         ProxyIndicatorTooltip = ProxyIndicatorState
             .Select(GetProxyStateText)
             .ToReadOnlyReactivePropertySlim()
-            .AddTo(_disposables);
+            .AddTo(_disposables)!;
         InitializeProxyIndicator();
     }
 

--- a/src/Beutl.PackageTools.UI/ViewModels/CleanViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/CleanViewModel.cs
@@ -39,8 +39,8 @@ public class CleanViewModel : IProgress<double>
         _logger.LogDebug("Condition changed for package {PackageId} to {Condition}.", package.Id, condition);
         long size = SizeToBeReleased.Value;
 
-        string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
-        if (directory is null)
+        string directory = Helper.ResolveInstalledDirectory(package);
+        if (!Directory.Exists(directory))
         {
             _logger.LogWarning("Installed directory not found for package {PackageId}.", package.Id);
             return;

--- a/src/Beutl.PackageTools.UI/ViewModels/CleanViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/CleanViewModel.cs
@@ -39,7 +39,13 @@ public class CleanViewModel : IProgress<double>
         _logger.LogDebug("Condition changed for package {PackageId} to {Condition}.", package.Id, condition);
         long size = SizeToBeReleased.Value;
 
-        string directory = Helper.PackagePathResolver.GetInstalledPath(package);
+        string? directory = Helper.PackagePathResolver.GetInstalledPath(package);
+        if (directory is null)
+        {
+            _logger.LogWarning("Installed directory not found for package {PackageId}.", package.Id);
+            return;
+        }
+
         foreach (string file in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
         {
             if (condition)

--- a/src/Beutl.PackageTools.UI/ViewModels/UninstallViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/UninstallViewModel.cs
@@ -34,12 +34,12 @@ public class UninstallViewModel(BeutlApiApplication app, ChangesModel changesMod
             {
                 installeds = repos.GetLocalPackages(package.Id)
                     .Select(x => Helper.PackagePathResolver.GetInstalledPath(x))
-                    .Where(x => x != null)
+                    .OfType<string>()
                     .ToArray();
             }
             else
             {
-                string installed = Helper.PackagePathResolver.GetInstalledPath(package);
+                string? installed = Helper.PackagePathResolver.GetInstalledPath(package);
                 if (installed != null)
                 {
                     installeds = [installed];

--- a/src/Beutl.PackageTools.UI/ViewModels/UninstallViewModel.cs
+++ b/src/Beutl.PackageTools.UI/ViewModels/UninstallViewModel.cs
@@ -33,21 +33,14 @@ public class UninstallViewModel(BeutlApiApplication app, ChangesModel changesMod
             if (!package.HasVersion)
             {
                 installeds = repos.GetLocalPackages(package.Id)
-                    .Select(x => Helper.PackagePathResolver.GetInstalledPath(x))
-                    .OfType<string>()
+                    .Select(Helper.ResolveInstalledDirectory)
+                    .Where(Directory.Exists)
                     .ToArray();
             }
             else
             {
-                string? installed = Helper.PackagePathResolver.GetInstalledPath(package);
-                if (installed != null)
-                {
-                    installeds = [installed];
-                }
-                else
-                {
-                    installeds = [];
-                }
+                string installed = Helper.ResolveInstalledDirectory(package);
+                installeds = Directory.Exists(installed) ? [installed] : [];
             }
 
             if (installeds.Length <= 0)

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -71,8 +71,9 @@
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="FluentIcons.Avalonia.Fluent" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <!-- Microsoft.Extensions.DependencyInjection / .Logging are supplied by the
+         Microsoft.AspNetCore.App FrameworkReference below, so referencing the packages here is
+         redundant (NU1510). -->
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="OpenTelemetry" />

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -90,7 +90,7 @@ internal class PackageOperationHandler
     {
         foreach (PackageIdentity item in _installedPackageRepository.GetLocalPackages(packageName))
         {
-            string? directory = Helper.PackagePathResolver.GetInstalledPath(item);
+            string directory = Helper.ResolveInstalledDirectory(item);
             if (Directory.Exists(directory))
             {
                 PackageUninstallContext ctx = _packageInstaller.PrepareForUninstall(directory);
@@ -106,7 +106,7 @@ internal class PackageOperationHandler
         {
             try
             {
-                string? directory = Helper.PackagePathResolver.GetInstalledPath(item);
+                string directory = Helper.ResolveInstalledDirectory(item);
                 if (Directory.Exists(directory))
                 {
                     var ctx = _packageInstaller.PrepareForUninstall(directory);

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -46,7 +46,9 @@ internal class PackageOperationHandler
 
         _installedPackageRepository.UpgradePackages(packageId);
 
-        string directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
+        string directory = Helper.PackagePathResolver.GetInstalledPath(packageId)
+                           ?? throw new InvalidOperationException(
+                               $"Package '{packageId}' was not found under the install directory after installation.");
         PackageFolderReader reader = new(directory);
         var localPackage = new LocalPackage(reader.NuspecReader) { InstalledPath = directory };
         _packageManager.Load(localPackage);
@@ -61,7 +63,9 @@ internal class PackageOperationHandler
 
         _installedPackageRepository.UpgradePackages(packageId);
 
-        string directory = Helper.PackagePathResolver.GetInstalledPath(packageId);
+        string directory = Helper.PackagePathResolver.GetInstalledPath(packageId)
+                           ?? throw new InvalidOperationException(
+                               $"Package '{packageId}' was not found under the install directory after installation.");
         PackageFolderReader reader = new(directory);
         var localPackage = new LocalPackage(reader.NuspecReader) { InstalledPath = directory };
         _packageManager.Load(localPackage);
@@ -86,7 +90,7 @@ internal class PackageOperationHandler
     {
         foreach (PackageIdentity item in _installedPackageRepository.GetLocalPackages(packageName))
         {
-            string directory = Helper.PackagePathResolver.GetInstalledPath(item);
+            string? directory = Helper.PackagePathResolver.GetInstalledPath(item);
             if (Directory.Exists(directory))
             {
                 PackageUninstallContext ctx = _packageInstaller.PrepareForUninstall(directory);
@@ -102,7 +106,7 @@ internal class PackageOperationHandler
         {
             try
             {
-                string directory = Helper.PackagePathResolver.GetInstalledPath(item);
+                string? directory = Helper.PackagePathResolver.GetInstalledPath(item);
                 if (Directory.Exists(directory))
                 {
                     var ctx = _packageInstaller.PrepareForUninstall(directory);

--- a/tests/Beutl.AgentToolkit.Tests/Reconciliation/DeclarativeAnimationTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Reconciliation/DeclarativeAnimationTests.cs
@@ -143,7 +143,7 @@ public sealed class DeclarativeAnimationTests
             Assert.That(createdFrames, Has.Length.EqualTo(2));
             Assert.That(createdValues, Is.EqualTo(new[] { 0f, 100f }));
             Assert.That(updateApply.IsSuccess, Is.True);
-            Assert.That(updateApply.Value!.Changes.Select(change => change.Operation), Does.Contain(ChangeOperations.RemoveChild));
+            Assert.That(updateApply.Value!.Changes!.Select(change => change.Operation), Does.Contain(ChangeOperations.RemoveChild));
             Assert.That(remaining.Id, Is.EqualTo(createdFrames[1].Id));
             Assert.That(remaining.KeyTime, Is.EqualTo(TimeSpan.FromSeconds(1.5)));
             Assert.That(remaining.Value, Is.EqualTo(80f));
@@ -325,9 +325,9 @@ public sealed class DeclarativeAnimationTests
         {
             Assert.That(apply.IsSuccess, Is.True, apply.Error?.Message);
             Assert.That(apply.Value!.Valid, Is.True);
-            Assert.That(apply.Value.Validation.Select(item => item.Status), Does.Contain(ValidationStatus.Warning));
-            Assert.That(apply.Value.Validation.Single(item => item.Status == ValidationStatus.Warning).Message, Does.Contain("UseGlobalClock=false"));
-            Assert.That(apply.Value.Validation.Single(item => item.Status == ValidationStatus.Warning).Hint, Does.Contain("UseGlobalClock=true"));
+            Assert.That(apply.Value.Validation!.Select(item => item.Status), Does.Contain(ValidationStatus.Warning));
+            Assert.That(apply.Value.Validation!.Single(item => item.Status == ValidationStatus.Warning).Message, Does.Contain("UseGlobalClock=false"));
+            Assert.That(apply.Value.Validation!.Single(item => item.Status == ValidationStatus.Warning).Hint, Does.Contain("UseGlobalClock=true"));
             Assert.That(text.Opacity.Animation, Is.Not.Null);
         });
     }
@@ -370,10 +370,10 @@ public sealed class DeclarativeAnimationTests
         Assert.Multiple(() =>
         {
             Assert.That(createApply.IsSuccess, Is.True, createApply.Error?.Message);
-            Assert.That(createApply.Value!.Validation.Select(item => item.Status), Does.Not.Contain(ValidationStatus.Warning));
+            Assert.That(createApply.Value!.Validation!.Select(item => item.Status), Does.Not.Contain(ValidationStatus.Warning));
             Assert.That(retimeApply.IsSuccess, Is.True, retimeApply.Error?.Message);
             Assert.That(retimeApply.Value!.Valid, Is.True);
-            Assert.That(retimeApply.Value.Validation.Select(item => item.Status), Does.Contain(ValidationStatus.Warning));
+            Assert.That(retimeApply.Value.Validation!.Select(item => item.Status), Does.Contain(ValidationStatus.Warning));
             Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
         });
     }

--- a/tests/Beutl.AgentToolkit.Tests/Tools/SessionSecurityTests.cs
+++ b/tests/Beutl.AgentToolkit.Tests/Tools/SessionSecurityTests.cs
@@ -56,7 +56,7 @@ public sealed class SessionSecurityTests
         string escaping = Path.Combine("..", "escape-project");
 
         string message = Assert.Throws<WorkspaceBoundaryException>(() =>
-            SessionTools.NormalizeProjectPath(new WorkspaceGuard(root), escaping, "path")).Message;
+            SessionTools.NormalizeProjectPath(new WorkspaceGuard(root), escaping, "path"))!.Message;
 
         Assert.That(message, Does.Contain("workspace"));
     }

--- a/tests/Beutl.E2ETests/BeutlDarkBorderThemeResourceTests.cs
+++ b/tests/Beutl.E2ETests/BeutlDarkBorderThemeResourceTests.cs
@@ -19,7 +19,7 @@ public class BeutlDarkBorderThemeResourceTests
     {
         var resources = (IResourceProvider)AvaloniaXamlLoader.Load(BeutlDarkBorderTheme.ResourceUri, null)!;
         IList<IResourceProvider> merged = Application.Current!.Resources.MergedDictionaries;
-        ThemeVariant previousVariant = Application.Current.RequestedThemeVariant;
+        ThemeVariant? previousVariant = Application.Current.RequestedThemeVariant;
         try
         {
             Application.Current.RequestedThemeVariant = ThemeVariant.Dark;

--- a/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
@@ -119,6 +119,17 @@ public class PackageInstallerCleanupTests
     }
 
     [Test]
+    public void PackageUninstallContext_ResolvesTheDirectory_WhenTheNupkgIsMissing()
+    {
+        var package = new PackageIdentity("Beutl.Package.ContextTest.NoNupkg", NuGetVersion.Parse("1.0.0"));
+        (string directory, _) = CreateInstalledDirectory(package);
+
+        var context = new PackageUninstallContext(package);
+
+        Assert.That(context.InstalledPath, Is.EqualTo(directory));
+    }
+
+    [Test]
     public void PackageUninstallContext_Throws_WhenThePackageIsNotInstalled()
     {
         var package = new PackageIdentity("Beutl.Package.UninstallTest.Unknown", NuGetVersion.Parse("1.0.0"));

--- a/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
@@ -1,0 +1,131 @@
+﻿using Beutl.Api.Services;
+using Beutl.Testing.Headless;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Beutl.UnitTests.Api;
+
+[TestFixture]
+[NonParallelizable]
+public class PackageInstallerCleanupTests
+{
+    private static string InstalledPackagesFile => Path.Combine(Helper.AppRoot, "installedPackages.json");
+
+    private HttpClient _httpClient = null!;
+    private InstalledPackageRepository _repository = null!;
+    private PackageInstaller _installer = null!;
+    private readonly List<string> _createdDirectories = [];
+
+    [SetUp]
+    public void SetUp()
+    {
+        Assert.That(Helper.AppRoot, Is.EqualTo(BeutlHomeIsolation.CurrentHome));
+
+        File.Delete(InstalledPackagesFile);
+        _httpClient = new HttpClient();
+        _repository = new InstalledPackageRepository();
+        _installer = new PackageInstaller(_httpClient, _repository, apiApplication: null!);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+        foreach (string directory in _createdDirectories.Where(Directory.Exists))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+
+        _createdDirectories.Clear();
+        File.Delete(InstalledPackagesFile);
+    }
+
+    [Test]
+    public void Clean_DeletesTheExtractedFiles_WhenTheNupkgIsMissing()
+    {
+        var package = new PackageIdentity("Beutl.Package.CleanTest.NoNupkg", NuGetVersion.Parse("1.0.0"));
+        (string directory, long size) = CreateInstalledDirectory(package);
+        _repository.UpgradePackages(package);
+
+        _installer.Clean(new PackageCleanContext([package], size), new Progress<double>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Directory.Exists(directory), Is.False, "the extracted files must be deleted");
+            Assert.That(_repository.ExistsPackage(package), Is.False);
+        });
+    }
+
+    [Test]
+    public void Clean_DropsTheRepositoryEntry_WhenTheInstallDirectoryIsGone()
+    {
+        var package = new PackageIdentity("Beutl.Package.CleanTest.Missing", NuGetVersion.Parse("1.0.0"));
+        _repository.UpgradePackages(package);
+
+        Assert.DoesNotThrow(() =>
+            _installer.Clean(new PackageCleanContext([package], 0), new Progress<double>()));
+
+        Assert.That(_repository.ExistsPackage(package), Is.False);
+    }
+
+    [Test]
+    public void Uninstall_DeletesTheExtractedFiles_WhenTheNupkgIsMissing()
+    {
+        var package = new PackageIdentity("Beutl.Package.UninstallTest.NoNupkg", NuGetVersion.Parse("1.0.0"));
+        (string directory, long size) = CreateInstalledDirectory(package);
+        _repository.UpgradePackages(package);
+
+        _installer.Uninstall(
+            new PackageUninstallContext(package, directory)
+            {
+                UnnecessaryPackages = [package],
+                SizeToBeReleased = size
+            },
+            new Progress<double>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Directory.Exists(directory), Is.False, "the extracted files must be deleted");
+            Assert.That(_repository.ExistsPackage(package), Is.False);
+        });
+    }
+
+    [Test]
+    public void Uninstall_DropsTheRepositoryEntry_WhenTheInstallDirectoryIsGone()
+    {
+        var package = new PackageIdentity("Beutl.Package.UninstallTest.Missing", NuGetVersion.Parse("1.0.0"));
+        _repository.UpgradePackages(package);
+        string missing = Helper.ResolveInstalledDirectory(package);
+
+        Assert.DoesNotThrow(() =>
+            _installer.Uninstall(
+                new PackageUninstallContext(package, missing) { UnnecessaryPackages = [package] },
+                new Progress<double>()));
+
+        Assert.That(_repository.ExistsPackage(package), Is.False);
+    }
+
+    [Test]
+    public void PackageUninstallContext_Throws_WhenThePackageIsNotInstalled()
+    {
+        var package = new PackageIdentity("Beutl.Package.UninstallTest.Unknown", NuGetVersion.Parse("1.0.0"));
+
+        Assert.Throws<ArgumentException>(() => new PackageUninstallContext(package));
+    }
+
+    // No .nupkg: PackagePathResolver.GetInstalledPath resolves such a directory to null even though
+    // its files are still on disk, which is the case cleanup must not skip.
+    private (string Directory, long Size) CreateInstalledDirectory(PackageIdentity package)
+    {
+        string directory = Path.Combine(Helper.InstallPath, $"{package.Id}.{package.Version}");
+        string libDirectory = Path.Combine(directory, "lib", "net10.0");
+        Directory.CreateDirectory(libDirectory);
+        _createdDirectories.Add(directory);
+
+        string file = Path.Combine(libDirectory, $"{package.Id}.dll");
+        File.WriteAllText(file, "not a real assembly");
+
+        Assert.That(Helper.PackagePathResolver.GetInstalledPath(package), Is.Null);
+        return (directory, new FileInfo(file).Length);
+    }
+}

--- a/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
+++ b/tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs
@@ -105,6 +105,19 @@ public class PackageInstallerCleanupTests
         Assert.That(_repository.ExistsPackage(package), Is.False);
     }
 
+    // Both the dependency scan (UnnecessaryPackages / Helper.GetPackageDependencies) and the deletion
+    // pass go through this, so the two agree on which directories exist. The scan itself cannot be
+    // unit-tested: it reaches CoreLibraries, which loads Beutl.dll from AppContext.BaseDirectory, and
+    // this assembly must not reference the app project.
+    [Test]
+    public void ResolveInstalledDirectory_FallsBackToTheInstallPath_WhenTheNupkgIsMissing()
+    {
+        var package = new PackageIdentity("Beutl.Package.ResolveTest.NoNupkg", NuGetVersion.Parse("1.0.0"));
+        (string directory, _) = CreateInstalledDirectory(package);
+
+        Assert.That(Helper.ResolveInstalledDirectory(package), Is.EqualTo(directory));
+    }
+
     [Test]
     public void PackageUninstallContext_Throws_WhenThePackageIsNotInstalled()
     {

--- a/tests/Beutl.UnitTests/Editor/Services/ElementObjectServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementObjectServiceTests.cs
@@ -41,6 +41,7 @@ public class ElementObjectServiceTests
         if (Directory.Exists(_basePath)) Directory.Delete(_basePath, recursive: true);
     }
 
+    [SuppressResourceClassGeneration]
     private sealed class TestEngineObject : EngineObject;
 
     [Test]

--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyMediaReaderTests.cs
@@ -1,4 +1,6 @@
-﻿using Beutl.Graphics;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Beutl.Graphics;
 using Beutl.Media;
 using Beutl.Media.Decoding;
 using Beutl.Media.Music;
@@ -148,13 +150,13 @@ public sealed class ProxyMediaReaderTests
         public override bool HasVideo => true;
         public override bool HasAudio => false;
 
-        public override bool ReadVideo(int frame, out Ref<Bitmap>? image)
+        public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
         {
             image = null;
             return false;
         }
 
-        public override bool ReadAudio(int start, int length, out Ref<IPcm>? sound)
+        public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
         {
             sound = null;
             return false;


### PR DESCRIPTION
## Summary

`dotnet build Beutl.slnx` emitted **512 warnings** (485 unique). This clears every one of them at its source — the solution now builds with **0 warnings, 0 errors**.

## What changed

| Warning | Count | Fix |
|---|---|---|
| `CS8669` | 374 | `external/.editorconfig` sets `generated_code = true` (to keep `dotnet format` off the vendored submodules). That also makes the compiler treat every submodule file as auto-generated, where a nullable annotation requires an explicit `#nullable` directive. Silence the rule in the same file instead of patching upstream sources. |
| `CS8600` / `CS8601` / `CS8604` | 60 | `PackagePathResolver.GetInstalledPath` returns `string?`. Receive it as `string?` and handle null explicitly (see the cleanup section below) instead of letting it reach `Directory.GetFiles`. |
| `NU1901` / `NU1903` | 27 | `nukebuild` transitively pulled `NuGet.Packaging` 6.12.1 (via `Nuke.Common`) and `System.Security.Cryptography.Xml` 9.0.0 (via `Microsoft.Build.Tasks.Core`), both carrying known advisories. Lift them to 7.6.0 / 10.0.10 with direct references. |
| `CS8619` | 6 | `.Where(x => x != null)` → `.OfType<string>()`; `!` on `ToReadOnlyReactivePropertySlim()`, whose return type is `ReadOnlyReactivePropertySlim<T?>`. |
| `NU1510` | 4 | Drop the `Microsoft.Extensions.DependencyInjection` / `.Logging` `PackageReference`s from `src/Beutl` — the `Microsoft.AspNetCore.App` `FrameworkReference` already supplies them. |
| `CS8765` | 4 | Add `[NotNullWhen(true)]` to the `out` parameters of the test fake's `MediaReader` overrides so they match the base contract. |
| `CS8618` | 4 | `PackageUninstallContext.InstalledPath` now throws instead of storing null; drop `ProxiesTabViewModel`'s `_scene != null` check, which contradicted every other use of the field. |
| `CS8602` | 4 | `!` on the `Assert.Throws` result; move `ElementViewModel`'s `Name` subscription after `IsEditable` is assigned, since the handler reads it. |
| `BESG001` | 2 | Give `ElementObjectServiceTests.TestEngineObject` the `[SuppressResourceClassGeneration]` attribute that every other nested `EngineObject`-derived test type already carries. |

## Package-cleanup null handling

`PackagePathResolver.GetInstalledPath` keys off the package's **`.nupkg` file**, so a directory whose
`.nupkg` was deleted resolves to `null` even though its extracted files are still on disk. Silencing
`CS8600`/`CS8604` therefore required deciding what that `null` actually means:

- `Helper.ResolveInstalledDirectory` falls back to `PackagePathResolver.GetInstallPath` (the
  deterministic path, no existence check), and callers gate on `Directory.Exists`. Cleanup now
  deletes the extracted files whenever they are present, instead of skipping the package because its
  `.nupkg` went missing.
- Only when the directory genuinely does not exist do `Clean` / `Uninstall` prune the repository
  entry, so package metadata can no longer outlive its files.
- The dependency scan (`UnnecessaryPackages`, `Helper.GetPackageDependencies`) and
  `PackageUninstallContext`'s constructor resolve the same way, so every pass agrees on what counts
  as installed — otherwise a package that contributes no dependency metadata would still be
  deletable, and a live dependency could be classified as unnecessary.
- Previously these paths threw `ArgumentNullException` out of `Directory.GetFiles(null, …)`, taking
  down the whole clean/uninstall run.

Covered by `tests/Beutl.UnitTests/Api/PackageInstallerCleanupTests.cs` (7 tests). The dependency scan
itself is not unit-testable from `Beutl.UnitTests`: it reaches `CoreLibraries`, which loads
`Beutl.dll` from `AppContext.BaseDirectory`, and that assembly must not reference the app project.
The tests cover the shared resolution primitive plus the `Clean` / `Uninstall` / constructor paths.

## Notes

**`BESG001` is not fixed with `partial`.** `EngineObjectResourceGenerator` emits the generated class
directly under the namespace without reproducing the outer type chain, so marking a *nested* type
`partial` makes the generated file fail to compile (`CS1527`, `CS0122`, `CS0115`). The established
convention for these test doubles is `[SuppressResourceClassGeneration]`; this one type was missing it.

## Verification

- `dotnet build Beutl.slnx -t:Rebuild` — **0 warnings, 0 errors**
- `dotnet test Beutl.slnx -f net10.0 --settings coverlet.runsettings` — 5,731 passed, 2 failed
  - The two failures are `StoryboardRendererTests.Render_contact_sheet_png_burns_timecode_label` and
    `…_labels_inbetween_frames_with_subdivision_marker`. Both fail identically on an unmodified `main`
    in the same environment (verified via `git stash`), so they are pre-existing and unrelated — the
    assertion looks for dark pixels from a rendered timecode label, which depends on available fonts.
- `dotnet format --verify-no-changes` over the changed files — clean

BREAKING CHANGE: `PackageUninstallContext`'s constructor now throws `ArgumentException` when
`installedPath` is omitted and no install directory exists on disk for the identity. It previously
returned a context whose `InstalledPath` was `null`, violating the property's non-nullable
declaration and surfacing later as a `NullReferenceException`. Callers that relied on constructing a
context for a package that is not installed must pass `installedPath` explicitly, or check
`Helper.PackagePathResolver.GetInstalledPath` before constructing. Affects `Beutl.Api`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package cleanup and uninstall behavior when package archives or installation folders are missing.
  * Prevented cleanup operations from failing when package locations cannot be resolved.
  * Improved package installation and dependency resolution reliability.
  * Fixed rename handling so locked timeline elements no longer retain unintended name changes.
* **Security**
  * Updated package components to include patched versions addressing known vulnerabilities.
* **Refactor**
  * Improved project dependency management and nullable-path handling for greater stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->