### PR TITLE
feat: strengthen the UI corner rounding

### DIFF
--- a/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
@@ -205,11 +205,11 @@
         </Setter>
 
         <Style Selector="^.RGB /template/ ContentPresenter">
-            <Setter Property="CornerRadius" Value="4 0 0 4" />
+            <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}" />
             <Setter Property="BorderThickness" Value="1 1 0 1" />
         </Style>
         <Style Selector="^.HSV /template/ ContentPresenter">
-            <Setter Property="CornerRadius" Value="0 4 4 0" />
+            <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
             <Setter Property="BorderThickness" Value="0 1 1 1" />
         </Style>
         <Style Selector="^:pointerover /template/ ContentPresenter">
@@ -437,7 +437,7 @@
                                         Grid.Column="4"
                                         Height="48"
                                         Background="{x:Static ui:ColorRamp.CheckeredBrush}"
-                                        CornerRadius="4" />
+                                        CornerRadius="{DynamicResource ControlCornerRadius}" />
                                 <Border Name="CurrentColorPreviewBorder"
                                         Grid.Row="1"
                                         Grid.Column="4"

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -63,6 +63,8 @@
                 <ResourceInclude Source="/ColorPicker/ColorPickerStyles.axaml" />
                 <ResourceInclude Source="/ColorPicker/ColorPickerButtonStyles.axaml" />
                 <ResourceInclude Source="/Styling/Dock/DockFluent.axaml" />
+                <!--  Last, so the theme-resource overrides win the reverse merged-dictionary lookup.  -->
+                <ResourceInclude Source="/Styling/CornerRadius.axaml" />
             </ResourceDictionary.MergedDictionaries>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Default">

--- a/src/Beutl.Controls/Styling/CornerRadius.axaml
+++ b/src/Beutl.Controls/Styling/CornerRadius.axaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Beutl's corner rounding, overriding FluentAvalonia's defaults (4 / 8).
+        These are the single source of truth: prefer
+        {DynamicResource ControlCornerRadius} / {DynamicResource OverlayCornerRadius}
+        over literal values so the whole shell stays in sync.
+        Literals remain only where the shape is not a rounded rectangle
+        (circular indicators, pills), where only some corners are rounded,
+        or where a child is inset by a stroke and must stay a hair tighter
+        than its parent — those spots carry a comment and follow their
+        parent's value by hand (ElementView's mediaClip, BrushEditor's
+        swatch, the Dock* geometry keys in Dock/DockFluent.axaml).
+        Timeline elements deliberately round less; see
+        TimelineElementCornerRadius in TimelineTab/Resources/TimelineResources.axaml.
+    -->
+    <CornerRadius x:Key="ControlCornerRadius">8</CornerRadius>
+    <CornerRadius x:Key="OverlayCornerRadius">12</CornerRadius>
+</ResourceDictionary>

--- a/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
+++ b/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
@@ -98,7 +98,8 @@
     <sys:Double x:Key="DockFontSizeNormal">12</sys:Double>
 
     <!--  ===== Geometry / density =====  -->
-    <sys:Double x:Key="DockCornerRadiusSmall">4</sys:Double>
+    <!--  The radii below mirror ControlCornerRadius; upstream Dock keys take a Double or only some corners.  -->
+    <sys:Double x:Key="DockCornerRadiusSmall">8</sys:Double>
     <sys:Double x:Key="DockHeaderHeight">28</sys:Double>
     <sys:Double x:Key="DockTabHeight">28</sys:Double>
     <sys:Double x:Key="DockTabItemMinHeight">26</sys:Double>
@@ -111,8 +112,8 @@
     <Thickness x:Key="DockDocumentTabItemPadding">10,4,10,4</Thickness>
     <Thickness x:Key="DockToolTabItemPadding">8,2,8,2</Thickness>
     <Thickness x:Key="DockToolTabItemSelectedPadding">8,2,8,2</Thickness>
-    <CornerRadius x:Key="DockDocumentTabItemCornerRadius">4,4,0,0</CornerRadius>
-    <CornerRadius x:Key="DockDocumentTabCreateButtonCornerRadius">4</CornerRadius>
+    <CornerRadius x:Key="DockDocumentTabItemCornerRadius">8,8,0,0</CornerRadius>
+    <CornerRadius x:Key="DockDocumentTabCreateButtonCornerRadius">8</CornerRadius>
 
     <sys:Double x:Key="DockIconSizeSmall">12</sys:Double>
     <sys:Double x:Key="DockIconSizeNormal">14</sys:Double>

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -76,7 +76,7 @@
                                     BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                                     BorderThickness="1"
                                     BoxShadow="0 4 16 0 #40000000"
-                                    CornerRadius="4">
+                                    CornerRadius="{DynamicResource OverlayCornerRadius}">
                                 <ListBox Name="PART_MarkerListBox"
                                          MinWidth="200"
                                          MaxHeight="240"

--- a/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
@@ -11,7 +11,7 @@
                   BasedOn="{StaticResource TransparentToggleButton}"
                   TargetType="ToggleButton">
         <Setter Property="Padding" Value="6,5,6,6" />
-        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </ControlTheme>
 
     <ControlTheme x:Key="LibraryItemPicker_ListBoxItem" TargetType="ListBoxItem">

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -11,14 +11,14 @@
                   BasedOn="{StaticResource TransparentToggleButton}"
                   TargetType="ToggleButton">
         <Setter Property="Padding" Value="6,5,6,6" />
-        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </ControlTheme>
 
     <ControlTheme x:Key="OutputPicker_MoreButton"
                   BasedOn="{StaticResource TransparentButton}"
                   TargetType="Button">
         <Setter Property="Padding" Value="6,5,6,6" />
-        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </ControlTheme>
 
     <ControlTheme x:Key="OutputPicker_ListBoxItem" TargetType="ListBoxItem">

--- a/src/Beutl.Controls/Styling/SegmentedControl.axaml
+++ b/src/Beutl.Controls/Styling/SegmentedControl.axaml
@@ -47,7 +47,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
         <Setter Property="Padding" Value="11,4,11,5" />
-        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerTabView.axaml
@@ -61,7 +61,7 @@
                                 </Style>
                                 <Style Selector="Border.value-badge">
                                     <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
-                                    <Setter Property="CornerRadius" Value="4" />
+                                    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
                                     <Setter Property="Padding" Value="6,1,6,1" />
                                     <Setter Property="VerticalAlignment" Value="Center" />
                                     <Setter Property="MinWidth" Value="48" />

--- a/src/Beutl.Editor.Components/EqualizerProperties/Views/EqualizerPropertiesEditor.axaml
+++ b/src/Beutl.Editor.Components/EqualizerProperties/Views/EqualizerPropertiesEditor.axaml
@@ -25,7 +25,7 @@
         <Border Padding="4,4,0,4"
                 BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
-                CornerRadius="4"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsVisible="{Binding SelectedBand.Value, Converter={x:Static ObjectConverters.IsNotNull}}">
             <StackPanel DataContext="{Binding SelectedBand.Value}" Spacing="2">
                 <!--  Debug中だけだが、個別にDataContextを設定しないと、なぜかInvalidCastExceptionが発生する。  -->

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
@@ -56,7 +56,7 @@
             <Border Padding="4"
                     Background="Transparent"
                     Classes="file-item"
-                    CornerRadius="4"
+                    CornerRadius="{DynamicResource ControlCornerRadius}"
                     DoubleTapped="OnItemDoubleTapped"
                     ToolTip.Tip="{Binding MediaInfoText.Value}">
                 <Interaction.Behaviors>

--- a/src/Beutl.Editor.Components/ProxiesTab/Views/ProxiesTabView.axaml
+++ b/src/Beutl.Editor.Components/ProxiesTab/Views/ProxiesTabView.axaml
@@ -38,7 +38,7 @@
             <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         </Style>
         <Style Selector="Border.proxyItem.ready">
             <Setter Property="BorderBrush" Value="{DynamicResource SystemFillColorSuccessBrush}" />

--- a/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Resources/TimelineResources.axaml
@@ -2,6 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:icons="using:FluentIcons.Avalonia.Fluent"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
+    <!--
+        Elements are only LayerHeight tall and sit edge to edge, so the shell's ControlCornerRadius
+        reads as too round on them. This is a deliberate exception, not a spot that fell out of sync.
+    -->
+    <CornerRadius x:Key="TimelineElementCornerRadius">4</CornerRadius>
+
     <ControlTheme x:Key="LayerHeaderColorPickerButtonTheme"
                   TargetType="ui:ColorPickerButton"
                   BasedOn="{StaticResource {x:Type ui:ColorPickerButton}}">

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -30,7 +30,7 @@
             Background="{Binding Color.Value, Converter={StaticResource ColorToBrushConverter}}"
             BorderThickness="1"
             ClipToBounds="True"
-            CornerRadius="4"
+            CornerRadius="{DynamicResource TimelineElementCornerRadius}"
             Classes.elm-disabled="{Binding !IsEnabled.Value}"
             Classes.elm-locked="{Binding !IsEditable.Value}"
             Classes.selected="{Binding IsSelected.Value}">
@@ -198,6 +198,7 @@
             </ui:FAMenuFlyout>
         </Border.ContextFlyout>
         <Panel>
+            <!--  One pixel tighter than TimelineElementCornerRadius, so it sits flush inside the element's stroke.  -->
             <Border x:Name="mediaClip"
                     ClipToBounds="True"
                     CornerRadius="3">

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -107,7 +107,7 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Background="{DynamicResource SystemFillColorCriticalBrush}"
-                CornerRadius="4"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsHitTestVisible="False"
                 IsVisible="{CompiledBinding IsRazorMode.Value}"
                 ZIndex="100">
@@ -139,7 +139,7 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Background="{DynamicResource SystemFillColorSuccessBrush}"
-                CornerRadius="4"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsHitTestVisible="False"
                 IsVisible="{CompiledBinding IsSlipMode.Value}"
                 ZIndex="100">
@@ -171,7 +171,7 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Background="{DynamicResource SystemFillColorCautionBrush}"
-                CornerRadius="4"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsHitTestVisible="False"
                 IsVisible="{CompiledBinding IsRollMode.Value}"
                 ZIndex="100">
@@ -203,7 +203,7 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Background="{DynamicResource SystemFillColorAttentionBrush}"
-                CornerRadius="4"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsHitTestVisible="False"
                 IsVisible="{CompiledBinding IsSlideMode.Value}"
                 ZIndex="100">

--- a/src/Beutl.PackageTools.UI/App.axaml
+++ b/src/Beutl.PackageTools.UI/App.axaml
@@ -38,6 +38,7 @@
                 <ResourceInclude Source="avares://Beutl.Controls/Styling/Fonts.axaml" />
                 <ResourceInclude Source="avares://Beutl.Controls/Styling/ButtonStyles.axaml" />
                 <ResourceInclude Source="avares://Beutl.Controls/Styling/ProgressRing.axaml" />
+                <ResourceInclude Source="avares://Beutl.Controls/Styling/CornerRadius.axaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <ControlTheme x:Key="{x:Type SelectableTextBlock}" TargetType="SelectableTextBlock">

--- a/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
@@ -23,13 +23,13 @@
                         Height="32"
                         VerticalAlignment="Center"
                         Background="{DynamicResource SubtleFillColorSecondaryBrush}"
-                        CornerRadius="4"
+                        CornerRadius="{DynamicResource ControlCornerRadius}"
                         IsVisible="{Binding LogoUrl, Converter={x:Static StringConverters.IsNullOrEmpty}}" />
 
                 <asyncImageLoader:AdvancedImage Width="32"
                                                 Height="32"
                                                 VerticalAlignment="Center"
-                                                ImageClipping.CornerRadius="4"
+                                                ImageClipping.CornerRadius="{DynamicResource ControlCornerRadius}"
                                                 IsVisible="{Binding LogoUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                                 RenderOptions.BitmapInterpolationMode="HighQuality"
                                                 Source="{Binding LogoUrl}" />

--- a/src/Beutl.PackageTools.UI/Views/ResultPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/ResultPage.axaml
@@ -29,13 +29,13 @@
                             Height="32"
                             VerticalAlignment="Center"
                             Background="{DynamicResource SubtleFillColorSecondaryBrush}"
-                            CornerRadius="4"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
                             IsVisible="{Binding LogoUrl, Converter={x:Static StringConverters.IsNullOrEmpty}}" />
 
                     <asyncImageLoader:AdvancedImage Width="32"
                                                     Height="32"
                                                     VerticalAlignment="Center"
-                                                    ImageClipping.CornerRadius="4"
+                                                    ImageClipping.CornerRadius="{DynamicResource ControlCornerRadius}"
                                                     IsVisible="{Binding LogoUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                                     RenderOptions.BitmapInterpolationMode="HighQuality"
                                                     Source="{Binding LogoUrl}" />

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -31,7 +31,7 @@
                 BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
                 BoxShadow="0 8 32 0 #40000000"
-                CornerRadius="8">
+                CornerRadius="{DynamicResource OverlayCornerRadius}">
             <Grid RowDefinitions="Auto,Auto,*">
                 <TextBox x:Name="QueryTextBox"
                          Margin="8,8,8,4"
@@ -86,7 +86,7 @@
                                         Padding="6,2"
                                         VerticalAlignment="Center"
                                         Background="{DynamicResource ControlAltFillColorSecondaryBrush}"
-                                        CornerRadius="4"
+                                        CornerRadius="{DynamicResource ControlCornerRadius}"
                                         IsVisible="{Binding KeyGestureText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                                     <TextBlock FontSize="11"
                                                Text="{Binding KeyGestureText}" />

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -258,7 +258,8 @@
         </Style>
 
         <Style Selector="^ /template/ Border">
-            <Setter Property="CornerRadius" Value="4,4,0,0" />
+            <!--  Top corners only, so it tracks ControlCornerRadius by hand.  -->
+            <Setter Property="CornerRadius" Value="8,8,0,0" />
         </Style>
     </Style>
 

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -39,8 +39,9 @@
                             Click="OpenFlyout_Click"
                             Theme="{StaticResource TransparentButton}">
                         <Panel>
-                            <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" CornerRadius="3.5" />
-                            <Border Background="{Binding AvaloniaBrush.Value}" CornerRadius="3.5" />
+                            <!--  Half a pixel tighter than ControlCornerRadius: the swatch sits inside the button's 1px padding.  -->
+                            <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" CornerRadius="7.5" />
+                            <Border Background="{Binding AvaloniaBrush.Value}" CornerRadius="7.5" />
                         </Panel>
                     </Button>
 

--- a/src/Beutl/Views/PlayerView.axaml
+++ b/src/Beutl/Views/PlayerView.axaml
@@ -169,7 +169,7 @@
                             Background="{DynamicResource SystemFillColorCriticalBackgroundBrush}"
                             BorderBrush="{DynamicResource SystemFillColorCriticalBrush}"
                             BorderThickness="1"
-                            CornerRadius="4">
+                            CornerRadius="{DynamicResource ControlCornerRadius}">
                         <StackPanel Spacing="8">
                             <TextBlock HorizontalAlignment="Center"
                                        FontSize="18"

--- a/src/Beutl/Views/Tutorial/TutorialOverlay.axaml
+++ b/src/Beutl/Views/Tutorial/TutorialOverlay.axaml
@@ -27,7 +27,7 @@
                 Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
                 BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
-                CornerRadius="8"
+                CornerRadius="{DynamicResource OverlayCornerRadius}"
                 IsHitTestVisible="True"
                 BoxShadow="0 8 32 0 #40000000">
             <StackPanel Spacing="12">

--- a/src/Beutl/Views/Tutorial/TutorialOverlay.axaml.cs
+++ b/src/Beutl/Views/Tutorial/TutorialOverlay.axaml.cs
@@ -194,7 +194,9 @@ public partial class TutorialOverlay : UserControl
             {
                 BorderBrush = Application.Current?.FindResource("AccentFillColorDefaultBrush") as IBrush,
                 BorderThickness = new Thickness(2),
-                CornerRadius = new CornerRadius(4),
+                CornerRadius = Application.Current?.FindResource("ControlCornerRadius") is CornerRadius cornerRadius
+                    ? cornerRadius
+                    : new CornerRadius(8),
                 IsVisible = false
             };
             _highlightBorders.Add(border);

--- a/tests/Beutl.E2ETests/CornerRadiusThemeResourceTests.cs
+++ b/tests/Beutl.E2ETests/CornerRadiusThemeResourceTests.cs
@@ -1,0 +1,81 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Controls;
+using Beutl.Testing.Headless;
+
+namespace Beutl.E2ETests;
+
+// FluentAvalonia ships ControlCornerRadius=4 and OverlayCornerRadius=8; Beutl.Controls' Styles.axaml
+// replaces both, and that only takes effect because Application.Styles is searched last-entry-first.
+// Reordering the StyleIncludes or dropping the merged dictionary would silently restore the stock
+// rounding across the whole shell, so pin the resolved values rather than the file contents.
+[TestFixture]
+public class CornerRadiusThemeResourceTests
+{
+    [AvaloniaTest]
+    public void ControlCornerRadius_IsBeutlsRounding()
+    {
+        bool found = Application.Current!.TryGetResource(
+            "ControlCornerRadius", Application.Current.ActualThemeVariant, out object? value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True, "ControlCornerRadius must resolve");
+            Assert.That(value, Is.EqualTo(new CornerRadius(8)), "Beutl's value, not FluentAvalonia's 4");
+        });
+    }
+
+    [AvaloniaTest]
+    public void OverlayCornerRadius_IsBeutlsRounding()
+    {
+        bool found = Application.Current!.TryGetResource(
+            "OverlayCornerRadius", Application.Current.ActualThemeVariant, out object? value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True, "OverlayCornerRadius must resolve");
+            Assert.That(value, Is.EqualTo(new CornerRadius(12)), "Beutl's value, not FluentAvalonia's 8");
+        });
+    }
+
+    // FluentAvalonia's own control themes reach the key with DynamicResource, so they resolve against
+    // the live application chain — this is what carries the override to most of the shell.
+    [AvaloniaTest]
+    public void AFluentAvaloniaControl_TakesTheOverride()
+    {
+        var button = new Button { Content = "ok" };
+        using var host = new ControlHost(button);
+
+        Assert.That(button.CornerRadius, Is.EqualTo(new CornerRadius(8)));
+    }
+
+    // Beutl's own dictionaries use StaticResource instead, which resolves through the parse-time parent
+    // stack of Beutl.Controls' merged dictionaries — a separate path that has to find the override too.
+    [AvaloniaTest]
+    public void ABeutlControlTheme_TakesTheOverride()
+    {
+        var item = new OptionsDisplayItem { Header = "header" };
+        using var host = new ControlHost(item);
+
+        Assert.That(item.CornerRadius, Is.EqualTo(new CornerRadius(8)));
+    }
+
+    private sealed class ControlHost : IDisposable
+    {
+        private readonly Window _window;
+
+        public ControlHost(Control content)
+        {
+            _window = new Window { Width = 320, Height = 200, Content = content };
+            _window.Show();
+            HeadlessTestHelpers.Settle();
+        }
+
+        public void Dispose()
+        {
+            _window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -253,10 +253,15 @@ public class ElementViewLayoutTests
         {
             // A real filmstrip/waveform never renders in this headless layout pass (both need async
             // media decode), so the rounding is asserted structurally: the wrapper Border rounds to
-            // the clip's inner radius (3px = 4px outer - 1px stroke) and clips its children.
+            // the clip's inner radius (3px = TimelineElementCornerRadius 4px outer - 1px stroke) and
+            // clips its children. An element is only LayerHeight tall, so it deliberately rounds less
+            // than the shell's ControlCornerRadius (8px) — pin that, or the exception drifts back.
+            var outer = (Border)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "border");
             var mediaClip = (Border)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "mediaClip");
             Assert.Multiple(() =>
             {
+                Assert.That(outer.CornerRadius, Is.EqualTo(new CornerRadius(4)),
+                    "Elements must keep the timeline's tighter rounding.");
                 Assert.That(mediaClip.CornerRadius, Is.EqualTo(new CornerRadius(3)),
                     "Media host must round to the clip's inner radius.");
                 Assert.That(mediaClip.ClipToBounds, Is.True,

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -252,10 +252,11 @@ public class ElementViewLayoutTests
         try
         {
             // A real filmstrip/waveform never renders in this headless layout pass (both need async
-            // media decode), so the rounding is asserted structurally: the wrapper Border rounds to
-            // the clip's inner radius (3px = TimelineElementCornerRadius 4px outer - 1px stroke) and
-            // clips its children. An element is only LayerHeight tall, so it deliberately rounds less
+            // media decode), so the rounding is asserted structurally. An element is only LayerHeight
+            // tall, so its outer Border deliberately rounds less (TimelineElementCornerRadius, 4px)
             // than the shell's ControlCornerRadius (8px) — pin that, or the exception drifts back.
+            // The mediaClip wrapper sits inside the element's 1px stroke, so it rounds to 3px and
+            // clips its children.
             var outer = (Border)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "border");
             var mediaClip = (Border)element.GetVisualDescendants().OfType<Control>().First(c => c.Name == "mediaClip");
             Assert.Multiple(() =>


### PR DESCRIPTION
## Description

- Beutl shipped FluentAvalonia's stock `ControlCornerRadius` (4) and `OverlayCornerRadius` (8) with no override anywhere. This raises them to **8 / 12** so the shell reads noticeably rounder.
- The two keys now live in one place — `src/Beutl.Controls/Styling/CornerRadius.axaml` — merged into `Beutl.Controls/Styles.axaml` (main app plus both headless test apps) and `Beutl.PackageTools.UI/App.axaml`. Tuning the rounding from now on is a two-line edit rather than a sweep.
- Sites that hardcoded the old `4` instead of the theme resource would have been left behind at the old rounding, so they now read `{DynamicResource ControlCornerRadius}`: timeline mode badges, file browser items, proxy cards, the player error card, the command palette key chips, the segmented control, the color picker preview and the package list icons. Popup surfaces (command palette, player marker list, tutorial callout) take `OverlayCornerRadius`.
- Literals stay only where they define a **shape** rather than a rounding (circular indicators, pill tracks, the corner-radius editor's corner icons), where only some corners are rounded (dock tabs), or where a child must sit a hair tighter than its stroked parent. Each of those carries a comment, and `CornerRadius.axaml` lists them so they are not mistaken for spots that fell out of sync.
- Timeline elements are only `LayerHeight` (25px) tall and sit edge to edge, so 8px reads as too round on them. They keep a tighter 4px through a dedicated `TimelineElementCornerRadius` in `TimelineResources.axaml` — a named, deliberate exception rather than a stray literal.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

`Beutl.PackageTools.UI` is also touched — it gets the same overrides and its package icons follow them.

## Breaking changes

None — no API surface changes. The shipped look does change, and an out-of-tree plugin that binds to `ControlCornerRadius` / `OverlayCornerRadius` picks up the new values automatically, which is the intent.

One known limitation, not introduced by this PR: FluentAvalonia's own `SettingsExpander`, `FAComboBox`, `NavigationView` and `TaskDialog` themes reach those keys through `StaticResource` inside their own dictionary, so the override cannot reach them. Of those Beutl only uses `NavigationView`, whose pane keeps 8px on its right corners. Fixing that would mean re-templating the control, which is out of scope here.

## Test plan

- New `tests/Beutl.E2ETests/CornerRadiusThemeResourceTests.cs` pins the *resolved* values rather than the file contents. The override only wins because Avalonia searches `Application.Styles` last-entry-first, so reordering the `StyleInclude`s or dropping the merged dictionary would silently restore FluentAvalonia's rounding. It covers both resolution paths that matter: `DynamicResource` (a FluentAvalonia `Button`) and `StaticResource` (Beutl's own `OptionsDisplayItem`).
- `tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs` updated: the media clip's inner radius follows the timeline's 4px outer, and a new assertion pins the element's outer radius at 4 so the deliberate exception does not drift back to the shell value.
- `dotnet build src/Beutl/Beutl.csproj` — succeeds, no new warnings.
- `dotnet test tests/Beutl.E2ETests` — 83 / 83 pass.
- `dotnet test tests/Beutl.HeadlessUITests` — 189 pass, 1 skipped (GPU-gated).
- `dotnet format Beutl.slnx` — produces no changes.
- No screenshots attached: this is a uniform radius swap with no layout movement, and the two radius exceptions are pinned by the assertions above. Still worth an eyeball on the timeline and the dock tabs before merge.

## Fixed issues / References

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced centralized theme corner-radius resources for standard, overlay, and timeline-specific rounding.
  * Updated key UI surfaces (controls, dialogs, previews, package views, dock tabs, tutorial overlays, and timeline elements) to use theme-driven rounded corners.
* **Bug Fixes**
  * Improved corner-radius behavior for color picker and preview elements to ensure consistent rounding across RGB/HSV layouts and overlays.
* **Tests**
  * Added automated coverage to verify theme resource overrides and that rendered controls pick up the expected corner radii.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->