### PR TITLE
fix: match terminal tab colors with other dock tabs

### DIFF
--- a/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
+++ b/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
@@ -19,7 +19,6 @@
             <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="#181818" />
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="#1C1C1C" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="#1A1A1A" />
-            <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="#1A1A1A" />
             <SolidColorBrush x:Key="TerminalForegroundBrush" Color="{DynamicResource TextFillColorPrimary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="#202020" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="#262626" />
@@ -51,7 +50,6 @@
             <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="{DynamicResource LayerFillColorDefault}" />
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="{DynamicResource ControlFillColorDefault}" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="{DynamicResource LayerFillColorDefault}" />
-            <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="{DynamicResource LayerFillColorDefault}" />
             <SolidColorBrush x:Key="TerminalForegroundBrush" Color="{DynamicResource TextFillColorPrimary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="{DynamicResource SubtleFillColorSecondary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="{DynamicResource SubtleFillColorTertiary}" />

--- a/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
+++ b/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
@@ -20,7 +20,7 @@
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="#1C1C1C" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="#1A1A1A" />
             <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="#1A1A1A" />
-            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#FFFFFF" />
+            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="{DynamicResource TextFillColorPrimary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="#202020" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="#262626" />
 
@@ -52,7 +52,7 @@
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="{DynamicResource ControlFillColorDefault}" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="{DynamicResource LayerFillColorDefault}" />
             <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="{DynamicResource LayerFillColorDefault}" />
-            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#1A1A1A" />
+            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="{DynamicResource TextFillColorPrimary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="{DynamicResource SubtleFillColorSecondary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="{DynamicResource SubtleFillColorTertiary}" />
 

--- a/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
+++ b/src/Beutl.Controls/Styling/Dock/DockFluent.axaml
@@ -19,6 +19,8 @@
             <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="#181818" />
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="#1C1C1C" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="#1A1A1A" />
+            <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="#1A1A1A" />
+            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#FFFFFF" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="#202020" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="#262626" />
 
@@ -49,6 +51,8 @@
             <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="{DynamicResource LayerFillColorDefault}" />
             <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="{DynamicResource ControlFillColorDefault}" />
             <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="{DynamicResource LayerFillColorDefault}" />
+            <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="{DynamicResource LayerFillColorDefault}" />
+            <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#1A1A1A" />
             <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="{DynamicResource SubtleFillColorSecondary}" />
             <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="{DynamicResource SubtleFillColorTertiary}" />
 

--- a/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
+++ b/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
@@ -1458,7 +1458,6 @@
     <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="#0E0E0F" />
-    <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#FFFFFF" />
     <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="#0E0E0F" />

--- a/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
+++ b/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
@@ -1458,6 +1458,8 @@
     <SolidColorBrush x:Key="DockSurfaceSidebarBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfaceEditorBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfacePanelBrush" Color="#0E0E0F" />
+    <SolidColorBrush x:Key="TerminalBackgroundBrush" Color="#0E0E0F" />
+    <SolidColorBrush x:Key="TerminalForegroundBrush" Color="#FFFFFF" />
     <SolidColorBrush x:Key="DockSurfaceHeaderBrush" Color="#0E0E0F" />
     <SolidColorBrush x:Key="DockSurfaceHeaderActiveBrush" Color="#0E0E0F" />
 

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
@@ -24,7 +24,7 @@
             </DockPanel>
         </Border>
         <terminal:TerminalControl Name="Terminal"
-                                  Background="{DynamicResource TerminalBackgroundBrush}"
+                                  Background="Transparent"
                                   BufferSize="5000"
                                   FontFamily="Consolas, Menlo, monospace"
                                   Foreground="{DynamicResource TerminalForegroundBrush}"

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
@@ -24,8 +24,10 @@
             </DockPanel>
         </Border>
         <terminal:TerminalControl Name="Terminal"
+                                  Background="{DynamicResource TerminalBackgroundBrush}"
                                   BufferSize="5000"
                                   FontFamily="Consolas, Menlo, monospace"
+                                  Foreground="{DynamicResource TerminalForegroundBrush}"
                                   Process=""
                                   ProcessExited="OnProcessExited" />
     </DockPanel>

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -1,8 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
+using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.VisualTree;
 
 using Beutl.Editor.Components.TerminalTab.ViewModels;
@@ -148,6 +151,64 @@ public class TerminalTabLifecycleTests
         finally
         {
             editor.CloseToolTab(transientContext);
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TerminalControl_ThemeResources_ResolvePerVariant()
+    {
+        await ResetProjectAsync();
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The Windows ConPTY path is not exercised by this headless test.");
+        }
+
+        EditViewModel editor = await OpenEditorForNewScene("terminal-tab-theme-resources");
+        IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
+        var terminalContext = new TerminalTabViewModel(editor);
+        Assert.That(editor.DockHost.OpenToolTab(terminalContext, bottomDock), Is.True);
+        var terminalDockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => ReferenceEquals(item.ToolContext, terminalContext));
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        if (Application.Current is not Application currentApp)
+        {
+            throw new InvalidOperationException("Application.Current is null");
+        }
+
+#pragma warning disable CS8600
+        ThemeVariant originalVariant = currentApp.RequestedThemeVariant;
+#pragma warning restore CS8600
+        try
+        {
+            window.Show();
+            editor.DockHost.Factory.SetActiveDockable(terminalDockable);
+            HeadlessTestHelpers.Render();
+
+            TerminalControl terminal = FindTerminal(view);
+
+            Assert.That((terminal.Background as ISolidColorBrush)?.Color, Is.EqualTo(Colors.Transparent));
+
+            Assert.That(terminal.Foreground, Is.Not.Null);
+
+            currentApp.RequestedThemeVariant = ThemeVariant.Dark;
+            HeadlessTestHelpers.Render();
+            Color darkForeground = (terminal.Foreground as ISolidColorBrush)?.Color ?? default;
+
+            currentApp.RequestedThemeVariant = ThemeVariant.Light;
+            HeadlessTestHelpers.Render();
+            Color lightForeground = (terminal.Foreground as ISolidColorBrush)?.Color ?? default;
+
+            Assert.That(darkForeground, Is.Not.EqualTo(lightForeground),
+                "terminal foreground should vary between Dark and Light theme variants");
+        }
+        finally
+        {
+            currentApp.RequestedThemeVariant = originalVariant;
+            editor.CloseToolTab(terminalContext);
             window.Close();
             HeadlessTestHelpers.Settle();
         }


### PR DESCRIPTION
## Description
- The terminal tool tab's `TerminalControl` hardcoded `Background="Black"` / `Foreground="White"` in the upstream `Iciclecreek.Avalonia.Terminal` theme, so it stood out against the other bottom-docked tool tabs (Timeline, GraphEditor, AudioVisualizer), which inherit `DockSurfacePanelBrush` from the `ToolControl` host.
- Introduce `TerminalBackgroundBrush` / `TerminalForegroundBrush` keyed to the existing dock theme dictionaries so the terminal follows the active theme: dark themes match `DockSurfacePanelBrush` (unified with sibling tabs), and the light theme uses `LayerFillColorDefault` for the background (matching the other tabs) with `#1A1A1A` text so the prompt stays legible on the light surface.
- Bind these brushes on the `TerminalControl` in `TerminalTabView.axaml`.

## Affected areas
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)

## Breaking changes
None — adds two DynamicResource brushes and binds them; no public API or existing behavior changes for callers that don't reference these keys.

## Test plan
- Built `Beutl.Controls` and `Beutl.Editor.Components` (the two affected projects, the latter rebuilding the former via dependency): 0 warnings, 0 errors.
- `dotnet format --verify-no-changes` on all three edited `.axaml` files: no formatting changes.
- Manual: switch between Dark / DarkBorder / Light themes and confirm the terminal tab's background and text color match the other bottom-docked tabs; verify the shell prompt text is legible in each theme.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved terminal appearance across themes with dedicated background and foreground colors.
  * Terminal colors now adapt automatically between dark and default themes.
  * Enhanced readability and visual consistency for terminal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->