### PR TITLE
fix: align graph editor colors with timeline

### DIFF
--- a/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
+++ b/src/Beutl.Controls/Styling/Themes/BeutlDarkBorder.axaml
@@ -2,9 +2,10 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--
         Color overrides for the first-party "Dark" theme (id "beutl.dark.border"), merged flat over
-        the Dark base variant by ThemeService. Every key here must also exist in the built-in "Dark
-        (Classic)" dictionaries (Styling/BeutlDarkColors.axaml, Dock/DockFluent.axaml, Styles.axaml's
-        Dark scope): swap the value, never leave a dangling key. Non-color design stays app-level.
+        the Dark base variant by ThemeService. Every key here must also exist in the app's built-in
+        "Dark (Classic)" resources (Styling/BeutlDarkColors.axaml, Dock/DockFluent.axaml,
+        Styles.axaml's Dark scope, or a component dictionary such as GraphEditorResources.axaml):
+        swap the value, never leave a dangling key. Non-color design stays app-level.
 
         Accent surfaces reference SystemAccentColor* dynamically so a configured custom accent
         retints them; with no custom accent, ThemeService seeds those shades from
@@ -1478,5 +1479,14 @@
 
     <SolidColorBrush x:Key="DockChromeButtonHoverBackgroundBrush" Color="#0BFFFFFF" />
     <SolidColorBrush x:Key="DockChromeButtonPressedBackgroundBrush" Color="#14FFFFFF" />
+
+    <!-- ===== Graph editor (shared with Timeline) ===== -->
+    <StaticResource x:Key="GraphEditorBackgroundBrush" ResourceKey="DockSurfacePanelBrush" />
+    <StaticResource x:Key="GraphEditorGridLineBrush" ResourceKey="TextFillColorTertiaryBrush" />
+    <StaticResource x:Key="GraphEditorScaleTextBrush" ResourceKey="TextControlForeground" />
+    <StaticResource x:Key="GraphEditorControlPointFillBrush" ResourceKey="SystemFillColorCautionBrush" />
+    <StaticResource x:Key="GraphEditorControlPointStrokeBrush" ResourceKey="SystemFillColorCautionBrush" />
+    <StaticResource x:Key="GraphEditorHandleLineBrush" ResourceKey="TextControlForeground" />
+    <StaticResource x:Key="GraphEditorKeyFrameBrush" ResourceKey="SystemFillColorCautionBrush" />
 
 </ResourceDictionary>

--- a/tests/Beutl.E2ETests/BeutlDarkBorderThemeResourceTests.cs
+++ b/tests/Beutl.E2ETests/BeutlDarkBorderThemeResourceTests.cs
@@ -14,6 +14,9 @@ namespace Beutl.E2ETests;
 [TestFixture]
 public class BeutlDarkBorderThemeResourceTests
 {
+    private static readonly Uri s_graphEditorResourceUri =
+        new("avares://Beutl.Editor.Components/GraphEditorTab/Resources/GraphEditorResources.axaml");
+
     [AvaloniaTest]
     public void ResourceDictionary_MergesStandalone_AndOverridesTheDarkPalette()
     {
@@ -50,22 +53,33 @@ public class BeutlDarkBorderThemeResourceTests
         Assert.That(BeutlDarkBorderTheme.AccentColor, Is.EqualTo(Color.FromRgb(0x25, 0x63, 0xEB)));
     }
 
-    // The theme is a flat value-swap over the classic dark dictionaries, so a key it defines that they
-    // do not is an override of nothing: it reads as a real design decision but changes no pixel. The
-    // dictionary is deliberately left unmerged — resolution must succeed on the classic keys alone.
+    // The theme is a flat value-swap over the classic dark resources, so a key it defines that they do
+    // not is an override of nothing: it reads as a real design decision but changes no pixel. This test
+    // app loads only the shared Controls styles, so add the GraphEditor component's classic resources
+    // while keeping the theme dictionary itself unmerged.
     [AvaloniaTest]
     public void EveryKeyItOverrides_ResolvesWithoutIt()
     {
         var resources = (IResourceDictionary)AvaloniaXamlLoader.Load(BeutlDarkBorderTheme.ResourceUri, null)!;
-        object[] dangling = resources.Keys
-            .Where(key => !Application.Current!.TryGetResource(key, ThemeVariant.Dark, out _))
-            .ToArray();
-
-        Assert.Multiple(() =>
+        var graphEditorResources = (IResourceProvider)AvaloniaXamlLoader.Load(s_graphEditorResourceUri, null)!;
+        IList<IResourceProvider> merged = Application.Current!.Resources.MergedDictionaries;
+        try
         {
-            Assert.That(resources.Keys, Is.Not.Empty, "precondition: the theme defines keys");
-            Assert.That(dangling, Is.Empty,
-                "the border theme must override an existing key, never introduce a dangling one");
-        });
+            merged.Add(graphEditorResources);
+            object[] dangling = resources.Keys
+                .Where(key => !Application.Current.TryGetResource(key, ThemeVariant.Dark, out _))
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resources.Keys, Is.Not.Empty, "precondition: the theme defines keys");
+                Assert.That(dangling, Is.Empty,
+                    "the border theme must override an existing key, never introduce a dangling one");
+            });
+        }
+        finally
+        {
+            merged.Remove(graphEditorResources);
+        }
     }
 }

--- a/tests/Beutl.HeadlessUITests/GraphEditorThemeResourceTests.cs
+++ b/tests/Beutl.HeadlessUITests/GraphEditorThemeResourceTests.cs
@@ -1,0 +1,116 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using Beutl.Editor.Components.GraphEditorTab.Views;
+using Beutl.Services.PrimitiveImpls;
+using Beutl.Testing.Headless;
+
+namespace Beutl.HeadlessUITests;
+
+// GraphEditor keeps its classic Light/Dark resources in the component dictionary. ThemeExtension
+// resources are merged flat at Application scope, so they must both replace those resources on a
+// live view and supply the first-party Dark design palette.
+[TestFixture]
+public class GraphEditorThemeResourceTests
+{
+    [AvaloniaTest]
+    public void DarkTheme_UsesTheTimelinePalette()
+    {
+        ThemeVariant? previousVariant = Application.Current!.RequestedThemeVariant;
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+        Uri resourceUri = DarkBorderThemeExtension.Instance.GetThemeDescriptor().ResourceUri!;
+        var resources = (IResourceProvider)AvaloniaXamlLoader.Load(resourceUri, null)!;
+        IList<IResourceProvider> merged = Application.Current.Resources.MergedDictionaries;
+        var probe = new Border();
+        var window = new Window { Content = probe, Width = 200, Height = 120 };
+        try
+        {
+            merged.Add(resources);
+            window.Show();
+            HeadlessTestHelpers.Render(1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ResolveFill(probe, "GraphEditorBackgroundBrush"),
+                    Is.EqualTo(ResolveFill(probe, "DockSurfacePanelBrush")));
+                Assert.That(ResolveFill(probe, "GraphEditorGridLineBrush"),
+                    Is.EqualTo(ResolveFill(probe, "TextFillColorTertiaryBrush")));
+                Assert.That(ResolveFill(probe, "GraphEditorScaleTextBrush"),
+                    Is.EqualTo(ResolveFill(probe, "TextControlForeground")));
+                Assert.That(ResolveFill(probe, "GraphEditorControlPointFillBrush"),
+                    Is.EqualTo(ResolveFill(probe, "SystemFillColorCautionBrush")));
+                Assert.That(ResolveFill(probe, "GraphEditorControlPointStrokeBrush"),
+                    Is.EqualTo(ResolveFill(probe, "SystemFillColorCautionBrush")));
+                Assert.That(ResolveFill(probe, "GraphEditorHandleLineBrush"),
+                    Is.EqualTo(ResolveFill(probe, "TextControlForeground")));
+                Assert.That(ResolveFill(probe, "GraphEditorKeyFrameBrush"),
+                    Is.EqualTo(ResolveFill(probe, "SystemFillColorCautionBrush")));
+            });
+        }
+        finally
+        {
+            window.Close();
+            merged.Remove(resources);
+            Application.Current.RequestedThemeVariant = previousVariant;
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void ThemeExtension_CanOverrideGraphEditorColors()
+    {
+        var overrideBrush = new SolidColorBrush(Colors.Magenta);
+        var resources = new ResourceDictionary
+        {
+            ["GraphEditorBackgroundBrush"] = overrideBrush
+        };
+        IList<IResourceProvider> merged = Application.Current!.Resources.MergedDictionaries;
+        ThemeVariant? previousVariant = Application.Current.RequestedThemeVariant;
+        var view = new GraphEditorView();
+        var window = new Window { Content = view, Width = 200, Height = 120 };
+        try
+        {
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+            window.Show();
+            HeadlessTestHelpers.Render(1);
+
+            Grid grid = view.GetVisualDescendants().OfType<Grid>().Single(item => item.Name == "grid");
+            Assert.That(grid.Background, Is.Not.SameAs(overrideBrush), "precondition: the base theme is active");
+
+            merged.Add(resources);
+            HeadlessTestHelpers.Render(1);
+
+            Assert.That(grid.Background, Is.SameAs(overrideBrush));
+
+            merged.Remove(resources);
+            HeadlessTestHelpers.Render(1);
+
+            Assert.That(grid.Background, Is.Not.SameAs(overrideBrush),
+                "removing the extension resources should restore the base theme");
+        }
+        finally
+        {
+            window.Close();
+            merged.Remove(resources);
+            Application.Current.RequestedThemeVariant = previousVariant;
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static (Color Color, double Opacity) ResolveFill(Control context, string key)
+    {
+        if (!context.TryFindResource(key, ThemeVariant.Dark, out object? value)
+            || value is not ISolidColorBrush brush)
+        {
+            Assert.Fail($"'{key}' should resolve to a solid color brush under Dark "
+                + $"(got {value?.GetType().Name ?? "nothing"})");
+            return default;
+        }
+
+        return (brush.Color, brush.Opacity);
+    }
+}


### PR DESCRIPTION
## Description

- Enable `ThemeExtension` dictionaries to override Graph Editor color resources and update live views when themes are applied or removed.
- Add Graph Editor overrides to the existing first-party Dark resource dictionary and reuse Timeline palette resources to keep both tabs visually consistent.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None.

## Test plan

- `dotnet format Beutl.slnx --verify-no-changes --no-restore`
- `dotnet build src/Beutl.Controls/Beutl.Controls.csproj -c Debug --no-restore --nologo -m:1`
- Headless UI tests covering the Dark theme descriptor, Timeline palette alignment, and live ThemeExtension overrides: 8 passed.
- E2E tests covering standalone Dark resource loading and override-key validity: 3 passed.
- Full pre-PR XAML and four-axis audits: no findings.
- Screenshots: None; headless resource and live-view assertions cover the visual resource behavior.

## Fixed issues / References

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dark-theme styling for the Graph Editor, including backgrounds, grid lines, scale text, control points, handle lines, and keyframes.
  - Graph Editor colors now align with the application’s classic dark-theme palette.

- **Bug Fixes**
  - Improved theme resource resolution so Graph Editor colors load correctly and support live theme overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->